### PR TITLE
Fix data race on configToChecks map in CheckScheduler.Unschedule

### DIFF
--- a/pkg/collector/scheduler.go
+++ b/pkg/collector/scheduler.go
@@ -105,6 +105,9 @@ func (s *CheckScheduler) Schedule(configs []integration.Config) {
 
 // Unschedule unschedules checks matching configs
 func (s *CheckScheduler) Unschedule(configs []integration.Config) {
+	s.m.Lock()
+	defer s.m.Unlock()
+
 	for _, config := range configs {
 		if !config.IsCheckConfig() {
 			// skip non check


### PR DESCRIPTION
### What does this PR do?

Adds the missing `s.m.Lock()` / `defer s.m.Unlock()` to `Unschedule`, matching the lock
already held by `GetChecksFromConfigs` (which uses `s.m.Lock()`).

### Motivation

`GetChecksFromConfigs` correctly acquires `s.m.Lock()` before reading or writing
`s.configToChecks`. `Unschedule` reads and writes the same map at multiple points
(lines 115, 134, 136, 140, 145) without holding any lock. Concurrent calls to `Schedule`
(which calls `GetChecksFromConfigs`) and `Unschedule` (from autodiscovery when a service
is removed) race on `configToChecks`, triggering a "concurrent map read and map write"
panic under the Go race detector and possibly in production as well.

### Describe how you validated your changes

`go test -tags test -race ./pkg/collector/...` passes.

### Additional Notes

Bug found by Claude during a codebase audit.