### PR TITLE
Fix goroutine leak in language detection handler: break exits select, not for loop

### DIFF
--- a/cmd/cluster-agent/api/v1/languagedetection/handler.go
+++ b/cmd/cluster-agent/api/v1/languagedetection/handler.go
@@ -79,7 +79,7 @@ func (handler *languageDetectionHandler) startCleanupInBackground(ctx context.Co
 					handler.ownersLanguages.cleanExpiredLanguages(handler.wlm)
 				}
 			case <-ctx.Done():
-				break
+				return
 			}
 		}
 	}()


### PR DESCRIPTION
### What does this PR do?

Fixes a goroutine leak in `startCleanupInBackground` in the cluster-agent language
detection handler.

### Motivation

In Go, `break` inside a `select` statement exits only the `select`, not any enclosing
`for` loop. The cleanup goroutine in `startCleanupInBackground` used `break` in the
`ctx.Done()` case:

```go
for {
    select {
    case <-cleanupTicker.C:
        ...
    case <-ctx.Done():
        break  // only exits select — goroutine loops forever
    }
}
```

After the context is cancelled the goroutine continues looping, checking the ticker and
the (already-cancelled) context repeatedly, leaking forever. The flush goroutine
immediately below in the same function correctly uses `return`. This PR aligns the cleanup
goroutine to do the same.

### Describe how you validated your changes
CI

### Additional Notes

Bug found by Claude during a codebase audit.