### PR TITLE
[ AGNTLOG-561 ] Add stack trace start detection to auto multi-line log grouping

### DIFF
--- a/comp/logs/agent/config/integration_config.go
+++ b/comp/logs/agent/config/integration_config.go
@@ -132,6 +132,9 @@ type SourceAutoMultiLineOptions struct {
 	// PatternTableMatchThreshold sets the threshold for pattern table match for this source.
 	PatternTableMatchThreshold *float64 `mapstructure:"pattern_table_match_threshold" json:"pattern_table_match_threshold" yaml:"pattern_table_match_threshold"`
 
+	// EnableStackTraceDetection allows to enable or disable the detection of non-timestamped stack trace start lines for this source.
+	EnableStackTraceDetection *bool `mapstructure:"enable_stack_trace_detection" json:"enable_stack_trace_detection" yaml:"enable_stack_trace_detection"`
+
 	// EnableJSONAggregation allows to enable or disable the aggregation of multi-line JSON logs for this source.
 	EnableJSONAggregation *bool `mapstructure:"enable_json_aggregation" json:"enable_json_aggregation" yaml:"enable_json_aggregation"`
 

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -2020,6 +2020,7 @@ func logsagent(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("logs_config.auto_multi_line.tokenizer_max_input_bytes", 60)
 	config.BindEnvAndSetDefault("logs_config.auto_multi_line.pattern_table_max_size", 20)
 	config.BindEnvAndSetDefault("logs_config.auto_multi_line.pattern_table_match_threshold", 0.75)
+	config.BindEnvAndSetDefault("logs_config.auto_multi_line.enable_stack_trace_detection", true)
 	config.BindEnvAndSetDefault("logs_config.auto_multi_line.enable_json_aggregation", true)
 	config.BindEnvAndSetDefault("logs_config.auto_multi_line.tag_aggregated_json", false)
 

--- a/pkg/logs/internal/decoder/auto_multiline_detection/stack_trace_detector.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/stack_trace_detector.go
@@ -1,0 +1,87 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package automultilinedetection
+
+import "bytes"
+
+// maxThreadNameLen is the maximum number of bytes to scan past "thread '" when
+// looking for the closing quote. Real Rust thread names are rarely longer than ~40 chars.
+const maxThreadNameLen = 64
+
+var (
+	prefixPanic           = []byte("panic: ")
+	prefixExceptionThread = []byte("Exception in thread \"")
+	prefixRustThreadPanic = []byte("thread '")
+	suffixRustPanicked    = []byte("' panicked")
+)
+
+// StackTraceDetector is a heuristic that detects the start of stack traces that lack timestamps.
+//
+// It only recognizes patterns that are exclusively emitted by language runtimes writing directly
+// to stderr (Go panics, Rust panics, Java's UncaughtExceptionHandler). Patterns that can
+// legitimately appear as continuation lines after a timestamped log entry (e.g. Python's
+// "Traceback") are intentionally excluded to avoid severing timestamped entries from their traces.
+//
+// For Go panics, only the "panic: " prefix is matched (not "goroutine N [status]:") so that the
+// panic message and goroutine frames are grouped into a single log entry.
+type StackTraceDetector struct{}
+
+// NewStackTraceDetector returns a new StackTraceDetector heuristic.
+func NewStackTraceDetector() *StackTraceDetector {
+	return &StackTraceDetector{}
+}
+
+// ProcessAndContinue checks if a message is the start of a stack trace.
+// It only acts on lines that have not been labeled by a prior heuristic.
+// On match, it labels the line as startGroup and short-circuits (returns false).
+func (s *StackTraceDetector) ProcessAndContinue(context *messageContext) bool {
+	if context.labelAssignedBy != defaultLabelSource {
+		return true
+	}
+
+	msg := context.rawMessage
+	if len(msg) == 0 {
+		return true
+	}
+
+	switch msg[0] {
+	case 'p':
+		if bytes.HasPrefix(msg, prefixPanic) {
+			context.label = startGroup
+			context.labelAssignedBy = "stack_trace_detector"
+			return false
+		}
+	case 'E':
+		if bytes.HasPrefix(msg, prefixExceptionThread) {
+			context.label = startGroup
+			context.labelAssignedBy = "stack_trace_detector"
+			return false
+		}
+	case 't':
+		if bytes.HasPrefix(msg, prefixRustThreadPanic) && isRustPanic(msg) {
+			context.label = startGroup
+			context.labelAssignedBy = "stack_trace_detector"
+			return false
+		}
+	}
+
+	return true
+}
+
+// isRustPanic checks for the full Rust panic pattern: thread '<name>' panicked
+// by scanning for the closing quote within a bounded window and verifying
+// "' panicked" follows it. This eliminates false positives from non-panic
+// thread-related log lines like "thread 'worker' processing request".
+func isRustPanic(msg []byte) bool {
+	nameStart := len(prefixRustThreadPanic)
+	end := min(len(msg), nameStart+maxThreadNameLen)
+	closeQuote := bytes.IndexByte(msg[nameStart:end], '\'')
+	if closeQuote < 0 {
+		return false
+	}
+	return bytes.HasPrefix(msg[nameStart+closeQuote:], suffixRustPanicked)
+}
+

--- a/pkg/logs/internal/decoder/auto_multiline_detection/stack_trace_detector_test.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/stack_trace_detector_test.go
@@ -1,0 +1,150 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package automultilinedetection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStackTraceDetector(t *testing.T) {
+	detector := NewStackTraceDetector()
+
+	testCases := []struct {
+		name           string
+		rawMessage     string
+		expectedLabel  Label
+		expectedResult bool
+	}{
+		// Go panic start marker (only panic: is matched; goroutine is not, to keep the
+		// panic message and goroutine frames in the same log entry)
+		{"go panic prefix", "panic: runtime error: index out of range [0] with length 0", startGroup, false},
+		{"go panic nil pointer", "panic: runtime error: invalid memory address or nil pointer dereference", startGroup, false},
+		{"go panic custom message", "panic: something went wrong", startGroup, false},
+
+		// Java/Kotlin UncaughtExceptionHandler
+		{"java exception in thread main", `Exception in thread "main" java.lang.NullPointerException`, startGroup, false},
+		{"java exception in thread custom", `Exception in thread "pool-1-thread-1" java.lang.RuntimeException: fail`, startGroup, false},
+		{"java exception in thread bare with quote", `Exception in thread "`, startGroup, false},
+
+		// Rust panic
+		{"rust thread panic pre-1.73", "thread 'main' panicked at 'index out of bounds: the len is 3 but the index is 5', src/main.rs:4:5", startGroup, false},
+		{"rust thread panic post-1.73", "thread 'main' panicked at src/main.rs:4:5:", startGroup, false},
+		{"rust thread panic custom worker", "thread 'tokio-runtime-worker' panicked at 'called `Result::unwrap()` on an `Err` value'", startGroup, false},
+		{"rust thread panic short name", "thread 'a' panicked at src/lib.rs:1:1", startGroup, false},
+
+		// Non-matching lines (should pass through with default aggregate)
+		{"normal log line", "2024-03-28 13:45:30 INFO Starting server", aggregate, true},
+		{"empty line", "", aggregate, true},
+		{"plain text", "Hello world", aggregate, true},
+		{"json line", `{"key": "value"}`, aggregate, true},
+		{"indented line", "    some indented content", aggregate, true},
+		{"tab indented line", "\tat some.method()", aggregate, true},
+		{"hash comment", "# this is a comment", aggregate, true},
+		{"number sign", "#include <stdio.h>", aggregate, true},
+
+		// Goroutine lines are intentionally NOT matched so they aggregate with panic:
+		{"goroutine running", "goroutine 1 [running]:", aggregate, true},
+		{"goroutine many digits", "goroutine 12345 [running]:", aggregate, true},
+		{"goroutine chan receive", "goroutine 42 [chan receive]:", aggregate, true},
+		{"goroutine word not panic", "goroutines are lightweight threads", aggregate, true},
+		{"goroutine pool", "goroutine pool size: 10", aggregate, true},
+		{"goroutine no digit", "goroutine [running]:", aggregate, true},
+		{"goroutine space only", "goroutine ", aggregate, true},
+		{"goroutine started", "goroutine 5 started processing batch", aggregate, true},
+		{"goroutine handling", "goroutine 42 handling request from client", aggregate, true},
+		{"goroutine count", "goroutine 2048 count exceeds threshold", aggregate, true},
+		{"goroutine digit only", "goroutine 1", aggregate, true},
+		{"goroutine digit space no bracket", "goroutine 1 running", aggregate, true},
+		{"exception word", "Exceptions should be handled properly", aggregate, true},
+		{"exception in thread bare no quote", "Exception in thread", aggregate, true},
+		{"exception in threading", "Exception in threading module failed", aggregate, true},
+		{"exception in threadpool", "Exception in threadpool handler timed out", aggregate, true},
+		{"thread word", "threads are running concurrently", aggregate, true},
+		{"thread no quote", "thread main panicked", aggregate, true},
+		{"panic no colon", "panicking is bad practice", aggregate, true},
+		{"panic no space", "panic!", aggregate, true},
+
+		// Rust false positive rejection: thread lifecycle logs that are NOT panics
+		{"thread processing", "thread 'worker-5' processing request", aggregate, true},
+		{"thread spawned", "thread 'tokio-runtime-worker' spawned", aggregate, true},
+		{"thread started", "thread 'main' started successfully", aggregate, true},
+		{"thread timed out", "thread 'pool-1' timed out waiting for task", aggregate, true},
+		{"thread initialized", "thread 'main' initialized", aggregate, true},
+		{"thread no closing quote", "thread 'this has no closing quote and goes on for a long time", aggregate, true},
+		{"thread bare prefix", "thread '", aggregate, true},
+
+		// Stack trace continuation lines (should remain default aggregate -- NOT our job)
+		{"java frame", "\tat com.example.MyClass.doSomething(MyClass.java:42)", aggregate, true},
+		{"python frame", `  File "/app/main.py", line 10, in main`, aggregate, true},
+		{"node frame", "    at processItems (/app/src/handler.js:25:18)", aggregate, true},
+		{"go frame", "\t/home/user/project/main.go:12 +0x1c0", aggregate, true},
+		{"caused by", "Caused by: java.io.IOException: Stream closed", aggregate, true},
+		{"rust frame", "   0: rust_begin_unwind", aggregate, true},
+
+		// Excluded patterns (must NOT match -- would cause regressions)
+		{"python traceback", "Traceback (most recent call last):", aggregate, true},
+		{"php fatal error", "Fatal error: Uncaught TypeError", aggregate, true},
+		{"linux kernel bug", "BUG: unable to handle page fault", aggregate, true},
+		{"linux call trace", "Call Trace:", aggregate, true},
+		{"android fatal", "FATAL EXCEPTION: main", aggregate, true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := &messageContext{
+				rawMessage:      []byte(tc.rawMessage),
+				label:           aggregate,
+				labelAssignedBy: defaultLabelSource,
+			}
+			result := detector.ProcessAndContinue(ctx)
+			assert.Equal(t, tc.expectedResult, result, "ProcessAndContinue return value")
+			assert.Equal(t, tc.expectedLabel, ctx.label, "label")
+		})
+	}
+}
+
+func TestStackTraceDetectorDoesntOverrideAssignedLabel(t *testing.T) {
+	detector := NewStackTraceDetector()
+
+	testCases := []struct {
+		name            string
+		rawMessage      string
+		priorLabel      Label
+		priorAssignedBy string
+	}{
+		{"timestamp already set startGroup", "panic: runtime error: nil pointer", startGroup, "timestamp_detector"},
+		{"user sample already set startGroup", "panic: something", startGroup, "user_sample"},
+		{"json detector set noAggregate", "panic: something", noAggregate, "JSON_detector"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := &messageContext{
+				rawMessage:      []byte(tc.rawMessage),
+				label:           tc.priorLabel,
+				labelAssignedBy: tc.priorAssignedBy,
+			}
+			result := detector.ProcessAndContinue(ctx)
+			assert.True(t, result, "should continue processing when label already assigned")
+			assert.Equal(t, tc.priorLabel, ctx.label, "should not change the label")
+			assert.Equal(t, tc.priorAssignedBy, ctx.labelAssignedBy, "should not change labelAssignedBy")
+		})
+	}
+}
+
+func TestStackTraceDetectorLabelAssignedBy(t *testing.T) {
+	detector := NewStackTraceDetector()
+
+	ctx := &messageContext{
+		rawMessage:      []byte("panic: runtime error: nil pointer"),
+		label:           aggregate,
+		labelAssignedBy: defaultLabelSource,
+	}
+	detector.ProcessAndContinue(ctx)
+	assert.Equal(t, "stack_trace_detector", ctx.labelAssignedBy)
+}

