### PR TITLE
fleet: preserve odbc.ini and odbcinst.ini across upgrades

### DIFF
--- a/pkg/fleet/installer/packages/datadog_agent_linux.go
+++ b/pkg/fleet/installer/packages/datadog_agent_linux.go
@@ -260,6 +260,9 @@ func postInstallDatadogAgent(ctx HookContext) (err error) {
 	if err := integrations.RestoreCustomIntegrations(ctx, ctx.PackagePath); err != nil {
 		log.Warnf("failed to restore custom integrations: %s", err)
 	}
+	if err := restoreODBCConfig(ctx.PackagePath); err != nil {
+		log.Warnf("failed to restore ODBC config: %s", err)
+	}
 	agentVersion := getCurrentAgentVersion()
 	if err := extensionsPkg.SetPackage(ctx, agentPackage, agentVersion, false); err != nil {
 		return fmt.Errorf("failed to set package version in extensions db: %w", err)
@@ -332,6 +335,9 @@ func preRemoveDatadogAgent(ctx HookContext) error {
 		if err := integrations.RemoveCompiledFiles(ctx.PackagePath); err != nil {
 			log.Warnf("failed to remove compiled files: %s", err)
 		}
+		if err := saveODBCConfig(ctx.PackagePath); err != nil {
+			log.Warnf("failed to save ODBC config: %s", err)
+		}
 	}
 	return nil
 }
@@ -348,6 +354,9 @@ func preStartExperimentDatadogAgent(ctx HookContext) error {
 	}
 	if err := saveAgentExtensions(ctx, false); err != nil {
 		log.Warnf("failed to save agent extensions: %s", err)
+	}
+	if err := saveODBCConfig(ctx.PackagePath); err != nil {
+		log.Warnf("failed to save ODBC config: %s", err)
 	}
 	return nil
 }
@@ -367,6 +376,9 @@ func postStartExperimentDatadogAgent(ctx HookContext) error {
 	}
 	if err := restoreAgentExtensions(ctx, experimentVersion, true); err != nil {
 		log.Warnf("failed to restore agent extensions: %s", err)
+	}
+	if err := restoreODBCConfig(ctx.PackagePath); err != nil {
+		log.Warnf("failed to restore ODBC config: %s", err)
 	}
 	if err := agentService.WriteExperiment(ctx); err != nil {
 		return err
@@ -813,4 +825,47 @@ func RestartDatadogAgent(ctx context.Context) error {
 		return nil
 	}
 	return systemd.RestartUnit(ctx, "datadog-agent.service")
+}
+
+var odbcConfigFiles = []string{"odbc.ini", "odbcinst.ini"}
+
+// saveODBCConfig saves the ODBC configuration files from embedded/etc/ to the
+// temporary directory so they can be restored after an upgrade.
+func saveODBCConfig(packagePath string) error {
+	for _, filename := range odbcConfigFiles {
+		src := filepath.Join(packagePath, "embedded", "etc", filename)
+		dst := filepath.Join(paths.RootTmpDir, filename)
+		data, err := os.ReadFile(src)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return fmt.Errorf("failed to read %s: %w", src, err)
+		}
+		if err := os.WriteFile(dst, data, 0644); err != nil {
+			return fmt.Errorf("failed to write %s: %w", dst, err)
+		}
+	}
+	return nil
+}
+
+// restoreODBCConfig restores the ODBC configuration files from the temporary
+// directory into the new package's embedded/etc/ directory after an upgrade.
+func restoreODBCConfig(packagePath string) error {
+	for _, filename := range odbcConfigFiles {
+		src := filepath.Join(paths.RootTmpDir, filename)
+		dst := filepath.Join(packagePath, "embedded", "etc", filename)
+		data, err := os.ReadFile(src)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return fmt.Errorf("failed to read %s: %w", src, err)
+		}
+		if err := os.WriteFile(dst, data, 0644); err != nil {
+			return fmt.Errorf("failed to write %s: %w", dst, err)
+		}
+		_ = os.Remove(src)
+	}
+	return nil
 }

