### PR TITLE
[CWS] Add SBOM generation support for Alpine Linux

### DIFF
--- a/pkg/security/resolvers/sbom/collectorv2/apk.go
+++ b/pkg/security/resolvers/sbom/collectorv2/apk.go
@@ -1,0 +1,139 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+// Package collectorv2 holds sbom related files
+package collectorv2
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	sbomtypes "github.com/DataDog/datadog-agent/pkg/security/resolvers/sbom/types"
+	"github.com/DataDog/datadog-agent/pkg/security/seclog"
+)
+
+const apkInstalledPath = "lib/apk/db/installed"
+
+type apkScanner struct{}
+
+func (s *apkScanner) Name() string {
+	return "apk"
+}
+
+func (s *apkScanner) ListPackages(_ context.Context, root *os.Root) ([]sbomtypes.PackageWithInstalledFiles, error) {
+	f, err := root.Open(apkInstalledPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open apk database (%s): %w", apkInstalledPath, err)
+	}
+	defer f.Close()
+
+	pkgs, err := parseAPKDatabase(f)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse apk database: %w", err)
+	}
+	return pkgs, nil
+}
+
+type apkPackage struct {
+	name    string
+	version string
+	epoch   int
+	release string
+	files   []string
+}
+
+func parseAPKDatabase(r io.Reader) ([]sbomtypes.PackageWithInstalledFiles, error) {
+	var packages []sbomtypes.PackageWithInstalledFiles
+	var current apkPackage
+	var currentDir string
+
+	finalize := func() {
+		if current.name == "" || current.version == "" {
+			return
+		}
+		packages = append(packages, sbomtypes.PackageWithInstalledFiles{
+			Package: sbomtypes.Package{
+				Name:       current.name,
+				Version:    current.version,
+				Epoch:      current.epoch,
+				Release:    current.release,
+				SrcVersion: current.version,
+				SrcEpoch:   current.epoch,
+				SrcRelease: current.release,
+			},
+			InstalledFiles: current.files,
+		})
+	}
+
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if line == "" {
+			finalize()
+			current = apkPackage{}
+			currentDir = ""
+			continue
+		}
+
+		if len(line) < 2 || line[1] != ':' {
+			seclog.Warnf("apk: unexpected line format: %q", line)
+			continue
+		}
+
+		key := line[0]
+		value := line[2:]
+
+		switch key {
+		case 'P':
+			current.name = value
+		case 'V':
+			current.epoch, current.version, current.release = parseAPKVersion(value)
+		case 'F':
+			currentDir = value
+		case 'R':
+			current.files = append(current.files, "/"+filepath.Join(currentDir, value))
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("failed to scan apk database: %w", err)
+	}
+
+	// Handle the last package if the file does not end with a blank line
+	finalize()
+
+	return packages, nil
+}
+
+// parseAPKVersion parses an APK version string (e.g. "1.2.3-r4" or "2:1.2.3-r4")
+// and returns (epoch, version, release). The release is the Alpine-specific "-rN" suffix.
+func parseAPKVersion(v string) (epoch int, version, release string) {
+	// Epoch prefix: "2:1.2.3-r4"
+	if i := strings.IndexByte(v, ':'); i != -1 {
+		if e, err := strconv.Atoi(v[:i]); err == nil {
+			epoch = e
+		}
+		v = v[i+1:]
+	}
+
+	// Release suffix: last "-r<N>" component
+	if i := strings.LastIndex(v, "-r"); i != -1 {
+		release = v[i+1:] // "rN"
+		version = v[:i]
+	} else {
+		version = v
+	}
+
+	return epoch, version, release
+}

