### PR TITLE
Mitigate ghcr.io pull timeouts in e2e CI with a GitHub App token

### DIFF
--- a/.gitlab/test/e2e/e2e.yml
+++ b/.gitlab/test/e2e/e2e.yml
@@ -94,7 +94,8 @@
       if [ "$DYNAMIC_TESTS_BREAKGLASS" == "true" ] || [ "$IS_DEV_BRANCH" == "false" ] || [ "$RUN_E2E_TESTS" == "on" ]; then
         export DYNAMIC_TESTS_FLAG=""
       fi
-    - dda inv -- -e new-e2e-tests.run $DYNAMIC_TESTS_FLAG $PRE_BUILT_BINARIES_FLAG $MAX_RETRIES_FLAG --local-package $CI_PROJECT_DIR/$OMNIBUS_BASE_DIR --result-json $E2E_RESULT_JSON --targets $TARGETS -c ddagent:imagePullRegistry=669783387624.dkr.ecr.us-east-1.amazonaws.com -c ddagent:imagePullUsername=AWS -c ddagent:imagePullPassword=$(aws ecr get-login-password) --junit-tar junit-${CI_JOB_ID}.tgz ${EXTRA_PARAMS} --test-washer --logs-folder=$E2E_OUTPUT_DIR/logs --logs-post-processing --logs-post-processing-test-depth=$E2E_LOGS_PROCESSING_TEST_DEPTH
+    - GHCR_TOKEN=$(dda inv github.get-token-from-app) || exit $?
+    - dda inv -- -e new-e2e-tests.run $DYNAMIC_TESTS_FLAG $PRE_BUILT_BINARIES_FLAG $MAX_RETRIES_FLAG --local-package $CI_PROJECT_DIR/$OMNIBUS_BASE_DIR --result-json $E2E_RESULT_JSON --targets $TARGETS -c ddagent:imagePullRegistry=669783387624.dkr.ecr.us-east-1.amazonaws.com -c ddagent:imagePullUsername=AWS -c ddagent:imagePullPassword=$(aws ecr get-login-password) -c ddinfra:ghcrToken=${GHCR_TOKEN} --junit-tar junit-${CI_JOB_ID}.tgz ${EXTRA_PARAMS} --test-washer --logs-folder=$E2E_OUTPUT_DIR/logs --logs-post-processing --logs-post-processing-test-depth=$E2E_LOGS_PROCESSING_TEST_DEPTH
   after_script:
     - CODECOV_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $CODECOV token) || exit $?; export CODECOV_TOKEN
     - $CI_PROJECT_DIR/tools/ci/junit_upload.sh "junit-${CI_JOB_ID}.tgz" "$E2E_RESULT_JSON"

--- a/.gitlab/test/e2e_pre_test/e2e_pre_test.yml
+++ b/.gitlab/test/e2e_pre_test/e2e_pre_test.yml
@@ -12,7 +12,8 @@ e2e_pre_test:
     - job: publish_fakeintake
       optional: true
   script:
-    - dda inv -- -e new-e2e-tests.run --targets ./test-infra-definition --result-json $E2E_RESULT_JSON --junit-tar junit-${CI_JOB_ID}.tgz ${EXTRA_PARAMS} --test-washer -c ddagent:imagePullRegistry=669783387624.dkr.ecr.us-east-1.amazonaws.com -c ddagent:imagePullUsername=AWS -c ddagent:imagePullPassword=$(aws ecr get-login-password)
+    - GHCR_TOKEN=$(dda inv github.get-token-from-app) || exit $?
+    - dda inv -- -e new-e2e-tests.run --targets ./test-infra-definition --result-json $E2E_RESULT_JSON --junit-tar junit-${CI_JOB_ID}.tgz ${EXTRA_PARAMS} --test-washer -c ddagent:imagePullRegistry=669783387624.dkr.ecr.us-east-1.amazonaws.com -c ddagent:imagePullUsername=AWS -c ddagent:imagePullPassword=$(aws ecr get-login-password) -c ddinfra:ghcrToken=${GHCR_TOKEN}
   after_script:
     - $CI_PROJECT_DIR/tools/ci/junit_upload.sh "junit-${CI_JOB_ID}.tgz" "$E2E_RESULT_JSON"
   variables:

