### PR TITLE
Fix Implementation of IsValueFromSecret and split Refresh into Refresh and RefreshNow

### DIFF
--- a/cmd/process-agent/api/secrets.go
+++ b/cmd/process-agent/api/secrets.go
@@ -10,7 +10,7 @@ import (
 )
 
 func secretRefreshHandler(deps APIServerDeps, w http.ResponseWriter, _ *http.Request) {
-	response, err := deps.Secrets.Refresh(true)
+	response, err := deps.Secrets.RefreshNow()
 	if err != nil {
 		deps.Log.Errorf("error while refreshing secrets: %s", err)
 		writeError(err, http.StatusInternalServerError, w)

--- a/cmd/security-agent/api/agent/agent.go
+++ b/cmd/security-agent/api/agent/agent.go
@@ -146,7 +146,7 @@ func (a *Agent) makeFlare(w http.ResponseWriter, _ *http.Request) {
 }
 
 func (a *Agent) refreshSecrets(w http.ResponseWriter, _ *http.Request) {
-	res, err := a.secrets.Refresh(true)
+	res, err := a.secrets.RefreshNow()
 	if err != nil {
 		log.Errorf("error while refreshing secrets: %s", err)
 		w.Header().Set("Content-Type", "application/json")

--- a/comp/core/autodiscovery/autodiscoveryimpl/secrets_test.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/secrets_test.go
@@ -59,7 +59,11 @@ func (m *MockSecretResolver) SubscribeToChanges(callback secrets.SecretChangeCal
 	m.subscribers = append(m.subscribers, callback)
 }
 
-func (m *MockSecretResolver) Refresh(_ bool) (string, error) {
+func (m *MockSecretResolver) Refresh() bool {
+	return false
+}
+
+func (m *MockSecretResolver) RefreshNow() (string, error) {
 	return "", nil
 }
 

--- a/comp/core/autodiscovery/autodiscoveryimpl/secrets_test.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/secrets_test.go
@@ -67,6 +67,10 @@ func (m *MockSecretResolver) RefreshNow() (string, error) {
 	return "", nil
 }
 
+func (m *MockSecretResolver) IsValueFromSecret(_ string) bool {
+	return false
+}
+
 func (m *MockSecretResolver) haveAllScenariosBeenCalled() bool {
 	for _, scenario := range m.scenarios {
 		if scenario.called == 0 {

--- a/comp/core/secrets/def/component.go
+++ b/comp/core/secrets/def/component.go
@@ -44,6 +44,8 @@ type Component interface {
 	Refresh() bool
 	// RefreshNow performs an immediate blocking secret refresh, returning an informative message suitable for user display.
 	RefreshNow() (string, error)
+	// IsValueFromSecret returns true if the given value was ever resolved from a secret handle.
+	IsValueFromSecret(value string) bool
 	// RemoveOrigin removes a origin from the internal cache of the secret component. This does not remove secrets
 	// from the cache but the reference where those secrets are used.
 	RemoveOrigin(origin string)

--- a/comp/core/secrets/def/component.go
+++ b/comp/core/secrets/def/component.go
@@ -39,10 +39,11 @@ type Component interface {
 	Resolve(data []byte, origin string, imageName string, kubeNamespace string, notify bool) ([]byte, error)
 	// SubscribeToChanges registers a callback to be invoked whenever secrets are resolved or refreshed
 	SubscribeToChanges(callback SecretChangeCallback)
-	// Refresh will resolve secret handles again, notifying any subscribers of changed values.
-	// If updateNow is true, the function performs the refresh immediately and blocks, returning an informative message suitable for user display.
-	// If updateNow is false, the function will asynchronously perform a refresh, and may fail to refresh due to throttling. No message is returned, just an empty string.
-	Refresh(updateNow bool) (string, error)
+	// Refresh schedules a throttled asynchronous secret refresh. Returns true if a refresh
+	// was actually triggered, so the caller knows whether to retry.
+	Refresh() bool
+	// RefreshNow performs an immediate blocking secret refresh, returning an informative message suitable for user display.
+	RefreshNow() (string, error)
 	// RemoveOrigin removes a origin from the internal cache of the secret component. This does not remove secrets
 	// from the cache but the reference where those secrets are used.
 	RemoveOrigin(origin string)

--- a/comp/core/secrets/def/component.go
+++ b/comp/core/secrets/def/component.go
@@ -39,8 +39,8 @@ type Component interface {
 	Resolve(data []byte, origin string, imageName string, kubeNamespace string, notify bool) ([]byte, error)
 	// SubscribeToChanges registers a callback to be invoked whenever secrets are resolved or refreshed
 	SubscribeToChanges(callback SecretChangeCallback)
-	// Refresh schedules a throttled asynchronous secret refresh. Returns true if a refresh
-	// was actually triggered, so the caller knows whether to retry.
+	// Refresh schedules a throttled asynchronous secret refresh. Returns true if the
+	// secret refresh mechanism is enabled (backend configured and refresh interval set).
 	Refresh() bool
 	// RefreshNow performs an immediate blocking secret refresh, returning an informative message suitable for user display.
 	RefreshNow() (string, error)

--- a/comp/core/secrets/impl/secrets.go
+++ b/comp/core/secrets/impl/secrets.go
@@ -690,7 +690,7 @@ func (r *secretResolver) processSecretResponse(secretResponse map[string]string,
 // Refresh schedules an asynchronous secret refresh (throttled). Returns true if async refresh is
 // enabled, so the caller knows whether to expect a follow-up retry to succeed.
 func (r *secretResolver) Refresh() bool {
-	if r.apiKeyFailureRefreshInterval == 0 {
+	if r.apiKeyFailureRefreshInterval == 0 || r.backendCommand == "" {
 		return false
 	}
 	// non-blocking send, max 1 at a time, others dropped

--- a/comp/core/secrets/impl/secrets.go
+++ b/comp/core/secrets/impl/secrets.go
@@ -211,7 +211,7 @@ func (r *secretResolver) writeDebugInfo(w http.ResponseWriter, _ *http.Request) 
 }
 
 func (r *secretResolver) handleRefresh(w http.ResponseWriter, _ *http.Request) {
-	result, err := r.Refresh(true)
+	result, err := r.RefreshNow()
 	if err != nil {
 		log.Infof("could not refresh secrets: %s", err)
 		setJSONError(w, err, 500)
@@ -679,21 +679,23 @@ func (r *secretResolver) processSecretResponse(secretResponse map[string]string,
 	return secretRefreshInfo{Handles: handleInfoList}
 }
 
-// Refresh will resolve secret handles again, notifying any subscribers of changed values.
-// If updateNow is true, the function performs the refresh immediately and blocks, returning an informative message suitable for user display.
-// If updateNow is false, the function will asynchronously perform a refresh, and may fail to refresh due to throttling. No message is returned, just an empty string.
-func (r *secretResolver) Refresh(updateNow bool) (string, error) {
-	if updateNow {
-		// blocking refresh
-		return r.performRefresh()
+// Refresh schedules an asynchronous secret refresh (throttled). Returns true if async refresh is
+// enabled, so the caller knows whether to expect a follow-up retry to succeed.
+func (r *secretResolver) Refresh() bool {
+	if r.apiKeyFailureRefreshInterval == 0 {
+		return false
 	}
-
-	// non-blocking refresh, max 1 at a time, others dropped
+	// non-blocking send, max 1 at a time, others dropped
 	select {
 	case r.refreshTrigger <- struct{}{}:
 	default:
 	}
-	return "", nil
+	return true
+}
+
+// RefreshNow performs an immediate blocking secret refresh and returns an informative message suitable for user display.
+func (r *secretResolver) RefreshNow() (string, error) {
+	return r.performRefresh()
 }
 
 // RemoveOrigin removes a origin from the cache

--- a/comp/core/secrets/impl/secrets.go
+++ b/comp/core/secrets/impl/secrets.go
@@ -86,6 +86,9 @@ type secretResolver struct {
 	// list of handles and where they were found
 	origin handleToContext
 
+	// set of all values ever resolved from the secret backend
+	resolvedValues map[string]struct{}
+
 	backendType                     string
 	backendConfig                   map[string]interface{}
 	backendCommand                  string
@@ -138,6 +141,7 @@ func newEnabledSecretResolver(telemetry telemetry.Component) *secretResolver {
 	return &secretResolver{
 		cache:                   make(map[string]string),
 		origin:                  make(handleToContext),
+		resolvedValues:          make(map[string]struct{}),
 		tlmSecretBackendElapsed: telemetry.NewGauge("secret_backend", "elapsed_ms", []string{"command", "exit_code"}, "Elapsed time of secret backend invocation"),
 		tlmSecretUnmarshalError: telemetry.NewCounter("secret_backend", "unmarshal_errors_count", []string{}, "Count of errors when unmarshalling the output of the secret binary"),
 		tlmSecretResolveError:   telemetry.NewCounter("secret_backend", "resolve_errors_count", []string{"error_kind", "handle"}, "Count of errors when resolving a secret"),
@@ -672,6 +676,10 @@ func (r *secretResolver) processSecretResponse(secretResponse map[string]string,
 	}
 	// add results to the cache
 	stdmaps.Copy(r.cache, secretResponse)
+	// track all resolved values in an append-only set for IsValueFromSecret lookups
+	for _, secretValue := range secretResponse {
+		r.resolvedValues[secretValue] = struct{}{}
+	}
 	// return info about the handles sorted by their name
 	sort.Slice(handleInfoList, func(i, j int) bool {
 		return handleInfoList[i].Name < handleInfoList[j].Name
@@ -696,6 +704,14 @@ func (r *secretResolver) Refresh() bool {
 // RefreshNow performs an immediate blocking secret refresh and returns an informative message suitable for user display.
 func (r *secretResolver) RefreshNow() (string, error) {
 	return r.performRefresh()
+}
+
+// IsValueFromSecret returns true if the given value was ever resolved from a secret handle.
+func (r *secretResolver) IsValueFromSecret(value string) bool {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	_, ok := r.resolvedValues[value]
+	return ok
 }
 
 // RemoveOrigin removes a origin from the cache

--- a/comp/core/secrets/impl/secrets.go
+++ b/comp/core/secrets/impl/secrets.go
@@ -86,8 +86,9 @@ type secretResolver struct {
 	// list of handles and where they were found
 	origin handleToContext
 
-	// set of all values ever resolved from the secret backend
-	resolvedValues map[string]struct{}
+	// resolvedSecretValues is an append-only set of all secret values ever returned by the backend.
+	// old values are retained for IsValueFromSecret lookups.
+	resolvedSecretValues map[string]struct{}
 
 	backendType                     string
 	backendConfig                   map[string]interface{}
@@ -141,7 +142,7 @@ func newEnabledSecretResolver(telemetry telemetry.Component) *secretResolver {
 	return &secretResolver{
 		cache:                   make(map[string]string),
 		origin:                  make(handleToContext),
-		resolvedValues:          make(map[string]struct{}),
+		resolvedSecretValues:    make(map[string]struct{}),
 		tlmSecretBackendElapsed: telemetry.NewGauge("secret_backend", "elapsed_ms", []string{"command", "exit_code"}, "Elapsed time of secret backend invocation"),
 		tlmSecretUnmarshalError: telemetry.NewCounter("secret_backend", "unmarshal_errors_count", []string{}, "Count of errors when unmarshalling the output of the secret binary"),
 		tlmSecretResolveError:   telemetry.NewCounter("secret_backend", "resolve_errors_count", []string{"error_kind", "handle"}, "Count of errors when resolving a secret"),
@@ -678,7 +679,7 @@ func (r *secretResolver) processSecretResponse(secretResponse map[string]string,
 	stdmaps.Copy(r.cache, secretResponse)
 	// track all resolved values in an append-only set for IsValueFromSecret lookups
 	for _, secretValue := range secretResponse {
-		r.resolvedValues[secretValue] = struct{}{}
+		r.resolvedSecretValues[secretValue] = struct{}{}
 	}
 	// return info about the handles sorted by their name
 	sort.Slice(handleInfoList, func(i, j int) bool {
@@ -687,8 +688,8 @@ func (r *secretResolver) processSecretResponse(secretResponse map[string]string,
 	return secretRefreshInfo{Handles: handleInfoList}
 }
 
-// Refresh schedules an asynchronous secret refresh (throttled). Returns true if async refresh is
-// enabled, so the caller knows whether to expect a follow-up retry to succeed.
+// Refresh schedules a throttled asynchronous secret refresh. Returns true if the
+// secret refresh mechanism is enabled (backend configured and refresh interval set).
 func (r *secretResolver) Refresh() bool {
 	if r.apiKeyFailureRefreshInterval == 0 || r.backendCommand == "" {
 		return false
@@ -710,7 +711,7 @@ func (r *secretResolver) RefreshNow() (string, error) {
 func (r *secretResolver) IsValueFromSecret(value string) bool {
 	r.lock.Lock()
 	defer r.lock.Unlock()
-	_, ok := r.resolvedValues[value]
+	_, ok := r.resolvedSecretValues[value]
 	return ok
 }
 

--- a/comp/core/secrets/impl/secrets_test.go
+++ b/comp/core/secrets/impl/secrets_test.go
@@ -591,7 +591,7 @@ func TestResolveThenRefresh(t *testing.T) {
 
 	// refresh the secrets and only collect newly updated keys
 	keysResolved = []string{}
-	output, err := resolver.Refresh(true)
+	output, err := resolver.RefreshNow()
 	require.NoError(t, err)
 	assert.Equal(t, testConfNestedOriginMultiple, resolver.origin)
 	assert.Equal(t, []string{"some/second_level"}, keysResolved)
@@ -610,7 +610,7 @@ func TestResolveThenRefresh(t *testing.T) {
 
 	// refresh one last time and only those two handles have updated keys
 	keysResolved = []string{}
-	_, err = resolver.Refresh(true)
+	_, err = resolver.RefreshNow()
 	require.NoError(t, err)
 	slices.Sort(keysResolved)
 	assert.Equal(t, testConfNestedOriginMultiple, resolver.origin)
@@ -655,7 +655,7 @@ func TestRefreshAllowlist(t *testing.T) {
 	allowListPaths = []string{"api_key"}
 
 	// Refresh means nothing changes because allowlist doesn't allow it
-	_, err := resolver.Refresh(true)
+	_, err := resolver.RefreshNow()
 	require.NoError(t, err)
 	assert.Equal(t, changes, []string{})
 
@@ -663,7 +663,7 @@ func TestRefreshAllowlist(t *testing.T) {
 	allowListPaths = []string{"setting"}
 
 	// Refresh sees the change to the handle
-	_, err = resolver.Refresh(true)
+	_, err = resolver.RefreshNow()
 	require.NoError(t, err)
 	assert.Equal(t, changes, []string{"second_value"})
 }
@@ -712,7 +712,7 @@ func TestRefreshAllowlistFromContainer(t *testing.T) {
 	})
 
 	// Refresh means nothing changes because allowlist doesn't allow it
-	_, err := resolver.Refresh(true)
+	_, err := resolver.RefreshNow()
 	require.NoError(t, err)
 	slices.Sort(changes)
 	assert.Equal(t, changes, []string{
@@ -759,7 +759,7 @@ func TestRefreshAllowlistAppliesToEachSettingPath(t *testing.T) {
 	}
 
 	// only 1 setting path got updated
-	_, err = resolver.Refresh(true)
+	_, err = resolver.RefreshNow()
 	require.NoError(t, err)
 	assert.Equal(t, changedPaths, []string{"instances/0/password"})
 }
@@ -795,7 +795,7 @@ func TestRefreshAddsToAuditFile(t *testing.T) {
 	}
 
 	// Refresh the secrets, which will add to the audit file
-	_, err = resolver.Refresh(true)
+	_, err = resolver.RefreshNow()
 	require.NoError(t, err)
 	assert.Equal(t, auditFileNumRows(tmpfile.Name()), 1)
 
@@ -806,7 +806,7 @@ func TestRefreshAddsToAuditFile(t *testing.T) {
 	}
 
 	// Refresh secrets again, which will add another row the audit file
-	_, err = resolver.Refresh(true)
+	_, err = resolver.RefreshNow()
 	require.NoError(t, err)
 	assert.Equal(t, auditFileNumRows(tmpfile.Name()), 2)
 
@@ -832,9 +832,9 @@ func TestRefreshModes(t *testing.T) {
 		return map[string]string{"api_key": "test_value"}, nil
 	}
 
-	t.Run("updateNow=true refreshes synchronously", func(t *testing.T) {
+	t.Run("RefreshNow refreshes synchronously", func(t *testing.T) {
 		calls.Store(0)
-		result, err := resolver.Refresh(true)
+		result, err := resolver.RefreshNow()
 		require.NoError(t, err)
 		assert.NotEmpty(t, result)
 		assert.Equal(t, int32(1), calls.Load())
@@ -848,16 +848,16 @@ func TestRefreshModes(t *testing.T) {
 		calls.Store(0)
 
 		// 1 refresh passes, 2 get dropped
-		resolver.Refresh(false)
-		resolver.Refresh(false)
-		resolver.Refresh(false)
+		resolver.Refresh()
+		resolver.Refresh()
+		resolver.Refresh()
 		time.Sleep(50 * time.Millisecond)
 
 		assert.Equal(t, int32(1), calls.Load(), "only first refresh should process")
 
 		// after interval, next should succeed
 		time.Sleep(100 * time.Millisecond)
-		resolver.Refresh(false)
+		resolver.Refresh()
 		time.Sleep(50 * time.Millisecond)
 
 		assert.Equal(t, int32(2), calls.Load(), "refresh after interval should process")
@@ -867,8 +867,8 @@ func TestRefreshModes(t *testing.T) {
 		resolver.apiKeyFailureRefreshInterval = 0
 
 		calls.Store(0)
-		resolver.Refresh(false)
-		resolver.Refresh(false)
+		resolver.Refresh()
+		resolver.Refresh()
 		time.Sleep(50 * time.Millisecond)
 
 		assert.Equal(t, int32(0), calls.Load(), "no refreshes when disabled")
@@ -1318,7 +1318,7 @@ func TestRefreshOutput(t *testing.T) {
 
 	password = "password2"
 
-	res, err := resolver.Refresh(true)
+	res, err := resolver.RefreshNow()
 	require.NoError(t, err)
 	res = strings.ReplaceAll(res, "\r", "") // templates use OS line breaks, removes \r line breaks from windows
 	assert.Equal(t, "=== Secret stats ===\nNumber of secrets reloaded: 1\nSecrets handle reloaded:\n\n- 'pass1':\n\tused in 'origin1' configuration in entry 'secret_backend_arguments/0'\n", res)

--- a/comp/core/secrets/noop-impl/types/types.go
+++ b/comp/core/secrets/noop-impl/types/types.go
@@ -24,8 +24,13 @@ func (r *SecretNoop) Resolve(data []byte, _ string, _ string, _ string, _ bool) 
 	return data, nil
 }
 
-// Refresh does nothing
-func (r *SecretNoop) Refresh(_ bool) (string, error) {
+// Refresh does nothing and returns false
+func (r *SecretNoop) Refresh() bool {
+	return false
+}
+
+// RefreshNow does nothing
+func (r *SecretNoop) RefreshNow() (string, error) {
 	return "", nil
 }
 

--- a/comp/core/secrets/noop-impl/types/types.go
+++ b/comp/core/secrets/noop-impl/types/types.go
@@ -34,5 +34,10 @@ func (r *SecretNoop) RefreshNow() (string, error) {
 	return "", nil
 }
 
+// IsValueFromSecret always returns false for noop
+func (r *SecretNoop) IsValueFromSecret(_ string) bool {
+	return false
+}
+
 // RemoveOrigin
 func (r *SecretNoop) RemoveOrigin(_ string) {}

--- a/comp/forwarder/defaultforwarder/default_forwarder.go
+++ b/comp/forwarder/defaultforwarder/default_forwarder.go
@@ -23,6 +23,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	secrets "github.com/DataDog/datadog-agent/comp/core/secrets/def"
+	secretnooptypes "github.com/DataDog/datadog-agent/comp/core/secrets/noop-impl/types"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/endpoints"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/internal/retry"
 	pkgresolver "github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/resolver"
@@ -225,6 +226,7 @@ func NewOptionsWithResolvers(config config.Component, log log.Component, domainR
 		APIKeyValidationInterval:       time.Duration(validationInterval) * time.Minute,
 		DomainResolvers:                domainResolvers,
 		ConnectionResetInterval:        time.Duration(config.GetInt("forwarder_connection_reset_interval")) * time.Second,
+		Secrets:                        &secretnooptypes.SecretNoop{}, // will get overwritten with actual secrets if needed
 	}
 
 	if config.IsConfigured(forwarderRetryQueueMaxSizeKey) {
@@ -294,7 +296,6 @@ type DefaultForwarder struct {
 // NewDefaultForwarder returns a new DefaultForwarder.
 // TODO: (components) Remove this method and other exported methods in comp/forwarder.
 func NewDefaultForwarder(config config.Component, log log.Component, options *Options) *DefaultForwarder {
-	log.Warnf("[SECRETPATH] NewDefaultForwarder: options.Secrets type=%T nil=%v", options.Secrets, options.Secrets == nil)
 	agentName := getAgentName(options)
 	f := &DefaultForwarder{
 		config:           config,

--- a/comp/forwarder/defaultforwarder/default_forwarder.go
+++ b/comp/forwarder/defaultforwarder/default_forwarder.go
@@ -294,6 +294,7 @@ type DefaultForwarder struct {
 // NewDefaultForwarder returns a new DefaultForwarder.
 // TODO: (components) Remove this method and other exported methods in comp/forwarder.
 func NewDefaultForwarder(config config.Component, log log.Component, options *Options) *DefaultForwarder {
+	log.Warnf("[SECRETPATH] NewDefaultForwarder: options.Secrets type=%T nil=%v", options.Secrets, options.Secrets == nil)
 	agentName := getAgentName(options)
 	f := &DefaultForwarder{
 		config:           config,

--- a/comp/forwarder/defaultforwarder/forwarder.go
+++ b/comp/forwarder/defaultforwarder/forwarder.go
@@ -39,14 +39,10 @@ type provides struct {
 }
 
 func newForwarder(dep dependencies) (provides, error) {
-	dep.Log.Warnf("[SECRETPATH] newForwarder: dep.Secrets type=%T value=%v nil=%v", dep.Secrets, dep.Secrets, dep.Secrets == nil)
-
 	options, err := createOptions(dep.Params, dep.Config, dep.Log, dep.Secrets)
 	if err != nil {
 		return provides{}, err
 	}
-
-	dep.Log.Warnf("[SECRETPATH] newForwarder: options.Secrets type=%T value=%v nil=%v", options.Secrets, options.Secrets, options.Secrets == nil)
 
 	return NewForwarder(dep.Config, dep.Log, dep.Lc, true, options), nil
 }

--- a/comp/forwarder/defaultforwarder/forwarder.go
+++ b/comp/forwarder/defaultforwarder/forwarder.go
@@ -39,10 +39,14 @@ type provides struct {
 }
 
 func newForwarder(dep dependencies) (provides, error) {
+	dep.Log.Warnf("[SECRETPATH] newForwarder: dep.Secrets type=%T value=%v nil=%v", dep.Secrets, dep.Secrets, dep.Secrets == nil)
+
 	options, err := createOptions(dep.Params, dep.Config, dep.Log, dep.Secrets)
 	if err != nil {
 		return provides{}, err
 	}
+
+	dep.Log.Warnf("[SECRETPATH] newForwarder: options.Secrets type=%T value=%v nil=%v", options.Secrets, options.Secrets, options.Secrets == nil)
 
 	return NewForwarder(dep.Config, dep.Log, dep.Lc, true, options), nil
 }

--- a/comp/forwarder/defaultforwarder/forwarder_health.go
+++ b/comp/forwarder/defaultforwarder/forwarder_health.go
@@ -327,7 +327,7 @@ func (fh *forwarderHealth) checkValidAPIKeys(domain string, keys []string) (apiE
 			fh.log.Warnf("api_key '%s' for domain %s is invalid", scrubbedAPIKey, domain)
 
 			// Trigger throttled secret refresh on invalid API key
-			_, _ = fh.secrets.Refresh(false)
+			fh.secrets.Refresh()
 		}
 	}
 

--- a/comp/forwarder/defaultforwarder/forwarder_health.go
+++ b/comp/forwarder/defaultforwarder/forwarder_health.go
@@ -327,7 +327,9 @@ func (fh *forwarderHealth) checkValidAPIKeys(domain string, keys []string) (apiE
 			fh.log.Warnf("api_key '%s' for domain %s is invalid", scrubbedAPIKey, domain)
 
 			// Trigger throttled secret refresh on invalid API key
-			fh.secrets.Refresh()
+			if fh.secrets != nil {
+				fh.secrets.Refresh()
+			}
 		}
 	}
 

--- a/comp/forwarder/defaultforwarder/forwarder_health.go
+++ b/comp/forwarder/defaultforwarder/forwarder_health.go
@@ -327,9 +327,7 @@ func (fh *forwarderHealth) checkValidAPIKeys(domain string, keys []string) (apiE
 			fh.log.Warnf("api_key '%s' for domain %s is invalid", scrubbedAPIKey, domain)
 
 			// Trigger throttled secret refresh on invalid API key
-			if fh.secrets != nil {
-				fh.secrets.Refresh()
-			}
+			fh.secrets.Refresh()
 		}
 	}
 

--- a/comp/forwarder/defaultforwarder/forwarder_health_test.go
+++ b/comp/forwarder/defaultforwarder/forwarder_health_test.go
@@ -460,11 +460,9 @@ func TestHealthInvalidAPIKeyTriggersSecretRefresh(t *testing.T) {
 	triggered := false
 
 	secrets := secretsmock.New(t)
-	secrets.SetRefreshHook(func(updateNow bool) (string, error) {
-		if !updateNow {
-			triggered = true
-		}
-		return "", nil
+	secrets.SetRefreshHook(func() bool {
+		triggered = true
+		return true
 	})
 
 	// test server that returns 403 for all keys

--- a/comp/forwarder/defaultforwarder/forwarder_test.go
+++ b/comp/forwarder/defaultforwarder/forwarder_test.go
@@ -87,7 +87,9 @@ func TestNewDefaultForwarderWithAutoscaling(t *testing.T) {
 
 	r, err := resolver.NewSingleDomainResolvers(keysPerDomains)
 	require.NoError(t, err)
-	forwarder := NewDefaultForwarder(mockConfig, log, NewOptionsWithResolvers(mockConfig, log, r))
+	options := NewOptionsWithResolvers(mockConfig, log, r)
+	options.Secrets = secretsmock.New(t)
+	forwarder := NewDefaultForwarder(mockConfig, log, options)
 	assert.NotNil(t, forwarder)
 	assert.Equal(t, 1, forwarder.NumberOfWorkers)
 	require.Len(t, forwarder.domainForwarders, 2) // 1 remote domain, 1 dca domain

--- a/comp/forwarder/defaultforwarder/go.mod
+++ b/comp/forwarder/defaultforwarder/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/core/log/mock v0.64.0-devel
 	github.com/DataDog/datadog-agent/comp/core/secrets/def v0.72.0-rc.1
 	github.com/DataDog/datadog-agent/comp/core/secrets/mock v0.72.0-rc.1
+	github.com/DataDog/datadog-agent/comp/core/secrets/noop-impl v0.77.0-devel.0.20260211235139-a5361978c2b6
 	github.com/DataDog/datadog-agent/comp/core/status v0.73.0-rc.5
 	github.com/DataDog/datadog-agent/comp/def v0.73.0-rc.5
 	github.com/DataDog/datadog-agent/pkg/api v0.61.0
@@ -41,7 +42,6 @@ require (
 	github.com/DataDog/datadog-agent/comp/core/delegatedauth v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/comp/core/flare/builder v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/comp/core/flare/types v0.72.0-rc.1 // indirect
-	github.com/DataDog/datadog-agent/comp/core/secrets/noop-impl v0.77.0-devel.0.20260211235139-a5361978c2b6 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets/utils v0.70.0 // indirect
 	github.com/DataDog/datadog-agent/comp/core/telemetry v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.61.0 // indirect

--- a/comp/forwarder/defaultforwarder/transaction/transaction.go
+++ b/comp/forwarder/defaultforwarder/transaction/transaction.go
@@ -437,7 +437,9 @@ func (t *HTTPTransaction) internalProcess(ctx context.Context, config config.Com
 		log.Errorf("API Key invalid (403 response), dropping transaction for %s", logURL)
 
 		// Trigger throttled secret refresh based on secret_refresh_on_api_key_failure_interval on API key error
-		secrets.Refresh()
+		if secrets != nil {
+			secrets.Refresh()
+		}
 
 		TransactionsDroppedByEndpoint.Add(transactionEndpointName, 1)
 		TransactionsDropped.Add(1)

--- a/comp/forwarder/defaultforwarder/transaction/transaction.go
+++ b/comp/forwarder/defaultforwarder/transaction/transaction.go
@@ -437,9 +437,7 @@ func (t *HTTPTransaction) internalProcess(ctx context.Context, config config.Com
 		log.Errorf("API Key invalid (403 response), dropping transaction for %s", logURL)
 
 		// Trigger throttled secret refresh based on secret_refresh_on_api_key_failure_interval on API key error
-		if secrets != nil {
-			_, _ = secrets.Refresh(false)
-		}
+		secrets.Refresh()
 
 		TransactionsDroppedByEndpoint.Add(transactionEndpointName, 1)
 		TransactionsDropped.Add(1)

--- a/comp/forwarder/defaultforwarder/transaction/transaction.go
+++ b/comp/forwarder/defaultforwarder/transaction/transaction.go
@@ -437,9 +437,7 @@ func (t *HTTPTransaction) internalProcess(ctx context.Context, config config.Com
 		log.Errorf("API Key invalid (403 response), dropping transaction for %s", logURL)
 
 		// Trigger throttled secret refresh based on secret_refresh_on_api_key_failure_interval on API key error
-		if secrets != nil {
-			secrets.Refresh()
-		}
+		secrets.Refresh()
 
 		TransactionsDroppedByEndpoint.Add(transactionEndpointName, 1)
 		TransactionsDropped.Add(1)

--- a/comp/forwarder/defaultforwarder/transaction/transaction_test.go
+++ b/comp/forwarder/defaultforwarder/transaction/transaction_test.go
@@ -193,11 +193,9 @@ func TestTransaction403TriggersSecretRefresh(t *testing.T) {
 	triggered := false
 
 	secrets := secretsmock.New(t)
-	secrets.SetRefreshHook(func(updateNow bool) (string, error) {
-		if !updateNow {
-			triggered = true
-		}
-		return "", nil
+	secrets.SetRefreshHook(func() bool {
+		triggered = true
+		return true
 	})
 
 	// test server that returns 403 for all reequests

--- a/comp/trace/agent/impl/agent.go
+++ b/comp/trace/agent/impl/agent.go
@@ -142,7 +142,7 @@ func NewAgent(deps dependencies) (traceagent.Component, error) {
 			log.Error("Secrets component not available, cannot trigger refresh")
 			return "", errors.New("secrets component not available")
 		}
-		return deps.Secrets.Refresh(true)
+		return deps.Secrets.RefreshNow()
 	}
 
 	c.Agent = pkgagent.NewAgent(

--- a/comp/trace/agent/impl/run.go
+++ b/comp/trace/agent/impl/run.go
@@ -84,7 +84,7 @@ func runAgentSidekicks(ag component) error {
 		// Adding IPC middleware to the secrets refresh endpoint to check validity of auth token Header.
 		ag.ipc.HTTPMiddleware(
 			http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				res, err := ag.secrets.Refresh(true)
+				res, err := ag.secrets.RefreshNow()
 				if err != nil {
 					log.Errorf("error while refresing secrets: %s", err)
 					w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
### What does this PR do?

#### Fixes this reverted PR: https://github.com/DataDog/datadog-agent/pull/47072 which didn't have a proper nil check on secrets:
```if secrets != nil ...```

also see this comment: https://github.com/DataDog/datadog-agent/pull/46704#discussion_r2866336968

https://github.com/DataDog/datadog-agent/pull/47082/changes/13d9fe2dc827438d472d658280378c31a13cbc60
https://github.com/DataDog/datadog-agent/pull/47082/changes/4134622efb5783806d0f10e69bd92e24f9ee0c30

---

Implements `IsValueFromSecret` and `resolvedValues` map that keeps track of secrets and allows a caller to find out if a value came from an `ENC[]` field. This will allow callers to intelligently call `Refresh` instead of wasting Re-tries.

Refactors the `Refresh` function that had the `updateNow` argument, to become two functions: `Refresh` and `RefreshNow`

as a QOL, `Refresh` also checks if `apiKeyFailureRefreshInterval` and `r.backendCommand` is configured and returns a bool that denotes whether an invalid payload should be retried or not

### Motivation

### Describe how you validated your changes
CI

### Additional Notes

https://github.com/DataDog/datadog-agent/pull/46704#discussion_r2853582461