--- a/pkg/fleet/installer/packages/datadog_agent_linux.go
+++ b/pkg/fleet/installer/packages/datadog_agent_linux.go
@@ -854,13 +854,17 @@ func saveODBCConfig(packagePath string) error {
 func restoreODBCConfig(packagePath string) error {
 	for _, filename := range odbcConfigFiles {
 		src := filepath.Join(paths.RootTmpDir, filename)
-		dst := filepath.Join(packagePath, "embedded", "etc", filename)
+		dstDir := filepath.Join(packagePath, "embedded", "etc")
+		dst := filepath.Join(dstDir, filename)
 		data, err := os.ReadFile(src)
 		if err != nil {
 			if os.IsNotExist(err) {
 				continue
 			}
 			return fmt.Errorf("failed to read %s: %w", src, err)
+		}
+		if err := os.MkdirAll(dstDir, 0755); err != nil {
+			return fmt.Errorf("failed to create directory %s: %w", dstDir, err)
 		}
 		if err := os.WriteFile(dst, data, 0644); err != nil {
 			return fmt.Errorf("failed to write %s: %w", dst, err)

--- a/releasenotes/notes/preserve-odbc-config-on-fleet-automation-upgrade-0b5903991cb1d179.yaml
+++ b/releasenotes/notes/preserve-odbc-config-on-fleet-automation-upgrade-0b5903991cb1d179.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Preserve ``odbc.ini`` and ``odbcinst.ini`` across Fleet Automation upgrades on Linux.

--- a/test/new-e2e/tests/fleet/upgrade_test.go
+++ b/test/new-e2e/tests/fleet/upgrade_test.go
@@ -114,7 +114,7 @@ func (s *upgradeSuite) TestODBCConfigPreservedOnUpgrade() {
 	s.Require().NoError(err)
 	_, err = s.Env().RemoteHost.Execute(`sudo sh -c 'printf "[ODBC Driver 18 for SQL Server]\nDescription=Microsoft ODBC Driver 18 for SQL Server\nDriver=/opt/microsoft/msodbcsql18/lib64/libmsodbcsql-18.6.so.1.1\nUsageCount=1\n" > /opt/datadog-agent/embedded/etc/odbcinst.ini'`)
 	s.Require().NoError(err)
-	
+
 	targetVersion := s.Backend.Catalog().Latest(backend.BranchTesting, "datadog-agent")
 	err = s.Backend.StartExperiment("datadog-agent", targetVersion)
 	s.Require().NoError(err)

--- a/test/new-e2e/tests/fleet/upgrade_test.go
+++ b/test/new-e2e/tests/fleet/upgrade_test.go
@@ -108,30 +108,22 @@ func (s *upgradeSuite) TestODBCConfigPreservedOnUpgrade() {
 	if s.Env().RemoteHost.OSFamily != e2eos.LinuxFamily {
 		s.T().Skip("ODBC config preservation is only relevant on Linux")
 	}
-
 	s.Agent.MustInstall(agent.WithRemoteUpdates(), agent.WithStablePackages())
 	defer s.Agent.MustUninstall()
-
-	// Simulate a customer who has registered ODBC drivers after installing the agent.
-	// The content below mirrors what the Microsoft ODBC Driver installer writes to
-	// /opt/datadog-agent/embedded/etc/odbcinst.ini on a Linux host.
 	_, err := s.Env().RemoteHost.Execute(`sudo sh -c 'printf "[ODBC]\nTrace=no\n" > /opt/datadog-agent/embedded/etc/odbc.ini'`)
 	s.Require().NoError(err)
 	_, err = s.Env().RemoteHost.Execute(`sudo sh -c 'printf "[ODBC Driver 18 for SQL Server]\nDescription=Microsoft ODBC Driver 18 for SQL Server\nDriver=/opt/microsoft/msodbcsql18/lib64/libmsodbcsql-18.6.so.1.1\nUsageCount=1\n" > /opt/datadog-agent/embedded/etc/odbcinst.ini'`)
 	s.Require().NoError(err)
-
-	// Upgrade to the testing (pipeline) version via experiment and promote it.
+	
 	targetVersion := s.Backend.Catalog().Latest(backend.BranchTesting, "datadog-agent")
 	err = s.Backend.StartExperiment("datadog-agent", targetVersion)
 	s.Require().NoError(err)
 	err = s.Backend.PromoteExperiment("datadog-agent")
 	s.Require().NoError(err)
 
-	// Verify that both ODBC config files survived the upgrade with their content intact.
 	odbcIni, err := s.Env().RemoteHost.Execute("sudo cat /opt/datadog-agent/embedded/etc/odbc.ini")
 	s.Require().NoError(err)
 	s.Require().Contains(odbcIni, "[ODBC]")
-
 	odbcInst, err := s.Env().RemoteHost.Execute("sudo cat /opt/datadog-agent/embedded/etc/odbcinst.ini")
 	s.Require().NoError(err)
 	s.Require().Contains(odbcInst, "[ODBC Driver 18 for SQL Server]")

--- a/test/new-e2e/tests/fleet/upgrade_test.go
+++ b/test/new-e2e/tests/fleet/upgrade_test.go
@@ -125,10 +125,11 @@ func (s *upgradeSuite) TestODBCConfigPreservedOnUpgrade() {
 	err = s.Backend.PromoteExperiment("datadog-agent")
 	s.Require().NoError(err)
 
-	odbcIni, err := s.Env().RemoteHost.Execute("sudo cat /opt/datadog-agent/embedded/etc/odbc.ini")
+	// After DEB→OCI promote, the agent runs from /opt/datadog-packages/datadog-agent/stable/
+	odbcIni, err := s.Env().RemoteHost.Execute("sudo cat /opt/datadog-packages/datadog-agent/stable/embedded/etc/odbc.ini")
 	s.Require().NoError(err)
 	s.Require().Contains(odbcIni, "[ODBC]")
-	odbcInst, err := s.Env().RemoteHost.Execute("sudo cat /opt/datadog-agent/embedded/etc/odbcinst.ini")
+	odbcInst, err := s.Env().RemoteHost.Execute("sudo cat /opt/datadog-packages/datadog-agent/stable/embedded/etc/odbcinst.ini")
 	s.Require().NoError(err)
 	s.Require().Contains(odbcInst, "[ODBC Driver 18 for SQL Server]")
 }

--- a/test/new-e2e/tests/fleet/upgrade_test.go
+++ b/test/new-e2e/tests/fleet/upgrade_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	e2eos "github.com/DataDog/datadog-agent/test/e2e-framework/components/os"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/fleet/agent"
@@ -97,4 +98,41 @@ func (s *upgradeSuite) TestUpgradeFailureHealth() {
 		require.NoError(c, err)
 		require.Equal(c, originalVersion, version)
 	}, 300*time.Second, 30*time.Second)
+}
+
+// TestODBCConfigPreservedOnUpgrade verifies that customer-modified ODBC config files
+// (odbc.ini and odbcinst.ini) in the agent's embedded/etc/ directory survive a
+// Fleet Automation upgrade. This covers the SQL Server DBM use case where customers
+// register ODBC drivers by editing those files after the agent is installed.
+func (s *upgradeSuite) TestODBCConfigPreservedOnUpgrade() {
+	if s.Env().RemoteHost.OSFamily != e2eos.LinuxFamily {
+		s.T().Skip("ODBC config preservation is only relevant on Linux")
+	}
+
+	s.Agent.MustInstall(agent.WithRemoteUpdates(), agent.WithStablePackages())
+	defer s.Agent.MustUninstall()
+
+	// Simulate a customer who has registered ODBC drivers after installing the agent.
+	// The content below mirrors what the Microsoft ODBC Driver installer writes to
+	// /opt/datadog-agent/embedded/etc/odbcinst.ini on a Linux host.
+	_, err := s.Env().RemoteHost.Execute(`sudo sh -c 'printf "[ODBC]\nTrace=no\n" > /opt/datadog-agent/embedded/etc/odbc.ini'`)
+	s.Require().NoError(err)
+	_, err = s.Env().RemoteHost.Execute(`sudo sh -c 'printf "[ODBC Driver 18 for SQL Server]\nDescription=Microsoft ODBC Driver 18 for SQL Server\nDriver=/opt/microsoft/msodbcsql18/lib64/libmsodbcsql-18.6.so.1.1\nUsageCount=1\n" > /opt/datadog-agent/embedded/etc/odbcinst.ini'`)
+	s.Require().NoError(err)
+
+	// Upgrade to the testing (pipeline) version via experiment and promote it.
+	targetVersion := s.Backend.Catalog().Latest(backend.BranchTesting, "datadog-agent")
+	err = s.Backend.StartExperiment("datadog-agent", targetVersion)
+	s.Require().NoError(err)
+	err = s.Backend.PromoteExperiment("datadog-agent")
+	s.Require().NoError(err)
+
+	// Verify that both ODBC config files survived the upgrade with their content intact.
+	odbcIni, err := s.Env().RemoteHost.Execute("sudo cat /opt/datadog-agent/embedded/etc/odbc.ini")
+	s.Require().NoError(err)
+	s.Require().Contains(odbcIni, "[ODBC]")
+
+	odbcInst, err := s.Env().RemoteHost.Execute("sudo cat /opt/datadog-agent/embedded/etc/odbcinst.ini")
+	s.Require().NoError(err)
+	s.Require().Contains(odbcInst, "[ODBC Driver 18 for SQL Server]")
 }

--- a/test/new-e2e/tests/fleet/upgrade_test.go
+++ b/test/new-e2e/tests/fleet/upgrade_test.go
@@ -108,7 +108,11 @@ func (s *upgradeSuite) TestODBCConfigPreservedOnUpgrade() {
 	if s.Env().RemoteHost.OSFamily != e2eos.LinuxFamily {
 		s.T().Skip("ODBC config preservation is only relevant on Linux")
 	}
-	s.Agent.MustInstall(agent.WithRemoteUpdates(), agent.WithStablePackages())
+	// TODO: This test uses a DEB→OCI upgrade (testing pipeline DEB as stable, testing
+	// pipeline OCI as experiment) because the ODBC save/restore code is new and not yet
+	// in a released stable binary. Once this fix ships as a stable release, rewrite this
+	// test to use WithStablePackages() + BranchTesting experiment, like other upgrade tests.
+	s.Agent.MustInstall(agent.WithRemoteUpdates())
 	defer s.Agent.MustUninstall()
 	_, err := s.Env().RemoteHost.Execute(`sudo sh -c 'printf "[ODBC]\nTrace=no\n" > /opt/datadog-agent/embedded/etc/odbc.ini'`)
 	s.Require().NoError(err)


### PR DESCRIPTION
## Summary

This PR preserves customer-modified ODBC configuration files (`odbc.ini` and `odbcinst.ini`) across agent upgrades via Fleet Automation.

## Motivation

When upgrading the agent via Fleet Automation, the old package directory is replaced entirely, which wipes out `embedded/etc/odbc.ini` and `embedded/etc/odbcinst.ini`. These files are modified by customers to register ODBC drivers (e.g. Microsoft ODBC Driver for SQL Server, MariaDB), causing integrations like SQL Server DBM to fail after upgrade with a missing driver error.

The issue does not occur with script-based upgrades since those preserve the `/opt/datadog-agent` directory.

Fixes: [SPFA-93](https://datadoghq.atlassian.net/browse/SPFA-93)

## How

Before removing the old package (on upgrade), `odbc.ini` and `odbcinst.ini` are copied to `paths.RootTmpDir` (`/opt/datadog-packages/tmp`). After the new package is installed, the files are restored from there into the new package's `embedded/etc/` directory and the temp copies are removed.

This mirrors the existing save/restore pattern used for custom integrations and extensions, and is applied to both the standard install path and the experiment (canary) path.

[SPFA-93]: https://datadoghq.atlassian.net/browse/SPFA-93?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