--- a/test/e2e-framework/common/config/environment.go
+++ b/test/e2e-framework/common/config/environment.go
@@ -62,6 +62,7 @@ const (
 	DDImagePullRegistryParamName         = "imagePullRegistry"
 	DDImagePullUsernameParamName         = "imagePullUsername"
 	DDImagePullPasswordParamName         = "imagePullPassword"
+	DDGHCRTokenParamName                 = "ghcrToken"
 	DDAgentAPIKeyParamName               = "apiKey"
 	DDAgentAPPKeyParamName               = "appKey"
 	DDAgentFakeintake                    = "fakeintake"
@@ -141,6 +142,7 @@ type Env interface {
 	ImagePullRegistry() string
 	ImagePullUsername() string
 	ImagePullPassword() pulumi.StringOutput
+	GHCRToken() pulumi.StringOutput
 	AgentAPIKey() pulumi.StringOutput
 	AgentAPPKey() pulumi.StringOutput
 	AgentUseFakeintake() bool
@@ -363,6 +365,10 @@ func (e *CommonEnvironment) ImagePullUsername() string {
 
 func (e *CommonEnvironment) ImagePullPassword() pulumi.StringOutput {
 	return e.AgentConfig.RequireSecret(DDImagePullPasswordParamName)
+}
+
+func (e *CommonEnvironment) GHCRToken() pulumi.StringOutput {
+	return e.InfraConfig.GetSecret(DDGHCRTokenParamName)
 }
 
 func (e *CommonEnvironment) AgentAPIKey() pulumi.StringOutput {

--- a/test/e2e-framework/scenarios/aws/ec2/run.go
+++ b/test/e2e-framework/scenarios/aws/ec2/run.go
@@ -44,10 +44,15 @@ func Run(ctx *pulumi.Context, awsEnv aws.Environment, env outputs.HostOutputs, p
 		}
 
 		dockerManager, err := docker.NewManager(&awsEnv, host, utils.PulumiDependsOn(installEcrCredsHelperCmd))
-
 		if err != nil {
 			return err
 		}
+
+		loginCmd, err := dockerManager.LoginRegistry("ghcr.io", "x-access-token", awsEnv.GHCRToken())
+		if err != nil {
+			return err
+		}
+
 		if params.agentOptions != nil {
 			// Agent install needs to be serial with the docker
 			// install because they both use the apt lock, and
@@ -55,7 +60,7 @@ func Run(ctx *pulumi.Context, awsEnv aws.Environment, env outputs.HostOutputs, p
 			// at the same time.
 			params.agentOptions = append(params.agentOptions,
 				agentparams.WithPulumiResourceOptions(
-					utils.PulumiDependsOn(dockerManager)))
+					utils.PulumiDependsOn(dockerManager, loginCmd)))
 		}
 	}
 


### PR DESCRIPTION
### What does this PR do?

- add `DDGHCRTokenParamName` / `GHCRToken()` to `CommonEnvironment` so the GHCR token can be threaded through as a Pulumi secret
- add `Manager.LoginRegistry()` to the docker component, which runs `docker login <registry>` only when the token is non-empty
- in `ec2/Run`, call `LoginRegistry("ghcr.io", …)` after the docker manager is installed, and make the agent install depend on it
- in GitLab CI (e2e and e2e_pre_test jobs), fetch the token via `dda inv github.get-token-from-app` and pass it as `-c ddinfra:ghcrToken=…`

### Motivation

Incidents #incident-50147 and #incident-50154: intermittent `timeout while getting response from ghcrio` errors caused e2e jobs to fail when pulling images anonymously. Authenticating with a GitHub App token raises the rate limit and avoids the timeouts.

### Describe how you validated your changes
CI.