### PR TITLE
Fix write-under-RLock data race and double RLock in forwarder retry queue

### DIFF
--- a/comp/forwarder/defaultforwarder/internal/retry/transaction_retry_queue.go
+++ b/comp/forwarder/defaultforwarder/internal/retry/transaction_retry_queue.go
@@ -215,10 +215,10 @@ func (tc *TransactionRetryQueue) FlushToDisk() error {
 	if tc.optionalStorage == nil {
 		return nil
 	}
-	tc.mutex.RLock()
-	defer tc.mutex.RUnlock()
+	tc.mutex.Lock()
+	defer tc.mutex.Unlock()
 
-	transactions := tc.extractTransactionsFromMemory(tc.GetMaxMemSizeInBytes())
+	transactions := tc.extractTransactionsFromMemory(tc.maxMemSizeInBytes)
 	return tc.optionalStorage.Store(transactions)
 }
 


### PR DESCRIPTION
### What does this PR do?

`TransactionRetryQueue.FlushToDisk()` held `mutex.RLock()` while calling `extractTransactionsFromMemory()`, which mutates `tc.transactions` and `tc.currentMemSizeInBytes`. Concurrent holders of `RLock()` (e.g. `GetTransactionCount()`) would race on those writes. Change to `mutex.Lock()`.

Also, the original code called `tc.GetMaxMemSizeInBytes()` from within the locked section, which tries to acquire `RLock()` again. With a write lock held, this would deadlock. Replace with a direct field access to `tc.maxMemSizeInBytes`.

### Motivation

`sync.RWMutex` allows multiple concurrent readers, so holding `RLock()` while mutating state shared with other `RLock()` holders is a data race. The `-race` detector would flag any concurrent call to `GetTransactionCount()` and `FlushToDisk()`.

### Describe how you validated your changes

- `go test -race -tags test ./comp/forwarder/defaultforwarder/internal/retry/...` passes.

### Additional Notes

Found by Claude.