### PR TITLE
(fleet) add TestUpgrade e2e test

### DIFF
--- a/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
@@ -179,6 +179,7 @@ func (ia *inventoryagent) initData() {
 	}
 
 	ia.data["agent_version"] = version.AgentVersion
+	ia.data["package_version"] = version.AgentPackageVersion
 	ia.data["agent_startup_time_ms"] = pkgconfigsetup.StartTime.UnixMilli()
 	ia.data["flavor"] = flavor.GetFlavor()
 

--- a/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
@@ -179,7 +179,6 @@ func (ia *inventoryagent) initData() {
 	}
 
 	ia.data["agent_version"] = version.AgentVersion
-	ia.data["package_version"] = version.AgentPackageVersion
 	ia.data["agent_startup_time_ms"] = pkgconfigsetup.StartTime.UnixMilli()
 	ia.data["flavor"] = flavor.GetFlavor()
 

--- a/test/new-e2e/tests/fleet/agent/agent.go
+++ b/test/new-e2e/tests/fleet/agent/agent.go
@@ -44,6 +44,15 @@ func (a *Agent) Version() (string, error) {
 	return status.AgentMetadata.AgentVersion, nil
 }
 
+// PackageVersion returns the OCI package version of the agent.
+func (a *Agent) PackageVersion() (string, error) {
+	status, err := a.Status()
+	if err != nil {
+		return "", err
+	}
+	return status.AgentMetadata.PackageVersion, nil
+}
+
 // Status returns the status of the agent.
 func (a *Agent) Status() (Status, error) {
 	rawStatus, err := a.runCommand("status", "--json")
@@ -226,6 +235,7 @@ type Status struct {
 		HostnameSource                           string        `json:"hostname_source"`
 		InfrastructureMode                       string        `json:"infrastructure_mode"`
 		InstallMethodInstallerVersion            string        `json:"install_method_installer_version"`
+		PackageVersion                           string        `json:"package_version"`
 		InstallMethodTool                        string        `json:"install_method_tool"`
 		InstallMethodToolVersion                 string        `json:"install_method_tool_version"`
 		SystemProbeCoreEnabled                   bool          `json:"system_probe_core_enabled"`

--- a/test/new-e2e/tests/fleet/backend/backend.go
+++ b/test/new-e2e/tests/fleet/backend/backend.go
@@ -171,7 +171,7 @@ func (b *Backend) StartExperiment(pkg string, version string) error {
 // PromoteExperiment promotes an update experiment for the given package.
 func (b *Backend) PromoteExperiment(pkg string) error {
 	b.t().Logf("Promoting update experiment for package %s", pkg)
-	output, err := b.runDaemonCommandWithRestart("promote-experiment", pkg)
+	output, err := b.runDaemonCommand("promote-experiment", pkg)
 	if err != nil {
 		return fmt.Errorf("%w, output: %s", err, output)
 	}

--- a/test/new-e2e/tests/fleet/upgrade_test.go
+++ b/test/new-e2e/tests/fleet/upgrade_test.go
@@ -47,9 +47,11 @@ func (s *upgradeSuite) TestUpgrade() {
 	err = s.Backend.PromoteExperiment("datadog-agent")
 	s.Require().NoError(err)
 
-	packageVersion, err := s.Agent.PackageVersion()
-	s.Require().NoError(err)
-	s.Require().Equal(targetVersion, packageVersion)
+	require.EventuallyWithT(s.T(), func(c *assert.CollectT) {
+		packageVersion, err := s.Agent.PackageVersion()
+		require.NoError(c, err)
+		require.Equal(c, targetVersion, packageVersion)
+	}, 300*time.Second, 30*time.Second)
 }
 
 func (s *upgradeSuite) TestUpgradeFailureTimeout() {

--- a/test/new-e2e/tests/fleet/upgrade_test.go
+++ b/test/new-e2e/tests/fleet/upgrade_test.go
@@ -47,9 +47,9 @@ func (s *upgradeSuite) TestUpgrade() {
 	err = s.Backend.PromoteExperiment("datadog-agent")
 	s.Require().NoError(err)
 
-	version, err = s.Agent.Version()
+	packageVersion, err := s.Agent.PackageVersion()
 	s.Require().NoError(err)
-	s.Require().Equal(targetVersion, version)
+	s.Require().Equal(targetVersion, packageVersion)
 }
 
 func (s *upgradeSuite) TestUpgradeFailureTimeout() {


### PR DESCRIPTION
## Summary

This PR adds `TestUpgrade` to the fleet upgrade test suite, covering the happy path of a simple agent upgrade.

## Motivation

The existing upgrade tests only cover failure scenarios (timeout-based rollback and health-based rollback). This adds coverage for the success path: start an experiment, verify the version changes, promote it, and verify the agent is running the target version.