### PR TITLE
[DCA] Generic pod evictor

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -466,6 +466,7 @@
 /pkg/cloudfoundry                       @DataDog/agent-integrations
 /pkg/clusteragent/                      @DataDog/container-platform
 /pkg/clusteragent/autoscaling/          @DataDog/container-autoscaling
+/pkg/clusteragent/evictor/              @DataDog/container-platform @DataDog/container-integrations
 /pkg/clusteragent/metricsstore/         @DataDog/container-autoscaling
 /pkg/clusteragent/admission/mutate/autoscaling          @DataDog/container-integrations
 /pkg/clusteragent/admission/mutate/appsec               @DataDog/container-platform @DataDog/asm-go

--- a/pkg/clusteragent/evictor/evictor.go
+++ b/pkg/clusteragent/evictor/evictor.go
@@ -1,0 +1,98 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+// Package evictor provides a shared API for evicting Kubernetes pods from
+// the Cluster Agent. It wraps the policy/v1 Eviction subresource and handles
+// PodDisruptionBudget-rejected evictions gracefully.
+package evictor
+
+import (
+	"context"
+	"net/http"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+var podGVR = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
+
+// EvictResult is the outcome of an Evict call.
+type EvictResult int
+
+const (
+	// Evicted means the eviction was accepted by the API server.
+	Evicted EvictResult = iota
+	// PDBBlocked means the eviction was rejected by a PodDisruptionBudget (HTTP 429).
+	PDBBlocked
+	// Skipped means this instance is not the leader; no API call was made.
+	Skipped
+	// Error means an error occurred while evicting the pod.
+	Error
+)
+
+// Client issues policy/v1 Evictions against pods via the dynamic client.
+// It optionally enforces leader election so evictions are only issued by the
+// cluster agent leader.
+type Client struct {
+	client   dynamic.Interface
+	isLeader func() bool
+}
+
+// NewClient creates a Client with the given dynamic client and an optional
+// leader check function. If isLeader is non-nil, Evict returns ResultSkipped
+// when the current instance is not the leader.
+func NewClient(client dynamic.Interface, isLeader func() bool) *Client {
+	return &Client{client: client, isLeader: isLeader}
+}
+
+// Evict creates a policy/v1 Eviction for the named pod.
+//
+// Returns (ResultSkipped, nil) if the current instance is not the leader.
+// Returns (ResultPDBBlocked, nil) if a PodDisruptionBudget rejected the eviction (HTTP 429).
+// Returns (ResultEvicted, nil) on success.
+// Returns (ResultError, err) on any other error.
+func (c *Client) Evict(ctx context.Context, namespace, name string) (EvictResult, error) {
+	if c.isLeader != nil && !c.isLeader() {
+		log.Debugf("[evictor] not leader, skipping eviction for %s/%s", namespace, name)
+		return Skipped, nil
+	}
+
+	eviction := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "policy/v1",
+			"kind":       "Eviction",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+			},
+		},
+	}
+
+	_, createErr := c.client.
+		Resource(podGVR).
+		Namespace(namespace).
+		Create(ctx, eviction, metav1.CreateOptions{}, "eviction")
+
+	if createErr == nil {
+		log.Debugf("[evictor] successfully evicted pod %s/%s", namespace, name)
+		return Evicted, nil
+	}
+
+	if statusErr, ok := createErr.(*k8serrors.StatusError); ok {
+		if statusErr.ErrStatus.Code == http.StatusTooManyRequests {
+			log.Debugf("[evictor] eviction of pod %s/%s blocked by PodDisruptionBudget", namespace, name)
+			return PDBBlocked, nil
+		}
+	}
+
+	return Error, createErr
+}

