### PR TITLE
mark TestDDOTInstallScript as a flake

### DIFF
--- a/flakes.yaml
+++ b/flakes.yaml
@@ -18,6 +18,9 @@
 # * Note:
 # If you mute a parent test it will ignore all the subtests as well.
 
+test/new-e2e/tests/agent-platform/ddot:
+  - test: TestDDOTInstallScript
+
 # TODO: https://datadoghq.atlassian.net/browse/CONTINT-4143
 test/new-e2e/tests/containers:
   - test: TestECSSuite/TestCPU/metric___container.cpu.usage{^ecs_container_name:stress-ng$}


### PR DESCRIPTION
incident-50229

Failing:
https://app.datadoghq.com/ci/pipeline-executions?query=ci_level%3Ajob%20%40ci.pipeline.name%3ADataDog%2Fdatadog-agent%20%40git.branch%3Amain%20%40ci.job.name%3A%22new-e2e-agent-platform-ddot-suse-a7-x86_64%22&agg_m=%40ci.job.name&agg_m_source=base&agg_t=cardinality&analyticsOptions=%5B%22line%22%2C%22dog_classic%22%2Cnull%2Cnull%2C%22value%22%5D&cipipeline_explorer_sort=time%2Cdesc&colorByAttr=meta%5B%27ci.stage.name%27%5D&cols=%40git.branch%2C%40ci.status%2Ctimestamp%2C%40ci.pipeline.name%2C%40ci.stage.name%2C%40ci.job.name%2C%40duration%2C%40ci.pipeline.id%2C%40git.repository.name&currentTab=trace&fromUser=false&graphType=flamegraph&index=cipipeline&mode=sliding&sort=time&spanViewType=metadata&step=86400000&viz=stream&start=1767029648456&end=1772213648456&paused=false


## suspected root cause
appears to be at [https://github.com/DataDog/datadog-agent/blob/6b957f8a0b67e5d2b44ddc2a7fd79039ed2e[…]e56/test/new-e2e/tests/agent-platform/ddot/ddot_install_test.go](https://github.com/DataDog/datadog-agent/blob/6b957f8a0b67e5d2b44ddc2a7fd79039ed2e0e56/test/new-e2e/tests/agent-platform/ddot/ddot_install_test.go#L147)

Perhaps this should be an async retry when the state is activating to check that it becomes active within a few seconds.
