### PR TITLE
[ABLD-250] Sign jmxfetch with a bazel rule

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,6 +15,10 @@ env_vars(
         "FORCED_PACKAGE_COMPRESSION_LEVEL",
         # This is the build pipeline id, which is used in some symlink paths.
         "PACKAGE_VERSION",
+        # macOS code signing: control whether to enable code signing
+        "SIGN_MAC",
+        # macOS code signing: control whether to enable hardened runtime entitlements
+        "HARDENED_RUNTIME_MAC",
     ],
 )
 

--- a/bazel/BUILD.bazel
+++ b/bazel/BUILD.bazel
@@ -1,1 +1,9 @@
 # Package delimiter
+
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+bzl_library(
+    name = "constants_bzl",
+    srcs = ["constants.bzl"],
+    visibility = ["//visibility:public"],
+)

--- a/bazel/constants.bzl
+++ b/bazel/constants.bzl
@@ -1,0 +1,6 @@
+"""Bazel constants for common configuration values."""
+
+# macOS Code Signing Identity
+# Used for signing native libraries and binaries on macOS
+# This should match the identity used in omnibus/config/projects/agent.rb
+apple_signing_identity = "Developer ID Application: Datadog, Inc. (JKFCB4CN7C)"

--- a/bazel/rules/macos/codesign/BUILD.bazel
+++ b/bazel/rules/macos/codesign/BUILD.bazel
@@ -1,0 +1,20 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+
+package(default_visibility = ["//visibility:private"])
+
+sh_binary(
+    name = "sign_jar_macos",
+    srcs = ["sign_jar_macos.sh"],
+    tags = ["manual"],
+    visibility = ["//visibility:public"],
+)
+
+bzl_library(
+    name = "code_sign_jar_macos_bzl",
+    srcs = ["code_sign_jar_macos.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@bazel_skylib//:bzl_library"],
+)
+
+exports_files(["Entitlements.plist"])

--- a/bazel/rules/macos/codesign/Entitlements.plist
+++ b/bazel/rules/macos/codesign/Entitlements.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+</dict>
+</plist>

--- a/bazel/rules/macos/codesign/code_sign_jar_macos.bzl
+++ b/bazel/rules/macos/codesign/code_sign_jar_macos.bzl
@@ -1,0 +1,114 @@
+"""Bazel rule for code-signing JAR files on macOS.
+
+This rule signs native libraries (.so, .dylib, .jnilib) inside a JAR file
+using the macOS codesign utility. It supports optional hardened runtime
+entitlements and can skip signing entirely if configured.
+
+The signing identity and entitlements file default to values from
+bazel/constants.bzl but can be overridden per-rule.
+
+Environment variables:
+  - SIGN_MAC: If "true", performs code signing. If not set or "false", just copies the JAR
+  - HARDENED_RUNTIME_MAC: If "true", applies hardened runtime entitlements
+"""
+
+load("@agent_volatile//:env_vars.bzl", "env_vars")
+load("//bazel:constants.bzl", "apple_signing_identity")
+
+def _code_sign_jar_macos_impl(ctx):
+    """Implementation of code_sign_jar_macos rule."""
+
+    input_jar = ctx.file.jar
+    output_jar = ctx.outputs.output
+
+    # Get signing parameters, using defaults from constants if not provided
+    signing_identity = ctx.attr.signing_identity or apple_signing_identity
+
+    # Check if signing should be performed
+    do_signing = env_vars.SIGN_MAC == "true"
+    hardened_runtime = env_vars.HARDENED_RUNTIME_MAC == "true"
+
+    if not do_signing:
+        # Just copy the JAR without signing
+        args = ctx.actions.args()
+        args.add(input_jar)
+        args.add(output_jar)
+
+        ctx.actions.run(
+            inputs = [input_jar],
+            outputs = [output_jar],
+            executable = "/bin/cp",
+            arguments = [args],
+            mnemonic = "CopyJar",
+            progress_message = "Copying JAR (signing skipped): {}".format(input_jar.short_path),
+        )
+    else:
+        # Sign the JAR
+        sign_script = ctx.executable._sign_script
+
+        # Build arguments for the signing script
+        args = ctx.actions.args()
+        args.add(input_jar)
+        args.add(output_jar)
+        args.add(signing_identity)
+        if hardened_runtime:
+            args.add(ctx.file.entitlements_file.path)
+
+        ctx.actions.run(
+            inputs = [input_jar, ctx.file.entitlements_file],
+            outputs = [output_jar],
+            tools = [sign_script],
+            executable = sign_script,
+            arguments = [args],
+            mnemonic = "CodeSignJarMacOS",
+            progress_message = "Code-signing JAR: {}".format(input_jar.short_path),
+        )
+
+    return [DefaultInfo(files = depset([output_jar]))]
+
+code_sign_jar_macos = rule(
+    implementation = _code_sign_jar_macos_impl,
+    attrs = {
+        "jar": attr.label(
+            mandatory = True,
+            allow_single_file = [".jar"],
+            doc = "The JAR file to sign.",
+        ),
+        "output": attr.output(
+            mandatory = True,
+            doc = "The output file path for the signed JAR.",
+        ),
+        "signing_identity": attr.string(
+            doc = "The macOS code signing identity (e.g., 'Developer ID Application: ...'). " +
+                  "If not provided, defaults to apple_signing_identity from bazel/constants.bzl.",
+        ),
+        "entitlements_file": attr.label(
+            doc = "Path to entitlements file for hardened runtime. " +
+                  "If not provided, defaults to apple_entitlements_file from bazel/constants.bzl. " +
+                  "Only used if HARDENED_RUNTIME_MAC environment variable is set to 'true'.",
+            default = Label("//bazel/rules/macos/codesign:Entitlements.plist"),
+            allow_single_file = True,
+        ),
+        "_sign_script": attr.label(
+            default = Label("//bazel/rules/macos/codesign:sign_jar_macos"),
+            executable = True,
+            cfg = "exec",
+        ),
+    },
+    doc = """Code-signs native libraries within a JAR file on macOS.
+
+    This rule unpacks a JAR, signs all native libraries (.so, .dylib, .jnilib),
+    and repacks the JAR. The original JAR is never modified.
+
+    Environment variables:
+      - SIGN_MAC: Set to "true" to sign (otherwise just copy the JAR)
+      - HARDENED_RUNTIME_MAC: Set to "true" to apply hardened runtime entitlements
+
+    Example:
+        code_sign_jar_macos(
+            name = "signed_jar",
+            jar = ":mylib.jar",
+            output = "signed/mylib.jar",
+        )
+    """,
+)

