### PR TITLE
fix: memory leaks in cluster checks agent

### DIFF
--- a/comp/core/autodiscovery/providers/clusterchecks.go
+++ b/comp/core/autodiscovery/providers/clusterchecks.go
@@ -204,12 +204,12 @@ func (c *ClusterChecksConfigProvider) heartbeatSender(ctx context.Context) {
 			if c.heartbeat.Load().Add(expirationTimeout).Add(-postStatusTimeout).Before(currentTime) &&
 				extraHeartbeatTime.Add(expirationTimeout).Add(-postStatusTimeout).Before(currentTime) {
 				postCtx, cancel := context.WithTimeout(ctx, postStatusTimeout)
-				defer cancel()
 				if err := c.postHeartbeat(postCtx); err == nil {
 					log.Infof("Sent extra heartbeat at: %v", currentTime)
 				} else {
 					log.Warnf("Unable to send extra heartbeat to Cluster Agent, err: %v", err)
 				}
+				cancel()
 				extraHeartbeatTime = currentTime
 			}
 

--- a/pkg/collector/scheduler.go
+++ b/pkg/collector/scheduler.go
@@ -124,6 +124,7 @@ func (s *CheckScheduler) Unschedule(configs []integration.Config) {
 					errorStats.setRunError(id, err.Error())
 				} else {
 					stopped[id] = struct{}{}
+					errorStats.removeRunError(id)
 				}
 			} else {
 				log.Errorf("Collector not available, unable to stop check %s", id)

--- a/pkg/collector/scheduler/job.go
+++ b/pkg/collector/scheduler/job.go
@@ -163,6 +163,7 @@ func (jq *jobQueue) run(s *Scheduler) {
 
 	go func() {
 		log.Debugf("Job queue is running...")
+		defer jq.bucketTicker.Stop()
 		for jq.process(s) {
 			// empty
 		}

--- a/pkg/collector/stats.go
+++ b/pkg/collector/stats.go
@@ -64,6 +64,13 @@ func (ce *collectorErrors) setRunError(checkID checkid.ID, err string) {
 	ce.run[checkID] = err
 }
 
+func (ce *collectorErrors) removeRunError(checkID checkid.ID) {
+	ce.m.Lock()
+	defer ce.m.Unlock()
+
+	delete(ce.run, checkID)
+}
+
 func (ce *collectorErrors) getRunErrors() map[checkid.ID]string {
 	ce.m.RLock()
 	defer ce.m.RUnlock()

--- a/releasenotes/notes/fix-clusterchecks-memory-leaks-1a43bddc54e34a57.yaml
+++ b/releasenotes/notes/fix-clusterchecks-memory-leaks-1a43bddc54e34a57.yaml
@@ -1,0 +1,15 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix memory leaks in the cluster checks agent: a context leak in the
+    heartbeat sender where ``defer cancel()`` inside a loop accumulated
+    unreleased contexts, an unbounded growth of check run error entries
+    that were never cleaned up, and a ticker goroutine leak in the
+    check scheduler job queue.


### PR DESCRIPTION
### What does this PR do?

Fixes three memory leaks in the cluster checks (CLC) agent that cause steady memory growth over time.

1. **Context leak in `heartbeatSender`** (`comp/core/autodiscovery/providers/clusterchecks.go`): `defer cancel()` was used inside an infinite `for` loop. In Go, `defer` executes when the *function* returns, not when the loop iteration ends. Since `heartbeatSender` never returns, every `context.WithTimeout` allocated a timer goroutine and cancel closure that accumulated indefinitely (~1 leak/second). Fixed by calling `cancel()` immediately after use.

2. **Unbounded run error map** (`pkg/collector/stats.go`): `collectorErrors.run` accumulated error entries for check IDs via `setRunError()`, but had no corresponding removal function. When checks are unscheduled in the cluster checks agent (which happens frequently due to rebalancing), errors were never cleaned up. Added `removeRunError()` and wired it into `Unschedule()` in `pkg/collector/scheduler.go`.

3. **Ticker goroutine leak in job queue** (`pkg/collector/scheduler/job.go`): The `bucketTicker` created in `newJobQueue()` was never stopped when the queue's goroutine exited via the stop channel. Added `defer jq.bucketTicker.Stop()` to the run goroutine.

### Motivation

The cluster checks agent exhibits linearly increasing memory usage over time. The primary cause is the context leak in `heartbeatSender`, which leaks resources every second the agent is running. The secondary leaks (run error map, ticker) contribute to long-term accumulation, especially in environments with high check churn.

### Describe how you validated your changes

- Code review confirming that `defer` inside a loop is a known Go pitfall — `defer` runs on function exit, not loop iteration exit (see [Go spec on defer](https://go.dev/ref/spec#Defer_statements))
- Verified that `cancel()` is called on all code paths (both success and error) before the next loop iteration
- Confirmed `removeRunError` is only called after a successful `StopCheck`, matching the lifecycle
- Confirmed `bucketTicker.Stop()` runs via `defer` when the goroutine exits on queue stop

### Additional Notes

- The context leak is the highest-impact fix; with a 1-second ticker and frequent heartbeat conditions, it produces significant memory growth over hours.
- Related past fixes: `fix-memory-leak-98276e2684780a7d` (orchestrator check ticker), `fix-clusterchecks-not-unscheduled-e2133ca522bcb160` (cluster checks unschedule bug).