--- a/pkg/security/resolvers/sbom/collectorv2/apk_test.go
+++ b/pkg/security/resolvers/sbom/collectorv2/apk_test.go
@@ -1,0 +1,131 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package collectorv2
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const sampleAPKDatabase = `C:Q1r0+sample==
+P:musl
+V:1.2.3-r4
+A:x86_64
+S:1234
+I:5678
+T:the musl c library
+U:https://musl.libc.org/
+L:MIT
+o:musl
+m:Maintainer
+t:1234567890
+c:abcdef
+D:so:libc.musl-x86_64.so.1
+F:lib
+R:ld-musl-x86_64.so.1
+a:0:0:0755
+Z:Q1abc
+R:libc.musl-x86_64.so.1
+a:0:0:0777
+Z:Q1def
+F:usr/lib
+R:libc.musl-x86_64.so.1
+a:0:0:0777
+Z:Q1ghi
+
+C:Q2r0+sample==
+P:zlib
+V:1.3.0-r0
+A:x86_64
+S:100
+I:200
+T:compression library
+U:https://zlib.net/
+L:zlib
+o:zlib
+F:lib
+R:libz.so.1
+a:0:0:0755
+Z:Q1zzz
+R:libz.so.1.3.0
+a:0:0:0755
+Z:Q1yyy
+
+`
+
+func TestParseAPKDatabase(t *testing.T) {
+	pkgs, err := parseAPKDatabase(strings.NewReader(sampleAPKDatabase))
+	require.NoError(t, err)
+	require.Len(t, pkgs, 2)
+
+	musl := pkgs[0]
+	assert.Equal(t, "musl", musl.Name)
+	assert.Equal(t, "1.2.3", musl.Version)
+	assert.Equal(t, 0, musl.Epoch)
+	assert.Equal(t, "r4", musl.Release)
+	assert.Equal(t, "1.2.3", musl.SrcVersion)
+	assert.Equal(t, 0, musl.SrcEpoch)
+	assert.Equal(t, "r4", musl.SrcRelease)
+	assert.Equal(t, []string{
+		"/lib/ld-musl-x86_64.so.1",
+		"/lib/libc.musl-x86_64.so.1",
+		"/usr/lib/libc.musl-x86_64.so.1",
+	}, musl.InstalledFiles)
+
+	zlib := pkgs[1]
+	assert.Equal(t, "zlib", zlib.Name)
+	assert.Equal(t, "1.3.0", zlib.Version)
+	assert.Equal(t, 0, zlib.Epoch)
+	assert.Equal(t, "r0", zlib.Release)
+	assert.Equal(t, []string{
+		"/lib/libz.so.1",
+		"/lib/libz.so.1.3.0",
+	}, zlib.InstalledFiles)
+}
+
+func TestParseAPKDatabaseNoTrailingNewline(t *testing.T) {
+	// File that doesn't end with an empty line — last package must still be captured
+	db := strings.TrimRight(sampleAPKDatabase, "\n")
+	pkgs, err := parseAPKDatabase(strings.NewReader(db))
+	require.NoError(t, err)
+	assert.Len(t, pkgs, 2)
+}
+
+func TestParseAPKDatabaseEmpty(t *testing.T) {
+	pkgs, err := parseAPKDatabase(strings.NewReader(""))
+	require.NoError(t, err)
+	assert.Empty(t, pkgs)
+}
+
+func TestParseAPKVersion(t *testing.T) {
+	tests := []struct {
+		input           string
+		expectedEpoch   int
+		expectedVersion string
+		expectedRelease string
+	}{
+		{"1.2.3-r4", 0, "1.2.3", "r4"},
+		{"1.3.0-r0", 0, "1.3.0", "r0"},
+		{"2:1.2.3-r4", 2, "1.2.3", "r4"},
+		{"1.2.3", 0, "1.2.3", ""},
+		{"1.2.3_alpha1-r0", 0, "1.2.3_alpha1", "r0"},
+		{"20230101-r0", 0, "20230101", "r0"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			epoch, version, release := parseAPKVersion(tt.input)
+			assert.Equal(t, tt.expectedEpoch, epoch)
+			assert.Equal(t, tt.expectedVersion, version)
+			assert.Equal(t, tt.expectedRelease, release)
+		})
+	}
+}

--- a/pkg/security/resolvers/sbom/collectorv2/collector.go
+++ b/pkg/security/resolvers/sbom/collectorv2/collector.go
@@ -33,6 +33,7 @@ func NewOSScanner() *OSScanner {
 		scanners: []actualScanner{
 			&dpkgScanner{},
 			&rpmScanner{},
+			&apkScanner{},
 		},
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Add a SBOM collector - specific to CWS - for Alpine Linux.

### Motivation

Alpine support was lost when dropping Trivy in favor of custom collectors.

### Describe how you validated your changes

### Additional Notes