--- a/pkg/clusteragent/evictor/evictor.go
+++ b/pkg/clusteragent/evictor/evictor.go
@@ -28,8 +28,8 @@ type EvictResult int
 const (
 	// Evicted means the eviction was accepted by the API server.
 	Evicted EvictResult = iota
-	// PDBBlocked means the eviction was rejected by a PodDisruptionBudget (HTTP 429).
-	PDBBlocked
+	// PDBLockedOrThrottle means the eviction was rejected by a PodDisruptionBudget (HTTP 429).
+	PDBLockedOrThrottle
 	// Skipped means this instance is not the leader; no API call was made.
 	Skipped
 	// Error means an error occurred while evicting the pod.
@@ -54,7 +54,7 @@ func NewClient(client kubernetes.Interface, isLeader func() bool) *Client {
 // Evict creates a policy/v1 Eviction for the named pod.
 //
 // Returns (Skipped, nil) if the current instance is not the leader.
-// Returns (PDBBlocked, nil) if a PodDisruptionBudget rejected the eviction (HTTP 429).
+// Returns (PDBLockedOrThrottle, nil) if a PodDisruptionBudget rejected the eviction (HTTP 429).
 // Returns (Evicted, nil) on success.
 // Returns (Error, err) on any other error.
 func (c *Client) Evict(ctx context.Context, namespace, name string) (EvictResult, error) {
@@ -79,7 +79,7 @@ func (c *Client) Evict(ctx context.Context, namespace, name string) (EvictResult
 
 	if k8serrors.IsTooManyRequests(evictErr) {
 		log.Debugf("[evictor] eviction of pod %s/%s blocked by PodDisruptionBudget", namespace, name)
-		return PDBBlocked, nil
+		return PDBLockedOrThrottle, nil
 	}
 
 	return Error, fmt.Errorf("failed to evict pod %s/%s: %w", namespace, name, evictErr)

--- a/pkg/clusteragent/evictor/evictor.go
+++ b/pkg/clusteragent/evictor/evictor.go
@@ -14,16 +14,13 @@ import (
 	"context"
 	"fmt"
 
+	policyv1 "k8s.io/api/policy/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
-
-var podGVR = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
 
 // EvictResult is the outcome of an Evict call.
 type EvictResult int
@@ -39,18 +36,18 @@ const (
 	Error
 )
 
-// Client issues policy/v1 Evictions against pods via the dynamic client.
+// Client issues policy/v1 Evictions against pods via the typed k8s client.
 // It optionally enforces leader election so evictions are only issued by the
 // cluster agent leader.
 type Client struct {
-	client   dynamic.Interface
+	client   kubernetes.Interface
 	isLeader func() bool
 }
 
-// NewClient creates a Client with the given dynamic client and an optional
+// NewClient creates a Client with the given kubernetes client and an optional
 // leader check function. If isLeader is non-nil, Evict returns Skipped
 // when the current instance is not the leader.
-func NewClient(client dynamic.Interface, isLeader func() bool) *Client {
+func NewClient(client kubernetes.Interface, isLeader func() bool) *Client {
 	return &Client{client: client, isLeader: isLeader}
 }
 
@@ -66,31 +63,24 @@ func (c *Client) Evict(ctx context.Context, namespace, name string) (EvictResult
 		return Skipped, nil
 	}
 
-	eviction := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "policy/v1",
-			"kind":       "Eviction",
-			"metadata": map[string]interface{}{
-				"name":      name,
-				"namespace": namespace,
-			},
+	eviction := &policyv1.Eviction{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
 		},
 	}
 
-	_, createErr := c.client.
-		Resource(podGVR).
-		Namespace(namespace).
-		Create(ctx, eviction, metav1.CreateOptions{}, "eviction")
+	evictErr := c.client.PolicyV1().Evictions(namespace).Evict(ctx, eviction)
 
-	if createErr == nil {
+	if evictErr == nil {
 		log.Debugf("[evictor] successfully evicted pod %s/%s", namespace, name)
 		return Evicted, nil
 	}
 
-	if k8serrors.IsTooManyRequests(createErr) {
+	if k8serrors.IsTooManyRequests(evictErr) {
 		log.Debugf("[evictor] eviction of pod %s/%s blocked by PodDisruptionBudget", namespace, name)
 		return PDBBlocked, nil
 	}
 
-	return Error, fmt.Errorf("failed to evict pod %s/%s: %w", namespace, name, createErr)
+	return Error, fmt.Errorf("failed to evict pod %s/%s: %w", namespace, name, evictErr)
 }

--- a/pkg/clusteragent/evictor/evictor_test.go
+++ b/pkg/clusteragent/evictor/evictor_test.go
@@ -1,0 +1,120 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package evictor
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func newFakeClient(objects ...*unstructured.Unstructured) *dynamicfake.FakeDynamicClient {
+	scheme := runtime.NewScheme()
+	var runtimeObjects []runtime.Object
+	for _, o := range objects {
+		runtimeObjects = append(runtimeObjects, o)
+	}
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{
+			podGVR: "PodList",
+		},
+		runtimeObjects...,
+	)
+}
+
+func newFakePod(namespace, name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+			},
+		},
+	}
+}
+
+func TestEvictSuccess(t *testing.T) {
+	client := newFakeClient(newFakePod("default", "my-pod"))
+	c := NewClient(client, nil)
+
+	result, err := c.Evict(context.Background(), "default", "my-pod")
+
+	require.NoError(t, err)
+	assert.Equal(t, Evicted, result)
+}
+
+func TestEvictPDBBlocked(t *testing.T) {
+	client := newFakeClient(newFakePod("default", "my-pod"))
+	client.PrependReactor("create", "pods", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, &k8serrors.StatusError{
+			ErrStatus: metav1.Status{Code: http.StatusTooManyRequests},
+		}
+	})
+	c := NewClient(client, nil)
+
+	result, err := c.Evict(context.Background(), "default", "my-pod")
+
+	require.NoError(t, err)
+	assert.Equal(t, PDBBlocked, result)
+}
+
+func TestEvictError(t *testing.T) {
+	client := newFakeClient(newFakePod("default", "my-pod"))
+	client.PrependReactor("create", "pods", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("connection refused")
+	})
+	c := NewClient(client, nil)
+
+	result, err := c.Evict(context.Background(), "default", "my-pod")
+
+	assert.Error(t, err)
+	assert.Equal(t, Error, result)
+}
+
+func TestEvictNotLeader(t *testing.T) {
+	client := newFakeClient()
+	c := NewClient(client, func() bool { return false })
+
+	result, err := c.Evict(context.Background(), "default", "my-pod")
+
+	require.NoError(t, err)
+	assert.Equal(t, Skipped, result)
+	assert.Empty(t, client.Actions(), "no API call should be made when not leader")
+}
+
+func TestEvictLeadershipChange(t *testing.T) {
+	client := newFakeClient(newFakePod("default", "my-pod"))
+	isLeader := false
+	c := NewClient(client, func() bool { return isLeader })
+
+	// Not leader
+	result, err := c.Evict(context.Background(), "default", "my-pod")
+	require.NoError(t, err)
+	assert.Equal(t, Skipped, result)
+	assert.Empty(t, client.Actions())
+
+	// Become leader
+	isLeader = true
+	result, err = c.Evict(context.Background(), "default", "my-pod")
+	require.NoError(t, err)
+	assert.Equal(t, Evicted, result)
+	assert.NotEmpty(t, client.Actions())
+}

