### PR TITLE
Drop transactions for unknown domains instead of panicking

### DIFF
--- a/comp/forwarder/defaultforwarder/default_forwarder.go
+++ b/comp/forwarder/defaultforwarder/default_forwarder.go
@@ -580,7 +580,11 @@ func (f *DefaultForwarder) sendHTTPTransactions(transactions []*transaction.HTTP
 
 	now := time.Now()
 	for _, t := range transactions {
-		forwarder := f.domainForwarders[t.Domain]
+		forwarder, ok := f.domainForwarders[t.Domain]
+		if !ok {
+			f.log.Errorf("No domain forwarder for domain %q, dropping transaction", t.Domain)
+			continue
+		}
 
 		forwarder.sendHTTPTransactions(t)
 


### PR DESCRIPTION
### What does this PR do?

When `sendHTTPTransactions` encounters a transaction whose `Domain` is not registered in
`f.domainForwarders`, it now logs an error and skips the transaction instead of
dereferencing a nil pointer and panicking.

### Motivation

`f.domainForwarders[t.Domain]` returns the zero value (nil pointer to
`*domainForwarder`) when the domain is absent. The next line,
`forwarder.sendHTTPTransactions(t)`, called a method on that nil pointer, causing a panic.

This can happen in practice if a transaction is requeued (e.g., from disk) after the
corresponding domain was removed from configuration, or if a transaction is created with a
domain that was never registered.

### Describe how you validated your changes

`go test -tags test ./comp/forwarder/defaultforwarder/...` passes.

### Additional Notes

Bug found by Claude during a codebase audit.