### PR TITLE
Ignore .claude/worktrees in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -234,5 +234,8 @@ CLAUDE_PERSONAL.md
 **/.claude/settings.local.json
 **/CLAUDE.local.md
 
+# Claude Code worktrees (local development, not for repo)
+.claude/worktrees/
+
 # Zed config
 .zed


### PR DESCRIPTION
## Summary

Add `.claude/worktrees/` to `.gitignore` to prevent Claude Code worktrees from showing up as untracked files.

## Motivation

Claude Code creates git worktrees under `.claude/worktrees/` for isolated development sessions. These are local-only and should not be tracked by git.