--- a/pkg/clusteragent/evictor/evictor_test.go
+++ b/pkg/clusteragent/evictor/evictor_test.go
@@ -42,7 +42,7 @@ func TestEvictSuccess(t *testing.T) {
 	assert.Equal(t, Evicted, result)
 }
 
-func TestEvictPDBBlocked(t *testing.T) {
+func TestEvictPDBLockedOrThrottle(t *testing.T) {
 	client := fake.NewSimpleClientset(newFakePod("default", "my-pod"))
 	client.PrependReactor("create", "pods", func(_ k8stesting.Action) (bool, runtime.Object, error) {
 		return true, nil, &k8serrors.StatusError{
@@ -54,7 +54,7 @@ func TestEvictPDBBlocked(t *testing.T) {
 	result, err := c.Evict(context.Background(), "default", "my-pod")
 
 	require.NoError(t, err)
-	assert.Equal(t, PDBBlocked, result)
+	assert.Equal(t, PDBLockedOrThrottle, result)
 }
 
 func TestEvictError(t *testing.T) {

--- a/pkg/clusteragent/evictor/evictor_test.go
+++ b/pkg/clusteragent/evictor/evictor_test.go
@@ -15,44 +15,25 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
 )
 
-func newFakeClient(objects ...*unstructured.Unstructured) *dynamicfake.FakeDynamicClient {
-	scheme := runtime.NewScheme()
-	var runtimeObjects []runtime.Object
-	for _, o := range objects {
-		runtimeObjects = append(runtimeObjects, o)
-	}
-	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
-		map[schema.GroupVersionResource]string{
-			podGVR: "PodList",
-		},
-		runtimeObjects...,
-	)
-}
-
-func newFakePod(namespace, name string) *unstructured.Unstructured {
-	return &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "v1",
-			"kind":       "Pod",
-			"metadata": map[string]interface{}{
-				"name":      name,
-				"namespace": namespace,
-			},
+func newFakePod(namespace, name string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
 		},
 	}
 }
 
 func TestEvictSuccess(t *testing.T) {
-	client := newFakeClient(newFakePod("default", "my-pod"))
+	client := fake.NewSimpleClientset(newFakePod("default", "my-pod"))
 	c := NewClient(client, nil)
 
 	result, err := c.Evict(context.Background(), "default", "my-pod")
@@ -62,7 +43,7 @@ func TestEvictSuccess(t *testing.T) {
 }
 
 func TestEvictPDBBlocked(t *testing.T) {
-	client := newFakeClient(newFakePod("default", "my-pod"))
+	client := fake.NewSimpleClientset(newFakePod("default", "my-pod"))
 	client.PrependReactor("create", "pods", func(_ k8stesting.Action) (bool, runtime.Object, error) {
 		return true, nil, &k8serrors.StatusError{
 			ErrStatus: metav1.Status{Code: http.StatusTooManyRequests},
@@ -77,7 +58,7 @@ func TestEvictPDBBlocked(t *testing.T) {
 }
 
 func TestEvictError(t *testing.T) {
-	client := newFakeClient(newFakePod("default", "my-pod"))
+	client := fake.NewSimpleClientset(newFakePod("default", "my-pod"))
 	client.PrependReactor("create", "pods", func(_ k8stesting.Action) (bool, runtime.Object, error) {
 		return true, nil, errors.New("connection refused")
 	})
@@ -90,7 +71,7 @@ func TestEvictError(t *testing.T) {
 }
 
 func TestEvictNotLeader(t *testing.T) {
-	client := newFakeClient()
+	client := fake.NewSimpleClientset()
 	c := NewClient(client, func() bool { return false })
 
 	result, err := c.Evict(context.Background(), "default", "my-pod")
@@ -101,7 +82,7 @@ func TestEvictNotLeader(t *testing.T) {
 }
 
 func TestEvictLeadershipChange(t *testing.T) {
-	client := newFakeClient(newFakePod("default", "my-pod"))
+	client := fake.NewSimpleClientset(newFakePod("default", "my-pod"))
 	isLeader := false
 	c := NewClient(client, func() bool { return isLeader })
 


### PR DESCRIPTION
### What does this PR do?
Implements a shared interface for eviction within the cluster agent.

### Motivation
In-place vertical pod resizing will require [eviction](https://datadoghq.atlassian.net/wiki/spaces/CONT/pages/6246498427/In-Place+Vertical+Pod+Resizing+for+Workload+Autoscaling#Eviction-Strategy), which is a first within the agent. Similar to the new [generic workload patcher](https://github.com/DataDog/datadog-agent/tree/main/pkg/clusteragent/patcher) in the DCA, this is will be a shared component intended for future eviction use cases. 

### Describe how you validated your changes
Unit tests and CI

### Additional Notes
Unused for now. 