### PR TITLE
[Backport 7.77.x][WINA-2413] enable par config template in the agent

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -4582,27 +4582,27 @@ api_key:
 #
 # private_action_runner:
 
-  ## @param enabled - boolean - optional - default: false
-  ## @env DD_PRIVATE_ACTION_RUNNER_ENABLED - boolean - optional - default: false
-  ## Set to true to enable the Private Action Runner.
-  #
-  # enabled: true
+## @param enabled - boolean - optional - default: false
+## @env DD_PRIVATE_ACTION_RUNNER_ENABLED - boolean - optional - default: false
+## Set to true to enable the Private Action Runner.
+#
+# enabled: true
 
-  ## @param self_enroll - boolean - optional - default: true
-  ## @env DD_PRIVATE_ACTION_RUNNER_SELF_ENROLL - boolean - optional - default: true
-  ## Automatically enroll the Private Action Runner on startup.
-  ## Requires an app_key with Actions API Enable and the following permissions:
-  ##   - Connection Write
-  ##   - Private Action Write
-  #
-  # self_enroll: true
+## @param self_enroll - boolean - optional - default: true
+## @env DD_PRIVATE_ACTION_RUNNER_SELF_ENROLL - boolean - optional - default: true
+## Automatically enroll the Private Action Runner on startup.
+## Requires an app_key with Actions API Enable and the following permissions:
+##   - Connection Write
+##   - Private Action Write
+#
+# self_enroll: true
 
-  ## @param actions_allowlist - list of strings - optional
-  ## @env DD_PRIVATE_ACTION_RUNNER_ACTIONS_ALLOWLIST - comma separated list of strings - optional
-  ## List of actions that the Private Action Runner is allowed to execute.
-  ## See http://docs.datadoghq.com/fr/actions/private_actions/use_private_actions#change-the-allowlist-of-a-runner
-  ## for the list of available actions.
-  #
-  # actions_allowlist:
-  #   - com.datadoghq.script.runPredefinedScript
+## @param actions_allowlist - list of strings - optional
+## @env DD_PRIVATE_ACTION_RUNNER_ACTIONS_ALLOWLIST - comma separated list of strings - optional
+## List of actions that the Private Action Runner is allowed to execute.
+## See http://docs.datadoghq.com/fr/actions/private_actions/use_private_actions#change-the-allowlist-of-a-runner
+## for the list of available actions.
+#
+# actions_allowlist:
+#   - com.datadoghq.script.runPredefinedScript
 {{ end -}}

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -4569,7 +4569,8 @@ api_key:
 #
 #     verbosity: normal
 {{ end -}}
-{{ if .PrivateActionRunner }}
+{{ if .PrivateActionRunner -}}
+
 #########################################
 ## Private Action Runner Configuration ##
 #########################################

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -4582,27 +4582,27 @@ api_key:
 #
 # private_action_runner:
 
-## @param enabled - boolean - optional - default: false
-## @env DD_PRIVATE_ACTION_RUNNER_ENABLED - boolean - optional - default: false
-## Set to true to enable the Private Action Runner.
+#   # @param enabled - boolean - optional - default: false
+#   # @env DD_PRIVATE_ACTION_RUNNER_ENABLED - boolean - optional - default: false
+#   # Set to true to enable the Private Action Runner.
 #
-# enabled: true
+#   enabled: true
 
-## @param self_enroll - boolean - optional - default: true
-## @env DD_PRIVATE_ACTION_RUNNER_SELF_ENROLL - boolean - optional - default: true
-## Automatically enroll the Private Action Runner on startup.
-## Requires an app_key with Actions API Enable and the following permissions:
-##   - Connection Write
-##   - Private Action Write
+#   # @param self_enroll - boolean - optional - default: true
+#   # @env DD_PRIVATE_ACTION_RUNNER_SELF_ENROLL - boolean - optional - default: true
+#   # Automatically enroll the Private Action Runner on startup.
+#   # Requires an app_key with Actions API Enable and the following permissions:
+#   #   - Connection Write
+#   #   - Private Action Write
 #
-# self_enroll: true
+#   self_enroll: true
 
-## @param actions_allowlist - list of strings - optional
-## @env DD_PRIVATE_ACTION_RUNNER_ACTIONS_ALLOWLIST - comma separated list of strings - optional
-## List of actions that the Private Action Runner is allowed to execute.
-## See http://docs.datadoghq.com/fr/actions/private_actions/use_private_actions#change-the-allowlist-of-a-runner
-## for the list of available actions.
+#   # @param actions_allowlist - list of strings - optional
+#   # @env DD_PRIVATE_ACTION_RUNNER_ACTIONS_ALLOWLIST - comma separated list of strings - optional
+#   # List of actions that the Private Action Runner is allowed to execute.
+#   # See http://docs.datadoghq.com/fr/actions/private_actions/use_private_actions#change-the-allowlist-of-a-runner
+#   # for the list of available actions.
 #
-# actions_allowlist:
-#   - com.datadoghq.script.runPredefinedScript
+#   actions_allowlist:
+#     - com.datadoghq.script.runPredefinedScript
 {{ end -}}

--- a/pkg/config/render_config.go
+++ b/pkg/config/render_config.go
@@ -61,8 +61,8 @@ func mkContext(buildType string, osName string) context {
 			ECS:                 true,
 			TraceAgent:          true,
 			Kubelet:             true,
-			KubeApiServer:       true,  // TODO: remove when phasing out from node-agent
-			PrivateActionRunner: false, // NOTE: hidden until v7.77.0
+			KubeApiServer:       true, // TODO: remove when phasing out from node-agent
+			PrivateActionRunner: true,
 		}
 	case "iot-agent":
 		return context{

--- a/releasenotes/notes/par-config-template-33f0ef1dd5cc4931.yaml
+++ b/releasenotes/notes/par-config-template-33f0ef1dd5cc4931.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The ``datadog.yaml`` configuration file now includes a commented-out
+    ``private_action_runner`` section on all platforms.


### PR DESCRIPTION
### What does this PR do?
Enables Private Action Runner config rendering in datadog.yaml.

### Motivation
We integrate Private Action Runner with Datadog Agent and starting from v7.77 we want to enable config template rendering for it to help users set up their runners.

### Describe how you validated your changes
Installed agent on Windows from CI artefacts ([pipeline-98840805](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/98840805)) and checked that datadog.yaml contains PAR template after installation.

### Additional Notes
