### PR TITLE
Revert changes in linux/BUILD and fix macos.sh script

### DIFF
--- a/bazel/rules/rewrite_rpath/macos.sh
+++ b/bazel/rules/rewrite_rpath/macos.sh
@@ -7,21 +7,20 @@ PREFIX=$2
 INPUT=$3
 OUTPUT=$4
 
+# PREFIX is the full rpath (e.g. {install_dir}/embedded/lib); use as-is, do not append /lib
 cp "$INPUT" "$OUTPUT"
-install_name_tool -add_rpath "$PREFIX/lib" "$OUTPUT" 2>/dev/null || true
-# Get the old install name/ID
+install_name_tool -add_rpath "$PREFIX" "$OUTPUT" 2>/dev/null || true
 dylib_name=$(basename "$OUTPUT")
-new_id="$PREFIX/lib/$dylib_name"
+new_id="$PREFIX/$dylib_name"
 
-# Change the dylib's own ID
 install_name_tool -id "$new_id" "$OUTPUT"
 
 # Update all dependency paths that point to sandbox locations
 ${OTOOL} -L "$OUTPUT" | tail -n +2 | awk '{print $1}' | while read -r dep; do
     if [[ "$dep" == *"sandbox"* ]] || [[ "$dep" == *"bazel-out"* ]]; then
         dep_name=$(basename "$dep")
-        new_dep="$PREFIX/lib/$dep_name"
+        new_dep="$PREFIX/$dep_name"
         install_name_tool -change "$dep" "$new_dep" "$OUTPUT" 2>/dev/null || true
-        install_name_tool -add_rpath "$PREFIX/lib" "$dep" 2>/dev/null || true
+        install_name_tool -add_rpath "$PREFIX" "$dep" 2>/dev/null || true
     fi
 done

--- a/packages/agent/linux/BUILD.bazel
+++ b/packages/agent/linux/BUILD.bazel
@@ -91,10 +91,6 @@ pkg_tar(
     # compression_threads COMPRESSION_THREADS
     # compression_level COMPRESSION_LEVEL
     owner = "0.0",
-    tags = [
-        "manual",
-        "no-remote",
-    ],
 )
 
 # TODO: Look at omnibus/config/projects/agent.rb for more content here.
@@ -120,17 +116,13 @@ See http://www.datadoghq.com/ for more information
     priority = "extra",
     recommends = ["datadog-signing-keys (>= 1:1.4.0)"],
     section = "utils",
+    # TODO: Stamp in pipeline: 1:7.77.0~devel.git.394.fe0d0bb.pipeline.95313893-1
+    version = "7",
 
     # TODO: pull in target_cpu as arch.
     # architecture = "$(COMPILATION_MODE)",
     # config = "config",
     #distribution = "trusty",
-    tags = [
-        "manual",
-        "no-remote",
-    ],
-    # TODO: Stamp in pipeline: 1:7.77.0~devel.git.394.fe0d0bb.pipeline.95313893-1
-    version = "7",
 )
 
 # Replacement for datadog-agent-installer-symlinks.rb

--- a/packages/agent/linux/BUILD.bazel
+++ b/packages/agent/linux/BUILD.bazel
@@ -6,23 +6,13 @@ load(
     "@rules_pkg//pkg:mappings.bzl",
     "pkg_attributes",
     "pkg_filegroup",
-    "pkg_files",
     "pkg_mkdirs",
 )
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
-load("//bazel/rules:collect_cc_dynamic_deps.bzl", "cc_dynamic_deps_filegroup")
 load("//bazel/rules:dd_agent_pkg_mklink.bzl", "dd_agent_pkg_mklink")
-load("//bazel/rules/rewrite_rpath:rewrite_rpath.bzl", "rewrite_rpath")
 load("//compliance:package_licenses.bzl", "package_licenses")
 
 package(default_visibility = ["//packages:__subpackages__"])
-
-pkg_filegroup(
-    name = "security_agent_components",
-    srcs = [
-        "@openscap//:lib_files",
-    ],
-)
 
 # This is everything in the distro. All the things that were explicit
 # in datadog-agent-dependencies.rb should show up here.
@@ -34,42 +24,27 @@ pkg_filegroup(
         "//packages/install_dir:embedded",
         "//packages/install_dir:etc",
         "@libpcap//:all_files",
-        # This should probably be in its own target instead and aggregated later on
-        # but this is good enough for now so that we can start pulling in dependencies
-        # in the package automatically
-        ":security_agent_components",
     ],
     prefix = "/opt/datadog-agent",
 )
 
