### PR TITLE
Add custom CI Visibility spans for new-e2e test jobs

### DIFF
--- a/.gitlab/.pre/common/ci_visibility_sections.yml
+++ b/.gitlab/.pre/common/ci_visibility_sections.yml
@@ -1,0 +1,25 @@
+---
+# Shared bash helper functions for CI Visibility custom spans.
+# These allow wrapping any shell block with datadog-ci span calls
+# to create custom spans visible in CI Visibility flamegraphs.
+#
+# Usage in before_script:
+#   - !reference [.setup_datadog_ci_sections]
+#   - datadog-ci-start-section
+#   - <your commands>
+#   - datadog-ci-end-section --category e2e-setup "Span Name"
+
+.setup_datadog_ci_sections:
+  - DATADOG_API_KEY=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_API_KEY_ORG2 token) || exit $?; export DATADOG_API_KEY
+  - |
+    datadog-ci-start-section() {
+      export _ci_section_start="$(date '+%s%N' | cut -b1-13)"
+    }
+    datadog-ci-end-section() {
+      _end="$(date '+%s%N' | cut -b1-13)"
+      _category=""
+      if [ "$1" = "--category" ]; then shift; _category="--tags agent-category:$1"; shift; fi
+      _name="$1"
+      datadog-ci span --name "$_name" --start-time "$_ci_section_start" --end-time "$_end" \
+        --tags agent-custom-span:true $_category || true
+    }

--- a/.gitlab/.pre/common/ci_visibility_sections.yml
+++ b/.gitlab/.pre/common/ci_visibility_sections.yml
@@ -1,6 +1,6 @@
 ---
 # Shared bash helper functions for CI Visibility custom spans.
-# These allow wrapping any shell block with datadog-ci span calls
+# These allow wrapping any shell block with datadog-ci trace span calls
 # to create custom spans visible in CI Visibility flamegraphs.
 #
 # Usage in before_script:
@@ -20,6 +20,6 @@
       _category=""
       if [ "$1" = "--category" ]; then shift; _category="--tags agent-category:$1"; shift; fi
       _name="$1"
-      datadog-ci span --name "$_name" --start-time "$_ci_section_start" --end-time "$_end" \
+      datadog-ci trace span --name "$_name" --start-time "$_ci_section_start" --end-time "$_end" \
         --tags agent-custom-span:true $_category || true
     }

--- a/.gitlab/.pre/common/ci_visibility_sections.yml
+++ b/.gitlab/.pre/common/ci_visibility_sections.yml
@@ -11,6 +11,14 @@
 
 .setup_datadog_ci_sections:
   - DATADOG_API_KEY=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_API_KEY_ORG2 token) || exit $?; export DATADOG_API_KEY
+  # Emit a retroactive span covering runner-managed phases (pod scheduling, git clone, artifact downloads)
+  # that happen before any user script runs. CI_JOB_STARTED_AT is set by GitLab Runner.
+  - |
+    _job_start_ms="$(date -d "$CI_JOB_STARTED_AT" '+%s%N' | cut -b1-13)"
+    _now_ms="$(date '+%s%N' | cut -b1-13)"
+    datadog-ci trace span --name "Runner setup (pod + git + artifacts)" \
+      --start-time "$_job_start_ms" --end-time "$_now_ms" \
+      --tags agent-custom-span:true --tags agent-category:e2e-setup || true
   - |
     datadog-ci-start-section() {
       export _ci_section_start="$(date '+%s%N' | cut -b1-13)"

--- a/.gitlab/test/e2e/e2e.yml
+++ b/.gitlab/test/e2e/e2e.yml
@@ -8,10 +8,22 @@
   needs:
     - !reference [.needs_new_e2e_template]
   before_script:
+    # Setup CI Visibility custom spans (fetches DATADOG_API_KEY + defines bash helpers)
+    - !reference [.setup_datadog_ci_sections]
+    # Retrieve e2e Go deps
+    - datadog-ci-start-section
     - !reference [.retrieve_linux_go_e2e_deps]
+    - datadog-ci-end-section --category e2e-setup "Retrieve e2e Go deps"
+    # Retrieve Pulumi plugins
+    - datadog-ci-start-section
     - !reference [.retrieve_linux_pulumi_plugins]
+    - datadog-ci-end-section --category e2e-setup "Retrieve Pulumi plugins"
+    # Retrieve Go tools deps
+    - datadog-ci-start-section
     - !reference [.retrieve_linux_go_tools_deps]
+    - datadog-ci-end-section --category e2e-setup "Retrieve Go tools deps"
     # Setup AWS Credentials
+    - datadog-ci-start-section
     - mkdir -p ~/.aws
     - |
       if [ -n "$E2E_USE_AWS_PROFILE" ]; then
@@ -27,6 +39,9 @@
         export AWS_SECRET_ACCESS_KEY="$(echo "$roleoutput" | jq -r '.Credentials.SecretAccessKey')"
         export AWS_SESSION_TOKEN="$(echo "$roleoutput" | jq -r '.Credentials.SessionToken')"
       fi
+    - datadog-ci-end-section --category e2e-setup "Setup AWS credentials"
+    # SSH Key retrieval
+    - datadog-ci-start-section
     # TODO: ADXT-768: Create new secret with different ssh key for the different cloud providers
     # SSH Key retrieval for AWS
     - $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E ssh_public_key_rsa > $E2E_AWS_PUBLIC_KEY_PATH || exit $?
@@ -37,8 +52,13 @@
     # SSH Key retrieval for GCP
     - $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E ssh_public_key_rsa > $E2E_GCP_PUBLIC_KEY_PATH || exit $?
     - touch $E2E_GCP_PRIVATE_KEY_PATH && chmod 600 $E2E_GCP_PRIVATE_KEY_PATH && $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E ssh_key_rsa > $E2E_GCP_PRIVATE_KEY_PATH || exit $?
-    # Use S3 backend
+    - datadog-ci-end-section --category e2e-setup "Retrieve SSH keys"
+    # Pulumi login
+    - datadog-ci-start-section
     - pulumi login "s3://dd-pulumi-state?region=us-east-1&awssdk=v2&profile=$AWS_PROFILE"
+    - datadog-ci-end-section --category e2e-setup "Pulumi login"
+    # Setup cloud credentials (Azure + GCP)
+    - datadog-ci-start-section
     # Setup Azure credentials. https://www.pulumi.com/registry/packages/azure-native/installation-configuration/#set-configuration-using-pulumi-config
     # The app is called `agent-e2e-tests`
     - ARM_CLIENT_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $E2E_AZURE client_id) || exit $?; export ARM_CLIENT_ID
