### PR TITLE
Add reinstall keeps custom user test

### DIFF
--- a/test/new-e2e/tests/installer/windows/suites/install-script/agent-user_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/install-script/agent-user_test.go
@@ -61,6 +61,17 @@ func (s *testInstallScriptWithAgentUserSuite) TestInstallScriptWithAgentUser() {
 	s.Require().Host(s.Env().RemoteHost).
 		HasAService("datadogagent").
 		WithIdentity(identity)
+
+	// Reinstall the same Agent again, but this time without the custom user arg
+	// it should keep the same user (settings read from registry)
+	out, err = s.InstallScript().Run()
+	s.T().Log(out)
+	s.Require().NoErrorf(err, "install script failed")
+	s.Require().Host(s.Env().RemoteHost).
+		HasARunningDatadogAgentService().
+		HasRegistryKey(consts.RegistryKeyPath).
+		WithValueEqual("installedUser", s.agentUser)
+
 }
 
 // TestInstallScriptChangesAgentUser tests that the install script changes the agent user when the Agent is already installed


### PR DESCRIPTION
### What does this PR do?

Adds a test to verify that reinstalling the agent preserves the custom user configuration.

### Motivation

Ensure reinstall behavior is covered by automated tests.