### PR TITLE
[CONTP-1261] test(endpoint_checks): Add e2e test for endpoint checks

### DIFF
--- a/test/e2e-framework/components/datadog/apps/redis/k8s.go
+++ b/test/e2e-framework/components/datadog/apps/redis/k8s.go
@@ -304,6 +304,22 @@ func K8sAppDefinition(e config.Env, kubeProvider *kubernetes.Provider, namespace
 			Labels: pulumi.StringMap{
 				"app": pulumi.String("redis"),
 			},
+			Annotations: pulumi.StringMap{
+				"ad.datadoghq.com/endpoints.checks": pulumi.String(utils.JSONMustMarshal(
+					map[string]interface{}{
+						"http_check": map[string]interface{}{
+							"init_config": map[string]interface{}{},
+							"instances": []map[string]interface{}{
+								{
+									"name":    "My Redis",
+									"url":     "http://%%host%%:%%port%%",
+									"timeout": 1,
+								},
+							},
+						},
+					},
+				)),
+			},
 		},
 		Spec: &corev1.ServiceSpecArgs{
 			Selector: pulumi.StringMap{

--- a/test/e2e-framework/components/datadog/kubernetesagentparams/params.go
+++ b/test/e2e-framework/components/datadog/kubernetesagentparams/params.go
@@ -349,3 +349,14 @@ func WithTimeout(timeoutSeconds int) func(*Params) error {
 		return nil
 	}
 }
+
+func WithKubernetesUseEndpointSlices() func(*Params) error {
+	return func(p *Params) error {
+		values := `
+datadog:
+  kubernetesUseEndpointSlices: true
+`
+		p.HelmValues = append(p.HelmValues, pulumi.NewStringAsset(values))
+		return nil
+	}
+}

--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -915,6 +915,32 @@ func (suite *k8sSuite) TestRedis() {
 		},
 	})
 
+	// Test AD annotated endpoint check configured as an 'http_check' for redis service
+	// http checks are expected to fail for redis services. This assertion is focused
+	// on confirming an endpoint check is scheduled and running as expected.
+	suite.testMetric(&testMetricArgs{
+		Filter: testMetricFilterArgs{
+			Name: "network.http.cant_connect",
+			Tags: []string{
+				`^kube_namespace:workload-redis$`,
+			},
+		},
+		Expect: testMetricExpectArgs{
+			Tags: suite.testClusterTags([]string{
+				`^cluster_name:`,
+				`^instance:My_Redis$`,
+				`^kube_cluster_name:`,
+				`^orch_cluster_id:`,
+				`^kube_namespace:workload-redis$`,
+				`^kube_service:redis$`,
+				`^kube_endpoint_ip:`,
+				`^pod_name:redis-[[:alnum:]]+-[[:alnum:]]+$`, // endpoint checks should have pod tags
+				`^pod_phase:running$`,
+			}),
+			AcceptUnexpectedTags: true,
+		},
+	})
+
 	// Test KSM metrics for the redis deployment
 	suite.testMetric(&testMetricArgs{
 		Filter: testMetricFilterArgs{

--- a/test/new-e2e/tests/containers/kindvm_test.go
+++ b/test/new-e2e/tests/containers/kindvm_test.go
@@ -13,7 +13,6 @@ import (
 	scenec2 "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/fakeintake"
 	scenkind "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/kindvm"
-
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
 	provkind "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/kubernetes/kindvm"
 )
@@ -45,6 +44,10 @@ clusterAgent:
 				kubernetesagentparams.WithDualShipping(),
 				kubernetesagentparams.WithHelmValues(helmValues),
 				kubernetesagentparams.WithHelmValues(containerHelmValues),
+				// Kind suite uses EndpointSlices backed providers while the EKS suite uses the default
+				// (legacy) Endpoints providers. This covers tests for both without having to create
+				// independent test suites for both configurations or modify providers at test runtime.
+				kubernetesagentparams.WithKubernetesUseEndpointSlices(),
 			),
 			scenkind.WithDeployArgoRollout(),
 		),


### PR DESCRIPTION
### What does this PR do?

Adds an E2E test for autodiscovery-based endpoint checks, validating that endpoint checks are correctly scheduled and run when configured via `ad.datadoghq.com/endpoints.checks` annotations on a Kubernetes Service. The test covers both the legacy `kube_endpoints` and the new `kube_endpointslices` backed providers:

- Adds an `http_check` endpoint check annotation to the existing Redis Service in the e2e test workload.
- Asserts the `network.http.cant_connect` metric is emitted with expected endpoint-check tags (`kube_service`, `kube_endpoint_ip`, `pod_name`, etc.).
- Enables `kubernetesUseEndpointSlices: true` in the Kind suite via a new `WithKubernetesUseEndpointSlices()` helper, while the EKS suite continues to use the default legacy Endpoints provider—covering both code paths without duplicating the test suite.

### Motivation

[CONTP-1261](https://datadoghq.atlassian.net/browse/CONTP-1261)

The new EndpointSlice-backed AD listeners and providers ([#45949](https://github.com/DataDog/datadog-agent/pull/45949), [#46080](https://github.com/DataDog/datadog-agent/pull/46080)) need E2E coverage to ensure they work correctly alongside the legacy `kube_endpoints` path. This PR adds that coverage by leveraging the existing Kind (EndpointSlices enabled) and EKS (legacy Endpoints) test suites to validate both configurations with the same assertions.

### Describe how you validated your changes

- Added an E2E metric assertion in `k8s_test.go` that verifies `network.http.cant_connect` is reported with the correct endpoint-check tags (including `kube_service`, `kube_endpoint_ip`, and `pod_name`).
- The Kind suite runs with `kubernetesUseEndpointSlices: true`, exercising the EndpointSlice-backed provider.
- The EKS suite runs with the default (legacy) Endpoints provider, exercising the legacy path.
- Both suites execute the same `TestRedis` assertions, confirming the endpoint check is scheduled and emitting metrics regardless of the underlying provider.

### Additional Notes

- The `http_check` against Redis is intentionally expected to fail (`network.http.cant_connect`), since Redis does not use HTTP. The test validates that the endpoint check is **scheduled and running**, not that the HTTP check succeeds.

[CONTP-1261]: https://datadoghq.atlassian.net/browse/CONTP-1261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