-# Automatically gather all cc_shared_library files that appear as dynamic_deps
-# of any target reachable from agent_components.  As more targets (agent binary,
-# cpython, …) are added to the Bazel build graph, their runtime shared-library
-# dependencies will be discovered here without any manual changes.
-cc_dynamic_deps_filegroup(
-    name = "auto_cc_dynamic_deps",
-    srcs = [":agent_components"],
-    visibility = ["//visibility:private"],
-)
-
-# Rewrite the rpath so that we can load our dependencies from their expected locations
-# By default bazel will include a path that points to the sandbox
-rewrite_rpath(
-    name = "auto_deps_fixed_rpath",
-    inputs = [":auto_cc_dynamic_deps"],
-    visibility = ["//visibility:private"],
-)
-
-pkg_files(
-    name = "auto_cc_dynamic_deps_pkg",
-    srcs = [":auto_deps_fixed_rpath"],
-    prefix = "embedded/lib",
-    visibility = ["//visibility:private"],
-)
-
+# This is the list of things we depend on transitively. It is temporary.
+# They are really deps of things that the agent binary or python3 depends
+# on. We should pick up the dependencies from the build graph.
+# https://datadoghq.atlassian.net/browse/ABLD-363 will resolve that.
+# This is good enough for today.
 pkg_filegroup(
-    name = "auto_cc_dynamic_deps_with_fixed_rpath",
-    srcs = [":auto_cc_dynamic_deps_pkg"],
+    name = "transitive_deps",
+    srcs = [
+        "//deps/gstatus:bin_files",
+        "//deps/msodbcsql18:all_files",
+        "//deps/nfsiostat:all_files",
+        "//deps/openscap:all_files",
+        "@freetds//:all_files",
+        "@krb5//:all_files",
+        "@nghttp2//:all_files",
+        "@xz//:all_files",
+    ],
     prefix = "/opt/datadog-agent",
 )
 
@@ -82,7 +57,7 @@ pkg_filegroup(
     name = "everything",
     srcs = [
         ":agent_components",
-        ":auto_cc_dynamic_deps_with_fixed_rpath",
+        ":transitive_deps",
     ],
 )
 
@@ -116,6 +91,7 @@ pkg_tar(
     # compression_threads COMPRESSION_THREADS
     # compression_level COMPRESSION_LEVEL
     owner = "0.0",
+    tags = ["no-remote", "manual"],
 )
 
 # TODO: Look at omnibus/config/projects/agent.rb for more content here.
@@ -148,6 +124,7 @@ See http://www.datadoghq.com/ for more information
     # architecture = "$(COMPILATION_MODE)",
     # config = "config",
     #distribution = "trusty",
+    tags = ["no-remote", "manual"],
 )
 
 # Replacement for datadog-agent-installer-symlinks.rb

--- a/packages/agent/linux/BUILD.bazel
+++ b/packages/agent/linux/BUILD.bazel
@@ -91,7 +91,10 @@ pkg_tar(
     # compression_threads COMPRESSION_THREADS
     # compression_level COMPRESSION_LEVEL
     owner = "0.0",
-    tags = ["no-remote", "manual"],
+    tags = [
+        "manual",
+        "no-remote",
+    ],
 )
 
 # TODO: Look at omnibus/config/projects/agent.rb for more content here.
@@ -117,14 +120,17 @@ See http://www.datadoghq.com/ for more information
     priority = "extra",
     recommends = ["datadog-signing-keys (>= 1:1.4.0)"],
     section = "utils",
-    # TODO: Stamp in pipeline: 1:7.77.0~devel.git.394.fe0d0bb.pipeline.95313893-1
-    version = "7",
 
     # TODO: pull in target_cpu as arch.
     # architecture = "$(COMPILATION_MODE)",
     # config = "config",
     #distribution = "trusty",
-    tags = ["no-remote", "manual"],
+    tags = [
+        "manual",
+        "no-remote",
+    ],
+    # TODO: Stamp in pipeline: 1:7.77.0~devel.git.394.fe0d0bb.pipeline.95313893-1
+    version = "7",
 )
 
 # Replacement for datadog-agent-installer-symlinks.rb


### PR DESCRIPTION
### What does this PR do?
1. Reverts changes in `linux/BUILD` as they were affecting license gathering process.
2. Fixes `macos.sh` to not add `lib` unconditionally and ensure the correct rpath and id

