### PR TITLE
fix(ci): Trigger e2e tests on config_template.yaml changes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -368,6 +368,9 @@ variables:
   changes:
     paths:
       - omnibus/**/*
+      - pkg/config/config_template.yaml
+      - pkg/config/security-agent_template.yaml
+      - pkg/config/system-probe_template.yaml
     compare_to: $COMPARE_TO_BRANCH
 
 #


### PR DESCRIPTION
### What does this PR do?

Adds `pkg/config/config_template.yaml` to the `.on_build_changes` GitLab CI rule so that changes to the config template file trigger E2E agent-platform and installer tests.

### Motivation

During incident-50080 we had to revert #46850 because it modified `config_template.yaml` and caused systematic failures on `new-e2e-agent-platform-ddot-debian-a7-x86_64` and `new-e2e-installer-script` jobs. These failures were not caught before merge because changes to `config_template.yaml` did not trigger those E2E tests on PRs.

Adding this path to `on_build_changes` ensures these tests (and all other agent-platform E2E/build jobs that share this anchor) run when `config_template.yaml` is modified.

### Describe how you validated your changes

CI config change only — validation will be the pipeline itself running on this PR.

### Additional Notes

The `on_build_changes` anchor is shared by all agent-platform E2E test rule templates (`.on_ddot_tests`, `.on_install_script_tests`, `.on_step_by_step_tests`, `.on_upgrade_tests`, `.on_persisting_integrations_tests`, `.on_rpm_tests`, `.on_package_signing_tests`) as well as build/deploy jobs. This is intentional — config template changes should broadly trigger these tests.