### PR TITLE
Use a better visibility pattern for env_vars.

### DIFF
--- a/bazel/repo/env_vars.bzl
+++ b/bazel/repo/env_vars.bzl
@@ -34,10 +34,10 @@ BUILD_FILE_CONTENT = """
 exports_files(
     ["env_vars.bzl"],
     # We may expand this in the future, but let's limit inventiveness for now.
-    visibility([
-        "@agent//bazel/rules/...",
-        "@agent//packages/...",
-    ]),
+    visibility = [
+        "@agent//bazel/rules:__subpackages__",
+        "@agent//packages:__subpackages__",
+    ],
 )
 """
 


### PR DESCRIPTION
The visibility(xx) specification fails with bazel query on some versions.

I discovered the problem in an unrelated PR when I tried to inspect if new variables were being added correctly.