### PR TITLE
[AGENTCFG-1] The diagnose command should error if an API key is not configured

### DIFF
--- a/cmd/agent/subcommands/diagnose/command.go
+++ b/cmd/agent/subcommands/diagnose/command.go
@@ -419,7 +419,7 @@ func cmdDiagnose(cliParams *cliParams,
 	}
 
 	// API key is required to run diagnose; without it no checks can run and the command would exit successfully with no useful output
-	if config.GetString("api_key") == "" {
+	if !config.IsConfigured("api_key") {
 		return errors.New("no API key configured: diagnose requires an API key to run checks. Set the API key in datadog.yaml or use the DD_API_KEY environment variable")
 	}
 

--- a/cmd/agent/subcommands/diagnose/command.go
+++ b/cmd/agent/subcommands/diagnose/command.go
@@ -9,6 +9,7 @@ package diagnose
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -415,6 +416,11 @@ func cmdDiagnose(cliParams *cliParams,
 			fmt.Fprintf(w, "  %d. %s\n", idx+1, suiteName)
 		}
 		return nil
+	}
+
+	// API key is required to run diagnose; without it no checks can run and the command would exit successfully with no useful output
+	if config.GetString("api_key") == "" {
+		return errors.New("no API key configured: diagnose requires an API key to run checks. Set the API key in datadog.yaml or use the DD_API_KEY environment variable")
 	}
 
 	// Run command

--- a/releasenotes/notes/diagnose-command-returns-error-API-key-is-not-set-3fb35261884b9930.yaml
+++ b/releasenotes/notes/diagnose-command-returns-error-API-key-is-not-set-3fb35261884b9930.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    The diagnose command now returns an error if an API key is not configured.
+


### PR DESCRIPTION
### What does this PR do?
When running the `diagnose` command without an API key configured the command exit successfully saying that no check where run.

We want to fail gracefully with an error message.

### Motivation

### Describe how you validated your changes

Added a unit test, and ran the agent with/without an api key set. The error appears when running the `diagnose` command without an api key.

### Additional Notes