--- a/pkg/logs/internal/decoder/auto_multiline_handler.go
+++ b/pkg/logs/internal/decoder/auto_multiline_handler.go
@@ -62,6 +62,14 @@ func NewAutoMultilineHandler(aggregator automultilinedetection.Aggregator, maxCo
 		heuristics = append(heuristics, automultilinedetection.NewTimestampDetector(timestampDetectorMatchThreshold))
 	}
 
+	enableStackTraceDetection := pkgconfigsetup.Datadog().GetBool("logs_config.auto_multi_line.enable_stack_trace_detection")
+	if sourceHasSettings && sourceSettings.EnableStackTraceDetection != nil {
+		enableStackTraceDetection = *sourceSettings.EnableStackTraceDetection
+	}
+	if enableStackTraceDetection {
+		heuristics = append(heuristics, automultilinedetection.NewStackTraceDetector())
+	}
+
 	patternTableMaxSize := pkgconfigsetup.Datadog().GetInt("logs_config.auto_multi_line.pattern_table_max_size")
 	if sourceHasSettings && sourceSettings.PatternTableMaxSize != nil {
 		patternTableMaxSize = *sourceSettings.PatternTableMaxSize

--- a/pkg/logs/internal/decoder/auto_multiline_handler_test.go
+++ b/pkg/logs/internal/decoder/auto_multiline_handler_test.go
@@ -411,3 +411,166 @@ func TestAutoMultilineHandler_CombiningMode_EnablesJSONAggregation(t *testing.T)
 	// Verify JSON aggregation is enabled
 	assert.True(t, handler.enableJSONAggregation, "JSON aggregation should be enabled in combining mode")
 }
