### PR TITLE
perf: reduce allocations in OTLP metrics dimensions and key hash cache

### DIFF
--- a/pkg/opentelemetry-mapping-go/otlp/metrics/dimensions_test.go
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/dimensions_test.go
@@ -100,6 +100,23 @@ func TestAddTags(t *testing.T) {
 	assert.ElementsMatch(t, []string{"key:val"}, testDims.tags)
 }
 
+// TestWithSuffixDotJoin verifies that WithSuffix uses "." as separator (not fmt.Sprintf).
+func TestWithSuffixDotJoin(t *testing.T) {
+	dims := Dimensions{name: "foo", host: "h", tags: []string{"t:v"}}
+	assert.Equal(t, "foo.bar", dims.WithSuffix("bar").name)
+	// Suffix with dots should work too
+	assert.Equal(t, "foo.a.b", dims.WithSuffix("a.b").name)
+}
+
+// TestStringConsistencyWithManyTags checks that String() is order-independent for many tags.
+func TestStringConsistencyWithManyTags(t *testing.T) {
+	tagsForward := []string{"aaa:1", "bbb:2", "ccc:3", "ddd:4"}
+	tagsReverse := []string{"ddd:4", "ccc:3", "bbb:2", "aaa:1"}
+	d1 := Dimensions{name: "m", host: "h", originID: "oid", tags: tagsForward}
+	d2 := Dimensions{name: "m", host: "h", originID: "oid", tags: tagsReverse}
+	assert.Equal(t, d1.String(), d2.String())
+}
+
 func TestAllFieldsAreCopied(t *testing.T) {
 	dims := &Dimensions{
 		name:     "example.name",

--- a/pkg/opentelemetry-mapping-go/otlp/metrics/internal/utils/tags.go
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/internal/utils/tags.go
@@ -15,15 +15,11 @@
 // Package utils provides utilities for the OpenTelemetry Collector.
 package utils
 
-import (
-	"fmt"
-)
-
 // FormatKeyValueTag takes a key-value pair, and creates a tag string out of it
 // Tags can't end with ":" so we replace empty values with "n/a"
 func FormatKeyValueTag(key, value string) string {
 	if value == "" {
 		value = "n/a"
 	}
-	return fmt.Sprintf("%s:%s", key, value)
+	return key + ":" + value
 }

--- a/pkg/opentelemetry-mapping-go/otlp/metrics/key_hash_cache.go
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/key_hash_cache.go
@@ -51,11 +51,12 @@ func (m *keyHashCache) set(s keyHashCacheKey, v interface{}, expiration time.Dur
 
 func (m *keyHashCache) computeKey(s string) keyHashCacheKey {
 	h1, h2 := murmur3.StringSum128(s)
-	var bytes [16]byte
-	binary.LittleEndian.PutUint64(bytes[0:], h1)
-	binary.LittleEndian.PutUint64(bytes[8:], h2)
+	var raw [16]byte
+	binary.LittleEndian.PutUint64(raw[0:], h1)
+	binary.LittleEndian.PutUint64(raw[8:], h2)
 
-	buf := make([]byte, ascii85.MaxEncodedLen(len(bytes)))
-	n := ascii85.Encode(buf, bytes[:])
+	// ascii85 encodes 4 input bytes → 5 output bytes, so 16 bytes → 20 bytes (fixed size).
+	var buf [20]byte
+	n := ascii85.Encode(buf[:], raw[:])
 	return keyHashCacheKey(buf[:n])
 }


### PR DESCRIPTION
### What does this PR do?

Reduces unnecessary allocations in the OTLP metrics mapping hot path:

- Replaces `fmt.Sprintf` with direct string concatenation in `WithSuffix` (`dimensions.go`) and `FormatKeyValueTag` (`internal/utils/tags.go`), removing the `"fmt"` import where no longer needed.
- Pre-grows the `strings.Builder` in `Dimensions.String()` by estimating the total output length, avoiding incremental reallocations.
- Pre-allocates the tag slice in `Dimensions.String()` with the correct final capacity so that appending the three fixed fields (`name:`, `host:`, `originID:`) never triggers a copy.
- Replaces the heap-allocated `[]byte` buffer in `keyHashCache.computeKey` with a fixed-size `[20]byte` stack array (ascii85 always encodes 16 bytes → 20 bytes), eliminating one `make` per cache-key computation.

### Motivation

These code paths are exercised on every metric point processed by the OTLP pipeline. Avoiding `fmt.Sprintf` formatting overhead and unnecessary heap allocations lowers GC pressure and improves throughput when the agent handles high-volume metric streams.

### Describe how you validated your changes

Run unit test

### Additional Notes

The rename of the local variable `bytes` → `raw` in `key_hash_cache.go` avoids shadowing the standard-library `bytes` package name (minor readability improvement).