### PR TITLE
Move code inside rtloader tests from _test to regular code

### DIFF
--- a/rtloader/test/uutil/uutil.go
+++ b/rtloader/test/uutil/uutil.go
@@ -36,7 +36,23 @@ import "C"
 var (
 	rtloader *C.rtloader_t
 	tmpfile  *os.File
+	stdout       string
+	stderr       string
+	setException bool
+	exception    string
+	retCode      int
+	args         []string
+	env          []string
 )
+
+func resetTest() {
+	stdout = ""
+	stderr = ""
+	setException = false
+	exception = ""
+	retCode = 0
+	args = nil
+}
 
 func setUp() error {
 	// Initialize memory tracking

--- a/rtloader/test/uutil/uutil_test.go
+++ b/rtloader/test/uutil/uutil_test.go
@@ -14,25 +14,6 @@ import (
 	"github.com/DataDog/datadog-agent/rtloader/test/helpers"
 )
 
-var (
-	stdout       string
-	stderr       string
-	setException bool
-	exception    string
-	retCode      int
-	args         []string
-	env          []string
-)
-
-func resetTest() {
-	stdout = ""
-	stderr = ""
-	setException = false
-	exception = ""
-	retCode = 0
-	args = nil
-}
-
 func TestMain(m *testing.M) {
 	err := setUp()
 	if err != nil {


### PR DESCRIPTION
### What does this PR do?

Moves a few variable and function definitions from uutil_test.go to uutil.go (where they're actually used).

### Motivation

I encountered this while trying to migrate rtloader to Bazel ([ABLD-323](https://datadoghq.atlassian.net/browse/ABLD-323)).

The way Bazel's gazelle generates rules in a standardized way, it builds `_test` files and regular code files separately. This caused a build failure, because `uutil.go` is making use of variables defined in `util_test.go`.

### Describe how you validated your changes

CI. Only changes test code.

### Additional Notes


[ABLD-323]: https://datadoghq.atlassian.net/browse/ABLD-323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