### PR TITLE
Detect the correct launch type for ECS Managed Instances when deployed as Daemon

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/ecs/v1parser_test.go
+++ b/comp/core/workloadmeta/collectors/internal/ecs/v1parser_test.go
@@ -15,9 +15,21 @@ import (
 	"github.com/stretchr/testify/require"
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/pkg/config/env"
 	v1 "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v1"
 	"github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v3or4"
 )
+
+func TestECSLaunchTypeFromEnvEC2(t *testing.T) {
+	launchType := ecsLaunchTypeFromEnv()
+	assert.Equal(t, workloadmeta.ECSLaunchTypeEC2, launchType)
+}
+
+func TestECSLaunchTypeFromEnvManagedInstances(t *testing.T) {
+	env.SetFeatures(t, env.ECSManagedInstances)
+	launchType := ecsLaunchTypeFromEnv()
+	assert.Equal(t, workloadmeta.ECSLaunchTypeManagedInstances, launchType)
+}
 
 // TestPullWithV1Parser tests the collector's Pull method by setting the taskCollectionParser to parseTasksFromV1Endpoint
 // which is the default parser when other metadata endpoints are not available.

--- a/comp/core/workloadmeta/collectors/util/ecs_util.go
+++ b/comp/core/workloadmeta/collectors/util/ecs_util.go
@@ -88,9 +88,11 @@ func ParseV4Task(task v3or4.Task, seen map[workloadmeta.EntityID]struct{}) []wor
 		entity.LaunchType = workloadmeta.ECSLaunchTypeFargate
 		source = workloadmeta.SourceRuntime
 	}
-	if strings.ToUpper(task.LaunchType) == "MANAGED_INSTANCES" && fargate.IsSidecar() {
-		source = workloadmeta.SourceRuntime
+	if strings.ToUpper(task.LaunchType) == "MANAGED_INSTANCES" {
 		entity.LaunchType = workloadmeta.ECSLaunchTypeManagedInstances
+		if fargate.IsSidecar() {
+			source = workloadmeta.SourceRuntime
+		}
 	}
 
 	events = append(events, containerEvents...)

--- a/comp/core/workloadmeta/collectors/util/ecs_util_test.go
+++ b/comp/core/workloadmeta/collectors/util/ecs_util_test.go
@@ -10,7 +10,11 @@ package util
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v3or4"
 )
 
 func TestParserECSAgentVersion(t *testing.T) {
@@ -61,4 +65,50 @@ func TestBuildServiceARN(t *testing.T) {
 func TestBuildTaskDefinitionARN(t *testing.T) {
 	arn := BuildTaskDefinitionARN("123456789012", "family-name", "us-east-1", "1")
 	require.Equal(t, "arn:aws:ecs:us-east-1:123456789012:task-definition/family-name:1", arn)
+}
+
+func newMinimalTask(launchType string) v3or4.Task {
+	return v3or4.Task{
+		TaskARN:     "arn:aws:ecs:us-east-1:123456789012:task/cluster/abc123",
+		Family:      "test-family",
+		Version:     "1",
+		ClusterName: "cluster",
+		LaunchType:  launchType,
+	}
+}
+
+func getECSTaskEntity(t *testing.T, events []workloadmeta.CollectorEvent) *workloadmeta.ECSTask {
+	t.Helper()
+	for _, e := range events {
+		if task, ok := e.Entity.(*workloadmeta.ECSTask); ok {
+			return task
+		}
+	}
+	t.Fatal("no ECSTask entity found in events")
+	return nil
+}
+
+func TestParseV4TaskLaunchTypeEC2(t *testing.T) {
+	events := ParseV4Task(newMinimalTask("EC2"), map[workloadmeta.EntityID]struct{}{})
+	task := getECSTaskEntity(t, events)
+	assert.Equal(t, workloadmeta.ECSLaunchTypeEC2, task.LaunchType)
+}
+
+func TestParseV4TaskLaunchTypeManagedInstances(t *testing.T) {
+	// MANAGED_INSTANCES should be set regardless of sidecar/daemon mode
+	events := ParseV4Task(newMinimalTask("MANAGED_INSTANCES"), map[workloadmeta.EntityID]struct{}{})
+	task := getECSTaskEntity(t, events)
+	assert.Equal(t, workloadmeta.ECSLaunchTypeManagedInstances, task.LaunchType)
+}
+
+func TestParseV4TaskLaunchTypeManagedInstancesCaseInsensitive(t *testing.T) {
+	events := ParseV4Task(newMinimalTask("managed_instances"), map[workloadmeta.EntityID]struct{}{})
+	task := getECSTaskEntity(t, events)
+	assert.Equal(t, workloadmeta.ECSLaunchTypeManagedInstances, task.LaunchType)
+}
+
+func TestParseV4TaskLaunchTypeFargate(t *testing.T) {
+	events := ParseV4Task(newMinimalTask("FARGATE"), map[workloadmeta.EntityID]struct{}{})
+	task := getECSTaskEntity(t, events)
+	assert.Equal(t, workloadmeta.ECSLaunchTypeFargate, task.LaunchType)
 }

--- a/releasenotes/notes/ecs-managed-instance-launch-type-detection-5ff0f4283fbbdce9.yaml
+++ b/releasenotes/notes/ecs-managed-instance-launch-type-detection-5ff0f4283fbbdce9.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Detect correct launch type for ECS Managed Instances when running in daemon mode.


### PR DESCRIPTION
### What does this PR do?
Fixes launch type detection so that tasks on ECS Managed Instances are correctly reported as `MANAGED_INSTANCES` in workloadmeta when the agent runs in daemon mode.

### Motivation
When the agent runs as a daemon on ECS Managed Instances, task and container entities in workloadmeta were not always getting the correct launch type. This change ensures the ECS collector sets `LaunchType` to `ECSLaunchTypeManagedInstances` for tasks with `LaunchType` `MANAGED_INSTANCES`, for both V1 and V4 metadata parsing.

### Describe how you validated your changes
- Deployed the Agent on ECS Managed Instances.
- Confirmed that the correct launch type appears in the agent workload.
- ECS Explorer reports correct launch type:
<img width="1048" height="269" alt="image" src="https://github.com/user-attachments/assets/07592fc4-93fa-4247-9680-69730bb9b5f2" />
