### PR TITLE
Drop generated `user.bazelrc` in `tools/bazel`

### DIFF
--- a/tools/bazel
+++ b/tools/bazel
@@ -19,10 +19,7 @@ if [ ! -d "${XDG_CACHE_HOME:-}" ]; then
     >&2 echo '    docker run --env=XDG_CACHE_HOME=/cache --volume="$HOME/.cache:/cache" ...'
   fi
 elif [ -n "${CI:-}" ]; then
-  # Pass CI-specific options through `.user.bazelrc` so any nested `bazel run` also honor them
-  cat >"$(dirname "$(dirname "$0")")/user.bazelrc" <<EOF
-common --config=ci
-EOF
+  exec "$BAZEL_REAL" ${1:+"$1" --config=ci} "${@:2}"
 fi
 
 exec "$BAZEL_REAL" "$@"


### PR DESCRIPTION
### What does this PR do?
On POSIX, inject `--config=ci` directly instead of writing a `user.bazelrc` file.

### Motivation
Unlike `tools/bazel.bat`, whose generated `user.bazelrc` is multi-line and encompasses computed startup options, `tools/bazel`'s shrunk down to a single static line.

Since every `bazel` invocation goes through the POSIX wrapper, injecting the option directly is both sufficient and without leftover in the filesystem.