### PR TITLE
Fix potential deadlock in ShouldAddCheckStats due to re-entrant RLock

### DIFF
--- a/pkg/collector/runner/runner.go
+++ b/pkg/collector/runner/runner.go
@@ -278,8 +278,10 @@ func (r *Runner) ShouldAddCheckStats(id checkid.ID) bool {
 	r.schedulerLock.RLock()
 	defer r.schedulerLock.RUnlock()
 
-	sc := r.getScheduler()
-	if sc == nil || sc.IsCheckScheduled(id) {
+	// Access r.scheduler directly; calling getScheduler() here would try to
+	// acquire schedulerLock.RLock() a second time on the same goroutine, which
+	// deadlocks when a writer is waiting for the lock.
+	if r.scheduler == nil || r.scheduler.IsCheckScheduled(id) {
 		return true
 	}
 


### PR DESCRIPTION
### What does this PR do?

`ShouldAddCheckStats` acquires `schedulerLock.RLock()` and then calls `getScheduler()`,
which also tries to acquire `schedulerLock.RLock()`. This is fixed by accessing
`r.scheduler` directly instead of going through `getScheduler()`.

### Motivation

Go's `sync.RWMutex` blocks new readers when a writer is waiting for the lock. The
deadlock sequence is:

1. Goroutine A calls `ShouldAddCheckStats`, acquires `schedulerLock.RLock()`
2. Goroutine B calls `SetScheduler`, tries `schedulerLock.Lock()` — blocks (A holds RLock)
3. Goroutine A calls `getScheduler()`, tries `schedulerLock.RLock()` again — blocked because B is waiting for the write lock
4. Goroutine A is now waiting for itself → deadlock

The fix is to access `r.scheduler` directly inside `ShouldAddCheckStats`, which already
holds the read lock, instead of calling `getScheduler()` which would try to acquire it
again.

### Describe how you validated your changes

`go test -tags test ./pkg/collector/runner/...` passes.

### Additional Notes

Bug found by Claude during a codebase audit.