### PR TITLE
Check if rtloader is initialized before locking OS thread

### DIFF
--- a/pkg/collector/python/helpers.go
+++ b/pkg/collector/python/helpers.go
@@ -93,8 +93,6 @@ var (
 // the GIL. It also sticks the goroutine to the current thread so that a
 // subsequent call to `Unlock` will unregister the very same thread.
 func newStickyLock() (*stickyLock, error) {
-	runtime.LockOSThread()
-
 	pyDestroyLock.RLock()
 	defer pyDestroyLock.RUnlock()
 
@@ -103,6 +101,7 @@ func newStickyLock() (*stickyLock, error) {
 		return nil, errors.New("error acquiring the GIL: rtloader is not initialized")
 	}
 
+	runtime.LockOSThread()
 	state := C.ensure_gil(rtloader)
 
 	return &stickyLock{


### PR DESCRIPTION
### What does this PR do?
Check if rtloader is initialized before locking OS thread.

### Motivation
If rtloader is not initialized, we don't need to lock OS thread. In that case `newStickyLock` returns an error, so `unlock` is not called, and the OS thread is never unlocked, which can lead to performance issues.

### Describe how you validated your changes
CI

### Additional Notes
