### PR TITLE
Remove unneded source refs from omnibus files

### DIFF
--- a/omnibus/config/software/openscap.rb
+++ b/omnibus/config/software/openscap.rb
@@ -6,15 +6,6 @@
 name 'openscap'
 default_version '1.4.3'
 
-license "LGPL-3.0-or-later"
-license_file "COPYING"
-
-version("1.4.3") { source sha256: "96ebe697aafc83eb297a8f29596d57319278112467c46e6aaf3649b311cf8fba" }
-
-ship_source_offer true
-
-source url: "https://github.com/OpenSCAP/openscap/releases/download/#{version}/openscap-#{version}.tar.gz"
-
 build do
   command_on_repo_root "bazelisk run -- @acl//:install --destdir='#{install_dir}'"
   command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \

--- a/omnibus/config/software/openssl3.rb
+++ b/omnibus/config/software/openssl3.rb
@@ -16,18 +16,12 @@
 
 name "openssl3"
 
-license "Apache-2.0"
-license_file "LICENSE.txt"
 skip_transitive_dependency_licensing true
 
 dependency "zlib" unless windows?
 dependency "cacerts"
 
 default_version "3.5.5"
-
-source url: "https://www.openssl.org/source/openssl-#{version}.tar.gz", extract: :lax_tar
-
-version("3.5.5") { source sha256: "b28c91532a8b65a1f983b4c28b7488174e4a01008e29ce8e69bd789f28bc2a89" }
 
 relative_path "openssl-#{version}"
 


### PR DESCRIPTION
This is a slight win for build speed because we don't fetch the source a second time.
It also might eliminate a redundant license copy.