### PR TITLE
ignore "no such process" error in container store

### DIFF
--- a/pkg/network/containers/container_item_linux.go
+++ b/pkg/network/containers/container_item_linux.go
@@ -18,6 +18,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/shirou/gopsutil/v4/process"
@@ -124,7 +125,7 @@ func (r *resolvStripper) readResolvConf(entry *events.Process) (string, error) {
 	resolvConfPath := filepath.Join(rootPath, "etc/resolv.conf")
 
 	resolvConf, err := r.stripResolvConfFilepath(resolvConfPath)
-	if errors.Is(err, os.ErrNotExist) {
+	if errors.Is(err, os.ErrNotExist) || errors.Is(err, syscall.ESRCH) {
 		// report no file. don't turn this into an error, since if the process exited,
 		// that will be checked later by isProcessStillRunning
 		return "<missing>", nil
@@ -141,6 +142,7 @@ func (r *resolvStripper) stripResolvConfFilepath(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	defer file.Close()
 
 	stat, err := file.Stat()
 	if err != nil {


### PR DESCRIPTION
### What does this PR do?

Treat "no such process" errors the same as missing files during `resolv.conf` resolution.

### Motivation

Fix logs `CNM ContainerStore failed to readContainerItem: readResolvConf failed to read /host/proc/*/root/etc/resolv.conf: open /host/proc/*/root/etc/resolv.conf: no such process`

### Describe how you validated your changes

### Additional Notes
