### PR TITLE
Fix kafka_connect_str matching for Kafka actions RC configs

### DIFF
--- a/releasenotes/notes/fix-data-streams-kafka-actions-matching-823142a7d7fd5dfd.yaml
+++ b/releasenotes/notes/fix-data-streams-kafka-actions-matching-823142a7d7fd5dfd.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Fix support of Kafka actions for configurations where kafka_connect_str is a list.


### PR DESCRIPTION
## Summary
- Handle `kafka_connect_str` as both a string and a YAML list (`[]interface{}`), fixing a silent type assertion failure when the config uses list format
- Align `normalizeBootstrapServers` with the Python `kafka_consumer` check's legacy tag normalization (replacing `,+*-/()[]{}` and whitespace with `_`) instead of using Go trace normalization which preserves hyphens and slashes

## Test plan
- [x] Verify topic creation works with `kafka_connect_str` as a list (`- kafka:19092`)
- [x] Verify topic creation works with `kafka_connect_str` as a string (`kafka:19092`)
- [x] Verify bootstrap server matching with special characters (hyphens, slashes) normalizes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)