### PR TITLE
Fix nil dereference in GetClientConfig when InClusterConfig fails

### DIFF
--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -219,6 +219,10 @@ func GetClientConfig(timeout time.Duration, qps float32, burst int) (*rest.Confi
 	cfgPath := pkgconfigsetup.Datadog().GetString("kubernetes_kubeconfig_path")
 	if cfgPath == "" {
 		clientConfig, err = rest.InClusterConfig()
+		if err != nil {
+			log.Debugf("Can't create a config for the official client from the service account's token: %v", err)
+			return nil, err
+		}
 
 		if !pkgconfigsetup.Datadog().GetBool("kubernetes_apiserver_tls_verify") {
 			clientConfig.TLSClientConfig.Insecure = true
@@ -226,11 +230,6 @@ func GetClientConfig(timeout time.Duration, qps float32, burst int) (*rest.Confi
 
 		if customCAPath := pkgconfigsetup.Datadog().GetString("kubernetes_apiserver_ca_path"); customCAPath != "" {
 			clientConfig.TLSClientConfig.CAFile = customCAPath
-		}
-
-		if err != nil {
-			log.Debugf("Can't create a config for the official client from the service account's token: %v", err)
-			return nil, err
 		}
 	} else {
 		// use the current context in kubeconfig


### PR DESCRIPTION
### What does this PR do?

Moves the error check for `rest.InClusterConfig()` to immediately after the call, before
any use of the returned `*rest.Config`.

### Motivation

`GetClientConfig` called `rest.InClusterConfig()` and then immediately accessed
`clientConfig.TLSClientConfig.Insecure` and `clientConfig.TLSClientConfig.CAFile` before
checking whether the call succeeded. When `InClusterConfig` fails (e.g., the agent is
running outside a Kubernetes pod), `clientConfig` is nil, and any field access on it
panics.

The error check at the bottom of the block was too late — the dereferences had already
happened.

### Describe how you validated your changes

`go test -tags kubeapiserver ./pkg/util/kubernetes/apiserver/...` passes.

### Additional Notes

Bug found by Claude during a codebase audit.