+
+func TestAutoMultilineHandler_GoPanicGroupsWithGoroutine(t *testing.T) {
+	outputChan := make(chan *message.Message, 10)
+	outputFn := func(m *message.Message) {
+		outputChan <- m
+	}
+
+	handler := newCombiningHandler(outputFn, 4096, 10*time.Second)
+
+	handler.process(newTestMessage("2024-03-28 13:45:30 INFO Starting server"))
+
+	// Full Go panic: panic: starts a new group, goroutine + frames aggregate with it.
+	handler.process(newTestMessage("panic: runtime error: index out of range"))
+	handler.process(newTestMessage(""))
+	handler.process(newTestMessage("goroutine 1 [running]:"))
+	handler.process(newTestMessage("main.handler(0xc0000b2000, 0x3, 0x5)"))
+	handler.process(newTestMessage("\t/home/user/project/main.go:12 +0x1c0"))
+
+	// Next timestamped line flushes the panic group
+	handler.process(newTestMessage("2024-03-28 13:45:32 INFO Recovered"))
+	handler.flush()
+
+	msg1 := <-outputChan
+	assert.Equal(t, []byte("2024-03-28 13:45:30 INFO Starting server"), msg1.GetContent())
+
+	// The panic message, goroutine header, and frames should all be in one entry.
+	msg2 := <-outputChan
+	content := string(msg2.GetContent())
+	assert.Contains(t, content, "panic: runtime error: index out of range")
+	assert.Contains(t, content, "goroutine 1 [running]:")
+	assert.Contains(t, content, "main.handler")
+	assert.Contains(t, content, "/home/user/project/main.go:12")
+	assert.True(t, msg2.ParsingExtra.IsMultiLine)
+
+	msg3 := <-outputChan
+	assert.Equal(t, []byte("2024-03-28 13:45:32 INFO Recovered"), msg3.GetContent())
+}
+
+func TestAutoMultilineHandler_GoPanicWithSignalInfo(t *testing.T) {
+	outputChan := make(chan *message.Message, 10)
+	outputFn := func(m *message.Message) {
+		outputChan <- m
+	}
+
+	handler := newCombiningHandler(outputFn, 4096, 10*time.Second)
+
+	handler.process(newTestMessage("2024-03-28 13:45:30 INFO Starting server"))
+
+	// Full Go panic with signal info: all lines should form one group.
+	handler.process(newTestMessage("panic: runtime error: invalid memory address or nil pointer dereference"))
+	handler.process(newTestMessage("[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x497783]"))
+	handler.process(newTestMessage(""))
+	handler.process(newTestMessage("goroutine 1 [running]:"))
+	handler.process(newTestMessage("main.(*Server).handleRequest(0xc0000b4000)"))
+	handler.process(newTestMessage("\t/home/user/project/server.go:42 +0x123"))
+
+	handler.process(newTestMessage("2024-03-28 13:45:32 INFO Next"))
+	handler.flush()
+
+	msg1 := <-outputChan
+	assert.Equal(t, []byte("2024-03-28 13:45:30 INFO Starting server"), msg1.GetContent())
+
+	// Panic message, signal info, goroutine header, and frames all in one entry.
+	msg2 := <-outputChan
+	content := string(msg2.GetContent())
+	assert.Contains(t, content, "panic: runtime error: invalid memory address")
+	assert.Contains(t, content, "[signal SIGSEGV")
+	assert.Contains(t, content, "goroutine 1 [running]:")
+	assert.Contains(t, content, "main.(*Server).handleRequest")
+	assert.True(t, msg2.ParsingExtra.IsMultiLine)
+
+	msg3 := <-outputChan
+	assert.Equal(t, []byte("2024-03-28 13:45:32 INFO Next"), msg3.GetContent())
+}
+
+func TestAutoMultilineHandler_JavaExceptionStartsNewGroup(t *testing.T) {
+	outputChan := make(chan *message.Message, 10)
+	outputFn := func(m *message.Message) {
+		outputChan <- m
+	}
+
+	handler := newCombiningHandler(outputFn, 4096, 10*time.Second)
+
+	handler.process(newTestMessage("2024-03-28 13:45:30 INFO Processing request"))
+
+	// Java UncaughtExceptionHandler output to stderr - should start a new group
+	handler.process(newTestMessage(`Exception in thread "main" java.lang.NullPointerException`))
+	handler.process(newTestMessage("\tat com.example.MyClass.doSomething(MyClass.java:42)"))
+	handler.process(newTestMessage("\tat com.example.Main.main(Main.java:15)"))
+
+	handler.process(newTestMessage("2024-03-28 13:45:32 INFO Next"))
+	handler.flush()
+
+	msg1 := <-outputChan
+	assert.Equal(t, []byte("2024-03-28 13:45:30 INFO Processing request"), msg1.GetContent())
+
+	msg2 := <-outputChan
+	expected2 := []byte("Exception in thread \"main\" java.lang.NullPointerException\\n\tat com.example.MyClass.doSomething(MyClass.java:42)\\n\tat com.example.Main.main(Main.java:15)")
+	assert.Equal(t, expected2, msg2.GetContent())
+	assert.True(t, msg2.ParsingExtra.IsMultiLine)
+
+	msg3 := <-outputChan
+	assert.Equal(t, []byte("2024-03-28 13:45:32 INFO Next"), msg3.GetContent())
+}
+
+func TestAutoMultilineHandler_RustPanicStartsNewGroup(t *testing.T) {
+	outputChan := make(chan *message.Message, 10)
+	outputFn := func(m *message.Message) {
+		outputChan <- m
+	}
+
+	handler := newCombiningHandler(outputFn, 4096, 10*time.Second)
+
+	handler.process(newTestMessage("2024-03-28 13:45:30 INFO Starting"))
+
+	// Rust panic - should start a new group
+	handler.process(newTestMessage("thread 'main' panicked at 'index out of bounds', src/main.rs:4:5"))
+	handler.process(newTestMessage("stack backtrace:"))
+	handler.process(newTestMessage("   0: rust_begin_unwind"))
+
+	handler.process(newTestMessage("2024-03-28 13:45:32 INFO Next"))
+	handler.flush()
+
+	msg1 := <-outputChan
+	assert.Equal(t, []byte("2024-03-28 13:45:30 INFO Starting"), msg1.GetContent())
+
+	msg2 := <-outputChan
+	expected2 := []byte("thread 'main' panicked at 'index out of bounds', src/main.rs:4:5\\nstack backtrace:\\n   0: rust_begin_unwind")
+	assert.Equal(t, expected2, msg2.GetContent())
+	assert.True(t, msg2.ParsingExtra.IsMultiLine)
+
+	msg3 := <-outputChan
+	assert.Equal(t, []byte("2024-03-28 13:45:32 INFO Next"), msg3.GetContent())
+}
+
+func TestAutoMultilineHandler_TimestampedStackTraceNotSevered(t *testing.T) {
+	outputChan := make(chan *message.Message, 10)
+	outputFn := func(m *message.Message) {
+		outputChan <- m
+	}
+
+	handler := newCombiningHandler(outputFn, 4096, 10*time.Second)
+
+	// A timestamped error followed by its stack trace should stay together.
+	// The continuation lines (without timestamps) must NOT be severed.
+	handler.process(newTestMessage("2024-03-28 13:45:30 ERROR Something failed"))
+	handler.process(newTestMessage("java.lang.NullPointerException: Cannot invoke method on null"))
+	handler.process(newTestMessage("\tat com.example.MyClass.doSomething(MyClass.java:42)"))
+	handler.process(newTestMessage("\tat com.example.Main.main(Main.java:15)"))
+
+	handler.process(newTestMessage("2024-03-28 13:45:31 INFO Next"))
+	handler.flush()
+
+	msg1 := <-outputChan
+	content := string(msg1.GetContent())
+	assert.Contains(t, content, "2024-03-28 13:45:30 ERROR Something failed")
+	assert.Contains(t, content, "java.lang.NullPointerException")
+	assert.Contains(t, content, "com.example.MyClass.doSomething")
+	assert.True(t, msg1.ParsingExtra.IsMultiLine)
+
+	msg2 := <-outputChan
+	assert.Equal(t, []byte("2024-03-28 13:45:31 INFO Next"), msg2.GetContent())
+}

