### PR TITLE
[AGENT-15664] Ignore down or unreachable devices in networkv2 check

### DIFF
--- a/pkg/collector/corechecks/net/networkv2/network.go
+++ b/pkg/collector/corechecks/net/networkv2/network.go
@@ -297,6 +297,9 @@ func handleEthtoolStats(sender sender.Sender, ethtoolObject ethtoolInterface, in
 	if err != nil {
 		if err == unix.ENOTTY || err == unix.EOPNOTSUPP {
 			log.Debugf("driver info is not supported for interface: %s", interfaceIO.Name)
+		} else if err == unix.ENODEV {
+			log.Debugf("interface is down or device unavailable, skipping ethtool stats: %s", interfaceIO.Name)
+			return nil
 		} else {
 			return errors.New("failed to get driver info for interface " + interfaceIO.Name + ": " + fmt.Sprintf("%d", err))
 		}
@@ -311,6 +314,9 @@ func handleEthtoolStats(sender sender.Sender, ethtoolObject ethtoolInterface, in
 	if err != nil {
 		if err == unix.ENOTTY || err == unix.EOPNOTSUPP {
 			log.Debugf("ethtool stats are not supported for interface: %s", interfaceIO.Name)
+		} else if err == unix.ENODEV {
+			log.Debugf("interface is down or device unavailable, skipping ethtool stats: %s", interfaceIO.Name)
+			return nil
 		} else {
 			return errors.New("failed to get ethtool stats information for interface " + interfaceIO.Name + ": " + fmt.Sprintf("%d", err))
 		}


### PR DESCRIPTION
### What does this PR do?
Ignore down or unreachable devices in networkv2 check, just debug log in that case.

### Motivation
The check shouldn't loudly error out if the host has a network interface which is down, it should just not emit metrics for this interface.

### Describe how you validated your changes
CI

### Additional Notes
