### PR TITLE
Fix nil panic in Oracle check: return early when GetSender fails

### DIFF
--- a/pkg/collector/corechecks/oracle/oracle.go
+++ b/pkg/collector/corechecks/oracle/oracle.go
@@ -129,7 +129,8 @@ type vDatabase struct {
 func handleServiceCheck(c *Check, err error) {
 	sender, errSender := c.GetSender()
 	if errSender != nil {
-		log.Errorf("%s failed to get sender for service check %s", c.logPrompt, err)
+		log.Errorf("%s failed to get sender for service check: %s", c.logPrompt, errSender)
+		return
 	}
 
 	message := ""


### PR DESCRIPTION
### What does this PR do?

In `handleServiceCheck` in the Oracle check, `c.GetSender()` is called at the top of the
function. If it fails, the error is logged but execution continues — reaching
`sender.Commit()` at the end of the function with a nil `sender`, causing a nil pointer
dereference panic.

Fix: add an early `return` when `GetSender` fails.

Also fixes a wrong variable in the error log at that site: it was printing `err` (the
connection error passed as a parameter) instead of `errSender` (the sender failure),
producing a misleading log message.

### Motivation

Missing `return` after an error check is a classic Go mistake. The function follows the
standard error-early-return pattern everywhere else; this site was the exception.

### Describe how you validated your changes

- Built with `-tags oracle`.
- The fix is consistent with the standard early-return-on-error pattern used throughout
  the rest of the function.

### Additional Notes

Bug found by Claude during a codebase audit.