### PR TITLE
perf(otlp/metrics): reduce heap allocations in Dimensions.String, FormatKeyValueTag, and keyHashCache.computeKey

### DIFF
--- a/pkg/opentelemetry-mapping-go/otlp/metrics/internal/utils/tags.go
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/internal/utils/tags.go
@@ -15,15 +15,16 @@
 // Package utils provides utilities for the OpenTelemetry Collector.
 package utils
 
-import (
-	"fmt"
-)
-
 // FormatKeyValueTag takes a key-value pair, and creates a tag string out of it
 // Tags can't end with ":" so we replace empty values with "n/a"
 func FormatKeyValueTag(key, value string) string {
 	if value == "" {
 		value = "n/a"
 	}
-	return fmt.Sprintf("%s:%s", key, value)
+	// Pre-size the buffer: key + ":" + value
+	b := make([]byte, 0, len(key)+1+len(value))
+	b = append(b, key...)
+	b = append(b, ':')
+	b = append(b, value...)
+	return string(b)
 }


### PR DESCRIPTION
### What does this PR do?

Reduces heap allocations in hot paths within the OpenTelemetry metrics mapping package:

- `Dimensions.String()`: replaces per-call `strings.Builder` and `make([]string, ...)` allocations with `sync.Pool`-backed reusable instances.
- `Dimensions.WithSuffix()`: replaces `fmt.Sprintf` with direct string concatenation (`+`).
- `FormatKeyValueTag()`: replaces `fmt.Sprintf` with a pre-sized `[]byte` append, removing the `fmt` import entirely.
- `keyHashCache.computeKey()`: replaces a heap-allocated `make([]byte, ...)` buffer with a fixed-size stack array (`[20]byte`), sized via a named constant `keyHashEncodedLen`.

### Motivation

These functions are called on every metric in the translation pipeline. Eliminating repeated small heap allocations reduces GC pressure and improves throughput, particularly under high-cardinality or high-volume metric workloads.

### Describe how you validated your changes

Run unit test

New tests added:
- `TestDimensionsStringPoolSafety` – concurrent correctness of the `sync.Pool` paths.
- `TestDimensionsStringPoolDoesNotMutateOriginalTags` – ensures pooled slice reuse does not clobber the caller's tag slice.
- `TestWithSuffixNonAllocating` – verifies string concatenation produces the correct result.
- `TestComputeKeyFixedBuffer` – verifies the fixed-buffer key computation is deterministic and handles edge cases.
- `TestKeyHashEncodedLenConstant` – validates the `keyHashEncodedLen` constant matches `ascii85.MaxEncodedLen(16)`.

### Additional Notes