### PR TITLE
[USM] Mark flaky test

### DIFF
--- a/pkg/network/usm/usm_grpc_monitor_test.go
+++ b/pkg/network/usm/usm_grpc_monitor_test.go
@@ -386,6 +386,7 @@ func (s *usmGRPCSuite) TestSimpleGRPCScenarios() {
 			// The second and third requests for different endpoints should be captured. (The mismatch in the internal dynamic counter
 			// should not affect subsequent requests due to the mismatch.)
 			runClients: func(t *testing.T, clientsCount int) {
+				flake.MarkOnJobName(t, "ubuntu_25.10")
 				clients, cleanup := getGRPCClientsArray(t, clientsCount, s.isTLS)
 				defer cleanup()
 				ctxWithoutHeaders := context.Background()


### PR DESCRIPTION
### What does this PR do?

Mark TestGRPCScenarios/validate_HTTP2_MAX_HEADERS_COUNT_FOR_FILTERING_limit_without_missmatch  as flaky.

### Motivation

Test is flaky on ubuntu_25.10 kernel. 

### Describe how you validated your changes

### Additional Notes
