### PR TITLE
[ AGNTLOG-560 ] Add COAT telemetry for auto multiline default-on impact analysis

### DIFF
--- a/comp/core/agenttelemetry/impl/config.go
+++ b/comp/core/agenttelemetry/impl/config.go
@@ -251,6 +251,9 @@ var defaultProfiles = `
           aggregate_tags:
             - truncated
             - line_type
+        - name: logs.auto_multi_line_default_total_lines
+        - name: logs.auto_multi_line_default_would_combine
+        - name: logs.auto_multi_line_default_would_truncate
         - name: logs_destination.destination_workers
         - name: point.sent
         - name: point.dropped

--- a/comp/logs/agent/config/integration_config_test.go
+++ b/comp/logs/agent/config/integration_config_test.go
@@ -81,6 +81,64 @@ func TestAutoMultilineEnabled(t *testing.T) {
 
 }
 
+func TestAutoMultiLineStatus(t *testing.T) {
+	t.Run("per-source false overrides global true", func(t *testing.T) {
+		mockConfig := config.NewMock(t)
+		mockConfig.SetWithoutSource("logs_config.auto_multi_line_detection", true)
+		enabled, isDefault := decode(`{"auto_multi_line_detection":false}`).AutoMultiLineStatus(mockConfig)
+		assert.False(t, enabled)
+		assert.False(t, isDefault)
+	})
+
+	t.Run("per-source true overrides global false", func(t *testing.T) {
+		mockConfig := config.NewMock(t)
+		mockConfig.SetWithoutSource("logs_config.auto_multi_line_detection", false)
+		enabled, isDefault := decode(`{"auto_multi_line_detection":true}`).AutoMultiLineStatus(mockConfig)
+		assert.True(t, enabled)
+		assert.False(t, isDefault)
+	})
+
+	t.Run("global explicitly true is not default", func(t *testing.T) {
+		mockConfig := config.NewMock(t)
+		mockConfig.SetWithoutSource("logs_config.auto_multi_line_detection", true)
+		enabled, isDefault := decode(`{}`).AutoMultiLineStatus(mockConfig)
+		assert.True(t, enabled)
+		assert.False(t, isDefault)
+	})
+
+	t.Run("global explicitly false is not default", func(t *testing.T) {
+		mockConfig := config.NewMock(t)
+		mockConfig.SetWithoutSource("logs_config.auto_multi_line_detection", false)
+		enabled, isDefault := decode(`{}`).AutoMultiLineStatus(mockConfig)
+		assert.False(t, enabled)
+		assert.False(t, isDefault)
+	})
+
+	t.Run("nothing configured is default", func(t *testing.T) {
+		mockConfig := config.NewMock(t)
+		enabled, isDefault := decode(`{}`).AutoMultiLineStatus(mockConfig)
+		assert.False(t, enabled)
+		assert.True(t, isDefault)
+	})
+
+	t.Run("deprecated experimental true is not default", func(t *testing.T) {
+		mockConfig := config.NewMock(t)
+		mockConfig.SetWithoutSource("logs_config.experimental_auto_multi_line_detection", true)
+		enabled, isDefault := decode(`{}`).AutoMultiLineStatus(mockConfig)
+		assert.True(t, enabled)
+		assert.False(t, isDefault)
+	})
+
+	t.Run("deprecated experimental false with auto true is not default", func(t *testing.T) {
+		mockConfig := config.NewMock(t)
+		mockConfig.SetWithoutSource("logs_config.experimental_auto_multi_line_detection", false)
+		mockConfig.SetWithoutSource("logs_config.auto_multi_line_detection", true)
+		enabled, isDefault := decode(`{}`).AutoMultiLineStatus(mockConfig)
+		assert.True(t, enabled)
+		assert.False(t, isDefault)
+	})
+}
+
 func decode(cfg string) *LogsConfig {
 	lc := LogsConfig{}
 	json.Unmarshal([]byte(cfg), &lc)

--- a/pkg/logs/internal/decoder/auto_multiline_handler_test.go
+++ b/pkg/logs/internal/decoder/auto_multiline_handler_test.go
@@ -41,7 +41,7 @@ func newDetectingHandler(outputChan chan *message.Message, _ int, flushTimeout t
 	tok := preprocessor.NewTokenizer(1000)
 	sampler := preprocessor.NewNoopSampler()
 	labeler := buildAutoMultilineLabeler(nil, nil, tailerInfo)
-	aggregator := preprocessor.NewDetectingAggregator(tailerInfo)
+	aggregator := preprocessor.NewDetectingAggregator(tailerInfo, 1000, false)
 	return newPreprocessorHandler(aggregator, tok, labeler, sampler, outputChan, preprocessor.NewNoopJSONAggregator(), flushTimeout, 0)
 }
 

--- a/pkg/logs/internal/decoder/decoder.go
+++ b/pkg/logs/internal/decoder/decoder.go
@@ -219,9 +219,11 @@ func buildLineHandler(source *sources.ReplaceableSource, multiLinePattern *regex
 		return newPreprocessorHandler(combiningAggregator, tok, labeler, sampler, outputChan, jsonAgg, flushTimeout, labelerMaxBytes)
 	} else if pkgconfigsetup.Datadog().GetBool("logs_config.auto_multi_line_detection_tagging") {
 		labeler := buildAutoMultilineLabeler(source.Config().AutoMultiLineOptions, source.Config().AutoMultiLineSamples, tailerInfo)
-		// JSON aggregation is disabled in detection mode — we don't want to combine JSON
-		// while only tagging everything else.
-		detectingAggregator := preprocessor.NewDetectingAggregator(tailerInfo)
+		cfg := pkgconfigsetup.Datadog()
+		isDefaultPath := source.Config().AutoMultiLine == nil &&
+			!cfg.IsConfigured("logs_config.auto_multi_line_detection") &&
+			!cfg.IsConfigured("logs_config.experimental_auto_multi_line_detection")
+		detectingAggregator := preprocessor.NewDetectingAggregator(tailerInfo, maxContentSize, isDefaultPath)
 		return newPreprocessorHandler(detectingAggregator, tok, labeler, sampler, outputChan, preprocessor.NewNoopJSONAggregator(), flushTimeout, labelerMaxBytes)
 	}
 	return newPreprocessorHandler(preprocessor.NewPassThroughAggregator(maxContentSize), tok, preprocessor.NewNoopLabeler(), sampler, outputChan, preprocessor.NewNoopJSONAggregator(), flushTimeout, 0)

--- a/pkg/logs/internal/decoder/decoder.go
+++ b/pkg/logs/internal/decoder/decoder.go
@@ -220,9 +220,7 @@ func buildLineHandler(source *sources.ReplaceableSource, multiLinePattern *regex
 	} else if pkgconfigsetup.Datadog().GetBool("logs_config.auto_multi_line_detection_tagging") {
 		labeler := buildAutoMultilineLabeler(source.Config().AutoMultiLineOptions, source.Config().AutoMultiLineSamples, tailerInfo)
 		cfg := pkgconfigsetup.Datadog()
-		isDefaultPath := source.Config().AutoMultiLine == nil &&
-			!cfg.IsConfigured("logs_config.auto_multi_line_detection") &&
-			!cfg.IsConfigured("logs_config.experimental_auto_multi_line_detection")
+		_, isDefaultPath := source.Config().AutoMultiLineStatus(cfg)
 		detectingAggregator := preprocessor.NewDetectingAggregator(tailerInfo, maxContentSize, isDefaultPath)
 		return newPreprocessorHandler(detectingAggregator, tok, labeler, sampler, outputChan, preprocessor.NewNoopJSONAggregator(), flushTimeout, labelerMaxBytes)
 	}

--- a/pkg/logs/internal/decoder/preprocessor/aggregator_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/aggregator_test.go
@@ -502,6 +502,7 @@ func TestDetectingAggregator_COATTelemetry_WouldCombine(t *testing.T) {
 
 	totalBefore := metrics.TlmAutoMultilineTotalLines.WithValues().Get()
 	combineBefore := metrics.TlmAutoMultilineWouldCombine.WithValues().Get()
+	truncBefore := metrics.TlmAutoMultilineWouldTruncate.WithValues().Get()
 
 	// startGroup followed by two aggregates: both aggregates would be combined
 	ag.Process(newMessage("timestamp line"), startGroup, nil)
@@ -510,55 +511,72 @@ func TestDetectingAggregator_COATTelemetry_WouldCombine(t *testing.T) {
 
 	totalAfter := metrics.TlmAutoMultilineTotalLines.WithValues().Get()
 	combineAfter := metrics.TlmAutoMultilineWouldCombine.WithValues().Get()
+	truncAfter := metrics.TlmAutoMultilineWouldTruncate.WithValues().Get()
 
 	assert.Equal(t, float64(3), totalAfter-totalBefore)
-	assert.Equal(t, float64(2), combineAfter-combineBefore)
+	assert.Equal(t, float64(3), combineAfter-combineBefore)
+	assert.Equal(t, float64(0), truncAfter-truncBefore)
 }
 
 func TestDetectingAggregator_COATTelemetry_NoCombineForStandaloneAggregates(t *testing.T) {
 	ag := NewDetectingAggregator(status.NewInfoRegistry(), 1000, true)
 
+	totalBefore := metrics.TlmAutoMultilineTotalLines.WithValues().Get()
 	combineBefore := metrics.TlmAutoMultilineWouldCombine.WithValues().Get()
+	truncBefore := metrics.TlmAutoMultilineWouldTruncate.WithValues().Get()
 
 	// Aggregate lines without a preceding startGroup should NOT count as would-combine
 	ag.Process(newMessage("orphan 1"), aggregate, nil)
 	ag.Process(newMessage("orphan 2"), aggregate, nil)
 
+	totalAfter := metrics.TlmAutoMultilineTotalLines.WithValues().Get()
 	combineAfter := metrics.TlmAutoMultilineWouldCombine.WithValues().Get()
+	truncAfter := metrics.TlmAutoMultilineWouldTruncate.WithValues().Get()
+	assert.Equal(t, float64(2), totalAfter-totalBefore)
 	assert.Equal(t, float64(0), combineAfter-combineBefore)
+	assert.Equal(t, float64(0), truncAfter-truncBefore)
 }
 
 func TestDetectingAggregator_COATTelemetry_WouldTruncate(t *testing.T) {
 	// maxContentSize=20 so combining will overflow
 	ag := NewDetectingAggregator(status.NewInfoRegistry(), 20, true)
 
-	truncBefore := metrics.TlmAutoMultilineWouldTruncateLines.WithValues().Get()
+	truncBefore := metrics.TlmAutoMultilineWouldTruncate.WithValues().Get()
 	totalBefore := metrics.TlmAutoMultilineTotalLines.WithValues().Get()
+	combineBefore := metrics.TlmAutoMultilineWouldCombine.WithValues().Get()
 
 	// startGroup(10 bytes content) + aggregate(15 bytes content) → 15 + 10 = 25 >= 20 → truncation
 	ag.Process(newMessage("1234567890"), startGroup, nil)     // 10 bytes content
 	ag.Process(newMessage("123456789012345"), aggregate, nil) // 15 bytes, RawDataLen=15, 15+10>=20 → truncate
 
-	truncAfter := metrics.TlmAutoMultilineWouldTruncateLines.WithValues().Get()
+	truncAfter := metrics.TlmAutoMultilineWouldTruncate.WithValues().Get()
 	totalAfter := metrics.TlmAutoMultilineTotalLines.WithValues().Get()
+	combineAfter := metrics.TlmAutoMultilineWouldCombine.WithValues().Get()
 
 	// Both lines (startGroup + overflowing aggregate) belong to the truncated group
 	assert.Equal(t, float64(2), truncAfter-truncBefore)
 	assert.Equal(t, float64(2), totalAfter-totalBefore)
+	assert.Equal(t, float64(2), combineAfter-combineBefore)
 }
 
 func TestDetectingAggregator_COATTelemetry_NoTruncateForOversizedSingleLine(t *testing.T) {
 	ag := NewDetectingAggregator(status.NewInfoRegistry(), 5, true)
 
-	truncBefore := metrics.TlmAutoMultilineWouldTruncateLines.WithValues().Get()
+	totalBefore := metrics.TlmAutoMultilineTotalLines.WithValues().Get()
+	truncBefore := metrics.TlmAutoMultilineWouldTruncate.WithValues().Get()
+	combineBefore := metrics.TlmAutoMultilineWouldCombine.WithValues().Get()
 
 	// A single startGroup >= maxContentSize is excluded from truncation counts
 	// (it would be truncated regardless of auto-multiline)
 	ag.Process(newMessage("12345"), startGroup, nil) // RawDataLen=5 >= maxContentSize=5
 	ag.Process(newMessage("67"), aggregate, nil)     // Not in group since startGroup was oversized
 
-	truncAfter := metrics.TlmAutoMultilineWouldTruncateLines.WithValues().Get()
+	totalAfter := metrics.TlmAutoMultilineTotalLines.WithValues().Get()
+	combineAfter := metrics.TlmAutoMultilineWouldCombine.WithValues().Get()
+	truncAfter := metrics.TlmAutoMultilineWouldTruncate.WithValues().Get()
 	assert.Equal(t, float64(0), truncAfter-truncBefore)
+	assert.Equal(t, float64(2), totalAfter-totalBefore)
+	assert.Equal(t, float64(0), combineAfter-combineBefore)
 }
 
 func TestDetectingAggregator_COATTelemetry_NoCountsWhenNotDefaultPath(t *testing.T) {
@@ -566,15 +584,18 @@ func TestDetectingAggregator_COATTelemetry_NoCountsWhenNotDefaultPath(t *testing
 
 	totalBefore := metrics.TlmAutoMultilineTotalLines.WithValues().Get()
 	combineBefore := metrics.TlmAutoMultilineWouldCombine.WithValues().Get()
+	truncBefore := metrics.TlmAutoMultilineWouldTruncate.WithValues().Get()
 
 	ag.Process(newMessage("timestamp line"), startGroup, nil)
 	ag.Process(newMessage("  continuation"), aggregate, nil)
 
 	totalAfter := metrics.TlmAutoMultilineTotalLines.WithValues().Get()
 	combineAfter := metrics.TlmAutoMultilineWouldCombine.WithValues().Get()
+	truncAfter := metrics.TlmAutoMultilineWouldTruncate.WithValues().Get()
 
 	assert.Equal(t, float64(0), totalAfter-totalBefore)
 	assert.Equal(t, float64(0), combineAfter-combineBefore)
+	assert.Equal(t, float64(0), truncAfter-truncBefore)
 }
 
 func TestDetectingAggregator_COATTelemetry_MultiGroupWithTruncation(t *testing.T) {
@@ -583,7 +604,7 @@ func TestDetectingAggregator_COATTelemetry_MultiGroupWithTruncation(t *testing.T
 
 	totalBefore := metrics.TlmAutoMultilineTotalLines.WithValues().Get()
 	combineBefore := metrics.TlmAutoMultilineWouldCombine.WithValues().Get()
-	truncBefore := metrics.TlmAutoMultilineWouldTruncateLines.WithValues().Get()
+	truncBefore := metrics.TlmAutoMultilineWouldTruncate.WithValues().Get()
 
 	// Group 1: fits (5 content + 2 LF + 3 content = 10 < 15)
 	ag.Process(newMessage("12345"), startGroup, nil) // 5 bytes
@@ -592,15 +613,16 @@ func TestDetectingAggregator_COATTelemetry_MultiGroupWithTruncation(t *testing.T
 	// Group 2: will truncate (10 content + RawDataLen=10 → 10+10=20 >= 15)
 	ag.Process(newMessage("1234567890"), startGroup, nil) // 10 bytes, starts new group
 	ag.Process(newMessage("1234567890"), aggregate, nil)  // RawDataLen=10, 10+10>=15 → truncate
+	ag.Process(newMessage("123"), aggregate, nil)         // Aggregate out of a startGroup should not count as would-combine
 
 	// noAggregate standalone
 	ag.Process(newMessage("standalone"), noAggregate, nil)
 
 	totalAfter := metrics.TlmAutoMultilineTotalLines.WithValues().Get()
 	combineAfter := metrics.TlmAutoMultilineWouldCombine.WithValues().Get()
-	truncAfter := metrics.TlmAutoMultilineWouldTruncateLines.WithValues().Get()
+	truncAfter := metrics.TlmAutoMultilineWouldTruncate.WithValues().Get()
 
-	assert.Equal(t, float64(5), totalAfter-totalBefore)
-	assert.Equal(t, float64(2), combineAfter-combineBefore) // 2 aggregate lines that would combine
+	assert.Equal(t, float64(6), totalAfter-totalBefore)
+	assert.Equal(t, float64(4), combineAfter-combineBefore) // group 1: startGroup + aggregate, group 2: startGroup + aggregate
 	assert.Equal(t, float64(2), truncAfter-truncBefore)     // group 2 (2 lines) would truncate
 }

--- a/pkg/logs/internal/decoder/preprocessor/aggregator_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/aggregator_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
 	status "github.com/DataDog/datadog-agent/pkg/logs/status/utils"
 )
 
@@ -384,7 +385,7 @@ func TestRegexAggregatorFirstLineMatchesWorksNormally(t *testing.T) {
 // Tests for detectingAggregator
 
 func TestDetectingAggregator_TagsMultilineStartOnly(t *testing.T) {
-	ag := NewDetectingAggregator(status.NewInfoRegistry())
+	ag := NewDetectingAggregator(status.NewInfoRegistry(), 100, false)
 
 	// startGroup: stored as pending, nothing emitted
 	require.Empty(t, processMsg(ag, newMessage("Error: Exception"), startGroup))
@@ -405,7 +406,7 @@ func TestDetectingAggregator_TagsMultilineStartOnly(t *testing.T) {
 }
 
 func TestDetectingAggregator_SingleLineNotTagged(t *testing.T) {
-	ag := NewDetectingAggregator(status.NewInfoRegistry())
+	ag := NewDetectingAggregator(status.NewInfoRegistry(), 100, false)
 
 	// startGroup: stored
 	require.Empty(t, processMsg(ag, newMessage("Single line 1"), startGroup))
@@ -424,7 +425,7 @@ func TestDetectingAggregator_SingleLineNotTagged(t *testing.T) {
 }
 
 func TestDetectingAggregator_NoAggregateOutputsImmediately(t *testing.T) {
-	ag := NewDetectingAggregator(status.NewInfoRegistry())
+	ag := NewDetectingAggregator(status.NewInfoRegistry(), 100, false)
 
 	msgs := processMsg(ag, newMessage("No aggregate 1"), noAggregate)
 	require.Len(t, msgs, 1)
@@ -438,7 +439,7 @@ func TestDetectingAggregator_NoAggregateOutputsImmediately(t *testing.T) {
 }
 
 func TestDetectingAggregator_FlushPendingMessage(t *testing.T) {
-	ag := NewDetectingAggregator(status.NewInfoRegistry())
+	ag := NewDetectingAggregator(status.NewInfoRegistry(), 100, false)
 
 	require.Empty(t, processMsg(ag, newMessage("Pending message"), startGroup))
 
@@ -449,7 +450,7 @@ func TestDetectingAggregator_FlushPendingMessage(t *testing.T) {
 }
 
 func TestDetectingAggregator_MixedSingleAndMultiLine(t *testing.T) {
-	ag := NewDetectingAggregator(status.NewInfoRegistry())
+	ag := NewDetectingAggregator(status.NewInfoRegistry(), 100, false)
 
 	// Single line stored
 	require.Empty(t, processMsg(ag, newMessage("Single"), startGroup))
@@ -478,7 +479,7 @@ func TestDetectingAggregator_MixedSingleAndMultiLine(t *testing.T) {
 }
 
 func TestDetectingAggregator_IsEmpty(t *testing.T) {
-	ag := NewDetectingAggregator(status.NewInfoRegistry())
+	ag := NewDetectingAggregator(status.NewInfoRegistry(), 100, false)
 
 	assert.True(t, ag.IsEmpty())
 
@@ -492,4 +493,114 @@ func TestDetectingAggregator_IsEmpty(t *testing.T) {
 	msgs = processMsg(ag, newMessage("Immediate"), noAggregate)
 	require.Len(t, msgs, 1)
 	assert.True(t, ag.IsEmpty())
+}
+
+// COAT telemetry tests
+
+func TestDetectingAggregator_COATTelemetry_WouldCombine(t *testing.T) {
+	ag := NewDetectingAggregator(status.NewInfoRegistry(), 1000, true)
+
+	totalBefore := metrics.TlmAutoMultilineTotalLines.WithValues().Get()
+	combineBefore := metrics.TlmAutoMultilineWouldCombine.WithValues().Get()
+
+	// startGroup followed by two aggregates: both aggregates would be combined
+	ag.Process(newMessage("timestamp line"), startGroup, nil)
+	ag.Process(newMessage("  continuation 1"), aggregate, nil)
+	ag.Process(newMessage("  continuation 2"), aggregate, nil)
+
+	totalAfter := metrics.TlmAutoMultilineTotalLines.WithValues().Get()
+	combineAfter := metrics.TlmAutoMultilineWouldCombine.WithValues().Get()
+
+	assert.Equal(t, float64(3), totalAfter-totalBefore)
+	assert.Equal(t, float64(2), combineAfter-combineBefore)
+}
+
+func TestDetectingAggregator_COATTelemetry_NoCombineForStandaloneAggregates(t *testing.T) {
+	ag := NewDetectingAggregator(status.NewInfoRegistry(), 1000, true)
+
+	combineBefore := metrics.TlmAutoMultilineWouldCombine.WithValues().Get()
+
+	// Aggregate lines without a preceding startGroup should NOT count as would-combine
+	ag.Process(newMessage("orphan 1"), aggregate, nil)
+	ag.Process(newMessage("orphan 2"), aggregate, nil)
+
+	combineAfter := metrics.TlmAutoMultilineWouldCombine.WithValues().Get()
+	assert.Equal(t, float64(0), combineAfter-combineBefore)
+}
+
+func TestDetectingAggregator_COATTelemetry_WouldTruncate(t *testing.T) {
+	// maxContentSize=20 so combining will overflow
+	ag := NewDetectingAggregator(status.NewInfoRegistry(), 20, true)
+
+	truncBefore := metrics.TlmAutoMultilineWouldTruncateLines.WithValues().Get()
+	totalBefore := metrics.TlmAutoMultilineTotalLines.WithValues().Get()
+
+	// startGroup(10 bytes content) + aggregate(15 bytes content) → 15 + 10 = 25 >= 20 → truncation
+	ag.Process(newMessage("1234567890"), startGroup, nil)     // 10 bytes content
+	ag.Process(newMessage("123456789012345"), aggregate, nil) // 15 bytes, RawDataLen=15, 15+10>=20 → truncate
+
+	truncAfter := metrics.TlmAutoMultilineWouldTruncateLines.WithValues().Get()
+	totalAfter := metrics.TlmAutoMultilineTotalLines.WithValues().Get()
+
+	// Both lines (startGroup + overflowing aggregate) belong to the truncated group
+	assert.Equal(t, float64(2), truncAfter-truncBefore)
+	assert.Equal(t, float64(2), totalAfter-totalBefore)
+}
+
+func TestDetectingAggregator_COATTelemetry_NoTruncateForOversizedSingleLine(t *testing.T) {
+	ag := NewDetectingAggregator(status.NewInfoRegistry(), 5, true)
+
+	truncBefore := metrics.TlmAutoMultilineWouldTruncateLines.WithValues().Get()
+
+	// A single startGroup >= maxContentSize is excluded from truncation counts
+	// (it would be truncated regardless of auto-multiline)
+	ag.Process(newMessage("12345"), startGroup, nil) // RawDataLen=5 >= maxContentSize=5
+	ag.Process(newMessage("67"), aggregate, nil)     // Not in group since startGroup was oversized
+
+	truncAfter := metrics.TlmAutoMultilineWouldTruncateLines.WithValues().Get()
+	assert.Equal(t, float64(0), truncAfter-truncBefore)
+}
+
+func TestDetectingAggregator_COATTelemetry_NoCountsWhenNotDefaultPath(t *testing.T) {
+	ag := NewDetectingAggregator(status.NewInfoRegistry(), 1000, false)
+
+	totalBefore := metrics.TlmAutoMultilineTotalLines.WithValues().Get()
+	combineBefore := metrics.TlmAutoMultilineWouldCombine.WithValues().Get()
+
+	ag.Process(newMessage("timestamp line"), startGroup, nil)
+	ag.Process(newMessage("  continuation"), aggregate, nil)
+
+	totalAfter := metrics.TlmAutoMultilineTotalLines.WithValues().Get()
+	combineAfter := metrics.TlmAutoMultilineWouldCombine.WithValues().Get()
+
+	assert.Equal(t, float64(0), totalAfter-totalBefore)
+	assert.Equal(t, float64(0), combineAfter-combineBefore)
+}
+
+func TestDetectingAggregator_COATTelemetry_MultiGroupWithTruncation(t *testing.T) {
+	// maxContentSize=15 to make the second group truncate
+	ag := NewDetectingAggregator(status.NewInfoRegistry(), 15, true)
+
+	totalBefore := metrics.TlmAutoMultilineTotalLines.WithValues().Get()
+	combineBefore := metrics.TlmAutoMultilineWouldCombine.WithValues().Get()
+	truncBefore := metrics.TlmAutoMultilineWouldTruncateLines.WithValues().Get()
+
+	// Group 1: fits (5 content + 2 LF + 3 content = 10 < 15)
+	ag.Process(newMessage("12345"), startGroup, nil) // 5 bytes
+	ag.Process(newMessage("678"), aggregate, nil)    // RawDataLen=3, 3+5=8 < 15 → ok, bufLen = 5+2+3 = 10
+
+	// Group 2: will truncate (10 content + RawDataLen=10 → 10+10=20 >= 15)
+	ag.Process(newMessage("1234567890"), startGroup, nil) // 10 bytes, starts new group
+	ag.Process(newMessage("1234567890"), aggregate, nil)  // RawDataLen=10, 10+10>=15 → truncate
+
+	// noAggregate standalone
+	ag.Process(newMessage("standalone"), noAggregate, nil)
+
+	totalAfter := metrics.TlmAutoMultilineTotalLines.WithValues().Get()
+	combineAfter := metrics.TlmAutoMultilineWouldCombine.WithValues().Get()
+	truncAfter := metrics.TlmAutoMultilineWouldTruncateLines.WithValues().Get()
+
+	assert.Equal(t, float64(5), totalAfter-totalBefore)
+	assert.Equal(t, float64(2), combineAfter-combineBefore) // 2 aggregate lines that would combine
+	assert.Equal(t, float64(2), truncAfter-truncBefore)     // group 2 (2 lines) would truncate
 }

--- a/pkg/logs/internal/decoder/preprocessor/detecting_aggregator.go
+++ b/pkg/logs/internal/decoder/preprocessor/detecting_aggregator.go
@@ -161,11 +161,16 @@ func (d *detectingAggregator) processSimulatedAggregate(msg *message.Message) {
 	// This line would be combined in combining mode
 	metrics.TlmAutoMultilineWouldCombine.Inc()
 
+	// When the first aggregate arrives, also count the startGroup line that anchors this group
+	if d.linesInCurrentGroup == 1 {
+		metrics.TlmAutoMultilineWouldCombine.Inc()
+	}
+
 	// Simulate the combining aggregator's overflow check:
 	// if msg.RawDataLen + bucket.buffer.Len() >= maxContentSize → truncation
 	if msg.RawDataLen+d.simulatedBufLen >= d.maxContentSize {
 		truncatedLines := float64(d.linesInCurrentGroup + 1)
-		metrics.TlmAutoMultilineWouldTruncateLines.Add(truncatedLines)
+		metrics.TlmAutoMultilineWouldTruncate.Add(truncatedLines)
 		d.resetSimulatedGroup()
 		return
 	}

--- a/pkg/logs/internal/decoder/preprocessor/detecting_aggregator.go
+++ b/pkg/logs/internal/decoder/preprocessor/detecting_aggregator.go
@@ -13,27 +13,48 @@ import (
 
 // detectingAggregator detects multiline groups and tags the start line without aggregating.
 // It outputs messages immediately for performance.
+//
+// When isDefaultPath is true, it also collects COAT telemetry that simulates what the
+// combining aggregator would do, tracking lines that would be combined and groups that
+// would be truncated if auto multiline were enabled by default.
 type detectingAggregator struct {
 	collected             []AggregatedMessageWithTokens
 	previousMsg           *message.Message
 	previousMsgTokens     []Token
 	previousWasStartGroup bool
 	multiLineMatchInfo    *status.CountInfo
+
+	// COAT simulation state
+	isDefaultPath       bool
+	maxContentSize      int
+	simulatedBufLen     int
+	linesInCurrentGroup int
+	inGroup             bool
 }
 
 // NewDetectingAggregator creates a new detecting aggregator.
-func NewDetectingAggregator(tailerInfo *status.InfoRegistry) Aggregator {
+// maxContentSize is used to simulate truncation detection for COAT telemetry.
+// isDefaultPath should be true when the source relies on the default value of
+// auto_multi_line_detection (not explicitly configured), meaning these metrics
+// reflect the impact of changing that default.
+func NewDetectingAggregator(tailerInfo *status.InfoRegistry, maxContentSize int, isDefaultPath bool) Aggregator {
 	multiLineMatchInfo := status.NewCountInfo("MultiLine matches")
 	tailerInfo.Register(multiLineMatchInfo)
 
 	return &detectingAggregator{
 		multiLineMatchInfo: multiLineMatchInfo,
+		isDefaultPath:      isDefaultPath,
+		maxContentSize:     maxContentSize,
 	}
 }
 
 // Process processes a message with a label and returns any emitted messages.
 func (d *detectingAggregator) Process(msg *message.Message, label Label, tokens []Token) []AggregatedMessageWithTokens {
 	d.collected = d.collected[:0]
+
+	if d.isDefaultPath {
+		metrics.TlmAutoMultilineTotalLines.Inc()
+	}
 
 	// Handle aggregate label
 	if label == aggregate {
@@ -55,6 +76,7 @@ func (d *detectingAggregator) Process(msg *message.Message, label Label, tokens 
 		}
 		// Output the current aggregate message immediately
 		d.collected = append(d.collected, AggregatedMessageWithTokens{Msg: msg, Tokens: tokens})
+		d.processSimulatedAggregate(msg)
 		return d.collected
 	}
 
@@ -68,6 +90,7 @@ func (d *detectingAggregator) Process(msg *message.Message, label Label, tokens 
 			d.previousWasStartGroup = false
 		}
 		d.collected = append(d.collected, AggregatedMessageWithTokens{Msg: msg, Tokens: tokens})
+		d.resetSimulatedGroup()
 		return d.collected
 	}
 
@@ -80,6 +103,7 @@ func (d *detectingAggregator) Process(msg *message.Message, label Label, tokens 
 		d.previousMsg = msg
 		d.previousMsgTokens = tokens
 		d.previousWasStartGroup = true
+		d.processSimulatedStartGroup(msg)
 		return d.collected
 	}
 
@@ -95,10 +119,65 @@ func (d *detectingAggregator) Flush() []AggregatedMessageWithTokens {
 		d.previousMsgTokens = nil
 		d.previousWasStartGroup = false
 	}
+	d.resetSimulatedGroup()
 	return d.collected
 }
 
 // IsEmpty returns true if there's no pending message.
 func (d *detectingAggregator) IsEmpty() bool {
 	return d.previousMsg == nil
+}
+
+// processSimulatedStartGroup handles the startGroup transition for COAT simulation.
+func (d *detectingAggregator) processSimulatedStartGroup(msg *message.Message) {
+	if !d.isDefaultPath {
+		return
+	}
+	// Finalize any previous group (no truncation on normal finalize)
+	d.resetSimulatedGroup()
+
+	// A startGroup that is already >= maxContentSize would be flushed immediately
+	// by the combining aggregator. That's a single oversized line -- excluded from
+	// our truncation metric since it would be truncated regardless.
+	if msg.RawDataLen >= d.maxContentSize {
+		return
+	}
+
+	d.inGroup = true
+	d.simulatedBufLen = len(msg.GetContent())
+	d.linesInCurrentGroup = 1
+}
+
+// processSimulatedAggregate handles the aggregate transition for COAT simulation.
+func (d *detectingAggregator) processSimulatedAggregate(msg *message.Message) {
+	if !d.isDefaultPath {
+		return
+	}
+
+	if !d.inGroup {
+		return
+	}
+
+	// This line would be combined in combining mode
+	metrics.TlmAutoMultilineWouldCombine.Inc()
+
+	// Simulate the combining aggregator's overflow check:
+	// if msg.RawDataLen + bucket.buffer.Len() >= maxContentSize → truncation
+	if msg.RawDataLen+d.simulatedBufLen >= d.maxContentSize {
+		truncatedLines := float64(d.linesInCurrentGroup + 1)
+		metrics.TlmAutoMultilineWouldTruncateLines.Add(truncatedLines)
+		d.resetSimulatedGroup()
+		return
+	}
+
+	// len(EscapedLineFeed) == 2
+	d.simulatedBufLen += len(message.EscapedLineFeed) + len(msg.GetContent())
+	d.linesInCurrentGroup++
+}
+
+// resetSimulatedGroup resets the COAT simulation state.
+func (d *detectingAggregator) resetSimulatedGroup() {
+	d.inGroup = false
+	d.simulatedBufLen = 0
+	d.linesInCurrentGroup = 0
 }

--- a/pkg/logs/metrics/metrics.go
+++ b/pkg/logs/metrics/metrics.go
@@ -140,6 +140,26 @@ var (
 	// Tags: status (success/failure/timeout), transport (tcp/http)
 	TlmRestartAttempt = telemetry.NewCounter("logs", "restart_attempt",
 		[]string{"status", "transport"}, "Count of logs agent restart attempts with status and target transport")
+
+	// COAT telemetry for auto multiline default-on impact analysis.
+	// These counters only increment for sources that rely on the default value of
+	// auto_multi_line_detection (i.e. sources where changing the default would alter behavior).
+
+	// TlmAutoMultilineTotalLines counts all lines processed by the detecting aggregator
+	// for sources on the default path. Used as the denominator for both X% and Y% metrics.
+	TlmAutoMultilineTotalLines = telemetry.NewCounter("logs", "auto_multi_line_default_total_lines",
+		nil, "Total lines processed by the detecting aggregator for default-path sources")
+
+	// TlmAutoMultilineWouldCombine counts lines that would be merged into a preceding
+	// startGroup message if auto multiline were enabled by default.
+	TlmAutoMultilineWouldCombine = telemetry.NewCounter("logs", "auto_multi_line_default_would_combine",
+		nil, "Lines that would be combined if auto multiline were the default")
+
+	// TlmAutoMultilineWouldTruncateLines counts raw input lines belonging to multiline
+	// groups that would exceed maxContentSize due to combining. Single lines that are
+	// individually oversized are excluded (they'd be truncated regardless).
+	TlmAutoMultilineWouldTruncateLines = telemetry.NewCounter("logs", "auto_multi_line_default_would_truncate_lines",
+		nil, "Lines belonging to groups that would be truncated if auto multiline were the default")
 )
 
 func init() {

--- a/pkg/logs/metrics/metrics.go
+++ b/pkg/logs/metrics/metrics.go
@@ -155,10 +155,10 @@ var (
 	TlmAutoMultilineWouldCombine = telemetry.NewCounter("logs", "auto_multi_line_default_would_combine",
 		nil, "Lines that would be combined if auto multiline were the default")
 
-	// TlmAutoMultilineWouldTruncateLines counts raw input lines belonging to multiline
+	// TlmAutoMultilineWouldTruncate counts raw input lines belonging to multiline
 	// groups that would exceed maxContentSize due to combining. Single lines that are
 	// individually oversized are excluded (they'd be truncated regardless).
-	TlmAutoMultilineWouldTruncateLines = telemetry.NewCounter("logs", "auto_multi_line_default_would_truncate_lines",
+	TlmAutoMultilineWouldTruncate = telemetry.NewCounter("logs", "auto_multi_line_default_would_truncate",
 		nil, "Lines belonging to groups that would be truncated if auto multiline were the default")
 )
 

--- a/releasenotes/notes/coat-auto-multiline-default-telemetry-54f92555f43d444b.yaml
+++ b/releasenotes/notes/coat-auto-multiline-default-telemetry-54f92555f43d444b.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Added internal telemetry counters to measure the impact of enabling
+    ``auto_multi_line_detection`` by default. The counters track how many
+    log lines would be combined and how many would risk truncation,
+    without changing any log processing behavior.


### PR DESCRIPTION
### What does this PR do?

Adds three COAT (Cost of Agent Telemetry) counters to the logs agent's detecting aggregator that measure what would change if `auto_multi_line_detection` were enabled by default:

- `auto_multi_line_default_total_lines` -- total lines processed (denominator for both percentage metrics)
- `auto_multi_line_default_would_combine` -- lines that would be merged into a preceding startGroup
- `auto_multi_line_default_would_truncate_lines` -- lines in groups that would exceed `maxContentSize` due to combining (excludes lines already individually oversized)

The counters only increment for sources truly relying on the default value of `auto_multi_line_detection`, using `IsConfigured()` and per-source nil checks to exclude explicitly configured sources. No behavioral changes to log processing; purely observational telemetry running inside the already-active detecting aggregator path.

### Motivation

We are evaluating changing `auto_multi_line_detection` from `false` to `true` by default. Before doing so, we need data on the impact: what percentage of lines would be conjoined differently, and what percentage would be at risk of truncation from the combining behavior. These counters provide that signal without altering any customer-facing behavior.

### Describe how you validated your changes

- 6 new unit tests covering: would-combine counting, no counting for standalone aggregates, would-truncate on simulated buffer overflow, exclusion of oversized single lines, no counting when `isDefaultPath=false`, and a multi-group mixed scenario.
- All existing automated tests pass
- E2E verification: built and ran the agent against a file source with no explicit `auto_multi_line_detection` set, appended timestamp + continuation lines, and confirmed all three counters incremented as expected via `curl localhost:5000/telemetry`. Negative test confirmed counters stay at zero when `auto_multi_line_detection: true` is set globally.

### Additional Notes