### PR TITLE
[observer] Add signal channel

### DIFF
--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -76,6 +76,8 @@ func NewComponent(deps Requires) Provides {
 	// Connect the reporter to the correlator's state
 	reporter.SetCorrelationState(correlator)
 
+	obsCh := make(chan observation, 1000)
+	signalCh := make(chan observerdef.Signal, 1000)
 	obs := &observerImpl{
 		logProcessors: []observerdef.LogProcessor{
 			&LogTimeSeriesAnalysis{
@@ -104,7 +106,8 @@ func NewComponent(deps Requires) Provides {
 			reporter,
 		},
 		storage:   newTimeSeriesStorage(),
-		obsCh:     make(chan observation, 1000),
+		obsCh:     obsCh,
+		signalCh:  signalCh,
 		maxEvents: 1000, // Keep last 1000 events for debugging
 	}
 
@@ -246,7 +249,8 @@ type observerImpl struct {
 	reporters         []observerdef.Reporter
 	storage           *timeSeriesStorage
 	obsCh             chan observation
-	handleFunc        observerdef.HandleFunc // Handle factory (may wrap with recorder middleware)
+	signalCh          chan observerdef.Signal // Anomaly events sent from anomaly detectors to be processed by signal processors
+	handleFunc        observerdef.HandleFunc  // Handle factory (may wrap with recorder middleware)
 
 	// NEW path: Signal-based processing (V2 architecture)
 	signalEmitters   []observerdef.SignalEmitter   // Layer 1: Point-based anomaly detection
@@ -273,12 +277,17 @@ type observerImpl struct {
 
 // run is the main dispatch loop, processing all observations sequentially.
 func (o *observerImpl) run() {
-	for obs := range o.obsCh {
-		if obs.metric != nil {
-			o.processMetric(obs.source, obs.metric)
-		}
-		if obs.log != nil {
-			o.processLog(obs.source, obs.log)
+	for {
+		select {
+		case signal := <-o.signalCh: // New anomaly signal
+			o.processSignal(signal)
+		case obs := <-o.obsCh: // New input
+			if obs.metric != nil {
+				o.processMetric(obs.source, obs.metric)
+			}
+			if obs.log != nil {
+				o.processLog(obs.source, obs.log)
+			}
 		}
 	}
 }
@@ -416,7 +425,7 @@ func (o *observerImpl) runSignalEmitters(series observerdef.Series, agg Aggregat
 			o.processAnomaly(anomaly)    // Send to correlators (GraphSketchCorrelator, etc.)
 
 			// Also send signal to signal processors (Layer 2)
-			o.processSignal(signal)
+			o.signalCh <- signal
 		}
 	}
 }


### PR DESCRIPTION
### What does this PR do?

This is used to asynchronously send result back to the observer from anomaly detectors.

Example design:

- We have an anomaly detector taking `signalCh` at initialization
- `Process(...)` doesn't return anything but adds the metric/log input to a channel
- A go routine does the anomaly detection and sends the result to `signalCh`
- The signal is transmitted to signal processors

> [!NOTE]
> Tell me if we prefer passing anomalies instead of signals / more data -> should we have `AnalyzerName` or `SourceSeriesID` into the signal?

### Motivation

### Describe how you validated your changes

Metric AD are using this now, I've seen the anomalies from the UI with my changes

### Additional Notes