--- a/releasenotes/notes/auto-multi-line-stack-trace-detection-778dc3b1cdb9ca0d.yaml
+++ b/releasenotes/notes/auto-multi-line-stack-trace-detection-778dc3b1cdb9ca0d.yaml
@@ -1,0 +1,21 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Auto multi-line log detection now recognizes non-timestamped stack trace
+    start markers from Go (``goroutine N [status]:`` and ``panic:``), Java
+    (``Exception in thread``), and Rust (``thread '<name>' panicked at``).
+    These patterns are emitted directly to stderr by language runtimes and were
+    previously missed by the timestamp-based detector, causing stack traces to
+    be split across multiple log entries.
+    The feature is enabled by default when auto multi-line detection is active
+    and can be toggled globally with
+    ``logs_config.auto_multi_line.enable_stack_trace_detection`` or per
+    integration via the ``enable_stack_trace_detection`` option in
+    ``auto_multi_line_extra_patterns``.


### PR DESCRIPTION
## What does this PR do?

Extends the auto multi-line log detection heuristic pipeline with a new `StackTraceDetector` that recognizes non-timestamped stack trace start markers from three language runtimes:

- **Go**: `goroutine N [status]:` and `panic: `
- **Java**: `Exception in thread`
- **Rust**: `thread '<name>' panicked at`

