### PR TITLE
NDM NetFlow: scale down batch size to 250 items at a time

### DIFF
--- a/comp/forwarder/eventplatform/eventplatformimpl/epforwarder.go
+++ b/comp/forwarder/eventplatform/eventplatformimpl/epforwarder.go
@@ -164,9 +164,10 @@ func getPassthroughPipelines() []passthroughPipelineDesc {
 			defaultBatchMaxConcurrentSend: 10,
 			defaultBatchMaxContentSize:    pkgconfigsetup.DefaultBatchMaxContentSize,
 
-			// Each NetFlow flow is about 500 bytes
-			// 10k BatchMaxSize is about 5Mo of content size
-			defaultBatchMaxSize: 10000,
+			// Each NetFlow flow is about 500 bytes, we could fit ~10k is the default 5Mb content size. However,
+			// this is also directly tied to the amount of work we need to do atomically in our event processing code to add enrichments.
+			// Let's limit this size to 100 events, there will be some increased overhead since more packets will need to be sent.
+			defaultBatchMaxSize: 100,
 			// High input chan is needed to handle high number of flows being flushed by NetFlow Server every 10s
 			// Customers might need to set `network_devices.forwarder.input_chan_size` to higher value if flows are dropped
 			// due to input channel being full.

--- a/comp/forwarder/eventplatform/eventplatformimpl/epforwarder.go
+++ b/comp/forwarder/eventplatform/eventplatformimpl/epforwarder.go
@@ -166,8 +166,8 @@ func getPassthroughPipelines() []passthroughPipelineDesc {
 
 			// Each NetFlow flow is about 500 bytes, we could fit ~10k is the default 5Mb content size. However,
 			// this is also directly tied to the amount of work we need to do atomically in our event processing code to add enrichments.
-			// Let's limit this size to 100 events, there will be some increased overhead since more packets will need to be sent.
-			defaultBatchMaxSize: 100,
+			// Let's limit this size to 250 events, there will be some increased overhead since more packets will need to be sent.
+			defaultBatchMaxSize: 250,
 			// High input chan is needed to handle high number of flows being flushed by NetFlow Server every 10s
 			// Customers might need to set `network_devices.forwarder.input_chan_size` to higher value if flows are dropped
 			// due to input channel being full.


### PR DESCRIPTION
### What does this PR do?
This PR reduces the max batch size for NDM NetFlow events submitted to the event platform. We are seeing that very large batch sizes are coming in, and the new EVP Workers do not handle batches this large as well as the Java code did.

This PR scales down the max batch size to 250 flows per batch, this is a more reasonable size for our enrichments, as we need to do lookups for multiple attributes depending on the customer's configuration.

In load tests, we saw that under full saturation, this led to a 35% increase in network bytes emitted by the agent running our load test - before the batch updates the agent submitted batches of around 8400 messages. This is a large increase from a relative stance. The overall traffic egressed from the agent went 61 kb/s to 83 kb/s.

With that noted, our load tests do not generate normal traffic, and exercise a wider range of IPs than are expected in customer environments.