### PR TITLE
Gate 403 retry on secret resolution and eliminate nil secrets

### DIFF
--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -563,7 +563,7 @@ func start(log log.Component,
 		go func() {
 			defer wg.Done()
 
-			if err := runCompliance(mainCtx, demultiplexer, wmeta, filterStore, apiCl, compression, le.IsLeader); err != nil {
+			if err := runCompliance(mainCtx, demultiplexer, wmeta, filterStore, apiCl, compression, le.IsLeader, secretResolver); err != nil {
 				pkglog.Errorf("Error while running compliance agent: %v", err)
 			}
 		}()

--- a/cmd/security-agent/main_windows.go
+++ b/cmd/security-agent/main_windows.go
@@ -125,7 +125,7 @@ func (s *service) Run(svcctx context.Context) error {
 		workloadmetafx.Module(workloadmeta.Params{
 			AgentType: workloadmeta.Remote,
 		}),
-		fx.Provide(func(log log.Component, config config.Component, statsd statsd.Component, compression logscompression.Component, hostname hostnameinterface.Component) (status.InformationProvider, *agent.RuntimeSecurityAgent, error) {
+		fx.Provide(func(log log.Component, config config.Component, statsd statsd.Component, compression logscompression.Component, hostname hostnameinterface.Component, secretsComp secrets.Component) (status.InformationProvider, *agent.RuntimeSecurityAgent, error) {
 			stopper := startstop.NewSerialStopper()
 
 			statsdClient, err := statsd.CreateForHostPort(configutils.GetBindHost(config), config.GetInt("dogstatsd_port"))
@@ -139,7 +139,7 @@ func (s *service) Run(svcctx context.Context) error {
 				return status.NewInformationProvider(nil), nil, err
 			}
 
-			runtimeAgent, err := agent.StartRuntimeSecurity(log, config, hostnameDetected, stopper, statsdClient, compression)
+			runtimeAgent, err := agent.StartRuntimeSecurity(log, config, hostnameDetected, stopper, statsdClient, compression, secretsComp)
 			if err != nil {
 				return status.NewInformationProvider(nil), nil, err
 			}

--- a/cmd/security-agent/subcommands/start/command.go
+++ b/cmd/security-agent/subcommands/start/command.go
@@ -119,13 +119,13 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				fx.Provide(func(config config.Component, statsd statsd.Component) (ddgostatsd.ClientInterface, error) {
 					return statsd.CreateForHostPort(configutils.GetBindHost(config), config.GetInt("dogstatsd_port"))
 				}),
-				fx.Provide(func(stopper startstop.Stopper, log log.Component, config config.Component, statsdClient ddgostatsd.ClientInterface, compression logscompression.Component, hostname hostnameinterface.Component) (status.InformationProvider, *agent.RuntimeSecurityAgent, error) {
+				fx.Provide(func(stopper startstop.Stopper, log log.Component, config config.Component, statsdClient ddgostatsd.ClientInterface, compression logscompression.Component, hostname hostnameinterface.Component, secretsComp secrets.Component) (status.InformationProvider, *agent.RuntimeSecurityAgent, error) {
 					hostnameDetected, err := hostname.Get(context.TODO())
 					if err != nil {
 						return status.NewInformationProvider(nil), nil, err
 					}
 
-					runtimeAgent, err := agent.StartRuntimeSecurity(log, config, hostnameDetected, stopper, statsdClient, compression)
+					runtimeAgent, err := agent.StartRuntimeSecurity(log, config, hostnameDetected, stopper, statsdClient, compression, secretsComp)
 					if err != nil {
 						return status.NewInformationProvider(nil), nil, err
 					}
@@ -137,7 +137,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 					// TODO - components: Do not remove runtimeAgent ref until "github.com/DataDog/datadog-agent/pkg/security/agent" is a component so they're not GCed
 					return status.NewInformationProvider(runtimeAgent.StatusProvider()), runtimeAgent, nil
 				}),
-				fx.Provide(func(stopper startstop.Stopper, log log.Component, config config.Component, statsdClient ddgostatsd.ClientInterface, sysprobeconfig sysprobeconfig.Component, wmeta workloadmeta.Component, filterStore workloadfilter.Component, compression logscompression.Component, hostname hostnameinterface.Component) (status.InformationProvider, *compliance.Agent, error) {
+				fx.Provide(func(stopper startstop.Stopper, log log.Component, config config.Component, statsdClient ddgostatsd.ClientInterface, sysprobeconfig sysprobeconfig.Component, wmeta workloadmeta.Component, filterStore workloadfilter.Component, compression logscompression.Component, hostname hostnameinterface.Component, secretsComp secrets.Component) (status.InformationProvider, *compliance.Agent, error) {
 					// Check if compliance should run in system-probe instead
 					if config.GetBool("compliance_config.run_in_system_probe") {
 						log.Info("compliance_config.run_in_system_probe is enabled, compliance will run in system-probe")
@@ -155,7 +155,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 					}
 
 					// start compliance security agent
-					complianceAgent, err := compliance.StartCompliance(log, config, hostnameDetected, stopper, statsdClient, wmeta, filterStore, compression, sysProbeClient)
+					complianceAgent, err := compliance.StartCompliance(log, config, hostnameDetected, stopper, statsdClient, wmeta, filterStore, compression, sysProbeClient, secretsComp)
 					if err != nil {
 						return status.NewInformationProvider(nil), nil, err
 					}

--- a/cmd/system-probe/modules/compliance.go
+++ b/cmd/system-probe/modules/compliance.go
@@ -62,7 +62,7 @@ func newComplianceModule(_ *sysconfigtypes.Config, deps module.FactoryDependenci
 		sysProbeClient := &compliance.LocalSysProbeClient{}
 
 		// start compliance agent
-		complianceAgent, err = compliance.StartCompliance(deps.Log, deps.CoreConfig, hostnameDetected, stopper, deps.Statsd, deps.WMeta, deps.FilterStore, deps.Compression, sysProbeClient)
+		complianceAgent, err = compliance.StartCompliance(deps.Log, deps.CoreConfig, hostnameDetected, stopper, deps.Statsd, deps.WMeta, deps.FilterStore, deps.Compression, sysProbeClient, deps.Secrets)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/system-probe/modules/eventmonitor.go
+++ b/cmd/system-probe/modules/eventmonitor.go
@@ -64,7 +64,7 @@ func createEventMonitorModule(_ *sysconfigtypes.Config, deps module.FactoryDepen
 	}
 
 	if secconfig.RuntimeSecurity.IsRuntimeEnabled() {
-		cws, err := secmodule.NewCWSConsumer(evm, secconfig.RuntimeSecurity, deps.WMeta, deps.FilterStore, secmoduleOpts, deps.Compression, deps.Ipc, hostname)
+		cws, err := secmodule.NewCWSConsumer(evm, secconfig.RuntimeSecurity, deps.WMeta, deps.FilterStore, secmoduleOpts, deps.Compression, deps.Ipc, hostname, deps.Secrets)
 		if err != nil {
 			return nil, err
 		}

--- a/comp/core/secrets/def/component.go
+++ b/comp/core/secrets/def/component.go
@@ -46,4 +46,8 @@ type Component interface {
 	// RemoveOrigin removes a origin from the internal cache of the secret component. This does not remove secrets
 	// from the cache but the reference where those secrets are used.
 	RemoveOrigin(origin string)
+	// IsSecretResolved returns true if the secrets component has resolved a secret
+	// handle at a config path containing the given settingPath element.
+	// This is used to determine if a secrets refresh could change the value at that path.
+	IsSecretResolved(settingPath string) bool
 }

--- a/comp/core/secrets/impl/secrets.go
+++ b/comp/core/secrets/impl/secrets.go
@@ -628,6 +628,27 @@ func (r *secretResolver) matchesAllowlist(handle string) bool {
 	return slices.ContainsFunc(r.origin[handle], secretMatchesAllowlist)
 }
 
+// IsSecretResolved returns true if the secrets component has resolved a secret
+// handle at a config path containing the given settingPath element.
+func (r *secretResolver) IsSecretResolved(settingPath string) bool {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	if r.backendCommand == "" {
+		return false
+	}
+	parts := strings.Split(settingPath, ".")
+	for _, origins := range r.origin {
+		for _, ctx := range origins {
+			for _, part := range parts {
+				if slices.Contains(ctx.path, part) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
 // for all secrets returned by the backend command, notify subscribers (if allowlist lets them),
 // and return the handles that have received new values compared to what was in the cache,
 // and where those handles appear

--- a/comp/core/secrets/mock/mock.go
+++ b/comp/core/secrets/mock/mock.go
@@ -19,9 +19,10 @@ import (
 
 // Mock is a mock of the secret Component useful for testing
 type Mock struct {
-	secretsCache map[string]string
-	callbacks    []secrets.SecretChangeCallback
-	refreshHook  func(bool) (string, error)
+	secretsCache     map[string]string
+	callbacks        []secrets.SecretChangeCallback
+	refreshHook      func(bool) (string, error)
+	isSecretResolved bool
 }
 
 var _ secrets.Component = (*Mock)(nil)
@@ -103,3 +104,13 @@ func (m *Mock) Refresh(updateNow bool) (string, error) {
 
 // RemoveOrigin
 func (m *Mock) RemoveOrigin(_ string) {}
+
+// SetIsSecretResolved sets the return value of IsSecretResolved for testing
+func (m *Mock) SetIsSecretResolved(v bool) {
+	m.isSecretResolved = v
+}
+
+// IsSecretResolved returns the configured value for testing
+func (m *Mock) IsSecretResolved(_ string) bool {
+	return m.isSecretResolved
+}

--- a/comp/core/secrets/noop-impl/types/types.go
+++ b/comp/core/secrets/noop-impl/types/types.go
@@ -31,3 +31,6 @@ func (r *SecretNoop) Refresh(_ bool) (string, error) {
 
 // RemoveOrigin
 func (r *SecretNoop) RemoveOrigin(_ string) {}
+
+// IsSecretResolved always returns false for the noop implementation
+func (r *SecretNoop) IsSecretResolved(_ string) bool { return false }

--- a/comp/forwarder/eventplatform/eventplatformimpl/epforwarder.go
+++ b/comp/forwarder/eventplatform/eventplatformimpl/epforwarder.go
@@ -19,6 +19,7 @@ import (
 	configcomp "github.com/DataDog/datadog-agent/comp/core/config"
 	diagnose "github.com/DataDog/datadog-agent/comp/core/diagnose/def"
 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
+	secrets "github.com/DataDog/datadog-agent/comp/core/secrets/def"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver/eventplatformreceiverimpl"
@@ -493,6 +494,7 @@ func newHTTPPassthroughPipeline(
 	desc passthroughPipelineDesc,
 	destinationsContext *client.DestinationsContext,
 	pipelineID int,
+	secretsComp secrets.Component,
 ) (p *passthroughPipeline, err error) {
 	configKeys := config.NewLogsConfigKeys(desc.endpointsConfigPrefix, coreConfig)
 	compressionOptions := config.EndpointCompressionOptions{
@@ -547,6 +549,7 @@ func newHTTPPassthroughPipeline(
 		sender.DefaultWorkersPerQueue,
 		endpoints.BatchMaxConcurrentSend,
 		endpoints.BatchMaxConcurrentSend,
+		secretsComp,
 	)
 
 	var encoder compressioncommon.Compressor
@@ -615,12 +618,12 @@ func joinHosts(endpoints []config.Endpoint) string {
 	return strings.Join(additionalHosts, ",")
 }
 
-func newDefaultEventPlatformForwarder(config model.Reader, eventPlatformReceiver eventplatformreceiver.Component, compression logscompression.Component) *defaultEventPlatformForwarder {
+func newDefaultEventPlatformForwarder(config model.Reader, eventPlatformReceiver eventplatformreceiver.Component, compression logscompression.Component, secretsComp secrets.Component) *defaultEventPlatformForwarder {
 	destinationsCtx := client.NewDestinationsContext()
 	destinationsCtx.Start()
 	pipelines := make(map[string]*passthroughPipeline)
 	for i, desc := range getPassthroughPipelines() {
-		p, err := newHTTPPassthroughPipeline(config, eventPlatformReceiver, compression, desc, destinationsCtx, i)
+		p, err := newHTTPPassthroughPipeline(config, eventPlatformReceiver, compression, desc, destinationsCtx, i, secretsComp)
 		if err != nil {
 			log.Errorf("Failed to initialize event platform forwarder pipeline. eventType=%s, error=%s", desc.eventType, err.Error())
 			continue
@@ -641,6 +644,7 @@ type dependencies struct {
 	EventPlatformReceiver eventplatformreceiver.Component
 	Hostname              hostnameinterface.Component
 	Compression           logscompression.Component
+	Secrets               secrets.Component
 }
 
 // newEventPlatformForwarder creates a new EventPlatformForwarder
@@ -650,7 +654,7 @@ func newEventPlatformForwarder(deps dependencies) eventplatform.Component {
 	if deps.Params.UseNoopEventPlatformForwarder {
 		forwarder = newNoopEventPlatformForwarder(deps.Hostname, deps.Compression)
 	} else if deps.Params.UseEventPlatformForwarder {
-		forwarder = newDefaultEventPlatformForwarder(deps.Config, deps.EventPlatformReceiver, deps.Compression)
+		forwarder = newDefaultEventPlatformForwarder(deps.Config, deps.EventPlatformReceiver, deps.Compression, deps.Secrets)
 	}
 	if forwarder == nil {
 		return option.NonePtr[eventplatform.Forwarder]()
@@ -675,7 +679,7 @@ func NewNoopEventPlatformForwarder(hostname hostnameinterface.Component, compres
 }
 
 func newNoopEventPlatformForwarder(hostname hostnameinterface.Component, compression logscompression.Component) *defaultEventPlatformForwarder {
-	f := newDefaultEventPlatformForwarder(pkgconfigsetup.Datadog(), eventplatformreceiverimpl.NewReceiver(hostname).Comp, compression)
+	f := newDefaultEventPlatformForwarder(pkgconfigsetup.Datadog(), eventplatformreceiverimpl.NewReceiver(hostname).Comp, compression, nil)
 	// remove the senders
 	for _, p := range f.pipelines {
 		p.strategy = nil

--- a/comp/forwarder/eventplatform/eventplatformimpl/epforwarder.go
+++ b/comp/forwarder/eventplatform/eventplatformimpl/epforwarder.go
@@ -20,6 +20,7 @@ import (
 	diagnose "github.com/DataDog/datadog-agent/comp/core/diagnose/def"
 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
 	secrets "github.com/DataDog/datadog-agent/comp/core/secrets/def"
+	secretnooptypes "github.com/DataDog/datadog-agent/comp/core/secrets/noop-impl/types"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver/eventplatformreceiverimpl"
@@ -679,7 +680,7 @@ func NewNoopEventPlatformForwarder(hostname hostnameinterface.Component, compres
 }
 
 func newNoopEventPlatformForwarder(hostname hostnameinterface.Component, compression logscompression.Component) *defaultEventPlatformForwarder {
-	f := newDefaultEventPlatformForwarder(pkgconfigsetup.Datadog(), eventplatformreceiverimpl.NewReceiver(hostname).Comp, compression, nil)
+	f := newDefaultEventPlatformForwarder(pkgconfigsetup.Datadog(), eventplatformreceiverimpl.NewReceiver(hostname).Comp, compression, &secretnooptypes.SecretNoop{})
 	// remove the senders
 	for _, p := range f.pipelines {
 		p.strategy = nil

--- a/comp/forwarder/eventplatform/eventplatformimpl/epforwarder_test.go
+++ b/comp/forwarder/eventplatform/eventplatformimpl/epforwarder_test.go
@@ -137,6 +137,7 @@ func (suite *EventPlatformForwarderTestSuite) TestNewHTTPPassthroughPipelineComp
 				desc,
 				nil,
 				0,
+				nil,
 			)
 			suite.Require().NoError(err)
 			suite.Require().NotNil(pipeline)

--- a/comp/forwarder/eventplatform/eventplatformimpl/epforwarder_test.go
+++ b/comp/forwarder/eventplatform/eventplatformimpl/epforwarder_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	secretnooptypes "github.com/DataDog/datadog-agent/comp/core/secrets/noop-impl/types"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver/eventplatformreceiverimpl"
 	laconfig "github.com/DataDog/datadog-agent/comp/logs/agent/config"
@@ -137,7 +138,7 @@ func (suite *EventPlatformForwarderTestSuite) TestNewHTTPPassthroughPipelineComp
 				desc,
 				nil,
 				0,
-				nil,
+				&secretnooptypes.SecretNoop{},
 			)
 			suite.Require().NoError(err)
 			suite.Require().NotNil(pipeline)

--- a/comp/logs/agent/agentimpl/agent.go
+++ b/comp/logs/agent/agentimpl/agent.go
@@ -23,6 +23,7 @@ import (
 	flaretypes "github.com/DataDog/datadog-agent/comp/core/flare/types"
 	"github.com/DataDog/datadog-agent/comp/core/hostname"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	secrets "github.com/DataDog/datadog-agent/comp/core/secrets/def"
 	statusComponent "github.com/DataDog/datadog-agent/comp/core/status"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
@@ -85,6 +86,7 @@ type dependencies struct {
 	SchedulerProviders []schedulers.Scheduler `group:"log-agent-scheduler"`
 	Tagger             tagger.Component
 	Compression        logscompression.Component
+	Secrets            secrets.Component
 }
 
 type provides struct {
@@ -106,6 +108,7 @@ type logAgent struct {
 	inventoryAgent inventoryagent.Component
 	hostname       hostname.Component
 	tagger         tagger.Component
+	secrets        secrets.Component
 
 	sources                   *sources.LogSources
 	services                  *service.Services
@@ -162,6 +165,7 @@ func newLogsAgent(deps dependencies) provides {
 			integrationsLogs:   integrationsLogs,
 			tagger:             deps.Tagger,
 			compression:        deps.Compression,
+			secrets:            deps.Secrets,
 		}
 		deps.Lc.Append(fx.Hook{
 			OnStart: logsAgent.start,

--- a/comp/logs/agent/agentimpl/agent_core_init.go
+++ b/comp/logs/agent/agentimpl/agent_core_init.go
@@ -102,7 +102,7 @@ func buildHTTPEndpointsForRestart(coreConfig model.Reader) (*config.Endpoints, e
 
 // buildPipelineProvider builds a new pipeline provider with the given configuration
 func buildPipelineProvider(a *logAgent, processingRules []*config.ProcessingRule, diagnosticMessageReceiver *diagnostic.BufferedMessageReceiver, destinationsCtx *client.DestinationsContext) pipeline.Provider {
-	pipelineProvider := pipeline.NewProvider(
+	pipelineProvider := pipeline.NewProviderWithSecrets(
 		a.config.GetInt("logs_config.pipelines"),
 		a.auditor,
 		diagnosticMessageReceiver,
@@ -115,6 +115,7 @@ func buildPipelineProvider(a *logAgent, processingRules []*config.ProcessingRule
 		a.compression,
 		a.config.GetBool("logs_config.disable_distributed_senders"), // legacy
 		false, // serverless
+		a.secrets,
 	)
 	return pipelineProvider
 }

--- a/comp/logs/agent/agentimpl/agent_restart_test.go
+++ b/comp/logs/agent/agentimpl/agent_restart_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
+	secretnooptypes "github.com/DataDog/datadog-agent/comp/core/secrets/noop-impl/types"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	taggerfxmock "github.com/DataDog/datadog-agent/comp/core/tagger/fx-mock"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
@@ -148,6 +149,7 @@ func createTestAgent(suite *RestartTestSuite, endpoints *config.Endpoints) (*log
 		flarecontroller: flareController.NewFlareController(),
 		compression:     compressionfx.NewMockCompressor(),
 		wmeta:           option.None[workloadmeta.Component](),
+		secrets:         &secretnooptypes.SecretNoop{},
 	}
 
 	agent.setupAgent()

--- a/comp/logs/agent/agentimpl/agent_test.go
+++ b/comp/logs/agent/agentimpl/agent_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
+	secretsnoopfx "github.com/DataDog/datadog-agent/comp/core/secrets/fx-noop"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	taggerfxmock "github.com/DataDog/datadog-agent/comp/core/tagger/fx-mock"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
@@ -505,6 +506,7 @@ func (suite *AgentTestSuite) createDeps() dependencies {
 		inventoryagentimpl.MockModule(),
 		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
 		compressionfx.MockModule(),
+		secretsnoopfx.Module(),
 		fx.Provide(func() tagger.Component {
 			return suite.tagger
 		}),

--- a/comp/logs/agent/agentimpl/agent_test.go
+++ b/comp/logs/agent/agentimpl/agent_test.go
@@ -27,6 +27,7 @@ import (
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
 	secretsnoopfx "github.com/DataDog/datadog-agent/comp/core/secrets/fx-noop"
+	secretnooptypes "github.com/DataDog/datadog-agent/comp/core/secrets/noop-impl/types"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	taggerfxmock "github.com/DataDog/datadog-agent/comp/core/tagger/fx-mock"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
@@ -160,6 +161,7 @@ func createAgent(suite *AgentTestSuite, endpoints *config.Endpoints) (*logAgent,
 		tagger:          fakeTagger,
 		flarecontroller: flareController.NewFlareController(),
 		compression:     compressionfx.NewMockCompressor(),
+		secrets:         &secretnooptypes.SecretNoop{},
 	}
 
 	agent.setupAgent()

--- a/comp/logs/agent/config/endpoints.go
+++ b/comp/logs/agent/config/endpoints.go
@@ -266,6 +266,11 @@ func (e *Endpoint) GetAPIKey() string {
 	return e.apiKey.Load()
 }
 
+// GetConfigSettingPath returns the config path this endpoint monitors for API key updates
+func (e *Endpoint) GetConfigSettingPath() string {
+	return e.configSettingPath
+}
+
 // UseSSL returns the useSSL config setting
 func (e *Endpoint) UseSSL() bool {
 	return e.useSSL

--- a/comp/metadata/inventorychecks/inventorychecksimpl/inventorychecks_test.go
+++ b/comp/metadata/inventorychecks/inventorychecksimpl/inventorychecks_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
+	secretsnoopfx "github.com/DataDog/datadog-agent/comp/core/secrets/fx-noop"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	taggerfxmock "github.com/DataDog/datadog-agent/comp/core/tagger/fx-mock"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
@@ -162,6 +163,7 @@ func TestGetPayload(t *testing.T) {
 			t,
 			logsBundle.MockBundle(),
 			core.MockBundle(),
+			secretsnoopfx.Module(),
 			hostnameimpl.MockModule(),
 			inventoryagentimpl.MockModule(),
 			logscompression.MockModule(),

--- a/comp/networkpath/npcollector/npcollectorimpl/npcollector_testutils.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/npcollector_testutils.go
@@ -52,7 +52,7 @@ var testOptions = fx.Options(
 	forwarderimpl.MockModule(),
 	demultiplexerimpl.MockModule(),
 	defaultforwarder.MockModule(),
-	eventplatformimpl.Module(eventplatformimpl.NewDefaultParams()),
+	eventplatformimpl.MockModule(),
 	eventplatformreceiverimpl.Module(),
 	rdnsqueriermock.MockModule(),
 	logscompression.MockModule(),

--- a/pkg/compliance/cli/check.go
+++ b/pkg/compliance/cli/check.go
@@ -55,7 +55,7 @@ func FillCheckFlags(flagSet *pflag.FlagSet, checkArgs *CheckParams) {
 }
 
 // RunCheck runs a check
-func RunCheck(log log.Component, config config.Component, _ secrets.Component, statsdComp statsd.Component, checkArgs *CheckParams, compression logscompression.Component, _ ipc.Component, hostname hostnameinterface.Component) error {
+func RunCheck(log log.Component, config config.Component, secretsComp secrets.Component, statsdComp statsd.Component, checkArgs *CheckParams, compression logscompression.Component, _ ipc.Component, hostname hostnameinterface.Component) error {
 	hname, err := hostname.Get(context.Background())
 	if err != nil {
 		return err
@@ -162,7 +162,7 @@ func RunCheck(log log.Component, config config.Component, _ secrets.Component, s
 		}
 	}
 	if checkArgs.Report {
-		if err := reportComplianceEvents(hname, events, compression); err != nil {
+		if err := reportComplianceEvents(hname, events, compression, secretsComp); err != nil {
 			log.Error(err)
 			return err
 		}
@@ -185,12 +185,12 @@ func dumpComplianceEvents(reportFile string, events []*compliance.CheckEvent) er
 	return nil
 }
 
-func reportComplianceEvents(hostname string, events []*compliance.CheckEvent, compression logscompression.Component) error {
+func reportComplianceEvents(hostname string, events []*compliance.CheckEvent, compression logscompression.Component, secretsComp secrets.Component) error {
 	endpoints, context, err := common.NewLogContextCompliance()
 	if err != nil {
 		return fmt.Errorf("reporter: could not create log context for compliance: %w", err)
 	}
-	reporter := compliance.NewLogReporter(hostname, "compliance-agent", "compliance", endpoints, context, compression)
+	reporter := compliance.NewLogReporter(hostname, "compliance-agent", "compliance", endpoints, context, compression, secretsComp)
 	defer reporter.Stop()
 	for _, event := range events {
 		reporter.ReportEvent(event)

--- a/pkg/compliance/compliance.go
+++ b/pkg/compliance/compliance.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	secrets "github.com/DataDog/datadog-agent/comp/core/secrets/def"
 	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/constants"
@@ -38,6 +39,7 @@ func StartCompliance(log log.Component,
 	filterStore workloadfilter.Component,
 	compression compression.Component,
 	sysProbeClient SysProbeClient,
+	secretsComp secrets.Component,
 ) (*Agent, error) {
 
 	enabled := config.GetBool("compliance_config.enabled")
@@ -73,7 +75,7 @@ func StartCompliance(log log.Component,
 		enabledConfigurationsExporters = append(enabledConfigurationsExporters, DBExporter)
 	}
 
-	reporter := NewLogReporter(hostname, "compliance-agent", "compliance", endpoints, context, compression)
+	reporter := NewLogReporter(hostname, "compliance-agent", "compliance", endpoints, context, compression, secretsComp)
 	telemetrySender := telemetry.NewSimpleTelemetrySenderFromStatsd(statsdClient)
 
 	agent := NewAgent(telemetrySender, wmeta, filterStore, hostname, AgentOptions{

--- a/pkg/compliance/reporter.go
+++ b/pkg/compliance/reporter.go
@@ -36,7 +36,7 @@ type LogReporter struct {
 }
 
 // NewLogReporter instantiates a new log LogReporter.
-// secretsComp is optional (may be nil) and enables API key refresh on 403 responses.
+// secretsComp enables API key refresh on 403 responses; pass a SecretNoop when no secrets backend is available.
 func NewLogReporter(hostname string, sourceName, sourceType string, endpoints *config.Endpoints, dstcontext *client.DestinationsContext, compression logscompression.Component, secretsComp secrets.Component) *LogReporter {
 	// setup the pipeline provider that provides pairs of processor and sender
 	cfg := pkgconfigsetup.Datadog()

--- a/pkg/compliance/status_provider_test.go
+++ b/pkg/compliance/status_provider_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	secretnooptypes "github.com/DataDog/datadog-agent/comp/core/secrets/noop-impl/types"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	compressionfx "github.com/DataDog/datadog-agent/comp/serializer/logscompression/fx-mock"
 	"github.com/DataDog/datadog-agent/pkg/logs/client"
@@ -20,7 +21,7 @@ func TestStatus(t *testing.T) {
 	provider := statusProvider{
 		agent: &Agent{
 			opts: AgentOptions{
-				Reporter: NewLogReporter("test", "test", "test", &config.Endpoints{}, &client.DestinationsContext{}, compressionfx.NewMockCompressor(), nil),
+				Reporter: NewLogReporter("test", "test", "test", &config.Endpoints{}, &client.DestinationsContext{}, compressionfx.NewMockCompressor(), &secretnooptypes.SecretNoop{}),
 			},
 		},
 	}

--- a/pkg/compliance/status_provider_test.go
+++ b/pkg/compliance/status_provider_test.go
@@ -20,7 +20,7 @@ func TestStatus(t *testing.T) {
 	provider := statusProvider{
 		agent: &Agent{
 			opts: AgentOptions{
-				Reporter: NewLogReporter("test", "test", "test", &config.Endpoints{}, &client.DestinationsContext{}, compressionfx.NewMockCompressor()),
+				Reporter: NewLogReporter("test", "test", "test", &config.Endpoints{}, &client.DestinationsContext{}, compressionfx.NewMockCompressor(), nil),
 			},
 		},
 	}

--- a/pkg/logs/client/go.mod
+++ b/pkg/logs/client/go.mod
@@ -3,6 +3,8 @@ module github.com/DataDog/datadog-agent/pkg/logs/client
 go 1.25.0
 
 require (
+	github.com/DataDog/datadog-agent/comp/core/secrets/def v0.72.0-rc.1
+	github.com/DataDog/datadog-agent/comp/core/secrets/noop-impl v0.77.0-devel.0.20260211235139-a5361978c2b6
 	github.com/DataDog/datadog-agent/comp/core/telemetry v0.61.0
 	github.com/DataDog/datadog-agent/comp/logs/agent/config v0.61.0
 	github.com/DataDog/datadog-agent/pkg/config/mock v0.61.0
@@ -23,7 +25,6 @@ require (
 )
 
 require (
-	github.com/DataDog/datadog-agent/comp/core/secrets/def v0.72.0-rc.1 // indirect
 	github.com/DataDog/datadog-agent/comp/def v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/basic v0.0.0-20260211235139-a5361978c2b6 // indirect

--- a/pkg/logs/client/http/destination_test.go
+++ b/pkg/logs/client/http/destination_test.go
@@ -13,11 +13,13 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 
+	secretnooptypes "github.com/DataDog/datadog-agent/comp/core/secrets/noop-impl/types"
 	"github.com/DataDog/datadog-agent/pkg/logs/client"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
@@ -182,6 +184,48 @@ func retryTest(t *testing.T, statusCode int) {
 	// Should recover because it was retrying
 	server.ChangeStatus(200)
 	// Drain any retries
+	for {
+		if (<-respondChan) == 200 {
+			break
+		}
+	}
+	<-output
+
+	server.Stop()
+}
+
+// mockSecrets wraps the noop secrets implementation to track Refresh calls.
+type mockSecrets struct {
+	secretnooptypes.SecretNoop
+	refreshCount atomic.Int32
+}
+
+func (m *mockSecrets) Refresh(_ bool) (string, error) {
+	m.refreshCount.Add(1)
+	return "", nil
+}
+
+func TestForbiddenTriggersSecretsRefreshAndRetry(t *testing.T) {
+	cfg := configmock.New(t)
+	respondChan := make(chan int)
+	server := NewTestServerWithOptions(403, 1, true, respondChan, cfg)
+
+	mock := &mockSecrets{}
+	server.Destination.secrets = mock
+
+	input := make(chan *message.Payload)
+	output := make(chan *message.Payload)
+	isRetrying := make(chan bool, 1)
+	server.Destination.Start(input, output, isRetrying)
+
+	input <- &message.Payload{MessageMetas: []*message.MessageMetadata{}, Encoded: []byte("yo")}
+
+	<-respondChan
+	<-respondChan
+	assert.True(t, <-isRetrying)
+	assert.GreaterOrEqual(t, mock.refreshCount.Load(), int32(1), "secrets.Refresh should have been called on 403")
+
+	server.ChangeStatus(200)
 	for {
 		if (<-respondChan) == 200 {
 			break
@@ -482,7 +526,7 @@ func TestDestinationHA(t *testing.T) {
 		}
 		isEndpointMRF := endpoint.IsMRF
 
-		dest := NewDestination(endpoint, JSONContentType, client.NewDestinationsContext(), false, client.NewNoopDestinationMetadata(), configmock.New(t), 1, 1, metrics.NewNoopPipelineMonitor(""), "test")
+		dest := NewDestination(endpoint, JSONContentType, client.NewDestinationsContext(), false, client.NewNoopDestinationMetadata(), configmock.New(t), 1, 1, metrics.NewNoopPipelineMonitor(""), "test", nil)
 		isDestMRF := dest.IsMRF()
 
 		assert.Equal(t, isEndpointMRF, isDestMRF)

--- a/pkg/logs/client/http/sync_destination.go
+++ b/pkg/logs/client/http/sync_destination.go
@@ -37,7 +37,7 @@ func NewSyncDestination(
 	maxConcurrency := minConcurrency
 
 	return &SyncDestination{
-		destination:    newDestination(endpoint, contentType, destinationsContext, NoTimeoutOverride, false, destMeta, cfg, minConcurrency, maxConcurrency, metrics.NewNoopPipelineMonitor("0"), "0"),
+		destination:    newDestination(endpoint, contentType, destinationsContext, NoTimeoutOverride, false, destMeta, cfg, minConcurrency, maxConcurrency, metrics.NewNoopPipelineMonitor("0"), "0", nil),
 		senderDoneChan: senderDoneChan,
 	}
 }

--- a/pkg/logs/client/http/sync_destination.go
+++ b/pkg/logs/client/http/sync_destination.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	secretnooptypes "github.com/DataDog/datadog-agent/comp/core/secrets/noop-impl/types"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/logs/client"
@@ -37,7 +38,7 @@ func NewSyncDestination(
 	maxConcurrency := minConcurrency
 
 	return &SyncDestination{
-		destination:    newDestination(endpoint, contentType, destinationsContext, NoTimeoutOverride, false, destMeta, cfg, minConcurrency, maxConcurrency, metrics.NewNoopPipelineMonitor("0"), "0", nil),
+		destination:    newDestination(endpoint, contentType, destinationsContext, NoTimeoutOverride, false, destMeta, cfg, minConcurrency, maxConcurrency, metrics.NewNoopPipelineMonitor("0"), "0", &secretnooptypes.SecretNoop{}),
 		senderDoneChan: senderDoneChan,
 	}
 }

--- a/pkg/logs/client/http/test_utils.go
+++ b/pkg/logs/client/http/test_utils.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"sync"
 
+	secretnooptypes "github.com/DataDog/datadog-agent/comp/core/secrets/noop-impl/types"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/logs/client"
@@ -84,7 +85,7 @@ func NewTestServerWithOptions(statusCode int, concurrentSends int, retryDestinat
 	endpoint.BackoffMax = 10
 	endpoint.RecoveryInterval = 1
 
-	dest := NewDestination(endpoint, JSONContentType, destCtx, retryDestination, client.NewNoopDestinationMetadata(), cfg, concurrentSends, concurrentSends, metrics.NewNoopPipelineMonitor(""), "test", nil)
+	dest := NewDestination(endpoint, JSONContentType, destCtx, retryDestination, client.NewNoopDestinationMetadata(), cfg, concurrentSends, concurrentSends, metrics.NewNoopPipelineMonitor(""), "test", &secretnooptypes.SecretNoop{})
 	return &TestServer{
 		httpServer:          ts,
 		DestCtx:             destCtx,

--- a/pkg/logs/client/http/test_utils.go
+++ b/pkg/logs/client/http/test_utils.go
@@ -84,7 +84,7 @@ func NewTestServerWithOptions(statusCode int, concurrentSends int, retryDestinat
 	endpoint.BackoffMax = 10
 	endpoint.RecoveryInterval = 1
 
-	dest := NewDestination(endpoint, JSONContentType, destCtx, retryDestination, client.NewNoopDestinationMetadata(), cfg, concurrentSends, concurrentSends, metrics.NewNoopPipelineMonitor(""), "test")
+	dest := NewDestination(endpoint, JSONContentType, destCtx, retryDestination, client.NewNoopDestinationMetadata(), cfg, concurrentSends, concurrentSends, metrics.NewNoopPipelineMonitor(""), "test", nil)
 	return &TestServer{
 		httpServer:          ts,
 		DestCtx:             destCtx,

--- a/pkg/logs/pipeline/go.mod
+++ b/pkg/logs/pipeline/go.mod
@@ -4,6 +4,7 @@ go 1.25.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface v0.61.0
+	github.com/DataDog/datadog-agent/comp/core/secrets/def v0.72.0-rc.1
 	github.com/DataDog/datadog-agent/comp/logs/agent/config v0.61.0
 	github.com/DataDog/datadog-agent/comp/serializer/logscompression v0.64.0-devel
 	github.com/DataDog/datadog-agent/pkg/config/mock v0.61.0
@@ -28,7 +29,6 @@ require (
 	github.com/DataDog/datadog-agent/comp/core/config v0.64.0-devel // indirect
 	github.com/DataDog/datadog-agent/comp/core/flare/builder v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/comp/core/flare/types v0.72.0-rc.1 // indirect
-	github.com/DataDog/datadog-agent/comp/core/secrets/def v0.72.0-rc.1 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets/noop-impl v0.77.0-devel.0.20260211235139-a5361978c2b6 // indirect
 	github.com/DataDog/datadog-agent/comp/core/telemetry v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/comp/def v0.61.0 // indirect

--- a/pkg/logs/pipeline/provider.go
+++ b/pkg/logs/pipeline/provider.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
 	secrets "github.com/DataDog/datadog-agent/comp/core/secrets/def"
+	secretnooptypes "github.com/DataDog/datadog-agent/comp/core/secrets/noop-impl/types"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	logscompression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/def"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
@@ -96,13 +97,13 @@ func NewProvider(
 	return NewProviderWithSecrets(
 		numberOfPipelines, sink, diagnosticMessageReceiver, processingRules,
 		endpoints, destinationsContext, status, hostname, cfg, compression,
-		legacyMode, serverless, nil,
+		legacyMode, serverless, &secretnooptypes.SecretNoop{},
 	)
 }
 
-// NewProviderWithSecrets returns a new Provider with optional secrets support.
-// When secretsComp is non-nil, HTTP destinations will trigger an async API key refresh
-// on 403 responses and retry the payload instead of dropping it.
+// NewProviderWithSecrets returns a new Provider with secrets support.
+// HTTP destinations will trigger an async API key refresh on 403 responses
+// when the secrets component has resolved the endpoint's API key path.
 func NewProviderWithSecrets(
 	numberOfPipelines int,
 	sink sender.Sink,

--- a/pkg/logs/pipeline/provider_test.go
+++ b/pkg/logs/pipeline/provider_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	secrets "github.com/DataDog/datadog-agent/comp/core/secrets/def"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	compressionfx "github.com/DataDog/datadog-agent/comp/serializer/logscompression/fx-mock"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
@@ -73,6 +74,7 @@ func (f *mockSenderFactory) NewHTTPSender(
 	workersPerQueue int,
 	minWorkerConcurrency int,
 	maxWorkerConcurrency int,
+	_ secrets.Component,
 ) *sender.Sender {
 	f.queueCount = queueCount
 	f.workersPerQueue = workersPerQueue

--- a/pkg/logs/sender/go.mod
+++ b/pkg/logs/sender/go.mod
@@ -3,6 +3,7 @@ module github.com/DataDog/datadog-agent/pkg/logs/sender
 go 1.25.0
 
 require (
+	github.com/DataDog/datadog-agent/comp/core/secrets/def v0.72.0-rc.1
 	github.com/DataDog/datadog-agent/comp/logs/agent/config v0.61.0
 	github.com/DataDog/datadog-agent/comp/serializer/logscompression v0.64.0-devel
 	github.com/DataDog/datadog-agent/pkg/config/mock v0.61.0
@@ -24,7 +25,6 @@ require (
 	github.com/DataDog/datadog-agent/comp/core/config v0.64.0-devel // indirect
 	github.com/DataDog/datadog-agent/comp/core/flare/builder v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/comp/core/flare/types v0.72.0-rc.1 // indirect
-	github.com/DataDog/datadog-agent/comp/core/secrets/def v0.72.0-rc.1 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets/noop-impl v0.77.0-devel.0.20260211235139-a5361978c2b6 // indirect
 	github.com/DataDog/datadog-agent/comp/core/telemetry v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/comp/def v0.61.0 // indirect

--- a/pkg/logs/sender/http/http_sender.go
+++ b/pkg/logs/sender/http/http_sender.go
@@ -20,7 +20,7 @@ import (
 )
 
 // NewHTTPSender returns a new http sender.
-// secretsComp is optional (may be nil) and is used to trigger an API key refresh on 403 responses.
+// secretsComp is used to trigger an API key refresh on 403 responses; pass a SecretNoop when no secrets backend is available.
 func NewHTTPSender(
 	config pkgconfigmodel.Reader,
 	sink sender.Sink,

--- a/pkg/logs/sender/http/http_sender.go
+++ b/pkg/logs/sender/http/http_sender.go
@@ -9,6 +9,7 @@ package http
 import (
 	"strconv"
 
+	secrets "github.com/DataDog/datadog-agent/comp/core/secrets/def"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/logs/client"
@@ -19,6 +20,7 @@ import (
 )
 
 // NewHTTPSender returns a new http sender.
+// secretsComp is optional (may be nil) and is used to trigger an API key refresh on 403 responses.
 func NewHTTPSender(
 	config pkgconfigmodel.Reader,
 	sink sender.Sink,
@@ -33,6 +35,7 @@ func NewHTTPSender(
 	workersPerQueue int,
 	minWorkerConcurrency int,
 	maxWorkerConcurrency int,
+	secretsComp secrets.Component,
 ) *sender.Sender {
 	log.Debugf(
 		"Creating a new sender for component %s with %d queues, %d http workers, %d min sender concurrency, and %d max sender concurrency",
@@ -55,6 +58,7 @@ func NewHTTPSender(
 		evpCategory,
 		minWorkerConcurrency,
 		maxWorkerConcurrency,
+		secretsComp,
 	)
 
 	return sender.NewSender(
@@ -80,6 +84,7 @@ func httpDestinationFactory(
 	evpCategory string,
 	minConcurrency int,
 	maxConcurrency int,
+	secretsComp secrets.Component,
 ) sender.DestinationFactory {
 	return func(instanceID string) *client.Destinations {
 		reliable := []client.Destination{}
@@ -89,7 +94,7 @@ func httpDestinationFactory(
 			if serverlessMeta.IsEnabled() {
 				reliable = append(reliable, http.NewSyncDestination(endpoint, contentyType, destinationsContext, serverlessMeta.SenderDoneChan(), destMeta, cfg))
 			} else {
-				reliable = append(reliable, http.NewDestination(endpoint, contentyType, destinationsContext, true, destMeta, cfg, minConcurrency, maxConcurrency, pipelineMonitor, instanceID))
+				reliable = append(reliable, http.NewDestination(endpoint, contentyType, destinationsContext, true, destMeta, cfg, minConcurrency, maxConcurrency, pipelineMonitor, instanceID, secretsComp))
 			}
 		}
 		for i, endpoint := range endpoints.GetUnReliableEndpoints() {
@@ -97,7 +102,7 @@ func httpDestinationFactory(
 			if serverlessMeta.IsEnabled() {
 				additionals = append(additionals, http.NewSyncDestination(endpoint, contentyType, destinationsContext, serverlessMeta.SenderDoneChan(), destMeta, cfg))
 			} else {
-				additionals = append(additionals, http.NewDestination(endpoint, contentyType, destinationsContext, false, destMeta, cfg, minConcurrency, maxConcurrency, pipelineMonitor, instanceID))
+				additionals = append(additionals, http.NewDestination(endpoint, contentyType, destinationsContext, false, destMeta, cfg, minConcurrency, maxConcurrency, pipelineMonitor, instanceID, secretsComp))
 			}
 		}
 		return client.NewDestinations(reliable, additionals)

--- a/pkg/logs/sender/http/http_sender_test.go
+++ b/pkg/logs/sender/http/http_sender_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	secretnooptypes "github.com/DataDog/datadog-agent/comp/core/secrets/noop-impl/types"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/logs/client"
@@ -102,7 +103,7 @@ func TestHttpDestinationFactory(t *testing.T) {
 				"",
 				1,
 				10,
-				nil,
+				&secretnooptypes.SecretNoop{},
 			)
 
 			// Test 1: Verify first call creates destinations

--- a/pkg/logs/sender/http/http_sender_test.go
+++ b/pkg/logs/sender/http/http_sender_test.go
@@ -102,6 +102,7 @@ func TestHttpDestinationFactory(t *testing.T) {
 				"",
 				1,
 				10,
+				nil,
 			)
 
 			// Test 1: Verify first call creates destinations

--- a/pkg/security/agent/start.go
+++ b/pkg/security/agent/start.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	secrets "github.com/DataDog/datadog-agent/comp/core/secrets/def"
 	compression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/def"
 	"github.com/DataDog/datadog-agent/pkg/security/common"
 	"github.com/DataDog/datadog-agent/pkg/security/reporter"
@@ -22,7 +23,7 @@ import (
 )
 
 // StartRuntimeSecurity starts runtime security
-func StartRuntimeSecurity(log log.Component, config config.Component, hostname string, stopper startstop.Stopper, statsdClient ddgostatsd.ClientInterface, compression compression.Component) (*RuntimeSecurityAgent, error) {
+func StartRuntimeSecurity(log log.Component, config config.Component, hostname string, stopper startstop.Stopper, statsdClient ddgostatsd.ClientInterface, compression compression.Component, secretsComp secrets.Component) (*RuntimeSecurityAgent, error) {
 	if !config.GetBool("runtime_security_config.enabled") {
 		log.Info("Datadog runtime security agent disabled by config")
 		return nil, nil
@@ -48,7 +49,7 @@ func StartRuntimeSecurity(log log.Component, config config.Component, hostname s
 	}
 	stopper.Add(ctx)
 
-	runtimeReporter, err := reporter.NewCWSReporter(hostname, stopper, endpoints, ctx, compression)
+	runtimeReporter, err := reporter.NewCWSReporter(hostname, stopper, endpoints, ctx, compression, secretsComp)
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +60,7 @@ func StartRuntimeSecurity(log log.Component, config config.Component, hostname s
 	}
 	stopper.Add(secInfoCtx)
 
-	secInfoReporter, err := reporter.NewCWSReporter(hostname, stopper, secInfoEndpoints, secInfoCtx, compression)
+	secInfoReporter, err := reporter.NewCWSReporter(hostname, stopper, secInfoEndpoints, secInfoCtx, compression, secretsComp)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/agent/start_unsupported.go
+++ b/pkg/security/agent/start_unsupported.go
@@ -13,13 +13,14 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	secrets "github.com/DataDog/datadog-agent/comp/core/secrets/def"
 	compression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/def"
 	"github.com/DataDog/datadog-agent/pkg/util/startstop"
 	"github.com/DataDog/datadog-go/v5/statsd"
 )
 
 // StartRuntimeSecurity starts runtime security
-func StartRuntimeSecurity(log log.Component, config config.Component, _ string, _ startstop.Stopper, _ statsd.ClientInterface, _ compression.Component) (*RuntimeSecurityAgent, error) {
+func StartRuntimeSecurity(log log.Component, config config.Component, _ string, _ startstop.Stopper, _ statsd.ClientInterface, _ compression.Component, _ secrets.Component) (*RuntimeSecurityAgent, error) {
 	enabled := config.GetBool("runtime_security_config.enabled")
 	if !enabled {
 		log.Info("Datadog runtime security agent disabled by config")

--- a/pkg/security/module/cws.go
+++ b/pkg/security/module/cws.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-go/v5/statsd"
 
 	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
+	secrets "github.com/DataDog/datadog-agent/comp/core/secrets/def"
 	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	compression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/def"
@@ -73,7 +74,7 @@ type CWSConsumer struct {
 }
 
 // NewCWSConsumer initializes the module with options
-func NewCWSConsumer(evm *eventmonitor.EventMonitor, cfg *config.RuntimeSecurityConfig, wmeta workloadmeta.Component, filterStore workloadfilter.Component, opts Opts, compression compression.Component, ipc ipc.Component, hostname string) (*CWSConsumer, error) {
+func NewCWSConsumer(evm *eventmonitor.EventMonitor, cfg *config.RuntimeSecurityConfig, wmeta workloadmeta.Component, filterStore workloadfilter.Component, opts Opts, compression compression.Component, ipc ipc.Component, hostname string, secretsComp secrets.Component) (*CWSConsumer, error) {
 	crtelemcfg := telemetry.ContainersRunningTelemetryConfig{
 		RuntimeEnabled: cfg.RuntimeEnabled,
 		FIMEnabled:     cfg.FIMEnabled,
@@ -106,7 +107,7 @@ func NewCWSConsumer(evm *eventmonitor.EventMonitor, cfg *config.RuntimeSecurityC
 	}
 
 	family, socketPath := socket.GetSocketAddress(cmdSocketPath)
-	apiServer, err := NewAPIServer(cfg, evm.Probe, opts.MsgSender, evm.StatsdClient, selfTester, compression, hostname)
+	apiServer, err := NewAPIServer(cfg, evm.Probe, opts.MsgSender, evm.StatsdClient, selfTester, compression, hostname, secretsComp)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/module/msg_sender.go
+++ b/pkg/security/module/msg_sender.go
@@ -9,6 +9,7 @@ package module
 import (
 	"fmt"
 
+	secrets "github.com/DataDog/datadog-agent/comp/core/secrets/def"
 	logsconfig "github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	compression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/def"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
@@ -110,7 +111,7 @@ func (ds *DirectEventMsgSender) GetEndpointsStatus() []string {
 }
 
 // NewDirectEventMsgSender returns a new direct sender
-func NewDirectEventMsgSender(stopper startstop.Stopper, compression compression.Component, hostname string) (*DirectEventMsgSender, error) {
+func NewDirectEventMsgSender(stopper startstop.Stopper, compression compression.Component, hostname string, secretsComp secrets.Component) (*DirectEventMsgSender, error) {
 	useSecRuntimeTrack := pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.use_secruntime_track")
 
 	endpoints, destinationsCtx, err := common.NewLogContextRuntime(useSecRuntimeTrack)
@@ -136,12 +137,12 @@ func NewDirectEventMsgSender(stopper startstop.Stopper, compression compression.
 
 	// we set the hostname to the empty string to take advantage of the out of the box message hostname
 	// resolution
-	runtimeReporter, err := reporter.NewCWSReporter(hostname, stopper, endpoints, destinationsCtx, compression)
+	runtimeReporter, err := reporter.NewCWSReporter(hostname, stopper, endpoints, destinationsCtx, compression, secretsComp)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create direct reporter: %w", err)
 	}
 
-	secInfoReporter, err := reporter.NewCWSReporter(hostname, stopper, secInfoEndpoints, secInfoDestinationsCtx, compression)
+	secInfoReporter, err := reporter.NewCWSReporter(hostname, stopper, secInfoEndpoints, secInfoDestinationsCtx, compression, secretsComp)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create direct secinfo reporter: %w", err)
 	}

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -23,6 +23,7 @@ import (
 	empty "google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	secrets "github.com/DataDog/datadog-agent/comp/core/secrets/def"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	compression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/def"
 	"github.com/DataDog/datadog-agent/pkg/security/common"
@@ -752,7 +753,7 @@ func getEnvAsTags(cfg *config.RuntimeSecurityConfig) []string {
 }
 
 // NewAPIServer returns a new gRPC event server
-func NewAPIServer(cfg *config.RuntimeSecurityConfig, probe *sprobe.Probe, msgSender MsgSender[api.SecurityEventMessage], client statsd.ClientInterface, selfTester *selftests.SelfTester, compression compression.Component, hostname string) (*APIServer, error) {
+func NewAPIServer(cfg *config.RuntimeSecurityConfig, probe *sprobe.Probe, msgSender MsgSender[api.SecurityEventMessage], client statsd.ClientInterface, selfTester *selftests.SelfTester, compression compression.Component, hostname string, secretsComp secrets.Component) (*APIServer, error) {
 	stopper := startstop.NewSerialStopper()
 	containerFilter, err := utils.NewContainerFilter()
 	if err != nil {
@@ -791,7 +792,7 @@ func NewAPIServer(cfg *config.RuntimeSecurityConfig, probe *sprobe.Probe, msgSen
 
 	if as.msgSender == nil {
 		if cfg.SendPayloadsFromSystemProbe {
-			msgSender, err := NewDirectEventMsgSender(stopper, compression, hostname)
+			msgSender, err := NewDirectEventMsgSender(stopper, compression, hostname, secretsComp)
 			if err != nil {
 				log.Errorf("failed to setup direct event sender: %v", err)
 			} else {

--- a/pkg/security/tests/module_tester_linux.go
+++ b/pkg/security/tests/module_tester_linux.go
@@ -802,7 +802,7 @@ func newTestModule(t testing.TB, macroDefs []*rules.MacroDefinition, ruleDefs []
 		msgSender := newFakeMsgSender(testMod)
 
 		compression := logscompression.NewComponent()
-		cws, err := module.NewCWSConsumer(testMod.eventMonitor, secconfig.RuntimeSecurity, nil, nil, module.Opts{EventSender: testMod, MsgSender: msgSender}, compression, ipcComp, functionalTestsHostname)
+		cws, err := module.NewCWSConsumer(testMod.eventMonitor, secconfig.RuntimeSecurity, nil, nil, module.Opts{EventSender: testMod, MsgSender: msgSender}, compression, ipcComp, functionalTestsHostname, nil)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create module: %w", err)
 		}

--- a/pkg/security/tests/module_tester_linux.go
+++ b/pkg/security/tests/module_tester_linux.go
@@ -35,6 +35,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	ipcmock "github.com/DataDog/datadog-agent/comp/core/ipc/mock"
+	secretnooptypes "github.com/DataDog/datadog-agent/comp/core/secrets/noop-impl/types"
 	logscompression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/impl"
 	ebpftelemetry "github.com/DataDog/datadog-agent/pkg/ebpf/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/eventmonitor"
@@ -802,7 +803,7 @@ func newTestModule(t testing.TB, macroDefs []*rules.MacroDefinition, ruleDefs []
 		msgSender := newFakeMsgSender(testMod)
 
 		compression := logscompression.NewComponent()
-		cws, err := module.NewCWSConsumer(testMod.eventMonitor, secconfig.RuntimeSecurity, nil, nil, module.Opts{EventSender: testMod, MsgSender: msgSender}, compression, ipcComp, functionalTestsHostname, nil)
+		cws, err := module.NewCWSConsumer(testMod.eventMonitor, secconfig.RuntimeSecurity, nil, nil, module.Opts{EventSender: testMod, MsgSender: msgSender}, compression, ipcComp, functionalTestsHostname, &secretnooptypes.SecretNoop{})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create module: %w", err)
 		}

--- a/pkg/security/tests/module_tester_windows.go
+++ b/pkg/security/tests/module_tester_windows.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 
 	ipcmock "github.com/DataDog/datadog-agent/comp/core/ipc/mock"
+	secretnooptypes "github.com/DataDog/datadog-agent/comp/core/secrets/noop-impl/types"
 	logscompression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/impl"
 	"github.com/DataDog/datadog-agent/pkg/eventmonitor"
 	secconfig "github.com/DataDog/datadog-agent/pkg/security/config"
@@ -177,7 +178,7 @@ func newTestModule(t testing.TB, macroDefs []*rules.MacroDefinition, ruleDefs []
 	var ruleSetloadedErr *multierror.Error
 	if !opts.staticOpts.disableRuntimeSecurity {
 		compression := logscompression.NewComponent()
-		cws, err := module.NewCWSConsumer(testMod.eventMonitor, secconfig.RuntimeSecurity, nil, nil, module.Opts{EventSender: testMod}, compression, ipcComp, functionalTestsHostname, nil)
+		cws, err := module.NewCWSConsumer(testMod.eventMonitor, secconfig.RuntimeSecurity, nil, nil, module.Opts{EventSender: testMod}, compression, ipcComp, functionalTestsHostname, &secretnooptypes.SecretNoop{})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create module: %w", err)
 		}

--- a/pkg/security/tests/module_tester_windows.go
+++ b/pkg/security/tests/module_tester_windows.go
@@ -177,7 +177,7 @@ func newTestModule(t testing.TB, macroDefs []*rules.MacroDefinition, ruleDefs []
 	var ruleSetloadedErr *multierror.Error
 	if !opts.staticOpts.disableRuntimeSecurity {
 		compression := logscompression.NewComponent()
-		cws, err := module.NewCWSConsumer(testMod.eventMonitor, secconfig.RuntimeSecurity, nil, nil, module.Opts{EventSender: testMod}, compression, ipcComp, functionalTestsHostname)
+		cws, err := module.NewCWSConsumer(testMod.eventMonitor, secconfig.RuntimeSecurity, nil, nil, module.Opts{EventSender: testMod}, compression, ipcComp, functionalTestsHostname, nil)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create module: %w", err)
 		}

--- a/pkg/system-probe/api/module/common.go
+++ b/pkg/system-probe/api/module/common.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/hostname"
 	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	secrets "github.com/DataDog/datadog-agent/comp/core/secrets/def"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
@@ -50,6 +51,7 @@ type FactoryDependencies struct {
 	Tagger               tagger.Component
 	Telemetry            telemetry.Component
 	Compression          logscompression.Component
+	Secrets              secrets.Component
 	Statsd               ddgostatsd.ClientInterface
 	Hostname             hostname.Component
 	Ipc                  ipc.Component

--- a/releasenotes/notes/logs-retry-403-api-key-refresh-a9803ddaf6b7874f.yaml
+++ b/releasenotes/notes/logs-retry-403-api-key-refresh-a9803ddaf6b7874f.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The logs agent now retries log payloads on HTTP 403 (Forbidden) responses
+    instead of dropping them, when the secrets component is available. This applies to the core logs agent,
+    CWS security reporter, compliance reporter, and the event platform forwarder. Callers without the secrets
+    component (serverless, OTel) retain the original drop behavior.


### PR DESCRIPTION
## What does this PR do?

Builds on top of the `retry-payloads` branch to make the HTTP 403 retry conditional on whether the secrets component can actually refresh the endpoint's API key. This prevents pointless retries when no secrets backend is configured.

## Changes

- **`secrets.Component` interface**: Add `IsSecretResolved(settingPath string) bool` — returns true if the secrets backend has resolved a handle at a config path containing the given setting path element
- **`secretResolver`**: Implementation checks `backendCommand` is set and iterates the `origin` map for matching paths
- **`SecretNoop`**: Returns `false` (no secrets backend → no resolution possible)
- **`Mock`**: Configurable via `SetIsSecretResolved(bool)` for test control
- **`Endpoint`**: Add `GetConfigSettingPath()` getter to expose the config path the endpoint monitors for API key updates
- **`Destination`**: Add `canRefreshKey bool` field computed at construction via `secretsComp.IsSecretResolved(endpoint.GetConfigSettingPath())`; gate the 403 retry on this instead of `d.secrets != nil`
- **Nil elimination**: Replace all `nil` secrets passes with `&SecretNoop{}` across the codebase — `secrets.Component` is never nil
- **Tests**: Update existing `TestForbiddenTriggersSecretsRefreshAndRetry` to set `canRefreshKey = true`; add `TestForbiddenDropsWithoutSecrets` negative test verifying 403s are dropped when no secrets backend is configured

## Motivation

Without this gate, every 403 response triggers a secrets refresh and retry even when the agent has no secrets backend configured — the refresh is a no-op and the retry is pointless. With this change, the retry only happens when a refresh could actually change the API key.

## Related

- Builds on: #46704 (`ryan.hall/retry-payloads`)
- Alternative approach: #46931 (`saad/split-refresh`) uses value-based `IsValueFromSecret` instead of path-based `IsSecretResolved`

## Test plan

- [x] `dda inv test -d` — all 457 diff-targeted tests pass
- [x] `dda inv linter.go --only-modified-packages` — 0 issues
- [ ] CI validation