### PR TITLE
Add common containers flakey tests for TestOpenShiftVMSuite 

### DIFF
--- a/flakes.yaml
+++ b/flakes.yaml
@@ -23,8 +23,10 @@ test/new-e2e/tests/containers:
   - test: TestECSSuite/TestCPU/metric___container.cpu.usage{^ecs_container_name:stress-ng$}
   - test: TestEKSSuite/TestCPU/metric___container.cpu.usage{^kube_deployment:stress-ng$,^kube_namespace:workload-cpustress$}
   - test: TestKindSuite/TestCPU/metric___container.cpu.usage{^kube_deployment:stress-ng$,^kube_namespace:workload-cpustress$}
+  - test: TestOpenShiftVMSuite/TestCPU/metric___container.cpu.usage{^kube_deployment:stress-ng$,^kube_namespace:workload-cpustress$}
   - test: TestKindSuite/TestAdmissionControllerWithAutoDetectedLanguage
   - test: TestEKSSuite/TestAdmissionControllerWithAutoDetectedLanguage
+  - test: TestOpenShiftVMSuite/TestAdmissionControllerWithAutoDetectedLanguage
 
 /tests/installer/windows:
   - test: TestAgentUpgradesOnDCWithGMSA


### PR DESCRIPTION
### What does this PR do?
`TestCPU/metric___container.cpu.usage{^kube_deployment:stress-ng$,^kube_namespace:workload-cpustress$}` and `TestAdmissionControllerWithAutoDetectedLanguage` are known to be flakey. Adding them for `TestOpenShiftVMSuite`. 

### Motivation
Related to https://github.com/DataDog/datadog-agent/pull/46360

### Describe how you validated your changes

### Additional Notes
