### PR TITLE
Allow `bazel` linters to be run independently of CI

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -22,6 +22,13 @@ common --incompatible_strict_action_env # Do not leak local environment variable
 common --test_output=errors # Print test errors to console output instead of only capturing them in buried test.log
 common --verbose_failures
 
+# Lint config (static code analyzers) ----------------------------------------------------------------------------------
+# Go -TODO(agent-build)
+# Python -TODO(agent-build)
+# Rust
+common:lint --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect --output_groups=+clippy_checks
+common:lint --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect --output_groups=+rustfmt_checks
+
 # Linux config ---------------------------------------------------------------------------------------------------------
 common:linux --strategy=sandboxed
 common:linux --remote_local_fallback_strategy=sandboxed
@@ -56,13 +63,8 @@ common:cache --remote_timeout=60
 # CI config ------------------------------------------------------------------------------------------------------------
 common:ci --config=adms
 common:ci --config=cache
+common:ci --config=lint
 common:ci --noexperimental_convenience_symlinks # not CI-suitable: "These symlinks are only for the user's convenience"
-
-# For Rust targets, enable clippy and rustfmt checks during the build
-build:ci --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect
-build:ci --output_groups=+clippy_checks
-build:ci --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect
-build:ci --output_groups=+rustfmt_checks
 
 # Project configs --------------------------------------------------------------------------------------
 import %workspace%/bazel/configs/sdagent.bazelrc

--- a/docs/public/guidelines/languages/RUST.md
+++ b/docs/public/guidelines/languages/RUST.md
@@ -374,19 +374,15 @@ In CI (with `--config=ci`), Rust builds automatically run:
 
 Configuration from `.bazelrc`:
 ```
-build:ci --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect
-build:ci --output_groups=+clippy_checks
-build:ci --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect
-build:ci --output_groups=+rustfmt_checks
+common:lint --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect --output_groups=+clippy_checks
+common:lint --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect --output_groups=+rustfmt_checks
 ```
 
 >**Note:** you can also enable these checks for your local development (for instance, to format code automatically). To do so create `user.bazelrc` file in the root of the project and just add the same flags without configuration name. This enforces unconditional usage of the flags for arbitrary `build` invocation:
 ```starlark
-build --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect
-build --output_groups=+clippy_checks
-build --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect
-build --output_groups=+rustfmt_checks
+build --config=lint
 ```
+(or just `bazel build --config=lint //...` for a one-off check)
 
 ## Local Development Tips
 


### PR DESCRIPTION
### What does this PR do?
Extract Rust `clippy` and `rustfmt` aspects out of `build:ci` into a new `common:lint` config included by `ci` via `--config=lint`.

### Motivation
We can now invoke registered `bazel` linters locally without pulling in the full CI config.

Using `common:` ensures the aspects apply to [all commands that support them](https://bazel.build/run/bazelrc#option-defaults) whether inheriting from `build` (e.g., `test`) or not (e.g., `mod`):
> If a command does not support an option specified in this way, the option is ignored so long as it is valid for _some_ other Bazel command.

### Additional Notes
- merge `--aspects` and `--output_groups` per linter onto one line for easy one-shot disabling,
- add TODO placeholders for Go and Python linters.