@@ -53,13 +73,16 @@
     - |
       gcp_acr_key=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $E2E_GCP credentials_acr_readonly) || exit $?
       export E2E_GCP_IMAGE_PULL_PASSWORD="b64=$(printf '%s' "$gcp_acr_key" | base64 -w 0)"
+    - datadog-ci-end-section --category e2e-setup "Setup cloud credentials"
     # Generate external links to CI VISIBILITY, used by artifacts:reports:annotations
+    - datadog-ci-start-section
     - dda inv -- -e gitlab.generate-ci-visibility-links --output=$EXTERNAL_LINKS_PATH
+    - datadog-ci-end-section --category e2e-setup "Generate CI Visibility links"
     - export DD_ENV=nativetest # TODO: Remove after testing native instrumentation
     - export DD_CIVISIBILITY_ENABLED=true
     - export DD_CIVISIBILITY_AGENTLESS_ENABLED=true
     - export DD_CIVISIBILITY_FLAKY_RETRY_ENABLED=false
-    - DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_API_KEY_ORG2 token) || exit $?; export DD_API_KEY
+    - export DD_API_KEY=$DATADOG_API_KEY
     # set the environment variables for the windows test signing
     - export WINDOWS_DDNPM_DRIVER=${WINDOWS_DDNPM_DRIVER:-$(dda inv release.get-release-json-value "dependencies::WINDOWS_DDNPM_DRIVER" --no-worktree)}
     - export WINDOWS_DDPROCMON_DRIVER=${WINDOWS_DDPROCMON_DRIVER:-$(dda inv release.get-release-json-value "dependencies::WINDOWS_DDPROCMON_DRIVER" --no-worktree)}

--- a/tasks/custom_task/custom_task.py
+++ b/tasks/custom_task/custom_task.py
@@ -15,6 +15,7 @@ from time import perf_counter
 
 from invoke import Context
 
+from tasks.libs.common.ci_visibility import CIVisibilitySection
 from tasks.libs.common.color import color_message
 from tasks.libs.common.utils import running_in_ci, running_in_pre_commit, running_in_pyapp
 
@@ -145,8 +146,15 @@ def custom__call__(self, *args, **kwargs):
         raise TypeError(err.format(type(args[0])))
 
     ## DATADOG INVOKE LOGGER CODE ##
-    with InvokeLogger(self):
-        result = self.body(*args, **kwargs)
+    try:
+        with InvokeLogger(self):
+            result = self.body(*args, **kwargs)
+    finally:
+        ## DATADOG CI VISIBILITY CODE ##
+        try:
+            CIVisibilitySection.send_all()
+        except Exception:
+            pass
 
     ## LEGACY INVOKE LIB CODE ##
     self.times_called += 1  # noqa

