### PR TITLE
Fix nil panic and double response in flare HTTP handler

### DIFF
--- a/comp/core/flare/flare.go
+++ b/comp/core/flare/flare.go
@@ -179,13 +179,10 @@ func (f *flare) createAndReturnFlarePath(w http.ResponseWriter, r *http.Request)
 	f.log.Infof("Making a flare")
 	filePath, err := f.Create(profile, providerTimeout, nil, []byte{})
 
-	if err != nil || filePath == "" {
-		if err != nil {
-			f.log.Errorf("The flare failed to be created: %s", err)
-		} else {
-			f.log.Warnf("The flare failed to be created")
-		}
+	if err != nil {
+		f.log.Errorf("The flare failed to be created: %s", err)
 		http.Error(w, err.Error(), 500)
+		return
 	}
 	w.Write([]byte(filePath))
 }


### PR DESCRIPTION
### What does this PR do?

Fixes two bugs in the flare HTTP handler:

1. **Double HTTP response write**: there was no `return` after `http.Error(w, ...)`, so `w.Write([]byte(filePath))` was always reached, writing a second response body even after an error was already sent.

2. **Nil panic**: the original code checked `err == nil && filePath == ""` and then called `err.Error()` — but if `err` is nil, this panics. The `filePath == ""` branch is removed: the real `Create` implementation never returns an empty path with a nil error (it either returns a non-empty path on success or a non-nil error on failure). The simplified `if err != nil` check is also more idiomatic Go — functions either return a meaningful value or an error, not both.

### Motivation

The handler would write two HTTP responses on any error, and would panic with a nil dereference when `filePath` was empty but no error occurred.

### Describe how you validated your changes

- Verified all `Create` implementation return paths: `fb.Save()` always returns either `("", err)` or `(archiveFinalPath, nil)` where `archiveFinalPath` is always non-empty.
- `go build ./comp/core/flare/...` succeeds.

### Additional Notes

Found by Claude.