### PR TITLE
Print errno strings instead of numbers in networkv2 check

### DIFF
--- a/pkg/collector/corechecks/net/networkv2/network.go
+++ b/pkg/collector/corechecks/net/networkv2/network.go
@@ -11,7 +11,6 @@ package networkv2
 import (
 	"bufio"
 	"bytes"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -298,7 +297,7 @@ func handleEthtoolStats(sender sender.Sender, ethtoolObject ethtoolInterface, in
 		if err == unix.ENOTTY || err == unix.EOPNOTSUPP {
 			log.Debugf("driver info is not supported for interface: %s", interfaceIO.Name)
 		} else {
-			return errors.New("failed to get driver info for interface " + interfaceIO.Name + ": " + fmt.Sprintf("%d", err))
+			return fmt.Errorf("failed to get driver info for interface %s: %w", interfaceIO.Name, err)
 		}
 	}
 
@@ -312,7 +311,7 @@ func handleEthtoolStats(sender sender.Sender, ethtoolObject ethtoolInterface, in
 		if err == unix.ENOTTY || err == unix.EOPNOTSUPP {
 			log.Debugf("ethtool stats are not supported for interface: %s", interfaceIO.Name)
 		} else {
-			return errors.New("failed to get ethtool stats information for interface " + interfaceIO.Name + ": " + fmt.Sprintf("%d", err))
+			return fmt.Errorf("failed to get ethtool stats information for interface %s: %w", interfaceIO.Name, err)
 		}
 	}
 


### PR DESCRIPTION
### What does this PR do?
Print errno strings instead of numbers in networkv2 check

### Motivation
Having actual error messages is much better than a number (which is not even clear it's an errno).

### Describe how you validated your changes

### Additional Notes
Wrapping the error is also better as it allows callers to handle it more easily.