### PR TITLE
Fix data race in JMX SetStartupError: wrong mutex used

### DIFF
--- a/pkg/status/jmx/jmx.go
+++ b/pkg/status/jmx/jmx.go
@@ -41,20 +41,6 @@ func (s *Status) GetInfo() (version, runtimeVersion string) {
 	return version, runtimeVersion
 }
 
-// StartupError holds startup status and errors
-type StartupError struct {
-	LastError string
-	Timestamp int64
-}
-
-// GetStartupError retrieves latest JMX startup error
-func GetStartupError() StartupError {
-	lastJMXStartupErrorMutex.RLock()
-	defer lastJMXStartupErrorMutex.RUnlock()
-	errorCopy := StartupError{lastJMXStartupError.LastError, lastJMXStartupError.Timestamp}
-	return errorCopy
-}
-
 // PopulateStatus populate stats with JMX information
 func PopulateStatus(stats map[string]interface{}) {
 	stats["JMXStatus"] = getJMXStatus()

--- a/pkg/status/jmx/state.go
+++ b/pkg/status/jmx/state.go
@@ -33,8 +33,8 @@ func ClearStatus() {
 
 // SetStartupError sets the last JMX startup error
 func SetStartupError(s StartupError) {
-	lastJMXStatusMutex.Lock()
-	defer lastJMXStatusMutex.Unlock()
+	lastJMXStartupErrorMutex.Lock()
+	defer lastJMXStartupErrorMutex.Unlock()
 
 	lastJMXStartupError = s
 }

--- a/pkg/status/jmx/state.go
+++ b/pkg/status/jmx/state.go
@@ -16,6 +16,20 @@ var (
 	lastJMXStartupErrorMutex sync.RWMutex
 )
 
+// StartupError holds startup status and errors
+type StartupError struct {
+	LastError string
+	Timestamp int64
+}
+
+// GetStartupError retrieves latest JMX startup error
+func GetStartupError() StartupError {
+	lastJMXStartupErrorMutex.RLock()
+	defer lastJMXStartupErrorMutex.RUnlock()
+	errorCopy := StartupError{lastJMXStartupError.LastError, lastJMXStartupError.Timestamp}
+	return errorCopy
+}
+
 // SetStatus sets the last JMX Status
 func SetStatus(s Status) {
 	lastJMXStatusMutex.Lock()

--- a/pkg/status/jmx/state_test.go
+++ b/pkg/status/jmx/state_test.go
@@ -1,0 +1,38 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package jmx
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSetStartupErrorConcurrent exercises SetStartupError and GetStartupError
+// concurrently. With the race detector enabled (-race) this test would have
+// caught the original bug where SetStartupError incorrectly held
+// lastJMXStatusMutex instead of lastJMXStartupErrorMutex.
+func TestSetStartupErrorConcurrent(t *testing.T) {
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			SetStartupError(StartupError{LastError: "err", Timestamp: 1})
+		}()
+		go func() {
+			defer wg.Done()
+			_ = GetStartupError()
+		}()
+	}
+	wg.Wait()
+
+	SetStartupError(StartupError{LastError: "final", Timestamp: 42})
+	got := GetStartupError()
+	assert.Equal(t, "final", got.LastError)
+	assert.Equal(t, int64(42), got.Timestamp)
+}


### PR DESCRIPTION
### What does this PR do?

`SetStartupError` was locking `lastJMXStatusMutex` instead of `lastJMXStartupErrorMutex`.
`GetStartupError` (correctly) uses `lastJMXStartupErrorMutex`, so concurrent calls to Set
and Get operated under two different locks, creating a data race on `lastJMXStartupError`.

The fix is a one-line change: use the correct mutex in `SetStartupError`.

### Motivation

Concurrent calls to `SetStartupError` (from the JMXFetch runner) and `GetStartupError`
(from the status API) race on the `lastJMXStartupError` variable. This is detectable with
`-race` and can produce torn reads of the `StartupError` struct in production.

### Describe how you validated your changes

Added `TestSetStartupErrorConcurrent` in `pkg/status/jmx/state_test.go` which runs 100
concurrent `SetStartupError`/`GetStartupError` pairs. The test passes cleanly under
`go test -race`.

### Additional Notes

Bug found by Claude during a codebase audit.