### PR TITLE
[AGENT-15675] Return an empty check slice when rtloader is not yet initialized

### DIFF
--- a/pkg/collector/python/helpers.go
+++ b/pkg/collector/python/helpers.go
@@ -100,7 +100,7 @@ func newStickyLock() (*stickyLock, error) {
 
 	// Ensure that rtloader isn't destroyed while we are trying to acquire GIL
 	if rtloader == nil {
-		return nil, errors.New("error acquiring the GIL: rtloader is not initialized")
+		return nil, fmt.Errorf("error acquiring the GIL: %w", ErrNotInitialized)
 	}
 
 	state := C.ensure_gil(rtloader)
@@ -130,6 +130,9 @@ func (sl *stickyLock) unlock() {
 func GetPythonIntegrationList() ([]string, error) {
 	glock, err := newStickyLock()
 	if err != nil {
+		if errors.Is(err, ErrNotInitialized) {
+			return []string{}, nil
+		}
 		return nil, err
 	}
 

--- a/pkg/collector/python/init.go
+++ b/pkg/collector/python/init.go
@@ -227,6 +227,9 @@ var (
 	pyInitLock    sync.RWMutex
 	pyDestroyLock sync.RWMutex
 	pyInitErrors  []string
+
+	// ErrNotInitialized is returned when rtloader is not initialized yet
+	ErrNotInitialized = errors.New("rtloader is not initialized")
 )
 
 func init() {

--- a/pkg/collector/python/test_check.go
+++ b/pkg/collector/python/test_check.go
@@ -248,11 +248,7 @@ func testRunCheckWithRuntimeNotInitializedError(t *testing.T) {
 	rtloader = nil
 
 	err = check.runCheck(false)
-	assert.EqualError(
-		t,
-		err,
-		"error acquiring the GIL: rtloader is not initialized",
-	)
+	assert.ErrorIs(t, err, ErrNotInitialized)
 }
 
 func testInitiCheckWithRuntimeNotInitialized(t *testing.T) {
@@ -265,11 +261,7 @@ func testInitiCheckWithRuntimeNotInitialized(t *testing.T) {
 		return
 	}
 
-	assert.EqualError(
-		t,
-		err,
-		"error acquiring the GIL: rtloader is not initialized",
-	)
+	assert.ErrorIs(t, err, ErrNotInitialized)
 
 	assert.Equal(t, C.int(0), C.gil_locked_calls)
 	assert.Equal(t, C.int(0), C.gil_unlocked_calls)


### PR DESCRIPTION
### What does this PR do?
Update `GetPythonIntegrationList` to return an empty slice when rtloader hasn't been loaded yet.

### Motivation
The GUI calls this function to list configured checks, and it was failing due to python being lazy loaded.
This change makes it more correct and transparent, if we didn't load python it means there is not check to run yet.

### Describe how you validated your changes
CI

### Additional Notes