--- a/tasks/libs/common/ci_visibility.py
+++ b/tasks/libs/common/ci_visibility.py
@@ -1,0 +1,148 @@
+"""
+CI Visibility helpers for creating custom spans in Datadog CI Visibility.
+
+Uses `datadog-ci span` to create custom spans that appear in CI Visibility flamegraphs.
+All helpers are no-ops outside of CI to avoid breaking local development.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+
+from tasks.libs.common.utils import running_in_ci
+
+
+def _shell_quote(s: str) -> str:
+    """Quote a string for safe shell usage."""
+    return "'" + s.replace("'", "'\\''") + "'"
+
+
+def _current_time_ms() -> int:
+    """Return current time in milliseconds since epoch."""
+    return int(time.time() * 1000)
+
+
+@dataclass
+class CIVisibilitySection:
+    """Represents a custom CI Visibility span."""
+
+    # Module-level accumulator for batch sending
+    _accumulated: list[CIVisibilitySection] = field(default_factory=list, init=False, repr=False)
+
+    name: str
+    start_time_ms: int
+    end_time_ms: int
+    tags: dict[str, str] = field(default_factory=dict)
+
+    def __post_init__(self):
+        # Ensure tags always include the custom span marker
+        self.tags.setdefault("agent-custom-span", "true")
+
+    @classmethod
+    def create(cls, name: str, start_time_ms: int, end_time_ms: int, tags: dict[str, str] | None = None) -> None:
+        """Register a section for batch sending later."""
+        section = cls(name=name, start_time_ms=start_time_ms, end_time_ms=end_time_ms, tags=tags or {})
+        _SECTIONS.append(section)
+
+    def send(self) -> bool:
+        """Send a single span via datadog-ci span."""
+        tag_args = " ".join(f"--tags {k}:{v}" for k, v in self.tags.items())
+        cmd = f"datadog-ci span --name {_shell_quote(self.name)} --start-time {self.start_time_ms} --end-time {self.end_time_ms} {tag_args}"
+
+        try:
+            subprocess.run(cmd, shell=True, check=True, capture_output=True, timeout=30)
+            return True
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError) as e:
+            print(f"Warning: failed to send CI visibility span '{self.name}': {e}")
+            return False
+
+    @classmethod
+    def send_all(cls) -> None:
+        """Batch-send all accumulated sections. Tries --payload-file first, falls back to individual sends."""
+        if not _SECTIONS or not running_in_ci():
+            _SECTIONS.clear()
+            return
+
+        # Try batch send via payload file
+        if _send_batch_payload(list(_SECTIONS)):
+            _SECTIONS.clear()
+            return
+
+        # Fall back to individual sends
+        for section in _SECTIONS:
+            section.send()
+
+        _SECTIONS.clear()
+
+
+# Module-level list, declared after class to avoid forward reference issues
+_SECTIONS: list[CIVisibilitySection] = []
+
+
+def _send_batch_payload(sections: list[CIVisibilitySection]) -> bool:
+    """Try to send all sections via a single datadog-ci span --payload-file call."""
+    payload = []
+    for section in sections:
+        entry = {
+            "name": section.name,
+            "start_time": section.start_time_ms,
+            "end_time": section.end_time_ms,
+            "tags": dict(section.tags),
+        }
+        payload.append(entry)
+
+    try:
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump(payload, f)
+            payload_file = f.name
+
+        result = subprocess.run(
+            f"datadog-ci span --payload-file {payload_file}",
+            shell=True,
+            capture_output=True,
+            timeout=30,
+        )
+
+        if result.returncode == 0:
+            return True
+
+        # --payload-file might not be supported in this version
+        return False
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
+        return False
+    finally:
+        try:
+            os.unlink(payload_file)
+        except (OSError, UnboundLocalError):
+            pass
+
+
+@contextmanager
+def ci_visibility_section(name: str, tags: dict[str, str] | None = None):
+    """Context manager that records timing and creates a CI Visibility section.
+
+    No-op outside of CI environments.
+
+    Usage:
+        with ci_visibility_section("my-operation", tags={"agent-category": "e2e"}):
+            do_something()
+    """
+    if not running_in_ci():
+        yield
+        return
+
+    all_tags = dict(tags) if tags else {}
+    all_tags.setdefault("agent-custom-span", "true")
+
+    start = _current_time_ms()
+    try:
+        yield
+    finally:
+        end = _current_time_ms()
+        CIVisibilitySection.create(name=name, start_time_ms=start, end_time_ms=end, tags=all_tags)

--- a/tasks/libs/common/ci_visibility.py
+++ b/tasks/libs/common/ci_visibility.py
@@ -1,16 +1,13 @@
 """
 CI Visibility helpers for creating custom spans in Datadog CI Visibility.
 
