### PR TITLE
Minor: rename `.bazel:defs:cache:ephemeral` to `:progressive`

### DIFF
--- a/.gitlab/build/bazel/defs.yml
+++ b/.gitlab/build/bazel/defs.yml
@@ -3,7 +3,7 @@
   variables:
     BAZELISK_HOME: "$XDG_CACHE_HOME/bazelisk" # not all bazelisk versions may honor $XDG_CACHE_HOME
 
-.bazel:defs:cache:ephemeral:
+.bazel:defs:cache:progressive:
   extends: .bazel:defs
   cache:
     - &bazelversion_cache
@@ -53,14 +53,14 @@
 .bazel:runner:linux-amd64:
   #extends: .bazel:defs:cache:persistent
   #tags: [ "k8s-persistent:amd64", "specific:true" ]
-  extends: .bazel:defs:cache:ephemeral
+  extends: .bazel:defs:cache:progressive
   tags: [ "arch:amd64", "specific:true" ]
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
 
 .bazel:runner:linux-arm64:
   #extends: .bazel:defs:cache:persistent
   #tags: [ "k8s-persistent:arm64", "specific:true" ]
-  extends: .bazel:defs:cache:ephemeral
+  extends: .bazel:defs:cache:progressive
   tags: [ "arch:arm64", "specific:true" ]
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
 

--- a/.gitlab/build/binary_build/system_probe.yml
+++ b/.gitlab/build/binary_build/system_probe.yml
@@ -1,6 +1,6 @@
 ---
 .system-probe_build_common:
-  extends: .bazel:defs:cache:ephemeral
+  extends: .bazel:defs:cache:progressive
   rules:
     - when: on_success
   before_script:

--- a/.gitlab/build/source_test/common.yml
+++ b/.gitlab/build/source_test/common.yml
@@ -8,6 +8,6 @@
   - dda inv -- -e coverage.upload-to-codecov $COVERAGE_CACHE_FLAG || true
 
 .unit_test_base:
-  extends: .bazel:defs:cache:ephemeral
+  extends: .bazel:defs:cache:progressive
   variables:
     FLAKY_PATTERNS_CONFIG: $CI_PROJECT_DIR/flaky-patterns-runtime.yaml

--- a/.gitlab/build/source_test/ebpf.yml
+++ b/.gitlab/build/source_test/ebpf.yml
@@ -50,7 +50,7 @@ tests_ebpf_arm64:
     TASK_ARCH: arm64
 
 .prepare_sysprobe_ebpf_functional_tests:
-  extends: .bazel:defs:cache:ephemeral
+  extends: .bazel:defs:cache:progressive
   stage: source_test
   rules:
     - !reference [.except_mergequeue]
@@ -88,7 +88,7 @@ prepare_sysprobe_ebpf_functional_tests_x64:
     DD_CXX: "x86_64-unknown-linux-gnu-g++"
 
 .prepare_secagent_ebpf_functional_tests:
-  extends: .bazel:defs:cache:ephemeral  # for `bazel run @libpcap//:install`
+  extends: .bazel:defs:cache:progressive
   stage: source_test
   rules:
     - !reference [.except_mergequeue]

--- a/.gitlab/build/source_test/tooling_unit_tests.yml
+++ b/.gitlab/build/source_test/tooling_unit_tests.yml
@@ -1,7 +1,7 @@
 ---
 # Unit test of internal python code
 invoke_unit_tests:
-  extends: .bazel:defs:cache:ephemeral
+  extends: .bazel:defs:cache:progressive
   stage: source_test
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:amd64", "specific:true"]

--- a/.gitlab/test/fuzz/infra.yml
+++ b/.gitlab/test/fuzz/infra.yml
@@ -1,5 +1,5 @@
 test_fuzz:
-  extends: .bazel:defs:cache:ephemeral
+  extends: .bazel:defs:cache:progressive
   rules:
     - !reference [.on_scheduled_main]
     - !reference [.manual]


### PR DESCRIPTION
### What does this PR do?
```diff
-.bazel:defs:cache:ephemeral
+.bazel:defs:cache:progressive
```
### Motivation
My bad, "ephemeral" was kind of misleading: admittedly used by ephemeral _runners_, but not ephemeral in itself since it's stored to S3 and retrieved from it...

### Additional Notes
"progressive" better reflects the controlled policy introduced in #46151: only `main` pushes to the cache, keeping it growing incrementally rather than going back and forth depending on the last pushing branch - whether antiquated or exploratory ("latest wins").