--- a/bazel/rules/macos/codesign/sign_jar_macos.sh
+++ b/bazel/rules/macos/codesign/sign_jar_macos.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Sign binaries and libraries inside a JAR file
+# Usage: sign_jar.sh <input_jar> <output_jar> <signing_identity> [entitlements_file]
+
+set -e
+
+INPUT_JAR="$1"
+OUTPUT_JAR="$2"
+SIGNING_IDENTITY="$3"
+ENTITLEMENTS_FILE="${4:-}"
+
+# Validate inputs
+if [[ -z "$INPUT_JAR" || -z "$OUTPUT_JAR" || -z "$SIGNING_IDENTITY" ]]; then
+    echo "Usage: $0 <input_jar> <output_jar> <signing_identity> [entitlements_file]" >&2
+    exit 1
+fi
+
+if [[ ! -f "$INPUT_JAR" ]]; then
+    echo "Error: Input JAR not found: $INPUT_JAR" >&2
+    exit 1
+fi
+
+if [[ -n "$ENTITLEMENTS_FILE" && ! -f "$ENTITLEMENTS_FILE" ]]; then
+    echo "Error: Entitlements file not found: $ENTITLEMENTS_FILE" >&2
+    exit 1
+fi
+
+# Convert OUTPUT_JAR to absolute path if it's relative
+if [[ ! "$OUTPUT_JAR" = /* ]]; then
+    OUTPUT_JAR="$(pwd)/$OUTPUT_JAR"
+fi
+
+# Create a temporary directory for unpacking
+TEMP_DIR=$(mktemp -d)
+trap "rm -rf '$TEMP_DIR'" EXIT
+
+# Extract jar to temp directory
+unzip -q "$INPUT_JAR" -d "$TEMP_DIR"
+
+# Build codesign command options
+CODESIGN_OPTS=(--force --timestamp --deep -s "$SIGNING_IDENTITY")
+if [[ -n "$ENTITLEMENTS_FILE" ]]; then
+    CODESIGN_OPTS+=(-o runtime --entitlements "$ENTITLEMENTS_FILE")
+fi
+
+# Find and sign all binary/library files
+# Search for .so, .dylib, and .jnilib files
+if find "$TEMP_DIR" -type f \( -name "*.so" -o -name "*.dylib" -o -name "*.jnilib" \) | grep -q .; then
+    echo "Signing native libraries in JAR..."
+    find . -type f \( -name "*.so" -o -name "*.dylib" -o -name "*.jnilib" \) | while read -r file; do
+        echo "  Signing: $file"
+        codesign "${CODESIGN_OPTS[@]}" "$file"
+    done
+else
+    echo "No native libraries found to sign"
+fi
+
+# Create output directory if needed
+mkdir -p "$(dirname "$OUTPUT_JAR")"
+
+# Create new signed jar, preserving the original structure
+cd "$TEMP_DIR"
+zip -q -r "$OUTPUT_JAR" .
+
+# Set permissions on output jar
+chmod 0644 "$OUTPUT_JAR"
+
+echo "Signed JAR created: $OUTPUT_JAR"

--- a/deps/jmxfetch/BUILD.bazel
+++ b/deps/jmxfetch/BUILD.bazel
@@ -3,15 +3,29 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_filegroup", "pkg_files")
+load("//bazel/rules/macos/codesign:code_sign_jar_macos.bzl", "code_sign_jar_macos")
 load(":module_utils_test.bzl", "jmxfetch_module_utils_test_suite")
 
 package(default_visibility = ["//packages:__subpackages__"])
 
+# Code-sign the jmxfetch JAR file (macOS only)
+# This only really signs if SIGN_MAC is set in the environment.
+code_sign_jar_macos(
+    name = "signed_jmxfetch_jar",
+    jar = "@jmxfetch//:jmxfetch.jar",
+    output = "signed/jmxfetch.jar",
+    # For testing signing on a developer machine, you can set the
+    # identity to "-", to get a mock signing. Then build with
+    #    SIGN_MAC=true bazel build //:hatever
+    signing_identity = "-",
+)
+
 pkg_files(
     name = "jar_file",
-    srcs = [
-        "@jmxfetch//:jmxfetch.jar",
-    ],
+    srcs = select({
+        "@platforms//os:macos": [":signed_jmxfetch_jar"],
+        "//conditions:default": ["@jmxfetch//:jmxfetch.jar"],
+    }),
     attributes = pkg_attributes(mode = "0644"),
     # This is essentially redundant, but it serves to document that
     # the code is under a different license.

--- a/omnibus/config/software/datadog-agent-dependencies.rb
+++ b/omnibus/config/software/datadog-agent-dependencies.rb
@@ -19,7 +19,9 @@ end
 dependency 'cacerts'
 
 # External agents
-dependency 'jmxfetch'
+build do
+    command_on_repo_root "bazelisk run -- //deps/jmxfetch:install --destdir=#{install_dir}", :live_stream => Omnibus.logger.live_stream(:info)
+end
 
 # Used for memory profiling with the `status py` agent subcommand
 dependency 'pympler'

--- a/pkg/procmgr/rust/BUILD.bazel
+++ b/pkg/procmgr/rust/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files")
-load("@rules_rust//rust:defs.bzl", "rust_binary")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_test")
 
 rust_binary(
     name = "dd-procmgrd",
@@ -32,4 +32,35 @@ pkg_files(
 pkg_install(
     name = "install",
     srcs = [":dd-procmgrd_pkg"],
+)
+
+# ============================================================================
+# Tests
+# ============================================================================
+
+rust_test(
+    name = "dd-procmgrd_test",
+    crate = ":dd-procmgrd",
+    edition = "2024",
+    deps = [
+        "@crates//:tempfile",
+    ],
+)
+
+rust_test(
+    name = "integration_test",
+    srcs = [
+        "tests/helpers/mod.rs",
+        "tests/integration.rs",
+    ],
+    crate_root = "tests/integration.rs",
+    data = [":dd-procmgrd"],
+    edition = "2024",
+    rustc_env = {
+        "CARGO_BIN_EXE_dd-procmgrd": "$(rootpath :dd-procmgrd)",
+    },
+    deps = [
+        "@crates//:nix",
+        "@crates//:tempfile",
+    ],
 )

--- a/pkg/procmgr/rust/Cargo.toml
+++ b/pkg/procmgr/rust/Cargo.toml
@@ -16,7 +16,8 @@ nix = { workspace = true, features = ["signal", "process"] }
 serde = { workspace = true, features = ["derive"] }
 serde_yaml.workspace = true
 simple_logger = { workspace = true, features = ["timestamps"] }
-tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal", "process", "fs", "time"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal", "process", "fs", "time", "sync"] }
 
 [dev-dependencies]
+nix = { workspace = true, features = ["signal", "process", "user"] }
 tempfile.workspace = true

--- a/pkg/procmgr/rust/src/config.rs
+++ b/pkg/procmgr/rust/src/config.rs
@@ -8,6 +8,7 @@ use log::{debug, warn};
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 const DEFAULT_CONFIG_DIR: &str = "/etc/datadog-agent/processes.d";
 
@@ -17,6 +18,19 @@ fn default_true() -> bool {
 
 fn default_inherit() -> String {
     "inherit".to_string()
+}
+
+fn default_restart() -> RestartPolicy {
+    RestartPolicy::Never
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum RestartPolicy {
+    Always,
+    OnFailure,
+    OnSuccess,
+    Never,
 }
 
 #[derive(Debug, Deserialize)]
@@ -41,6 +55,53 @@ pub struct ProcessConfig {
     pub auto_start: bool,
     pub condition_path_exists: Option<String>,
     pub stop_timeout: Option<u64>,
+    #[serde(default = "default_restart")]
+    pub restart: RestartPolicy,
+    pub restart_sec: Option<f64>,
+    pub restart_max_delay_sec: Option<f64>,
+    pub start_limit_burst: Option<u32>,
+    pub start_limit_interval_sec: Option<u64>,
+    pub runtime_success_sec: Option<u64>,
+}
+
+const DEFAULT_STOP_TIMEOUT_SECS: u64 = 90;
+const DEFAULT_RESTART_SEC: f64 = 1.0;
+const DEFAULT_RESTART_MAX_DELAY_SEC: f64 = 60.0;
+const DEFAULT_START_LIMIT_BURST: u32 = 5;
+const DEFAULT_START_LIMIT_INTERVAL_SEC: u64 = 10;
+const DEFAULT_RUNTIME_SUCCESS_SEC: u64 = 1;
+
+impl ProcessConfig {
+    pub fn stop_timeout(&self) -> Duration {
+        Duration::from_secs(self.stop_timeout.unwrap_or(DEFAULT_STOP_TIMEOUT_SECS))
+    }
+
+    pub fn restart_delay(&self) -> f64 {
+        self.restart_sec.unwrap_or(DEFAULT_RESTART_SEC)
+    }
+
+    pub fn max_restart_delay(&self) -> f64 {
+        self.restart_max_delay_sec
+            .unwrap_or(DEFAULT_RESTART_MAX_DELAY_SEC)
+    }
+
+    pub fn burst_limit(&self) -> u32 {
+        self.start_limit_burst.unwrap_or(DEFAULT_START_LIMIT_BURST)
+    }
+
+    pub fn burst_interval(&self) -> Duration {
+        Duration::from_secs(
+            self.start_limit_interval_sec
+                .unwrap_or(DEFAULT_START_LIMIT_INTERVAL_SEC),
+        )
+    }
+
+    pub fn runtime_success(&self) -> Duration {
+        Duration::from_secs(
+            self.runtime_success_sec
+                .unwrap_or(DEFAULT_RUNTIME_SUCCESS_SEC),
+        )
+    }
 }
 
 pub fn config_dir() -> PathBuf {
@@ -53,8 +114,6 @@ pub fn config_dir() -> PathBuf {
 /// The process name is derived from the filename (without extension).
 /// Files that fail to parse are logged and skipped.
 pub fn load_configs(dir: &Path) -> Result<Vec<(String, ProcessConfig)>> {
-    let mut configs = Vec::new();
-
     let entries = std::fs::read_dir(dir)
         .with_context(|| format!("failed to read config directory: {}", dir.display()))?;
 
@@ -80,6 +139,7 @@ pub fn load_configs(dir: &Path) -> Result<Vec<(String, ProcessConfig)>> {
 
     yaml_files.sort_by_key(|e| e.file_name());
 
+    let mut configs = Vec::new();
     for entry in yaml_files {
         let path = entry.path();
         let name = path
@@ -234,14 +294,19 @@ condition_path_exists: /usr/bin/sleep
     #[cfg(unix)]
     #[test]
     fn test_load_configs_unreadable_directory() {
+        use nix::unistd::Uid;
         use std::os::unix::fs::PermissionsExt;
+
+        if Uid::effective().is_root() {
+            eprintln!("skipping test_load_configs_unreadable_directory: running as root");
+            return;
+        }
 
         let dir = tempfile::tempdir().unwrap();
         fs::write(dir.path().join("proc.yaml"), "command: /a\n").unwrap();
         fs::set_permissions(dir.path(), fs::Permissions::from_mode(0o000)).unwrap();
 
         let result = load_configs(dir.path());
-        // Restore permissions so tempdir cleanup succeeds.
         fs::set_permissions(dir.path(), fs::Permissions::from_mode(0o755)).unwrap();
         assert!(result.is_err());
     }

--- a/pkg/procmgr/rust/src/env.rs
+++ b/pkg/procmgr/rust/src/env.rs
@@ -1,0 +1,70 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+use anyhow::{Context, Result};
+
+/// Parse a systemd-style environment file into key-value pairs.
+/// Supports `KEY=VALUE`, `KEY="VALUE"`, `KEY='VALUE'`, comments (#), and blank lines.
+pub fn parse_environment_file(path: &str) -> Result<Vec<(String, String)>> {
+    let contents = std::fs::read_to_string(path)
+        .with_context(|| format!("reading environment file: {path}"))?;
+    let mut vars = Vec::new();
+    for line in contents.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        if let Some((key, raw_val)) = trimmed.split_once('=') {
+            let val = raw_val
+                .trim()
+                .trim_matches('"')
+                .trim_matches('\'')
+                .to_string();
+            vars.push((key.trim().to_string(), val));
+        }
+    }
+    Ok(vars)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_parse_full() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("env");
+        std::fs::write(
+            &path,
+            r#"# Datadog env
+DD_API_KEY=abc123
+PATH="/usr/local/bin:/usr/bin"
+QUOTED='single'
+malformed line without equals
+   
+# blank lines above are skipped
+LANG=en_US.UTF-8
+"#,
+        )
+        .unwrap();
+
+        let vars: HashMap<String, String> = parse_environment_file(path.to_str().unwrap())
+            .unwrap()
+            .into_iter()
+            .collect();
+
+        assert_eq!(vars["DD_API_KEY"], "abc123");
+        assert_eq!(vars["PATH"], "/usr/local/bin:/usr/bin");
+        assert_eq!(vars["QUOTED"], "single");
+        assert_eq!(vars["LANG"], "en_US.UTF-8");
+        assert_eq!(vars.len(), 4, "malformed line should be silently skipped");
+    }
+
+    #[test]
+    fn test_parse_missing_file() {
+        assert!(parse_environment_file("/nonexistent/env").is_err());
+    }
+}

--- a/pkg/procmgr/rust/src/process.rs
+++ b/pkg/procmgr/rust/src/process.rs
@@ -3,34 +3,127 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2026-present Datadog, Inc.
 
-use crate::config::ProcessConfig;
+use crate::config::{ProcessConfig, RestartPolicy};
+use crate::env::parse_environment_file;
+use crate::state::ProcessState;
 use anyhow::{Context, Result};
 use log::{info, warn};
 use nix::sys::signal::{self, Signal};
 use nix::unistd::Pid;
 use std::process::Stdio;
 use tokio::process::{Child, Command};
-use tokio::time::{Duration, timeout};
+use tokio::task::JoinHandle;
+use tokio::time::{self, Duration, Instant};
 
-pub const DEFAULT_STOP_TIMEOUT_SECS: u64 = 90;
-const SIGKILL_TIMEOUT: Duration = Duration::from_secs(10);
+// ---------------------------------------------------------------------------
+// RestartTracker
+// ---------------------------------------------------------------------------
+
+struct RestartTracker {
+    count: u32,
+    timestamps: Vec<Instant>,
+    current_delay: f64,
+    last_spawn_time: Option<Instant>,
+}
+
+impl RestartTracker {
+    const BACKOFF_MULTIPLIER: f64 = 2.0;
+    const MAX_TIMESTAMPS: usize = 100;
+
+    fn new(initial_delay: f64) -> Self {
+        Self {
+            count: 0,
+            timestamps: Vec::new(),
+            current_delay: initial_delay,
+            last_spawn_time: None,
+        }
+    }
+
+    fn mark_spawned(&mut self) {
+        self.last_spawn_time = Some(Instant::now());
+    }
+
+    fn is_burst_limited(&self, burst: u32, interval: Duration) -> bool {
+        let cutoff = Instant::now() - interval;
+        let recent = self.timestamps.iter().filter(|t| **t > cutoff).count() as u32;
+        recent >= burst
+    }
+
+    /// Record a restart. Resets backoff if the process ran long enough.
+    fn record(&mut self, base_delay: f64, runtime_success: Duration) {
+        if let Some(spawn_time) = self.last_spawn_time
+            && spawn_time.elapsed() >= runtime_success
+        {
+            self.current_delay = base_delay;
+            self.count = 0;
+        }
+        self.count += 1;
+        self.timestamps.push(Instant::now());
+        if self.timestamps.len() > Self::MAX_TIMESTAMPS {
+            self.timestamps.remove(0);
+        }
+    }
+
+    fn advance_backoff(&mut self, max_delay: f64) {
+        self.current_delay = (self.current_delay * Self::BACKOFF_MULTIPLIER).min(max_delay);
+    }
+
+    fn delay(&self) -> Duration {
+        Duration::from_secs_f64(self.current_delay)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ManagedProcess
+// ---------------------------------------------------------------------------
 
 pub struct ManagedProcess {
     pub name: String,
     config: ProcessConfig,
+    state: ProcessState,
+    pid: Option<u32>,
     child: Option<Child>,
+    watcher_handle: Option<JoinHandle<()>>,
+    restarts: RestartTracker,
 }
 
 impl ManagedProcess {
+    const SIGKILL_TIMEOUT: Duration = Duration::from_secs(10);
+
     pub fn new(name: String, config: ProcessConfig) -> Self {
+        let restarts = RestartTracker::new(config.restart_delay());
         Self {
             name,
             config,
+            state: ProcessState::Created,
+            pid: None,
             child: None,
+            watcher_handle: None,
+            restarts,
         }
     }
 
-    /// Check `condition_path_exists` and return false if the path is missing.
+    #[cfg(test)]
+    pub fn state(&self) -> ProcessState {
+        self.state
+    }
+
+    fn transition_to(&mut self, next: ProcessState) {
+        if !self.state.can_transition_to(next) {
+            warn!(
+                "[{}] invalid state transition: {} -> {next}, ignoring",
+                self.name, self.state
+            );
+            debug_assert!(
+                false,
+                "[{}] invalid state transition: {} -> {next}",
+                self.name, self.state
+            );
+            return;
+        }
+        self.state = next;
+    }
+
     pub fn should_start(&self) -> bool {
         if !self.config.auto_start {
             info!("[{}] auto_start=false, skipping", self.name);
@@ -46,6 +139,26 @@ impl ManagedProcess {
     }
 
     pub fn spawn(&mut self) -> Result<()> {
+        let mut cmd = self.build_command()?;
+
+        let child = cmd
+            .spawn()
+            .with_context(|| format!("[{}] failed to spawn: {}", self.name, self.config.command))?;
+
+        self.pid = child.id();
+        info!(
+            "[{}] spawned (pid={}, cmd={})",
+            self.name,
+            self.pid.map_or("unknown".to_string(), |p| p.to_string()),
+            self.config.command
+        );
+        self.child = Some(child);
+        self.transition_to(ProcessState::Running);
+        self.restarts.mark_spawned();
+        Ok(())
+    }
+
+    fn build_command(&self) -> Result<Command> {
         let mut cmd = Command::new(&self.config.command);
         cmd.args(&self.config.args);
 
@@ -69,75 +182,181 @@ impl ManagedProcess {
         cmd.stdout(stdio_from_str(&self.config.stdout));
         cmd.stderr(stdio_from_str(&self.config.stderr));
 
-        let child = cmd
-            .spawn()
-            .with_context(|| format!("[{}] failed to spawn: {}", self.name, self.config.command))?;
-
-        let pid = child.id().unwrap_or(0);
-        info!(
-            "[{}] spawned (pid={}, cmd={})",
-            self.name, pid, self.config.command
-        );
-        self.child = Some(child);
-        Ok(())
+        Ok(cmd)
     }
 
     pub fn is_running(&self) -> bool {
+        self.state.is_alive()
+    }
+
+    /// Hand the child handle to a watcher task.
+    /// The process remains in `Running` state — only the handle moves.
+    pub fn take_child(&mut self) -> Option<Child> {
+        self.child.take()
+    }
+
+    fn has_child_handle(&self) -> bool {
         self.child.is_some()
     }
 
-    /// Send a signal to the child process. The caller must still call `wait()`
-    /// afterward to reap the child and avoid zombie processes. This is kept
-    /// separate from `wait()` so `shutdown_all()` can fan out SIGTERM to all
-    /// processes before blocking on each.
+    pub(crate) fn set_watcher_handle(&mut self, handle: JoinHandle<()>) {
+        self.watcher_handle = Some(handle);
+    }
+
+    fn take_watcher_handle(&mut self) -> Option<JoinHandle<()>> {
+        self.watcher_handle.take()
+    }
+
+    /// Record that the child exited. Transitions state to Exited or Failed.
+    pub fn set_last_status(&mut self, status: std::process::ExitStatus) {
+        if status.success() {
+            self.transition_to(ProcessState::Exited);
+        } else {
+            self.transition_to(ProcessState::Failed);
+        }
+    }
+
+    /// Send SIGTERM if the process is running.
+    pub fn request_stop(&self) {
+        if self.is_running() {
+            info!("[{}] sending SIGTERM", self.name);
+            self.send_signal(Signal::SIGTERM);
+        }
+    }
+
+    /// Send a signal using the stored PID (works even after take_child).
+    /// The caller must still call `wait()` afterward to reap the child and
+    /// avoid zombie processes. This is kept separate from `wait()` so
+    /// `shutdown_all()` can fan out SIGTERM to all processes before blocking
+    /// on each.
     pub fn send_signal(&self, sig: Signal) {
-        if let Some(ref child) = self.child
-            && let Some(pid) = child.id()
-            && let Err(e) = signal::kill(Pid::from_raw(pid as i32), sig)
+        if let Some(raw_pid) = self.pid
+            && let Err(e) = signal::kill(Pid::from_raw(raw_pid as i32), sig)
         {
             warn!("[{}] failed to send {sig}: {e}", self.name);
         }
     }
 
-    /// Wait for the child to exit. Returns the exit status.
+    /// Wait for the child to exit. Only works when we still hold the handle.
     pub async fn wait(&mut self) -> Result<std::process::ExitStatus> {
-        let child = self.child.as_mut().context("no child process to wait on")?;
+        let child = self.child.as_mut().context("no child handle to wait on")?;
         let status = child.wait().await?;
         info!("[{}] exited with {status}", self.name);
         self.child = None;
         Ok(status)
     }
 
-    pub fn stop_timeout(&self) -> Duration {
-        Duration::from_secs(
-            self.config
-                .stop_timeout
-                .unwrap_or(DEFAULT_STOP_TIMEOUT_SECS),
-        )
+    fn stop_timeout(&self) -> Duration {
+        self.config.stop_timeout()
     }
-}
 
-/// Parse a systemd-style environment file into key-value pairs.
-/// Supports `KEY=VALUE`, `KEY="VALUE"`, `KEY='VALUE'`, comments (#), and blank lines.
-fn parse_environment_file(path: &str) -> Result<Vec<(String, String)>> {
-    let contents = std::fs::read_to_string(path)
-        .with_context(|| format!("reading environment file: {path}"))?;
-    let mut vars = Vec::new();
-    for line in contents.lines() {
-        let trimmed = line.trim();
-        if trimmed.is_empty() || trimmed.starts_with('#') {
-            continue;
+    /// Wait for the process to stop after SIGTERM has been sent.
+    /// Escalates to SIGKILL if the process doesn't exit within `stop_timeout`.
+    pub async fn wait_for_stop(&mut self) {
+        if !self.is_running() {
+            return;
         }
-        if let Some((key, raw_val)) = trimmed.split_once('=') {
-            let val = raw_val
-                .trim()
-                .trim_matches('"')
-                .trim_matches('\'')
-                .to_string();
-            vars.push((key.trim().to_string(), val));
+        let stop = self.stop_timeout();
+        if let Some(handle) = self.take_watcher_handle() {
+            tokio::pin!(handle);
+            if time::timeout(stop, &mut handle).await.is_err() {
+                warn!(
+                    "[{}] stop timeout ({}s) reached, sending SIGKILL",
+                    self.name,
+                    stop.as_secs()
+                );
+                self.send_signal(Signal::SIGKILL);
+                if time::timeout(Self::SIGKILL_TIMEOUT, handle).await.is_err() {
+                    warn!("[{}] still running after SIGKILL, giving up", self.name);
+                }
+            }
+        } else if self.has_child_handle() && time::timeout(stop, self.wait()).await.is_err() {
+            warn!(
+                "[{}] stop timeout ({}s) reached, sending SIGKILL",
+                self.name,
+                stop.as_secs()
+            );
+            self.send_signal(Signal::SIGKILL);
+            if time::timeout(Self::SIGKILL_TIMEOUT, self.wait())
+                .await
+                .is_err()
+            {
+                warn!("[{}] still running after SIGKILL, giving up", self.name);
+            }
+        }
+        self.mark_stopped();
+    }
+
+    fn mark_stopped(&mut self) {
+        self.transition_to(ProcessState::Stopped);
+        self.pid = None;
+    }
+
+    #[cfg(test)]
+    pub fn should_restart(&self, status: &std::process::ExitStatus) -> bool {
+        match self.config.restart {
+            RestartPolicy::Never => false,
+            RestartPolicy::Always => true,
+            RestartPolicy::OnFailure => !status.success(),
+            RestartPolicy::OnSuccess => status.success(),
         }
     }
-    Ok(vars)
+
+    #[cfg(test)]
+    pub fn restart_policy(&self) -> &RestartPolicy {
+        &self.config.restart
+    }
+
+    /// Single entry point for restart logic: check policy, burst limit, backoff, respawn.
+    /// Returns true if the process was restarted.
+    pub async fn handle_restart(&mut self) -> bool {
+        let should_restart = match (self.state, &self.config.restart) {
+            (ProcessState::Exited | ProcessState::Failed, RestartPolicy::Always) => true,
+            (ProcessState::Failed, RestartPolicy::OnFailure) => true,
+            (ProcessState::Exited, RestartPolicy::OnSuccess) => true,
+            (ProcessState::Exited | ProcessState::Failed, _) => false,
+            _ => return false,
+        };
+
+        if !should_restart {
+            if self.config.restart != RestartPolicy::Never {
+                info!(
+                    "[{}] exit does not match restart policy, not restarting",
+                    self.name
+                );
+            }
+            return false;
+        }
+
+        if self
+            .restarts
+            .is_burst_limited(self.config.burst_limit(), self.config.burst_interval())
+        {
+            warn!("[{}] start limit reached, not restarting", self.name);
+            return false;
+        }
+
+        self.restarts
+            .record(self.config.restart_delay(), self.config.runtime_success());
+        let delay = self.restarts.delay();
+        info!(
+            "[{}] restart #{} in {:.1}s",
+            self.name,
+            self.restarts.count,
+            delay.as_secs_f64()
+        );
+        tokio::time::sleep(delay).await;
+        self.restarts
+            .advance_backoff(self.config.max_restart_delay());
+
+        match self.spawn() {
+            Ok(()) => true,
+            Err(e) => {
+                warn!("[{}] restart failed: {e:#}", self.name);
+                false
+            }
+        }
+    }
 }
 
 fn stdio_from_str(s: &str) -> Stdio {
@@ -147,41 +366,13 @@ fn stdio_from_str(s: &str) -> Stdio {
     }
 }
 
-/// Send SIGTERM to all running processes, wait per-process `stop_timeout`, then SIGKILL stragglers.
-pub async fn shutdown_all(processes: &mut [ManagedProcess]) {
-    for proc in processes.iter() {
-        if proc.is_running() {
-            info!("[{}] sending SIGTERM", proc.name);
-            proc.send_signal(Signal::SIGTERM);
-        }
-    }
-
-    for proc in processes.iter_mut() {
-        if !proc.is_running() {
-            continue;
-        }
-        let stop = proc.stop_timeout();
-        if timeout(stop, proc.wait()).await.is_err() {
-            warn!(
-                "[{}] stop timeout ({}s) reached, sending SIGKILL",
-                proc.name,
-                stop.as_secs()
-            );
-            proc.send_signal(Signal::SIGKILL);
-            if timeout(SIGKILL_TIMEOUT, proc.wait()).await.is_err() {
-                warn!("[{}] still running after SIGKILL, giving up", proc.name);
-            }
-        }
-    }
-}
-
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use super::*;
     use crate::config::ProcessConfig;
     use std::collections::HashMap;
 
-    fn make_config(command: &str, args: Vec<&str>) -> ProcessConfig {
+    pub fn make_config(command: &str, args: Vec<&str>) -> ProcessConfig {
         ProcessConfig {
             description: None,
             command: command.to_string(),
@@ -195,7 +386,94 @@ mod tests {
             auto_start: true,
             condition_path_exists: None,
             stop_timeout: None,
+            restart: RestartPolicy::Never,
+            restart_sec: None,
+            restart_max_delay_sec: None,
+            start_limit_burst: None,
+            start_limit_interval_sec: None,
+            runtime_success_sec: None,
         }
+    }
+
+    fn exit_status(code: i32) -> std::process::ExitStatus {
+        std::process::Command::new("/bin/sh")
+            .args(["-c", &format!("exit {code}")])
+            .status()
+            .unwrap()
+    }
+
+    // -- state lifecycle tests --
+
+    #[test]
+    fn test_initial_state_is_created() {
+        let proc = ManagedProcess::new("test".into(), make_config("/bin/true", vec![]));
+        assert_eq!(proc.state(), ProcessState::Created);
+        assert!(!proc.is_running());
+    }
+
+    #[tokio::test]
+    async fn test_state_transitions_spawn_exit_success() {
+        let mut proc =
+            ManagedProcess::new("t".into(), make_config("/bin/sh", vec!["-c", "exit 0"]));
+        assert_eq!(proc.state(), ProcessState::Created);
+
+        proc.spawn().unwrap();
+        assert_eq!(proc.state(), ProcessState::Running);
+        assert!(proc.is_running());
+
+        let status = proc.wait().await.unwrap();
+        assert!(status.success());
+        proc.set_last_status(status);
+        assert_eq!(proc.state(), ProcessState::Exited);
+        assert!(!proc.is_running());
+    }
+
+    #[tokio::test]
+    async fn test_state_transitions_spawn_exit_failure() {
+        let mut proc =
+            ManagedProcess::new("t".into(), make_config("/bin/sh", vec!["-c", "exit 1"]));
+        proc.spawn().unwrap();
+        assert_eq!(proc.state(), ProcessState::Running);
+
+        let status = proc.wait().await.unwrap();
+        assert!(!status.success());
+        proc.set_last_status(status);
+        assert_eq!(proc.state(), ProcessState::Failed);
+    }
+
+    #[tokio::test]
+    async fn test_state_after_take_child_still_running() {
+        let mut proc = ManagedProcess::new("t".into(), make_config("/bin/sleep", vec!["60"]));
+        proc.spawn().unwrap();
+        assert_eq!(proc.state(), ProcessState::Running);
+
+        let child = proc.take_child();
+        assert!(child.is_some());
+        assert_eq!(
+            proc.state(),
+            ProcessState::Running,
+            "state should remain Running after take_child"
+        );
+        assert!(proc.is_running());
+
+        // Clean up
+        proc.send_signal(Signal::SIGKILL);
+        let mut child = child.unwrap();
+        let _ = child.wait().await;
+    }
+
+    #[tokio::test]
+    async fn test_send_signal_works_after_take_child() {
+        let mut proc = ManagedProcess::new("t".into(), make_config("/bin/sleep", vec!["60"]));
+        proc.spawn().unwrap();
+        let mut child = proc.take_child().unwrap();
+
+        proc.send_signal(Signal::SIGTERM);
+        let status = child.wait().await.unwrap();
+        assert!(
+            !status.success(),
+            "signal by stored PID should reach child after take_child"
+        );
     }
 
     // -- should_start tests --
@@ -244,7 +522,6 @@ mod tests {
         proc.send_signal(Signal::SIGKILL);
         let status = proc.wait().await.unwrap();
         assert!(!status.success());
-        assert!(!proc.is_running());
     }
 
     #[tokio::test]
@@ -253,14 +530,13 @@ mod tests {
         let mut proc = ManagedProcess::new("bad".into(), cfg);
         assert!(proc.spawn().is_err());
         assert!(!proc.is_running());
+        assert_eq!(proc.state(), ProcessState::Created);
     }
 
     #[tokio::test]
     async fn test_spawn_with_env() {
         let mut cfg = make_config("/bin/sh", vec!["-c", "exit $MY_EXIT_CODE"]);
         cfg.env.insert("MY_EXIT_CODE".to_string(), "42".to_string());
-        cfg.stdout = "null".to_string();
-        cfg.stderr = "null".to_string();
 
         let mut proc = ManagedProcess::new("env-test".into(), cfg);
         proc.spawn().unwrap();
@@ -296,43 +572,7 @@ mod tests {
         proc.send_signal(Signal::SIGTERM);
     }
 
-    // -- shutdown_all tests --
-
-    #[tokio::test]
-    async fn test_shutdown_all_graceful() {
-        let cfg1 = make_config("/bin/sleep", vec!["60"]);
-        let cfg2 = make_config("/bin/sleep", vec!["60"]);
-
-        let mut p1 = ManagedProcess::new("p1".into(), cfg1);
-        let mut p2 = ManagedProcess::new("p2".into(), cfg2);
-        p1.spawn().unwrap();
-        p2.spawn().unwrap();
-
-        let mut procs = vec![p1, p2];
-        shutdown_all(&mut procs).await;
-
-        assert!(!procs[0].is_running());
-        assert!(!procs[1].is_running());
-    }
-
-    #[tokio::test]
-    async fn test_shutdown_all_empty() {
-        let mut procs: Vec<ManagedProcess> = vec![];
-        shutdown_all(&mut procs).await;
-    }
-
-    #[tokio::test]
-    async fn test_shutdown_all_sigkill_on_timeout() {
-        let mut cfg = make_config("/bin/sh", vec!["-c", "trap '' TERM; sleep 60"]);
-        cfg.stop_timeout = Some(1);
-        let mut proc = ManagedProcess::new("stubborn".into(), cfg);
-        proc.spawn().unwrap();
-
-        let mut procs = vec![proc];
-        shutdown_all(&mut procs).await;
-
-        assert!(!procs[0].is_running());
-    }
+    // -- env tests --
 
     #[tokio::test]
     async fn test_spawn_does_not_inherit_parent_env() {
@@ -367,8 +607,6 @@ mod tests {
             vec!["-c", "test \"$FROM_FILE\" = 'hello' && echo $PATH"],
         );
         cfg.environment_file = Some(env_file.to_str().unwrap().to_string());
-        cfg.stdout = "null".to_string();
-        cfg.stderr = "null".to_string();
 
         let mut proc = ManagedProcess::new("envfile".into(), cfg);
         proc.spawn().unwrap();
@@ -396,8 +634,6 @@ mod tests {
         cfg.environment_file = Some(env_file.to_str().unwrap().to_string());
         cfg.env
             .insert("MY_VAR".to_string(), "overridden".to_string());
-        cfg.stdout = "null".to_string();
-        cfg.stderr = "null".to_string();
 
         let mut proc = ManagedProcess::new("override".into(), cfg);
         proc.spawn().unwrap();
@@ -407,41 +643,6 @@ mod tests {
             Some(0),
             "config env should override environment_file"
         );
-    }
-
-    #[test]
-    fn test_parse_environment_file_full() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("env");
-        std::fs::write(
-            &path,
-            r#"# Datadog env
-DD_API_KEY=abc123
-PATH="/usr/local/bin:/usr/bin"
-QUOTED='single'
-malformed line without equals
-   
-# blank lines above are skipped
-LANG=en_US.UTF-8
-"#,
-        )
-        .unwrap();
-
-        let vars: HashMap<String, String> = parse_environment_file(path.to_str().unwrap())
-            .unwrap()
-            .into_iter()
-            .collect();
-
-        assert_eq!(vars["DD_API_KEY"], "abc123");
-        assert_eq!(vars["PATH"], "/usr/local/bin:/usr/bin");
-        assert_eq!(vars["QUOTED"], "single");
-        assert_eq!(vars["LANG"], "en_US.UTF-8");
-        assert_eq!(vars.len(), 4, "malformed line should be silently skipped");
-    }
-
-    #[test]
-    fn test_parse_environment_file_missing() {
-        assert!(parse_environment_file("/nonexistent/env").is_err());
     }
 
     #[tokio::test]
@@ -454,5 +655,161 @@ LANG=en_US.UTF-8
             "spawn should fail if environment_file is unreadable"
         );
         assert!(!proc.is_running());
+    }
+
+    // -- restart policy tests --
+
+    #[test]
+    fn test_should_restart_never() {
+        let cfg = make_config("/bin/sh", vec![]);
+        let proc = ManagedProcess::new("t".into(), cfg);
+        assert!(!proc.should_restart(&exit_status(1)));
+    }
+
+    #[test]
+    fn test_should_restart_always_on_success() {
+        let mut cfg = make_config("/bin/sh", vec![]);
+        cfg.restart = RestartPolicy::Always;
+        let proc = ManagedProcess::new("t".into(), cfg);
+        assert!(proc.should_restart(&exit_status(0)));
+    }
+
+    #[test]
+    fn test_should_restart_always_on_failure() {
+        let mut cfg = make_config("/bin/sh", vec![]);
+        cfg.restart = RestartPolicy::Always;
+        let proc = ManagedProcess::new("t".into(), cfg);
+        assert!(proc.should_restart(&exit_status(1)));
+    }
+
+    #[test]
+    fn test_should_restart_on_failure_with_failure() {
+        let mut cfg = make_config("/bin/sh", vec![]);
+        cfg.restart = RestartPolicy::OnFailure;
+        let proc = ManagedProcess::new("t".into(), cfg);
+        assert!(proc.should_restart(&exit_status(1)));
+    }
+
+    #[test]
+    fn test_should_restart_on_failure_with_success() {
+        let mut cfg = make_config("/bin/sh", vec![]);
+        cfg.restart = RestartPolicy::OnFailure;
+        let proc = ManagedProcess::new("t".into(), cfg);
+        assert!(!proc.should_restart(&exit_status(0)));
+    }
+
+    #[test]
+    fn test_should_restart_on_success_with_success() {
+        let mut cfg = make_config("/bin/sh", vec![]);
+        cfg.restart = RestartPolicy::OnSuccess;
+        let proc = ManagedProcess::new("t".into(), cfg);
+        assert!(proc.should_restart(&exit_status(0)));
+    }
+
+    #[test]
+    fn test_should_restart_on_success_with_failure() {
+        let mut cfg = make_config("/bin/sh", vec![]);
+        cfg.restart = RestartPolicy::OnSuccess;
+        let proc = ManagedProcess::new("t".into(), cfg);
+        assert!(!proc.should_restart(&exit_status(1)));
+    }
+
+    #[test]
+    fn test_burst_limiting() {
+        let mut cfg = make_config("/bin/true", vec![]);
+        cfg.restart = RestartPolicy::Always;
+        cfg.start_limit_burst = Some(3);
+        cfg.start_limit_interval_sec = Some(60);
+        let mut proc = ManagedProcess::new("burst".into(), cfg);
+
+        let burst = proc.config.burst_limit();
+        let interval = proc.config.burst_interval();
+
+        assert!(!proc.restarts.is_burst_limited(burst, interval));
+        proc.restarts
+            .record(proc.config.restart_delay(), proc.config.runtime_success());
+        assert!(!proc.restarts.is_burst_limited(burst, interval));
+        proc.restarts
+            .record(proc.config.restart_delay(), proc.config.runtime_success());
+        assert!(!proc.restarts.is_burst_limited(burst, interval));
+        proc.restarts
+            .record(proc.config.restart_delay(), proc.config.runtime_success());
+        assert!(
+            proc.restarts.is_burst_limited(burst, interval),
+            "should be limited after 3 restarts"
+        );
+    }
+
+    #[test]
+    fn test_backoff_increases() {
+        let mut cfg = make_config("/bin/true", vec![]);
+        cfg.restart = RestartPolicy::Always;
+        cfg.restart_sec = Some(1.0);
+        cfg.restart_max_delay_sec = Some(10.0);
+        let mut proc = ManagedProcess::new("backoff".into(), cfg);
+
+        assert!((proc.restarts.current_delay - 1.0).abs() < 0.001);
+        proc.restarts.advance_backoff(10.0);
+        assert!((proc.restarts.current_delay - 2.0).abs() < 0.001);
+        proc.restarts.advance_backoff(10.0);
+        assert!((proc.restarts.current_delay - 4.0).abs() < 0.001);
+        proc.restarts.advance_backoff(10.0);
+        assert!((proc.restarts.current_delay - 8.0).abs() < 0.001);
+        proc.restarts.advance_backoff(10.0);
+        assert!(
+            (proc.restarts.current_delay - 10.0).abs() < 0.001,
+            "should cap at max_delay"
+        );
+    }
+
+    #[test]
+    fn test_backoff_resets_on_long_runtime() {
+        let mut cfg = make_config("/bin/true", vec![]);
+        cfg.restart = RestartPolicy::Always;
+        cfg.restart_sec = Some(1.0);
+        cfg.runtime_success_sec = Some(0);
+        let mut proc = ManagedProcess::new("reset".into(), cfg);
+
+        proc.restarts.last_spawn_time = Some(Instant::now() - Duration::from_secs(5));
+        proc.restarts.current_delay = 16.0;
+        proc.restarts.count = 5;
+
+        proc.restarts
+            .record(proc.config.restart_delay(), proc.config.runtime_success());
+        assert!(
+            (proc.restarts.current_delay - 1.0).abs() < 0.001,
+            "delay should reset after long runtime"
+        );
+        assert_eq!(proc.restarts.count, 1, "counter should reset to 1");
+    }
+
+    #[test]
+    fn test_restart_config_defaults() {
+        let cfg = make_config("/bin/true", vec![]);
+        let proc = ManagedProcess::new("defaults".into(), cfg);
+        assert_eq!(*proc.restart_policy(), RestartPolicy::Never);
+        assert!((proc.restarts.current_delay - 1.0).abs() < 0.001);
+        assert_eq!(proc.restarts.count, 0);
+    }
+
+    #[test]
+    fn test_restart_config_from_yaml() {
+        let yaml = r#"
+command: /bin/sleep
+args: ["60"]
+restart: on-failure
+restart_sec: 2.5
+restart_max_delay_sec: 30
+start_limit_burst: 10
+start_limit_interval_sec: 120
+runtime_success_sec: 5
+"#;
+        let cfg: ProcessConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(cfg.restart, RestartPolicy::OnFailure);
+        assert_eq!(cfg.restart_sec, Some(2.5));
+        assert_eq!(cfg.restart_max_delay_sec, Some(30.0));
+        assert_eq!(cfg.start_limit_burst, Some(10));
+        assert_eq!(cfg.start_limit_interval_sec, Some(120));
+        assert_eq!(cfg.runtime_success_sec, Some(5));
     }
 }

--- a/pkg/procmgr/rust/src/shutdown.rs
+++ b/pkg/procmgr/rust/src/shutdown.rs
@@ -1,0 +1,77 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+use crate::process::ManagedProcess;
+
+/// Send SIGTERM to all running processes, wait per-process `stop_timeout`, then SIGKILL stragglers.
+pub async fn shutdown_all(processes: &mut [ManagedProcess]) {
+    for proc in processes.iter() {
+        proc.request_stop();
+    }
+    for proc in processes.iter_mut() {
+        proc.wait_for_stop().await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::process::tests::make_config;
+    use crate::state::ProcessState;
+
+    #[tokio::test]
+    async fn test_shutdown_all_graceful() {
+        let cfg1 = make_config("/bin/sleep", vec!["60"]);
+        let cfg2 = make_config("/bin/sleep", vec!["60"]);
+
+        let mut p1 = ManagedProcess::new("p1".into(), cfg1);
+        let mut p2 = ManagedProcess::new("p2".into(), cfg2);
+        p1.spawn().unwrap();
+        p2.spawn().unwrap();
+
+        let mut procs = vec![p1, p2];
+        shutdown_all(&mut procs).await;
+
+        assert_eq!(procs[0].state(), ProcessState::Stopped);
+        assert_eq!(procs[1].state(), ProcessState::Stopped);
+        assert!(!procs[0].is_running());
+        assert!(!procs[1].is_running());
+    }
+
+    #[tokio::test]
+    async fn test_shutdown_all_empty() {
+        let mut procs: Vec<ManagedProcess> = vec![];
+        shutdown_all(&mut procs).await;
+    }
+
+    #[tokio::test]
+    async fn test_shutdown_all_sigkill_on_timeout() {
+        let mut cfg = make_config("/bin/sh", vec!["-c", "trap '' TERM; sleep 60"]);
+        cfg.stop_timeout = Some(1);
+        let mut proc = ManagedProcess::new("stubborn".into(), cfg);
+        proc.spawn().unwrap();
+
+        let mut procs = vec![proc];
+        shutdown_all(&mut procs).await;
+
+        assert_eq!(procs[0].state(), ProcessState::Stopped);
+    }
+
+    #[tokio::test]
+    async fn test_shutdown_all_after_take_child() {
+        let mut proc = ManagedProcess::new("t".into(), make_config("/bin/sleep", vec!["60"]));
+        proc.spawn().unwrap();
+        let _child = proc.take_child();
+
+        assert!(proc.is_running(), "state should still be Running");
+        let mut procs = vec![proc];
+        shutdown_all(&mut procs).await;
+        assert_eq!(
+            procs[0].state(),
+            ProcessState::Stopped,
+            "shutdown should transition to Stopped even without child handle"
+        );
+    }
+}

--- a/pkg/procmgr/rust/src/state.rs
+++ b/pkg/procmgr/rust/src/state.rs
@@ -1,0 +1,52 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProcessState {
+    /// Config loaded, never started.
+    Created,
+    /// Child process is alive.
+    Running,
+    /// Exited with code 0.
+    Exited,
+    /// Exited with non-zero code or signal.
+    Failed,
+    /// Explicitly stopped during shutdown.
+    Stopped,
+}
+
+impl ProcessState {
+    pub fn is_alive(self) -> bool {
+        self == ProcessState::Running
+    }
+
+    pub(crate) fn can_transition_to(self, next: ProcessState) -> bool {
+        use ProcessState::*;
+        matches!(
+            (self, next),
+            (Created, Running)
+                | (Running, Exited)
+                | (Running, Failed)
+                | (Running, Stopped)
+                | (Exited, Running)
+                | (Failed, Running)
+                | (Stopped, Running)
+        )
+    }
+}
+
+impl fmt::Display for ProcessState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ProcessState::Created => write!(f, "created"),
+            ProcessState::Running => write!(f, "running"),
+            ProcessState::Exited => write!(f, "exited"),
+            ProcessState::Failed => write!(f, "failed"),
+            ProcessState::Stopped => write!(f, "stopped"),
+        }
+    }
+}

--- a/pkg/procmgr/rust/tests/helpers/mod.rs
+++ b/pkg/procmgr/rust/tests/helpers/mod.rs
@@ -1,0 +1,197 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+use nix::sys::signal::{self, Signal};
+use nix::unistd::Pid;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+use std::process::{Child, Command, Stdio};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Handle to a running dd-procmgrd daemon process.
+pub struct DaemonHandle {
+    child: Child,
+    log_lines: Arc<Mutex<Vec<String>>>,
+    _reader_thread: std::thread::JoinHandle<()>,
+    _stderr_thread: std::thread::JoinHandle<()>,
+}
+
+impl DaemonHandle {
+    /// Start the daemon with `DD_PM_CONFIG_DIR` pointing to the given directory.
+    pub fn start(config_dir: &Path) -> Self {
+        let bin = env!("CARGO_BIN_EXE_dd-procmgrd");
+        let mut child = Command::new(bin)
+            .env("DD_PM_CONFIG_DIR", config_dir)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("failed to start dd-procmgrd");
+
+        let stdout = child.stdout.take().expect("failed to capture stdout");
+        let stderr = child.stderr.take().expect("failed to capture stderr");
+        let log_lines = Arc::new(Mutex::new(Vec::<String>::new()));
+        let lines_clone = Arc::clone(&log_lines);
+        let lines_clone2 = Arc::clone(&log_lines);
+
+        // simple_logger writes INFO to stdout, WARN/ERROR to stderr.
+        let reader_thread = std::thread::spawn(move || {
+            let reader = BufReader::new(stdout);
+            for line in reader.lines() {
+                match line {
+                    Ok(l) => {
+                        eprintln!("[daemon] {l}");
+                        lines_clone.lock().unwrap().push(l);
+                    }
+                    Err(_) => break,
+                }
+            }
+        });
+
+        let _stderr_thread = std::thread::spawn(move || {
+            let reader = BufReader::new(stderr);
+            for line in reader.lines() {
+                match line {
+                    Ok(l) => {
+                        eprintln!("[daemon:err] {l}");
+                        lines_clone2.lock().unwrap().push(l);
+                    }
+                    Err(_) => break,
+                }
+            }
+        });
+
+        Self {
+            child,
+            log_lines,
+            _reader_thread: reader_thread,
+            _stderr_thread,
+        }
+    }
+
+    /// Wait until a log line containing `pattern` appears, or timeout.
+    pub fn wait_for_log(&self, pattern: &str, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        loop {
+            {
+                let lines = self.log_lines.lock().unwrap();
+                if lines.iter().any(|l| l.contains(pattern)) {
+                    return true;
+                }
+            }
+            if Instant::now() >= deadline {
+                return false;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    }
+
+    /// Wait until a log line containing `pattern` appears using the default timeout.
+    pub fn wait_for_log_default(&self, pattern: &str) -> bool {
+        self.wait_for_log(pattern, DEFAULT_TIMEOUT)
+    }
+
+    /// Count how many log lines contain `pattern`.
+    pub fn count_log_matches(&self, pattern: &str) -> usize {
+        let lines = self.log_lines.lock().unwrap();
+        lines.iter().filter(|l| l.contains(pattern)).count()
+    }
+
+    /// Wait until the count of log lines matching `pattern` reaches at least `n`.
+    pub fn wait_for_log_count(&self, pattern: &str, n: usize, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        loop {
+            if self.count_log_matches(pattern) >= n {
+                return true;
+            }
+            if Instant::now() >= deadline {
+                return false;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    }
+
+    /// Send a signal to the daemon process.
+    pub fn send_signal(&self, sig: Signal) {
+        let pid = self.child.id() as i32;
+        signal::kill(Pid::from_raw(pid), sig).expect("failed to send signal to daemon");
+    }
+
+    /// Send SIGTERM and wait for the daemon to exit. Returns the exit status.
+    pub fn stop(&mut self) -> std::process::ExitStatus {
+        self.send_signal(Signal::SIGTERM);
+        self.wait_with_timeout(DEFAULT_TIMEOUT)
+    }
+
+    /// Wait for the daemon to exit within the given timeout.
+    pub fn wait_with_timeout(&mut self, timeout: Duration) -> std::process::ExitStatus {
+        let deadline = Instant::now() + timeout;
+        loop {
+            match self
+                .child
+                .try_wait()
+                .expect("failed to check daemon status")
+            {
+                Some(status) => return status,
+                None => {
+                    if Instant::now() >= deadline {
+                        self.child.kill().ok();
+                        return self.child.wait().expect("failed to wait on killed daemon");
+                    }
+                    std::thread::sleep(Duration::from_millis(50));
+                }
+            }
+        }
+    }
+
+    /// Extract PIDs from "spawned (pid=NNN" log lines.
+    pub fn spawned_pids(&self) -> Vec<u32> {
+        let lines = self.log_lines.lock().unwrap();
+        lines
+            .iter()
+            .filter_map(|l| {
+                let marker = "spawned (pid=";
+                let start = l.find(marker)? + marker.len();
+                let end = l[start..].find(|c: char| !c.is_ascii_digit())? + start;
+                l[start..end].parse().ok()
+            })
+            .collect()
+    }
+}
+
+impl Drop for DaemonHandle {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// Write a YAML config file into `dir` with the given process `name`.
+pub fn write_config(dir: &Path, name: &str, yaml: &str) {
+    let path = dir.join(format!("{name}.yaml"));
+    std::fs::write(&path, yaml)
+        .unwrap_or_else(|e| panic!("failed to write {}: {e}", path.display()));
+}
+
+/// Check if a PID is still alive.
+pub fn pid_is_alive(pid: u32) -> bool {
+    signal::kill(Pid::from_raw(pid as i32), None).is_ok()
+}
+
+/// Wait until a PID is no longer alive, or timeout.
+pub fn wait_for_pid_gone(pid: u32, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if !pid_is_alive(pid) {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}

--- a/pkg/procmgr/rust/tests/integration.rs
+++ b/pkg/procmgr/rust/tests/integration.rs
@@ -1,0 +1,557 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+mod helpers;
+
+use helpers::{DaemonHandle, pid_is_alive, wait_for_pid_gone, write_config};
+use std::time::Duration;
+
+// ===========================================================================
+// Group 1: Basic Lifecycle
+// ===========================================================================
+
+#[test]
+fn test_daemon_starts_and_spawns_process() {
+    let dir = tempfile::tempdir().unwrap();
+    write_config(
+        dir.path(),
+        "sleeper",
+        "command: /bin/sleep\nargs:\n  - '300'\n",
+    );
+
+    let mut daemon = DaemonHandle::start(dir.path());
+    assert!(
+        daemon.wait_for_log_default("spawned"),
+        "daemon should log spawned"
+    );
+
+    let pids = daemon.spawned_pids();
+    assert_eq!(pids.len(), 1, "expected 1 spawned process");
+    assert!(pid_is_alive(pids[0]), "managed process should be alive");
+
+    let status = daemon.stop();
+    assert!(status.success(), "daemon should exit cleanly");
+    assert!(
+        wait_for_pid_gone(pids[0], Duration::from_secs(5)),
+        "managed process should be gone after shutdown"
+    );
+}
+
+#[test]
+fn test_daemon_no_config_dir() {
+    let dir = tempfile::tempdir().unwrap();
+    let nonexistent = dir.path().join("nonexistent");
+
+    let mut daemon = DaemonHandle::start(&nonexistent);
+    assert!(
+        daemon.wait_for_log_default("does not exist"),
+        "daemon should log missing config dir"
+    );
+
+    let status = daemon.stop();
+    assert!(status.success(), "daemon should exit cleanly");
+}
+
+#[test]
+fn test_daemon_empty_config_dir() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let mut daemon = DaemonHandle::start(dir.path());
+    assert!(
+        daemon.wait_for_log_default("loaded 0 process config(s)"),
+        "daemon should log zero configs"
+    );
+
+    let status = daemon.stop();
+    assert!(status.success(), "daemon should exit cleanly");
+}
+
+// ===========================================================================
+// Group 2: Graceful Shutdown
+// ===========================================================================
+
+#[test]
+fn test_shutdown_stops_managed_processes() {
+    let dir = tempfile::tempdir().unwrap();
+    write_config(
+        dir.path(),
+        "sleep1",
+        "command: /bin/sleep\nargs:\n  - '300'\n",
+    );
+    write_config(
+        dir.path(),
+        "sleep2",
+        "command: /bin/sleep\nargs:\n  - '300'\n",
+    );
+
+    let mut daemon = DaemonHandle::start(dir.path());
+    assert!(
+        daemon.wait_for_log("loaded 2 process config(s)", Duration::from_secs(5)),
+        "daemon should load 2 configs"
+    );
+    assert!(
+        daemon.wait_for_log_count("spawned", 2, Duration::from_secs(5)),
+        "daemon should spawn 2 processes"
+    );
+
+    let pids = daemon.spawned_pids();
+    assert_eq!(pids.len(), 2);
+    for &pid in &pids {
+        assert!(
+            pid_is_alive(pid),
+            "pid {pid} should be alive before shutdown"
+        );
+    }
+
+    let status = daemon.stop();
+    assert!(status.success(), "daemon should exit cleanly");
+
+    for &pid in &pids {
+        assert!(
+            wait_for_pid_gone(pid, Duration::from_secs(5)),
+            "pid {pid} should be gone after shutdown"
+        );
+    }
+}
+
+#[test]
+fn test_shutdown_sends_sigterm_to_children() {
+    let dir = tempfile::tempdir().unwrap();
+    write_config(
+        dir.path(),
+        "sleeper",
+        "command: /bin/sleep\nargs:\n  - '300'\n",
+    );
+
+    let mut daemon = DaemonHandle::start(dir.path());
+    assert!(
+        daemon.wait_for_log_default("spawned"),
+        "daemon should spawn the process"
+    );
+
+    let pids = daemon.spawned_pids();
+    assert_eq!(pids.len(), 1);
+
+    let status = daemon.stop();
+    assert!(
+        daemon.wait_for_log("sending SIGTERM", Duration::from_secs(0)),
+        "daemon should log sending SIGTERM during shutdown"
+    );
+    assert!(status.success(), "daemon should exit cleanly");
+}
+
+// ===========================================================================
+// Group 3: Restart Policies
+// ===========================================================================
+
+#[test]
+fn test_restart_always_on_failure() {
+    let dir = tempfile::tempdir().unwrap();
+    write_config(
+        dir.path(),
+        "crasher",
+        "command: /bin/sh\nargs:\n  - '-c'\n  - 'exit 1'\nrestart: always\nrestart_sec: 0.1\n",
+    );
+
+    let mut daemon = DaemonHandle::start(dir.path());
+    assert!(
+        daemon.wait_for_log_count("spawned", 3, Duration::from_secs(10)),
+        "process should be restarted at least 3 times, got {}",
+        daemon.count_log_matches("spawned")
+    );
+
+    let status = daemon.stop();
+    assert!(status.success());
+}
+
+#[test]
+fn test_restart_never() {
+    let dir = tempfile::tempdir().unwrap();
+    write_config(
+        dir.path(),
+        "once",
+        "command: /bin/sh\nargs:\n  - '-c'\n  - 'exit 0'\nrestart: never\n",
+    );
+
+    let mut daemon = DaemonHandle::start(dir.path());
+    assert!(
+        daemon.wait_for_log_default("exited with"),
+        "process should exit"
+    );
+    // Wait a bit to make sure no restart happens.
+    std::thread::sleep(Duration::from_secs(1));
+    assert_eq!(
+        daemon.count_log_matches("spawned"),
+        1,
+        "process should NOT be restarted"
+    );
+
+    let status = daemon.stop();
+    assert!(status.success());
+}
+
+#[test]
+fn test_restart_on_failure_with_success_exit() {
+    let dir = tempfile::tempdir().unwrap();
+    write_config(
+        dir.path(),
+        "success",
+        "command: /bin/sh\nargs:\n  - '-c'\n  - 'exit 0'\nrestart: on-failure\n",
+    );
+
+    let mut daemon = DaemonHandle::start(dir.path());
+    assert!(
+        daemon.wait_for_log_default("exited with"),
+        "process should exit"
+    );
+    std::thread::sleep(Duration::from_secs(1));
+    assert_eq!(
+        daemon.count_log_matches("spawned"),
+        1,
+        "on-failure should NOT restart on success exit"
+    );
+
+    let status = daemon.stop();
+    assert!(status.success());
+}
+
+#[test]
+fn test_restart_on_success() {
+    let dir = tempfile::tempdir().unwrap();
+    write_config(
+        dir.path(),
+        "ok-loop",
+        "command: /bin/sh\nargs:\n  - '-c'\n  - 'exit 0'\nrestart: on-success\nrestart_sec: 0.1\n",
+    );
+
+    let mut daemon = DaemonHandle::start(dir.path());
+    assert!(
+        daemon.wait_for_log_count("spawned", 3, Duration::from_secs(10)),
+        "on-success should restart on exit 0, got {} spawns",
+        daemon.count_log_matches("spawned")
+    );
+
+    let status = daemon.stop();
+    assert!(status.success());
+}
+
+// ===========================================================================
+// Group 4: Backoff and Burst Limiting
+// ===========================================================================
+
+#[test]
+fn test_burst_limiting_stops_restarts() {
+    let dir = tempfile::tempdir().unwrap();
+    write_config(
+        dir.path(),
+        "burst",
+        concat!(
+            "command: /bin/sh\n",
+            "args:\n  - '-c'\n  - 'exit 1'\n",
+            "restart: always\n",
+            "restart_sec: 0.05\n",
+            "start_limit_burst: 3\n",
+            "start_limit_interval_sec: 60\n",
+        ),
+    );
+
+    let mut daemon = DaemonHandle::start(dir.path());
+    assert!(
+        daemon.wait_for_log("start limit reached", Duration::from_secs(10)),
+        "daemon should log start limit reached"
+    );
+
+    // After start limit, no more restarts. Initial spawn + 3 restarts = 4 total max.
+    std::thread::sleep(Duration::from_secs(1));
+    let total_spawns = daemon.count_log_matches("spawned");
+    assert!(
+        total_spawns <= 4,
+        "expected at most 4 spawns (1 initial + 3 burst), got {total_spawns}"
+    );
+
+    let status = daemon.stop();
+    assert!(status.success());
+}
+
+// ===========================================================================
+// Group 5: Condition and Config
+// ===========================================================================
+
+#[test]
+fn test_condition_path_exists_not_met() {
+    let dir = tempfile::tempdir().unwrap();
+    write_config(
+        dir.path(),
+        "missing-bin",
+        "command: /nonexistent/binary\ncondition_path_exists: /nonexistent/binary\n",
+    );
+
+    let mut daemon = DaemonHandle::start(dir.path());
+    assert!(
+        daemon.wait_for_log_default("condition_path_exists not met"),
+        "daemon should log condition not met"
+    );
+
+    assert_eq!(
+        daemon.count_log_matches("spawned"),
+        0,
+        "process should NOT be spawned"
+    );
+
+    let status = daemon.stop();
+    assert!(status.success());
+}
+
+#[test]
+fn test_auto_start_false() {
+    let dir = tempfile::tempdir().unwrap();
+    write_config(
+        dir.path(),
+        "disabled",
+        "command: /bin/sleep\nargs:\n  - '300'\nauto_start: false\n",
+    );
+
+    let mut daemon = DaemonHandle::start(dir.path());
+    assert!(
+        daemon.wait_for_log_default("auto_start=false, skipping"),
+        "daemon should log auto_start skip"
+    );
+
+    assert_eq!(
+        daemon.count_log_matches("spawned"),
+        0,
+        "process should NOT be spawned"
+    );
+
+    let status = daemon.stop();
+    assert!(status.success());
+}
+
+// ===========================================================================
+// Group 6: Additional restart policy combinations
+// ===========================================================================
+
+#[test]
+fn test_restart_on_failure_with_failure_exit() {
+    let dir = tempfile::tempdir().unwrap();
+    write_config(
+        dir.path(),
+        "crasher",
+        "command: /bin/sh\nargs:\n  - '-c'\n  - 'exit 1'\nrestart: on-failure\nrestart_sec: 0.1\n",
+    );
+
+    let mut daemon = DaemonHandle::start(dir.path());
+    assert!(
+        daemon.wait_for_log_count("spawned", 3, Duration::from_secs(10)),
+        "on-failure should restart on failure exit, got {} spawns",
+        daemon.count_log_matches("spawned")
+    );
+
+    let status = daemon.stop();
+    assert!(status.success());
+}
+
+#[test]
+fn test_restart_on_success_with_failure_exit() {
+    let dir = tempfile::tempdir().unwrap();
+    write_config(
+        dir.path(),
+        "fail-once",
+        "command: /bin/sh\nargs:\n  - '-c'\n  - 'exit 1'\nrestart: on-success\n",
+    );
+
+    let mut daemon = DaemonHandle::start(dir.path());
+    assert!(
+        daemon.wait_for_log_default("exited with"),
+        "process should exit"
+    );
+    std::thread::sleep(Duration::from_secs(1));
+    assert_eq!(
+        daemon.count_log_matches("spawned"),
+        1,
+        "on-success should NOT restart on failure exit"
+    );
+
+    let status = daemon.stop();
+    assert!(status.success());
+}
+
+// ===========================================================================
+// Group 7: SIGINT shutdown
+// ===========================================================================
+
+#[test]
+fn test_shutdown_via_sigint() {
+    let dir = tempfile::tempdir().unwrap();
+    write_config(
+        dir.path(),
+        "sleeper",
+        "command: /bin/sleep\nargs:\n  - '300'\n",
+    );
+
+    let mut daemon = DaemonHandle::start(dir.path());
+    assert!(
+        daemon.wait_for_log_default("spawned"),
+        "daemon should spawn the process"
+    );
+
+    let pids = daemon.spawned_pids();
+    assert_eq!(pids.len(), 1);
+
+    daemon.send_signal(nix::sys::signal::Signal::SIGINT);
+    let status = daemon.wait_with_timeout(Duration::from_secs(10));
+
+    assert!(
+        daemon.wait_for_log("received SIGINT", Duration::from_secs(0)),
+        "daemon should log received SIGINT"
+    );
+    assert!(status.success(), "daemon should exit cleanly on SIGINT");
+}
+
+// ===========================================================================
+// Group 8: Environment handling
+// ===========================================================================
+
+#[test]
+fn test_environment_file_loading() {
+    let dir = tempfile::tempdir().unwrap();
+    let env_file = dir.path().join("test.env");
+    std::fs::write(&env_file, "MY_VAR=from_file\n").unwrap();
+
+    write_config(
+        dir.path(),
+        "env-test",
+        &format!(
+            concat!(
+                "command: /bin/sh\n",
+                "args:\n",
+                "  - '-c'\n",
+                "  - 'exit $(test \"$MY_VAR\" = \"from_file\" && echo 0 || echo 1)'\n",
+                "environment_file: {}\n",
+                "restart: never\n",
+            ),
+            env_file.display()
+        ),
+    );
+
+    let mut daemon = DaemonHandle::start(dir.path());
+    assert!(
+        daemon.wait_for_log_default("exited with exit status: 0"),
+        "child should see env var from environment_file"
+    );
+
+    let status = daemon.stop();
+    assert!(status.success());
+}
+
+#[test]
+fn test_env_overrides_environment_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let env_file = dir.path().join("test.env");
+    std::fs::write(&env_file, "MY_VAR=from_file\n").unwrap();
+
+    write_config(
+        dir.path(),
+        "override-test",
+        &format!(
+            concat!(
+                "command: /bin/sh\n",
+                "args:\n",
+                "  - '-c'\n",
+                "  - 'exit $(test \"$MY_VAR\" = \"overridden\" && echo 0 || echo 1)'\n",
+                "environment_file: {}\n",
+                "env:\n",
+                "  MY_VAR: overridden\n",
+                "restart: never\n",
+            ),
+            env_file.display()
+        ),
+    );
+
+    let mut daemon = DaemonHandle::start(dir.path());
+    assert!(
+        daemon.wait_for_log_default("exited with exit status: 0"),
+        "per-process env should override environment_file"
+    );
+
+    let status = daemon.stop();
+    assert!(status.success());
+}
+
+#[test]
+fn test_child_does_not_inherit_parent_env() {
+    let dir = tempfile::tempdir().unwrap();
+    write_config(
+        dir.path(),
+        "clean-env",
+        concat!(
+            "command: /bin/sh\n",
+            "args:\n",
+            "  - '-c'\n",
+            "  - 'test -z \"$HOME\" && exit 0 || exit 1'\n",
+            "restart: never\n",
+        ),
+    );
+
+    let mut daemon = DaemonHandle::start(dir.path());
+    assert!(
+        daemon.wait_for_log_default("exited with exit status: 0"),
+        "child should NOT inherit parent env (HOME should be unset)"
+    );
+
+    let status = daemon.stop();
+    assert!(status.success());
+}
+
+// ===========================================================================
+// Group 9: Error handling
+// ===========================================================================
+
+#[test]
+fn test_spawn_failure_logged_and_skipped() {
+    let dir = tempfile::tempdir().unwrap();
+    write_config(dir.path(), "bad-bin", "command: /nonexistent/binary\n");
+
+    let mut daemon = DaemonHandle::start(dir.path());
+    assert!(
+        daemon.wait_for_log_default("failed to spawn"),
+        "daemon should log spawn failure"
+    );
+    assert_eq!(
+        daemon.count_log_matches("spawned (pid="),
+        0,
+        "no process should be spawned"
+    );
+
+    let status = daemon.stop();
+    assert!(
+        status.success(),
+        "daemon should keep running despite spawn failure"
+    );
+}
+
+#[test]
+fn test_invalid_yaml_skipped() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("good.yaml"),
+        "command: /bin/sleep\nargs:\n  - '300'\n",
+    )
+    .unwrap();
+    std::fs::write(dir.path().join("bad.yaml"), "not: valid: yaml: [").unwrap();
+
+    let mut daemon = DaemonHandle::start(dir.path());
+    assert!(
+        daemon.wait_for_log_default("loaded 1 process config(s)"),
+        "daemon should load only the valid config"
+    );
+    assert!(
+        daemon.wait_for_log_default("spawned"),
+        "valid process should be spawned"
+    );
+
+    let status = daemon.stop();
+    assert!(status.success());
+}

--- a/releasenotes/notes/dd-procmgrd-restart-policies-d844000553eb4954.yaml
+++ b/releasenotes/notes/dd-procmgrd-restart-policies-d844000553eb4954.yaml
@@ -1,0 +1,3 @@
+features:
+  - |
+    ``dd-procmgrd`` now supervises managed processes with configurable restart policies, exponential backoff, and burst limiting.

--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -128,6 +128,8 @@ def get_omnibus_env(
 
         if skip_sign:
             env['SKIP_SIGN_MAC'] = 'true'
+        else:
+            env['SIGN_MAC'] = 'true'
         if hardened_runtime:
             env['HARDENED_RUNTIME_MAC'] = 'true'
 


### PR DESCRIPTION
- Create a rule for signing jar files on macos
   - This now contains a copy of Entitlements.plist.  When replace the other code signing omnibus scripts we will use this new one, and eventually delete the omnibus copy.
- Splice that into the jmxfetch install
- Lift jmxfetch.rb into datadog-agent-dependencies.rb
- import code signing environment variables into bazel build.

Mostly claude for the code
    - with a lot of direction from me about how to get the environment variables and where the constants should be declared.
    - and then I rewrote it because I didn't like my first choices.

## Future
The existing tasks/omnibus model around deciding to sign and when to used hardened is confusing. It should be changed to:
- Signing is the default. It can be skipped with a build flag (not an environment variable)
- Developer builds will use "-" as the identity, doing a fake sign
- CI builds should use an identity that is either "-" or very clearly "Datadog TEST"
- Only release builds done by the delivery team should use the real identity and have access to the keys that allow it.
- using the hardened entitlement should be the default. Currently CI passes it in to the omnibus job on the command line.