-Uses `datadog-ci span` to create custom spans that appear in CI Visibility flamegraphs.
+Uses `datadog-ci trace span` to create custom spans that appear in CI Visibility flamegraphs.
 All helpers are no-ops outside of CI to avoid breaking local development.
 """
 
 from __future__ import annotations
 
-import json
-import os
 import subprocess
-import tempfile
 import time
 from contextlib import contextmanager
 from dataclasses import dataclass, field
@@ -51,9 +48,9 @@ class CIVisibilitySection:
         _SECTIONS.append(section)
 
     def send(self) -> bool:
-        """Send a single span via datadog-ci span."""
+        """Send a single span via datadog-ci trace span."""
         tag_args = " ".join(f"--tags {k}:{v}" for k, v in self.tags.items())
-        cmd = f"datadog-ci span --name {_shell_quote(self.name)} --start-time {self.start_time_ms} --end-time {self.end_time_ms} {tag_args}"
+        cmd = f"datadog-ci trace span --name {_shell_quote(self.name)} --start-time {self.start_time_ms} --end-time {self.end_time_ms} {tag_args}"
 
         try:
             subprocess.run(cmd, shell=True, check=True, capture_output=True, timeout=30)
@@ -64,17 +61,11 @@ class CIVisibilitySection:
 
     @classmethod
     def send_all(cls) -> None:
-        """Batch-send all accumulated sections. Tries --payload-file first, falls back to individual sends."""
+        """Send all accumulated sections individually via datadog-ci trace span."""
         if not _SECTIONS or not running_in_ci():
             _SECTIONS.clear()
             return
 
-        # Try batch send via payload file
-        if _send_batch_payload(list(_SECTIONS)):
-            _SECTIONS.clear()
-            return
-
-        # Fall back to individual sends
         for section in _SECTIONS:
             section.send()
 
@@ -83,44 +74,6 @@ class CIVisibilitySection:
 
 # Module-level list, declared after class to avoid forward reference issues
 _SECTIONS: list[CIVisibilitySection] = []
-
-
-def _send_batch_payload(sections: list[CIVisibilitySection]) -> bool:
-    """Try to send all sections via a single datadog-ci span --payload-file call."""
-    payload = []
-    for section in sections:
-        entry = {
-            "name": section.name,
-            "start_time": section.start_time_ms,
-            "end_time": section.end_time_ms,
-            "tags": dict(section.tags),
-        }
-        payload.append(entry)
-
-    try:
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
-            json.dump(payload, f)
-            payload_file = f.name
-
-        result = subprocess.run(
-            f"datadog-ci span --payload-file {payload_file}",
-            shell=True,
-            capture_output=True,
-            timeout=30,
-        )
-
-        if result.returncode == 0:
-            return True
-
-        # --payload-file might not be supported in this version
-        return False
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
-        return False
-    finally:
-        try:
-            os.unlink(payload_file)
-        except (OSError, UnboundLocalError):
-            pass
 
 
 @contextmanager

--- a/tasks/libs/common/ci_visibility.py
+++ b/tasks/libs/common/ci_visibility.py
@@ -7,6 +7,8 @@ All helpers are no-ops outside of CI to avoid breaking local development.
 
 from __future__ import annotations
 
+import json
+import os
 import subprocess
 import time
 from contextlib import contextmanager
@@ -74,6 +76,103 @@ class CIVisibilitySection:
 
 # Module-level list, declared after class to avoid forward reference issues
 _SECTIONS: list[CIVisibilitySection] = []
+
+
+def create_spans_from_test_json(result_json_path: str, tags: dict[str, str] | None = None) -> int:
+    """Parse a gotestsum JSON output file and create a CI Visibility span for each test.
+
+    Each test gets a span from its "run" event to its terminal event (pass/fail/skip).
+    Returns the number of spans created.
+    """
+    if not running_in_ci():
+        return 0
+
+    if not os.path.isfile(result_json_path):
+        print(f"Warning: test result JSON not found at {result_json_path}, skipping span creation")
+        return 0
+
+    base_tags = dict(tags) if tags else {}
+    base_tags.setdefault("agent-custom-span", "true")
+
+    # Collect per-test events: (package, test) -> {start_time, end_time, action}
+    # We track the "run" time as start and the terminal action time as end.
+    test_runs: dict[tuple[str, str], dict] = {}
+
+    with open(result_json_path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            test_name = event.get("Test")
+            if not test_name:
+                # Package-level event, skip
+                continue
+
+            package = event.get("Package", "")
+            action = event.get("Action")
+            event_time = event.get("Time")
+
+            if not event_time or not action:
+                continue
+
+            key = (package, test_name)
+
+            if action == "run":
+                test_runs[key] = {"start_time": event_time, "package": package, "test": test_name}
+            elif action in ("pass", "fail", "skip") and key in test_runs:
+                test_runs[key]["end_time"] = event_time
+                test_runs[key]["result"] = action
+                # Capture elapsed if present (more precise than timestamp diff)
+                if "Elapsed" in event:
+                    test_runs[key]["elapsed"] = event["Elapsed"]
+
+    count = 0
+    for (package, test_name), data in test_runs.items():
+        if "end_time" not in data:
+            # Test started but never finished (e.g. panic/timeout), skip
+            continue
+
+        start_ms = _iso_to_ms(data["start_time"])
+        end_ms = _iso_to_ms(data["end_time"])
+
+        if start_ms is None or end_ms is None:
+            continue
+
+        # Use elapsed field for more precise end time if available
+        if "elapsed" in data and start_ms is not None:
+            end_ms = start_ms + int(data["elapsed"] * 1000)
+
+        span_tags = dict(base_tags)
+        span_tags["test.name"] = test_name
+        span_tags["test.package"] = package
+        span_tags["test.result"] = data.get("result", "unknown")
+
+        # Use short package name for the span name
+        short_pkg = package.rsplit("/", 1)[-1] if "/" in package else package
+        span_name = f"{short_pkg}/{test_name}"
+
+        CIVisibilitySection.create(name=span_name, start_time_ms=start_ms, end_time_ms=end_ms, tags=span_tags)
+        count += 1
+
+    return count
+
+
+def _iso_to_ms(iso_time: str) -> int | None:
+    """Convert an ISO 8601 / RFC 3339 timestamp to milliseconds since epoch."""
+    from datetime import datetime, timezone
+
+    try:
+        dt = datetime.fromisoformat(iso_time)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return int(dt.timestamp() * 1000)
+    except (ValueError, OSError):
+        return None
 
 
 @contextmanager

--- a/tasks/libs/common/ci_visibility.py
+++ b/tasks/libs/common/ci_visibility.py
@@ -7,8 +7,6 @@ All helpers are no-ops outside of CI to avoid breaking local development.
 
 from __future__ import annotations
 
-import json
-import os
 import subprocess
 import time
 from contextlib import contextmanager
@@ -76,103 +74,6 @@ class CIVisibilitySection:
 
 # Module-level list, declared after class to avoid forward reference issues
 _SECTIONS: list[CIVisibilitySection] = []
-
-
-def create_spans_from_test_json(result_json_path: str, tags: dict[str, str] | None = None) -> int:
-    """Parse a gotestsum JSON output file and create a CI Visibility span for each test.
-
-    Each test gets a span from its "run" event to its terminal event (pass/fail/skip).
-    Returns the number of spans created.
-    """
-    if not running_in_ci():
-        return 0
-
-    if not os.path.isfile(result_json_path):
-        print(f"Warning: test result JSON not found at {result_json_path}, skipping span creation")
-        return 0
-
-    base_tags = dict(tags) if tags else {}
-    base_tags.setdefault("agent-custom-span", "true")
-
-    # Collect per-test events: (package, test) -> {start_time, end_time, action}
-    # We track the "run" time as start and the terminal action time as end.
-    test_runs: dict[tuple[str, str], dict] = {}
-
-    with open(result_json_path) as f:
-        for line in f:
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                event = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-
-            test_name = event.get("Test")
-            if not test_name:
-                # Package-level event, skip
-                continue
-
-            package = event.get("Package", "")
-            action = event.get("Action")
-            event_time = event.get("Time")
-
-            if not event_time or not action:
-                continue
-
-            key = (package, test_name)
-
-            if action == "run":
-                test_runs[key] = {"start_time": event_time, "package": package, "test": test_name}
-            elif action in ("pass", "fail", "skip") and key in test_runs:
-                test_runs[key]["end_time"] = event_time
-                test_runs[key]["result"] = action
-                # Capture elapsed if present (more precise than timestamp diff)
-                if "Elapsed" in event:
-                    test_runs[key]["elapsed"] = event["Elapsed"]
-
-    count = 0
-    for (package, test_name), data in test_runs.items():
-        if "end_time" not in data:
-            # Test started but never finished (e.g. panic/timeout), skip
-            continue
-
-        start_ms = _iso_to_ms(data["start_time"])
-        end_ms = _iso_to_ms(data["end_time"])
-
-        if start_ms is None or end_ms is None:
-            continue
-
-        # Use elapsed field for more precise end time if available
-        if "elapsed" in data and start_ms is not None:
-            end_ms = start_ms + int(data["elapsed"] * 1000)
-
-        span_tags = dict(base_tags)
-        span_tags["test.name"] = test_name
-        span_tags["test.package"] = package
-        span_tags["test.result"] = data.get("result", "unknown")
-
-        # Use short package name for the span name
-        short_pkg = package.rsplit("/", 1)[-1] if "/" in package else package
-        span_name = f"{short_pkg}/{test_name}"
-
-        CIVisibilitySection.create(name=span_name, start_time_ms=start_ms, end_time_ms=end_ms, tags=span_tags)
-        count += 1
-
-    return count
-
-
-def _iso_to_ms(iso_time: str) -> int | None:
-    """Convert an ISO 8601 / RFC 3339 timestamp to milliseconds since epoch."""
-    from datetime import datetime, timezone
-
-    try:
-        dt = datetime.fromisoformat(iso_time)
-        if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=timezone.utc)
-        return int(dt.timestamp() * 1000)
-    except (ValueError, OSError):
-        return None
 
 
 @contextmanager

--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -25,6 +25,7 @@ from invoke.tasks import task
 from tasks.flavor import AgentFlavor
 from tasks.gotest import process_test_result, test_flavor
 from tasks.libs.ciproviders.gitlab_api import get_gitlab_repo
+from tasks.libs.common.ci_visibility import ci_visibility_section
 from tasks.libs.common.color import Color
 from tasks.libs.common.git import get_commit_sha, get_current_branch, get_modified_files
 from tasks.libs.common.go import download_go_dependencies
@@ -290,25 +291,26 @@ def run(
         e2e_module.test_targets = targets
 
     if impacted and running_in_ci():
-        try:
-            print(color_message("Using dynamic tests", "yellow"))
-            # DynTestExecutor needs to access build stable account to retrieve the index. Temporarly remove the AWS_PROFILE to avoid connecting on agent-qa account
-            with environ({"AWS_PROFILE": "DELETE"}):
-                backend = S3Backend(DEFAULT_DYNTEST_BUCKET_URI)
-                executor = DynTestExecutor(ctx, backend, IndexKind.DIFFED_PACKAGE, get_commit_sha(ctx, short=True))
-                changed_files = get_modified_files(ctx)
-                changed_packages = list({os.path.dirname(change) for change in changed_files})
-                print(color_message(f"The following changes were detected: {changed_files}", "yellow"))
-                test_job_name = os.getenv("CI_JOB_NAME")
-                if test_job_name.endswith("-init"):
-                    test_job_name = test_job_name.removesuffix("-init")
-                to_skip = executor.tests_to_skip(test_job_name, changed_packages + changed_files)
-                ctx.run(f"datadog-ci measure --level job --measures 'e2e.skipped_tests:{len(to_skip)}'", warn=True)
-                print(color_message(f"The following tests will be skipped: {to_skip}", "yellow"))
-                skip.extend(to_skip)
-        except Exception as e:
-            print(color_message(f"Error using dynamic tests: {e}", "red"))
-            print(color_message("Continuing with static tests", "yellow"))
+        with ci_visibility_section("dynamic-test-calculation", tags={"agent-category": "e2e"}):
+            try:
+                print(color_message("Using dynamic tests", "yellow"))
+                # DynTestExecutor needs to access build stable account to retrieve the index. Temporarly remove the AWS_PROFILE to avoid connecting on agent-qa account
+                with environ({"AWS_PROFILE": "DELETE"}):
+                    backend = S3Backend(DEFAULT_DYNTEST_BUCKET_URI)
+                    executor = DynTestExecutor(ctx, backend, IndexKind.DIFFED_PACKAGE, get_commit_sha(ctx, short=True))
+                    changed_files = get_modified_files(ctx)
+                    changed_packages = list({os.path.dirname(change) for change in changed_files})
+                    print(color_message(f"The following changes were detected: {changed_files}", "yellow"))
+                    test_job_name = os.getenv("CI_JOB_NAME")
+                    if test_job_name.endswith("-init"):
+                        test_job_name = test_job_name.removesuffix("-init")
+                    to_skip = executor.tests_to_skip(test_job_name, changed_packages + changed_files)
+                    ctx.run(f"datadog-ci measure --level job --measures 'e2e.skipped_tests:{len(to_skip)}'", warn=True)
+                    print(color_message(f"The following tests will be skipped: {to_skip}", "yellow"))
+                    skip.extend(to_skip)
+            except Exception as e:
+                print(color_message(f"Error using dynamic tests: {e}", "red"))
+                print(color_message("Continuing with static tests", "yellow"))
 
     env_vars = {}
     if profile:
@@ -488,19 +490,20 @@ def run(
         partial_result_junit = f"junit-out-{str(AgentFlavor.base)}-{attempt}.xml"
         result_junits.append(partial_result_junit)
 
-        test_res = test_flavor(
-            ctx,
-            flavor=AgentFlavor.base,
-            build_tags=tags,
-            modules=[e2e_module],
-            args=args,
-            cmd=cmd,
-            env=env_vars,
-            result_junit=partial_result_junit,
-            result_json=partial_result_json,
-            test_profiler=None,
-            recursive=recursive,
-        )
+        with ci_visibility_section(f"test-execution-attempt-{attempt}", tags={"agent-category": "e2e"}):
+            test_res = test_flavor(
+                ctx,
+                flavor=AgentFlavor.base,
+                build_tags=tags,
+                modules=[e2e_module],
+                args=args,
+                cmd=cmd,
+                env=env_vars,
+                result_junit=partial_result_junit,
+                result_json=partial_result_json,
+                test_profiler=None,
+                recursive=recursive,
+            )
         if test_res is None:
             ctx.run("datadog-ci tag --level job --tags 'e2e.skipped_all_tests:true'")
             return
@@ -553,40 +556,43 @@ def run(
     # Make sure that any non-successful test suites that were not retried (i.e., fully-known-flaky-failing suites) are torn down
     # Do this by calling the tests with the E2E_TEARDOWN_ONLY env var set, which will only run the teardown logic
     if to_teardown:
-        print(
-            color_message(
-                f"Tearing down {len(to_teardown)} leftover test infras",
-                "yellow",
+        with ci_visibility_section("teardown-flaky-infra", tags={"agent-category": "e2e"}):
+            print(
+                color_message(
+                    f"Tearing down {len(to_teardown)} leftover test infras",
+                    "yellow",
+                )
             )
-        )
-        affected_packages = {
-            os.path.relpath(package, "github.com/DataDog/datadog-agent/test/new-e2e/") for package, _ in to_teardown
-        }
-        e2e_module.test_targets = list(affected_packages)
-        args["run"] = '-test.run ' + create_test_selection_gotest_regex([test for _, test in to_teardown])
-        env_vars["E2E_TEARDOWN_ONLY"] = "true"
-        test_flavor(
-            ctx,
-            flavor=AgentFlavor.base,
-            build_tags=tags,
-            modules=[e2e_module],
-            args=args,
-            cmd=cmd,
-            env=env_vars,
-            result_junit="",  # No need to store JUnit results for teardown-only runs
-            result_json="",  # No need to store results for teardown-only runs
-            test_profiler=None,
-        )
+            affected_packages = {
+                os.path.relpath(package, "github.com/DataDog/datadog-agent/test/new-e2e/") for package, _ in to_teardown
+            }
+            e2e_module.test_targets = list(affected_packages)
+            args["run"] = '-test.run ' + create_test_selection_gotest_regex([test for _, test in to_teardown])
+            env_vars["E2E_TEARDOWN_ONLY"] = "true"
+            test_flavor(
+                ctx,
+                flavor=AgentFlavor.base,
+                build_tags=tags,
+                modules=[e2e_module],
+                args=args,
+                cmd=cmd,
+                env=env_vars,
+                result_junit="",  # No need to store JUnit results for teardown-only runs
+                result_json="",  # No need to store results for teardown-only runs
+                test_profiler=None,
+            )
 
     # Merge all the partial result JSON files into the final result JSON
-    with open(result_json, "w") as merged_file:
-        for partial_file in result_jsons:
-            with open(partial_file) as f:
-                merged_file.writelines(line.strip() + "\n" for line in f.readlines())
+    with ci_visibility_section("merge-result-jsons", tags={"agent-category": "e2e"}):
+        with open(result_json, "w") as merged_file:
+            for partial_file in result_jsons:
+                with open(partial_file) as f:
+                    merged_file.writelines(line.strip() + "\n" for line in f.readlines())
 
-    success = process_test_result(
-        ctx, test_res, junit_tar, result_junits, AgentFlavor.base, test_washer, test_system="e2e"
-    )
+    with ci_visibility_section("process-test-results", tags={"agent-category": "e2e"}):
+        success = process_test_result(
+            ctx, test_res, junit_tar, result_junits, AgentFlavor.base, test_washer, test_system="e2e"
+        )
 
     if running_in_ci():
         # Do not print all the params, they could contain secrets needed only in the CI
@@ -607,21 +613,22 @@ def run(
         )
 
     if logs_post_processing:
-        post_processed_output = post_process_output(
-            test_res.result_json_path, test_depth=logs_post_processing_test_depth
-        )
-        os.makedirs(logs_folder, exist_ok=True)
-        write_result_to_log_files(
-            post_processed_output,
-            logs_folder,
-            test_depth=logs_post_processing_test_depth,
-        )
+        with ci_visibility_section("logs-post-processing", tags={"agent-category": "e2e"}):
+            post_processed_output = post_process_output(
+                test_res.result_json_path, test_depth=logs_post_processing_test_depth
+            )
+            os.makedirs(logs_folder, exist_ok=True)
+            write_result_to_log_files(
+                post_processed_output,
+                logs_folder,
+                test_depth=logs_post_processing_test_depth,
+            )
 
-        pretty_print_logs(
-            test_res.result_json_path,
-            post_processed_output,
-            test_depth=logs_post_processing_test_depth,
-        )
+            pretty_print_logs(
+                test_res.result_json_path,
+                post_processed_output,
+                test_depth=logs_post_processing_test_depth,
+            )
 
     if not success:
         raise Exit(code=1)

--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -25,7 +25,7 @@ from invoke.tasks import task
 from tasks.flavor import AgentFlavor
 from tasks.gotest import process_test_result, test_flavor
 from tasks.libs.ciproviders.gitlab_api import get_gitlab_repo
-from tasks.libs.common.ci_visibility import ci_visibility_section
+from tasks.libs.common.ci_visibility import ci_visibility_section, create_spans_from_test_json
 from tasks.libs.common.color import Color
 from tasks.libs.common.git import get_commit_sha, get_current_branch, get_modified_files
 from tasks.libs.common.go import download_go_dependencies
@@ -504,6 +504,12 @@ def run(
                 test_profiler=None,
                 recursive=recursive,
             )
+        # Create per-test CI Visibility spans from the JSON output
+        create_spans_from_test_json(
+            partial_result_json,
+            tags={"agent-category": "e2e", "test.attempt": str(attempt)},
+        )
+
         if test_res is None:
             ctx.run("datadog-ci tag --level job --tags 'e2e.skipped_all_tests:true'")
             return

--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -25,7 +25,7 @@ from invoke.tasks import task
 from tasks.flavor import AgentFlavor
 from tasks.gotest import process_test_result, test_flavor
 from tasks.libs.ciproviders.gitlab_api import get_gitlab_repo
-from tasks.libs.common.ci_visibility import ci_visibility_section, create_spans_from_test_json
+from tasks.libs.common.ci_visibility import ci_visibility_section
 from tasks.libs.common.color import Color
 from tasks.libs.common.git import get_commit_sha, get_current_branch, get_modified_files
 from tasks.libs.common.go import download_go_dependencies
@@ -504,12 +504,6 @@ def run(
                 test_profiler=None,
                 recursive=recursive,
             )
-        # Create per-test CI Visibility spans from the JSON output
-        create_spans_from_test_json(
-            partial_result_json,
-            tags={"agent-category": "e2e", "test.attempt": str(attempt)},
-        )
-
         if test_res is None:
             ctx.run("datadog-ci tag --level job --tags 'e2e.skipped_all_tests:true'")
             return


### PR DESCRIPTION
## Summary
- Add `datadog-ci span` instrumentation to e2e pipeline jobs so each setup step and test phase appears as a separate span in CI Visibility flamegraphs
- Create shared bash helpers (`.setup_datadog_ci_sections`) for before_script spans and Python helpers (`ci_visibility_section` context manager) for invoke task spans
- Auto-send accumulated Python spans via `CIVisibilitySection.send_all()` hook in `custom_task.py`

## What Changed
- **New `tasks/libs/common/ci_visibility.py`**: Python CI Visibility helpers — `CIVisibilitySection` dataclass with batch send, `ci_visibility_section()` context manager (no-op outside CI)
- **New `.gitlab/.pre/common/ci_visibility_sections.yml`**: Bash helpers (`datadog-ci-start-section` / `datadog-ci-end-section`) + `DATADOG_API_KEY` fetch
- **Modified `.gitlab/test/e2e/e2e.yml`**: Wrapped 8 before_script steps with span functions (dep retrieval, AWS creds, SSH keys, Pulumi login, cloud creds, CI Visibility links)
- **Modified `tasks/custom_task/custom_task.py`**: Added `CIVisibilitySection.send_all()` in finally block after each invoke task
- **Modified `tasks/new_e2e_tests.py`**: Wrapped 6 phases in `run()` with `ci_visibility_section` (dynamic test calc, test execution attempts, teardown, merge results, process results, logs post-processing)

Before - no spans on e2e jobs
<img width="1508" height="104" alt="image" src="https://github.com/user-attachments/assets/09b3d71d-6866-473c-ae0a-19d7c9ee3e02" />


After
<img width="969" height="441" alt="image" src="https://github.com/user-attachments/assets/08b25273-1adf-465a-9044-34b6c622f388" />

## Span Tagging Convention
- `agent-custom-span:true` — filter for agent custom spans
- `agent-category:e2e-setup` — before_script spans
- `agent-category:e2e` — script (invoke task) spans

## Test plan
- [x] Push to feature branch, trigger e2e pipeline
- [x] Verify spans in [CI Visibility](https://app.datadoghq.com/ci/pipeline-executions?query=ci_level%3Acustom%20%40agent-custom-span%3Atrue%20%40agent-category%3Ae2e*) with filter `ci_level:custom @agent-custom-span:true`
- [x] Confirm flamegraph shows before_script spans (tar extraction, credential setup) and script spans (test execution attempts)
- [x] Verify e2e tests still pass — span sending uses `|| true` / `warn=True` so failures are non-blocking

🤖 Generated with [Claude Code](https://claude.com/claude-code)