### PR TITLE
otlp/metrics: optimize string formatting by replacing fmt.Sprintf with string concatenation

### DIFF
--- a/pkg/opentelemetry-mapping-go/otlp/metrics/dimensions.go
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/dimensions.go
@@ -15,7 +15,6 @@
 package metrics
 
 import (
-	"fmt"
 	"sort"
 	"strings"
 
@@ -113,7 +112,7 @@ func (d *Dimensions) WithAttributeMap(labels pcommon.Map) *Dimensions {
 // WithSuffix creates a new dimensions struct with an extra name suffix.
 func (d *Dimensions) WithSuffix(suffix string) *Dimensions {
 	return &Dimensions{
-		name:                fmt.Sprintf("%s.%s", d.name, suffix),
+		name:                d.name + "." + suffix,
 		host:                d.host,
 		tags:                d.tags,
 		originID:            d.originID,
@@ -134,16 +133,22 @@ func concatDimensionValue(metricKeyBuilder *strings.Builder, value string) {
 // String maps dimensions to a string to use as an identifier.
 // The tags order does not matter.
 func (d *Dimensions) String() string {
-	var metricKeyBuilder strings.Builder
-
-	dimensions := make([]string, len(d.tags))
+	// Allocate the slice with exact capacity upfront to avoid any re-growth.
+	dimensions := make([]string, len(d.tags), len(d.tags)+3)
 	copy(dimensions, d.tags)
-
 	dimensions = append(dimensions, "name:"+d.name)
 	dimensions = append(dimensions, "host:"+d.host)
 	dimensions = append(dimensions, "originID:"+d.originID)
 	sort.Strings(dimensions)
 
+	// Pre-compute total length so the Builder does a single allocation.
+	totalLen := 0
+	for _, dim := range dimensions {
+		totalLen += len(dim) + 1 // +1 for dimensionSeparator
+	}
+
+	var metricKeyBuilder strings.Builder
+	metricKeyBuilder.Grow(totalLen)
 	for _, dim := range dimensions {
 		concatDimensionValue(&metricKeyBuilder, dim)
 	}

--- a/pkg/opentelemetry-mapping-go/otlp/metrics/internal/utils/tags.go
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/internal/utils/tags.go
@@ -15,15 +15,11 @@
 // Package utils provides utilities for the OpenTelemetry Collector.
 package utils
 
-import (
-	"fmt"
-)
-
 // FormatKeyValueTag takes a key-value pair, and creates a tag string out of it
 // Tags can't end with ":" so we replace empty values with "n/a"
 func FormatKeyValueTag(key, value string) string {
 	if value == "" {
-		value = "n/a"
+		return key + ":n/a"
 	}
-	return fmt.Sprintf("%s:%s", key, value)
+	return key + ":" + value
 }


### PR DESCRIPTION
### What does this PR do?

Optimizes string formatting in the OTLP metrics mapping package by replacing `fmt.Sprintf` calls with direct string concatenation, and improves the `Dimensions.String()` method to pre-allocate slices with exact capacity and pre-compute the total string length before building the key string.

### Motivation

`fmt.Sprintf` incurs overhead from format string parsing and interface boxing. Replacing it with simple string concatenation (`+`) is more efficient for short, fixed-format strings. Additionally, pre-growing the `strings.Builder` buffer avoids repeated memory allocations during the dimension key construction loop, which is a hot path in metrics processing.

### Describe how you validated your changes

Run unit test

### Additional Notes

The `fmt` import is removed from both changed files since it is no longer used after the refactor.