These patterns are emitted directly to stderr by language runtimes without timestamps. The existing `TimestampDetector` cannot group them, so they were previously split across multiple log entries or errantly aggregated into unrelated lines.

The detector is inserted into the heuristic chain after `TimestampDetector` and only acts on lines that have not already been labeled by a prior heuristic. On match it labels the line as `startGroup` and short-circuits further processing.

**Configuration**: Enabled by default when auto multi-line detection is active. Controllable globally via `logs_config.auto_multi_line.enable_stack_trace_detection` and per integration via the `enable_stack_trace_detection` field in `auto_multi_line_extra_patterns`.

## Motivation

When language runtimes panic or crash, they write stack traces directly to stderr without timestamps. The auto multi-line system's timestamp-based detector has no signal to group these lines, causing stack traces to be fragmented across separate log entries. This makes debugging significantly harder.

This change closes that coverage gap by recognizing the specific start-of-trace markers that runtimes emit. It is intentionally conservative — only patterns that are exclusively emitted as standalone stderr output are detected. Patterns that can legitimately appear as continuation lines after a timestamped log entry (e.g. Python's `Traceback`, PHP `Fatal error`) are excluded to avoid severing correctly aggregated entries.

## Describe how you validated your changes

- Existing auto multi-line unit and integration tests pass.
- Added comprehensive unit tests for `StackTraceDetector` covering:
  - Positive matches for all four patterns (Go goroutine, Go panic, Java exception, Rust panic)
  - False positive rejection for lines that share a prefix but lack the required structure (e.g. `goroutine 5 started processing`, `thread 'worker' processing request`)
  - Verification that the detector does not override labels set by prior heuristics
- Added 5 integration tests in `auto_multiline_handler_test.go` validating end-to-end behavior through the full `combiningHandler` pipeline, including a regression test confirming that timestamped stack traces are not severed.

## Additional Notes

- The `panic: ` pattern has limited structural elements for secondary validation since user-defined `panic()` calls can contain arbitrary strings. False positive risk is low in practice because the prefix must appear at byte position 0 and timestamped lines are handled by the upstream `TimestampDetector`.
- Pattern stability: all chosen prefixes have been de facto stable across language versions for many years (Go since 1.0, Java since 1.0, Rust since 1.0).
- This change is additive — it does not alter the behavior of the existing `TimestampDetector` or `JSONDetector` heuristics.