### PR TITLE
Fix nil dereference on msg.Origin in logs processor and encoders

### DIFF
--- a/pkg/logs/message/origin.go
+++ b/pkg/logs/message/origin.go
@@ -43,6 +43,10 @@ func (o *Origin) Tags(processingTags []string) []string {
 
 // TagsPayload returns the raw tag payload of the origin.
 func (o *Origin) TagsPayload(processingTags []string) []byte {
+	if o == nil || o.LogSource == nil {
+		return []byte{}
+	}
+
 	var tagsPayload []byte
 
 	source := o.Source()
@@ -80,6 +84,9 @@ func (o *Origin) TagsToString(processingTags []string) string {
 }
 
 func (o *Origin) tagsToStringArray(processingTags []string) []string {
+	if o == nil || o.LogSource == nil {
+		return processingTags
+	}
 	sourceCategory := o.LogSource.Config.SourceCategory
 	configTags := o.LogSource.Config.Tags
 
@@ -116,6 +123,9 @@ func (o *Origin) SetSource(source string) {
 // Source returns the source of the configuration if set or the source of the message,
 // if none are defined, returns an empty string by default.
 func (o *Origin) Source() string {
+	if o == nil || o.LogSource == nil {
+		return ""
+	}
 	if o.LogSource.Config.Source != "" {
 		return o.LogSource.Config.Source
 	}
@@ -130,6 +140,9 @@ func (o *Origin) SetService(service string) {
 // Service returns the service of the configuration if set or the service of the message,
 // if none are defined, returns an empty string by default.
 func (o *Origin) Service() string {
+	if o == nil || o.LogSource == nil {
+		return ""
+	}
 	if o.LogSource.Config.Service != "" {
 		return o.LogSource.Config.Service
 	}

--- a/pkg/logs/processor/processor.go
+++ b/pkg/logs/processor/processor.go
@@ -248,7 +248,11 @@ func (p *Processor) applyRedactingRules(msg *message.Message) bool {
 	// Use the internal scrubbing implementation of the Agent
 	// ---------------------------
 
-	rules := append(p.processingRules, msg.Origin.LogSource.Config.ProcessingRules...)
+	var extraRules []*config.ProcessingRule
+	if msg.Origin != nil && msg.Origin.LogSource != nil {
+		extraRules = msg.Origin.LogSource.Config.ProcessingRules
+	}
+	rules := append(p.processingRules, extraRules...)
 	for _, rule := range rules {
 		switch rule.Type {
 		case config.ExcludeAtMatch:


### PR DESCRIPTION
### What does this PR do?

Fixes nil pointer dereferences when `msg.Origin` is nil in the logs processor.

Several code paths dereference `msg.Origin` unconditionally:
- `json.go` lines 55-56: `msg.Origin.Service()` / `msg.Origin.Source()`
- `proto.go` lines 34-35: `msg.Origin.Service()` / `msg.Origin.Source()`
- `raw.go` line 50: `msg.Origin.Service()`
- `raw.go` line 61: `msg.Origin.TagsPayload()`
- `processor.go` line 236 (`filterMRFMessages`): `msg.Origin.Service()`
- `processor.go` line 251 (`applyRedactingRules`): `msg.Origin.LogSource.Config.ProcessingRules`

Many other call sites in the same package already guard against nil (e.g., `processor.go:185`, `message.go:380`), proving `Origin` can legitimately be nil (e.g., synthetic messages, serverless paths).

Changes:
- Make `Service()`, `Source()`, `TagsPayload()`, and `tagsToStringArray()` nil-safe on `*Origin` (nil receiver or nil `LogSource` returns empty/default value).
- Guard the direct struct field access in `applyRedactingRules` explicitly with a nil check.

### Motivation

Any message entering the pipeline without `Origin` set crashes the agent with a nil pointer dereference. The nil check pattern is established in the same codebase; these were missed occurrences.

### Describe how you validated your changes

- `go test -race -tags test ./pkg/logs/processor/...` passes.
- `go test -race ./pkg/logs/message/...` passes.

### Additional Notes

Found by Claude.