### PR TITLE
[RC] Trigger cache bypass when client adds new products

### DIFF
--- a/pkg/config/remote/service/clients.go
+++ b/pkg/config/remote/service/clients.go
@@ -93,7 +93,7 @@ func (c *clients) active(pbClient *pbgo.Client) bool {
 
 // hasNewProducts checks whether the client's request contains products that
 // were not present when the client was last seen. This detects the case where
-// a tracer adds a new RC product (e.g., FFE_FLAGS) after the initial connection,
+// a tracer adds a new RC product after the initial connection,
 // which should trigger a cache bypass so the Agent fetches configs for the new product.
 func (c *clients) hasNewProducts(pbClient *pbgo.Client) bool {
 	c.m.Lock()

--- a/pkg/config/remote/service/clients.go
+++ b/pkg/config/remote/service/clients.go
@@ -6,6 +6,7 @@
 package service
 
 import (
+	"slices"
 	"sync"
 	"time"
 
@@ -102,15 +103,8 @@ func (c *clients) hasNewProducts(pbClient *pbgo.Client) bool {
 	if !ok {
 		return false
 	}
-	for _, newProduct := range pbClient.Products {
-		found := false
-		for _, existingProduct := range existing.pbClient.Products {
-			if newProduct == existingProduct {
-				found = true
-				break
-			}
-		}
-		if !found {
+	for _, product := range pbClient.Products {
+		if !slices.Contains(existing.pbClient.Products, product) {
 			return true
 		}
 	}

--- a/pkg/config/remote/service/clients_test.go
+++ b/pkg/config/remote/service/clients_test.go
@@ -37,6 +37,62 @@ func TestClients(t *testing.T) {
 	assert.Empty(t, clients.clients)
 }
 
+func TestHasNewProducts(t *testing.T) {
+	testTTL := time.Second * 30
+	clock := clock.NewMock()
+	clock.Set(time.Now())
+	clients := newClients(clock, testTTL)
+
+	// A client that has never been seen has no new products (hasNewProducts
+	// returns false for unknown clients — the new-client bypass handles that case).
+	unknownClient := &pbgo.Client{
+		Id:       "unknown",
+		Products: []string{"APM_TRACING"},
+	}
+	assert.False(t, clients.hasNewProducts(unknownClient))
+
+	// Register a client with APM_TRACING
+	client := &pbgo.Client{
+		Id:       "client1",
+		Products: []string{"APM_TRACING"},
+	}
+	clients.seen(client)
+
+	// Same products → no new products
+	assert.False(t, clients.hasNewProducts(&pbgo.Client{
+		Id:       "client1",
+		Products: []string{"APM_TRACING"},
+	}))
+
+	// Adding FFE_FLAGS → has new products
+	assert.True(t, clients.hasNewProducts(&pbgo.Client{
+		Id:       "client1",
+		Products: []string{"APM_TRACING", "FFE_FLAGS"},
+	}))
+
+	// After seen() with the new product set, no longer has new products
+	clients.seen(&pbgo.Client{
+		Id:       "client1",
+		Products: []string{"APM_TRACING", "FFE_FLAGS"},
+	})
+	assert.False(t, clients.hasNewProducts(&pbgo.Client{
+		Id:       "client1",
+		Products: []string{"APM_TRACING", "FFE_FLAGS"},
+	}))
+
+	// Removing a product is NOT considered a "new product" — no bypass needed
+	assert.False(t, clients.hasNewProducts(&pbgo.Client{
+		Id:       "client1",
+		Products: []string{"APM_TRACING"},
+	}))
+
+	// Adding a different new product triggers again
+	assert.True(t, clients.hasNewProducts(&pbgo.Client{
+		Id:       "client1",
+		Products: []string{"APM_TRACING", "FFE_FLAGS", "LIVE_DEBUGGING"},
+	}))
+}
+
 func TestCacheBypassClientsRateLimit(t *testing.T) {
 	clock := clock.NewMock()
 	cacheBypassClients := rateLimiter{

--- a/pkg/config/remote/service/clients_test.go
+++ b/pkg/config/remote/service/clients_test.go
@@ -64,20 +64,20 @@ func TestHasNewProducts(t *testing.T) {
 		Products: []string{"APM_TRACING"},
 	}))
 
-	// Adding FFE_FLAGS → has new products
+	// Adding a second product → has new products
 	assert.True(t, clients.hasNewProducts(&pbgo.Client{
 		Id:       "client1",
-		Products: []string{"APM_TRACING", "FFE_FLAGS"},
+		Products: []string{"APM_TRACING", "LIVE_DEBUGGING"},
 	}))
 
 	// After seen() with the new product set, no longer has new products
 	clients.seen(&pbgo.Client{
 		Id:       "client1",
-		Products: []string{"APM_TRACING", "FFE_FLAGS"},
+		Products: []string{"APM_TRACING", "LIVE_DEBUGGING"},
 	})
 	assert.False(t, clients.hasNewProducts(&pbgo.Client{
 		Id:       "client1",
-		Products: []string{"APM_TRACING", "FFE_FLAGS"},
+		Products: []string{"APM_TRACING", "LIVE_DEBUGGING"},
 	}))
 
 	// Removing a product is NOT considered a "new product" — no bypass needed
@@ -89,7 +89,7 @@ func TestHasNewProducts(t *testing.T) {
 	// Adding a different new product triggers again
 	assert.True(t, clients.hasNewProducts(&pbgo.Client{
 		Id:       "client1",
-		Products: []string{"APM_TRACING", "FFE_FLAGS", "LIVE_DEBUGGING"},
+		Products: []string{"APM_TRACING", "LIVE_DEBUGGING", "ASM_DATA"},
 	}))
 }
 

--- a/pkg/config/remote/service/clients_test.go
+++ b/pkg/config/remote/service/clients_test.go
@@ -38,7 +38,7 @@ func TestClients(t *testing.T) {
 }
 
 func TestHasNewProducts(t *testing.T) {
-	testTTL := time.Second * 30
+	testTTL := time.Hour // TTL is irrelevant for hasNewProducts; any large value works
 	clock := clock.NewMock()
 	clock.Set(time.Now())
 	clients := newClients(clock, testTTL)

--- a/pkg/config/remote/service/service.go
+++ b/pkg/config/remote/service/service.go
@@ -983,8 +983,8 @@ func (s *CoreAgentService) ClientGetConfigs(_ context.Context, request *pbgo.Cli
 	if !s.clients.active(request.Client) || s.clients.hasNewProducts(request.Client) {
 		// Trigger a bypass to directly get configurations from the agent.
 		// This fires for new clients AND for existing clients that have added
-		// new products since their last request (e.g., a tracer that adds
-		// FFE_FLAGS after initially connecting for APM products).
+		// new products since their last request (e.g., a tracer that registers
+		// a new RC product after initially connecting for APM).
 		// This will timeout to avoid blocking the tracer if:
 		// - The previous request is still pending
 		// - The triggered request takes too long

--- a/pkg/config/remote/service/service.go
+++ b/pkg/config/remote/service/service.go
@@ -980,8 +980,11 @@ func (s *CoreAgentService) ClientGetConfigs(_ context.Context, request *pbgo.Cli
 		return nil, err
 	}
 
-	if !s.clients.active(request.Client) {
+	if !s.clients.active(request.Client) || s.clients.hasNewProducts(request.Client) {
 		// Trigger a bypass to directly get configurations from the agent.
+		// This fires for new clients AND for existing clients that have added
+		// new products since their last request (e.g., a tracer that adds
+		// FFE_FLAGS after initially connecting for APM products).
 		// This will timeout to avoid blocking the tracer if:
 		// - The previous request is still pending
 		// - The triggered request takes too long

--- a/pkg/config/remote/service/service_test.go
+++ b/pkg/config/remote/service/service_test.go
@@ -1543,6 +1543,7 @@ func TestBypassTriggersOnNewProducts(t *testing.T) {
 	uptaneClient.On("StoredOrgUUID").Return("abcdef", nil)
 	uptaneClient.On("TUFVersionState").Return(uptane.TUFVersions{}, nil)
 	uptaneClient.On("TargetsCustom").Return([]byte{}, nil)
+	uptaneClient.On("TimestampExpires").Return(clk.Now().Add(1*time.Hour), nil)
 	api.On("Fetch", mock.Anything, mock.Anything).Return(lastConfigResponse, nil)
 	uptaneClient.On("Update", lastConfigResponse).Return(nil)
 
@@ -1555,9 +1556,12 @@ func TestBypassTriggersOnNewProducts(t *testing.T) {
 		State: &pbgo.ClientState{
 			RootVersion: 1,
 		},
-		IsTracer:     true,
-		ClientTracer: &pbgo.ClientTracer{},
-		Products:     []string{string(rdata.ProductAPMSampling)},
+		IsTracer: true,
+		ClientTracer: &pbgo.ClientTracer{
+			RuntimeId: "runtime-1",
+			Language:  "go",
+		},
+		Products: []string{string(rdata.ProductAPMSampling)},
 	}
 	_, err := service.ClientGetConfigs(context.Background(), &pbgo.ClientGetConfigsRequest{Client: clientAPM})
 	require.NoError(t, err)
@@ -1574,9 +1578,12 @@ func TestBypassTriggersOnNewProducts(t *testing.T) {
 		State: &pbgo.ClientState{
 			RootVersion: 1,
 		},
-		IsTracer:     true,
-		ClientTracer: &pbgo.ClientTracer{},
-		Products:     []string{string(rdata.ProductAPMSampling)},
+		IsTracer: true,
+		ClientTracer: &pbgo.ClientTracer{
+			RuntimeId: "runtime-1",
+			Language:  "go",
+		},
+		Products: []string{string(rdata.ProductAPMSampling)},
 	}
 	_, err = service.ClientGetConfigs(context.Background(), &pbgo.ClientGetConfigsRequest{Client: clientSameProducts})
 	require.NoError(t, err)
@@ -1594,9 +1601,12 @@ func TestBypassTriggersOnNewProducts(t *testing.T) {
 		State: &pbgo.ClientState{
 			RootVersion: 1,
 		},
-		IsTracer:     true,
-		ClientTracer: &pbgo.ClientTracer{},
-		Products:     []string{string(rdata.ProductAPMSampling), "FFE_FLAGS"},
+		IsTracer: true,
+		ClientTracer: &pbgo.ClientTracer{
+			RuntimeId: "runtime-1",
+			Language:  "go",
+		},
+		Products: []string{string(rdata.ProductAPMSampling), "FFE_FLAGS"},
 	}
 	_, err = service.ClientGetConfigs(context.Background(), &pbgo.ClientGetConfigsRequest{Client: clientWithFFE})
 	require.NoError(t, err)

--- a/pkg/config/remote/service/service_test.go
+++ b/pkg/config/remote/service/service_test.go
@@ -1525,7 +1525,7 @@ func TestWithOrgStatusPollingIntervalConfigPassed(t *testing.T) {
 }
 
 // TestBypassTriggersOnNewProducts verifies that when an already-active client
-// adds a new product (e.g., FFE_FLAGS after initially connecting for APM), the
+// adds a new product after initially connecting for APM, the
 // cache bypass fires. This is the fix for the startup latency issue where the
 // bypass only fired for new clients, not new products.
 func TestBypassTriggersOnNewProducts(t *testing.T) {
@@ -1594,9 +1594,9 @@ func TestBypassTriggersOnNewProducts(t *testing.T) {
 	// Advance the clock past the 1-second minimum between refreshes
 	clk.Add(2 * time.Second)
 
-	// Now the client adds FFE_FLAGS. This should trigger a bypass because
+	// Now the client adds a new product. This should trigger a bypass because
 	// the product set changed — even though the client is still active.
-	clientWithFFE := &pbgo.Client{
+	clientWithNewProduct := &pbgo.Client{
 		Id: "tracer-1",
 		State: &pbgo.ClientState{
 			RootVersion: 1,
@@ -1606,13 +1606,13 @@ func TestBypassTriggersOnNewProducts(t *testing.T) {
 			RuntimeId: "runtime-1",
 			Language:  "go",
 		},
-		Products: []string{string(rdata.ProductAPMSampling), "FFE_FLAGS"},
+		Products: []string{string(rdata.ProductAPMSampling), string(rdata.ProductLiveDebugging)},
 	}
-	_, err = service.ClientGetConfigs(context.Background(), &pbgo.ClientGetConfigsRequest{Client: clientWithFFE})
+	_, err = service.ClientGetConfigs(context.Background(), &pbgo.ClientGetConfigsRequest{Client: clientWithNewProduct})
 	require.NoError(t, err)
 
-	fetchCountAfterFFE := countFetchCalls(api)
-	assert.Greater(t, fetchCountAfterFFE, fetchCountAfterSame, "new product FFE_FLAGS should trigger bypass and call Fetch")
+	fetchCountAfterNew := countFetchCalls(api)
+	assert.Greater(t, fetchCountAfterNew, fetchCountAfterSame, "new product should trigger bypass and call Fetch")
 }
 
 // countFetchCalls returns the number of times api.Fetch was called.

--- a/pkg/config/remote/service/service_test.go
+++ b/pkg/config/remote/service/service_test.go
@@ -1546,6 +1546,10 @@ func TestBypassTriggersOnNewProducts(t *testing.T) {
 	uptaneClient.On("TimestampExpires").Return(clk.Now().Add(1*time.Hour), nil)
 	api.On("Fetch", mock.Anything, mock.Anything).Return(lastConfigResponse, nil)
 	uptaneClient.On("Update", lastConfigResponse).Return(nil)
+	api.On("FetchOrgStatus", mock.Anything).Return(&pbgo.OrgStatusResponse{
+		Enabled:    true,
+		Authorized: true,
+	}, nil)
 
 	service.Start()
 

--- a/pkg/config/remote/service/service_test.go
+++ b/pkg/config/remote/service/service_test.go
@@ -1526,8 +1526,7 @@ func TestWithOrgStatusPollingIntervalConfigPassed(t *testing.T) {
 
 // TestBypassTriggersOnNewProducts verifies that when an already-active client
 // adds a new product after initially connecting for APM, the
-// cache bypass fires. This is the fix for the startup latency issue where the
-// bypass only fired for new clients, not new products.
+// cache bypass fires. The bypass should trigger for new products, not just new clients.
 func TestBypassTriggersOnNewProducts(t *testing.T) {
 	api := &mockAPI{}
 	uptaneClient := &mockCoreAgentUptane{}

--- a/releasenotes/notes/rc-product-aware-cache-bypass-075c82c74deae54c.yaml
+++ b/releasenotes/notes/rc-product-aware-cache-bypass-075c82c74deae54c.yaml
@@ -1,0 +1,7 @@
+---
+enhancements:
+  - |
+    Remote Configuration cache bypass now triggers when an existing client
+    adds new products, not only when a new client connects. This reduces
+    startup latency for products like feature flags (FFE_FLAGS) that are
+    registered after the tracer's initial RC connection.

--- a/releasenotes/notes/rc-product-aware-cache-bypass-075c82c74deae54c.yaml
+++ b/releasenotes/notes/rc-product-aware-cache-bypass-075c82c74deae54c.yaml
@@ -3,5 +3,5 @@ enhancements:
   - |
     Remote Configuration cache bypass now triggers when an existing client
     adds new products, not only when a new client connects. This reduces
-    startup latency for products like feature flags (FFE_FLAGS) that are
-    registered after the tracer's initial RC connection.
+    startup latency for products that are registered after the tracer's
+    initial RC connection.


### PR DESCRIPTION
## Motivation

Products delivered via Remote Configuration (RC) experience 50-60s startup delays when they are registered after the tracer's initial RC connection. This is because the Agent's cache bypass mechanism only fires when a **client** is new — not when an existing client adds a **new product**.

All tracer SDKs use a singleton RC client shared across products. Products like APM_TRACING and LIVE_DEBUGGING are subscribed during `tracer.Start()` — they're present on the first poll and get the new-client bypass. But products registered by user code after startup (e.g., via an SDK `init()` call) miss the bypass entirely because the client is already active.

```mermaid
sequenceDiagram
    participant T as Tracer
    participant A as Agent
    participant B as Backend

    T->>T: tracer.Start() — RC client created
    T->>A: Poll #1 (products: [APM])
    A->>A: New client → bypass!
    A->>B: Fetch configs
    B-->>A: APM configs
    A-->>T: APM configs ✓
    A->>A: Mark client ACTIVE

    T->>T: Subscribe(NEW_PRODUCT)

    T->>A: Poll #2 (products: [APM, NEW_PRODUCT])
    A->>A: Client is ACTIVE → no bypass
    A-->>T: Serve from cache (no NEW_PRODUCT) ✗

    Note over T,A: Tracer polls every 5s, always gets stale cache...

    A->>B: Background poll (~50s later)
    B-->>A: APM + NEW_PRODUCT configs

    T->>A: Poll #N
    A-->>T: NEW_PRODUCT configs ✓ (after ~50-60s)
```

### Why this can't be fixed in the backend alone

The backend can recommend a faster Agent poll interval via `agent_refresh_interval` in the TUF targets response. Some products already have this — LIVE_DEBUGGING, HA_AGENT, and DSM_LIVE_MESSAGES are hardcoded to 5s in `rc-delivery`. But this doesn't help for the initial delivery:

1. The backend sets `agent_refresh_interval` based on the products in the Agent's request.
2. The Agent only includes a new product in its request after it appears in an active client's product list.
3. That only happens on the next **background poll** (~50s), which is the same poll that delivers the data.
4. So the faster interval takes effect **after** the initial delivery — it helps with subsequent updates, not startup.

The problem is structural: the Agent doesn't know it needs to fetch a new product until its next background poll. The bypass mechanism was designed to solve exactly this (fetch immediately when something new appears), but it only checks for new **clients**, not new **products**. This is an Agent-side fix.

## Changes

The bypass condition in `ClientGetConfigs` goes from `!active(client)` to `!active(client) || hasNewProducts(client)`. The new `hasNewProducts` method on the `clients` struct compares the incoming request's products against `pbClient.Products` from the last `seen()` call — no new fields or allocations needed since `seen()` already stores the full `pbClient`.

```mermaid
sequenceDiagram
    participant T as Tracer
    participant A as Agent
    participant B as Backend

    T->>T: tracer.Start() — RC client created
    T->>A: Poll #1 (products: [APM])
    A->>A: New client → bypass!
    A->>B: Fetch configs
    B-->>A: APM configs
    A-->>T: APM configs ✓
    A->>A: Mark client ACTIVE

    T->>T: Subscribe(NEW_PRODUCT)

    T->>A: Poll #2 (products: [APM, NEW_PRODUCT])
    A->>A: Client ACTIVE but has new product → bypass!
    A->>B: Fetch configs
    B-->>A: APM + NEW_PRODUCT configs
    A-->>T: NEW_PRODUCT configs ✓ (seconds, not minutes)
```

No new feature flags or rate limiter changes. The existing `refreshBypassLimiter` (5 per window) bounds bypass frequency the same way it does for new-client bypasses today.

### What about load shedding?

We've separately identified that the bypass rate limiter and thundering-herd behavior under high tracer counts can compound delivery delays. That's a real concern but it's secondary to this change — this PR fixes the base case where a single tracer adding a new product gets no bypass at all. Load shedding improvements can build on top of this without conflicting.

## Validation

### Hypothesis

When a tracer registers FFE_FLAGS after the RC client is already "active" in the agent, the baseline agent does not trigger a cache bypass. The tracer waits for the agent's next background poll (up to 60s) before receiving flag configuration. With the product-aware bypass, the agent detects the new product and fetches immediately.

### Test setup

A Go timing test app ([`ffe-dogfooding/apps/rc-bypass-timing-test`](https://github.com/DataDog/ffe-dogfooding/tree/leo/rc-bypass-timing-test/apps/rc-bypass-timing-test)) measures `SetProviderAndWait` duration — the time the tracer blocks waiting for FFE_FLAGS config after registering the product. The test reproduces the exact production sequence:

1. **Agent starts** and completes its initial RC polls (20s warmup).
2. **`tracer.Start()`** — the RC client connects to the agent with APM-only products. The new-client bypass fires. The agent marks this client as "active".
3. **Sleep 10 seconds** — ensures at least one full RC poll cycle (5s interval) completes with APM-only products. The client is now firmly "active" in the agent's client table. This is critical: with a shorter sleep (e.g. 2s), FFE_FLAGS is added before the first poll, so both agents see a new client with FFE_FLAGS already present and the test produces identical results.
4. **`NewDatadogProvider()` + `SetProviderAndWait()`** — adds FFE_FLAGS to the RC client's product list and blocks until flag configuration arrives.

Both agents are configured with `DD_REMOTE_CONFIGURATION_REFRESH_INTERVAL=60s` (the production default) and the same org/API key (`DD_SERVICE=ffe-dogfooding-go`, `DD_ENV=prod`).

### Observations

**Baseline agent (v7.75.2):** After FFE_FLAGS is registered at step 4, the tracer polls the agent every 5s. The agent sees FFE_FLAGS in the client's products but the client is already active — no bypass fires. The agent serves from its cache, which does not contain FFE_FLAGS data. The agent's next background poll happens ~60s later, fetches FFE_FLAGS from the backend, populates the cache. The tracer's next 5s poll after that gets the data.

**Modified agent (this branch):** The agent detects FFE_FLAGS as a new product via `hasNewProducts()`. The bypass fires immediately. Agent debug log confirms:
```
Making bypass request for client erdHd7iiXixl5hbnOkIRB
fetching configurations at https://config.datadoghq.com./api/v0.1/configurations
Commit successful. 4 keys
```
The backend returns FFE_FLAGS configs. The tracer's next 5s poll receives the data.

### Results (5 runs)

| Run | Baseline (v7.75.2) | Modified (this branch) |
|-----|-------------------|----------------------|
| 1 | 59.8s | 4.7s |
| 2 | 59.8s | 4.8s |
| 3 | 59.7s | 4.8s |
| 4 | 59.3s | 4.7s |
| 5 | 59.6s | 4.8s |

All runs returned `"variant_3"` ✓. The baseline is locked to the 60s poll interval. The modified agent consistently delivers in under 5s.

### Unit tests

All existing tests in `pkg/config/remote/service/` pass. New tests cover `hasNewProducts` (unknown client, same products, new product, removal, multiple additions) and `TestBypassTriggersOnNewProducts` (end-to-end: registers client with APM, verifies same-products doesn't bypass, adds new product, verifies bypass fires and `Fetch` is called).

### Reproducing

```bash
# Clone the timing test
git clone -b leo/rc-bypass-timing-test https://github.com/DataDog/ffe-dogfooding.git
cd ffe-dogfooding/apps/rc-bypass-timing-test && go build -o timing-test .

DD_SERVICE=ffe-dogfooding-go DD_ENV=prod \
DD_AGENT_HOST=localhost DD_TRACE_AGENT_PORT=8126 \
DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED=true \
./timing-test
# Look for TIMING_RESULT in output
```

## Risks

Each new product registration triggers at most one bypass per Agent (not per tracer — only the first tracer with FFE_FLAGS triggers it, the rest read from cache). The existing rate limiter (5 per window per Agent) bounds this. Products don't change after startup in practice, so flapping isn't a concern.

