### PR TITLE
[CASCL-623][cluster-agent] add DPA constraint and status metrics to generator

### DIFF
--- a/pkg/clusteragent/autoscaling/workload/metrics/generator.go
+++ b/pkg/clusteragent/autoscaling/workload/metrics/generator.go
@@ -236,9 +236,21 @@ func GeneratePodAutoscalerMetrics(obj interface{}) metricsstore.StructuredMetric
 		}
 
 		// 9. Vertical scaling container constraints (per container, CPU in millicores, memory in bytes)
+		// Mirror the resolveMinMaxBounds fallback from controller_vertical_helpers.go:
+		// prefer top-level MinAllowed/MaxAllowed; fall back to deprecated Requests field.
 		for _, container := range spec.Constraints.Containers {
 			containerTags := autoscalerTagsWithContainerName(namespace, targetName, name, container.Name)
-			if cpuMin, ok := container.MinAllowed[corev1.ResourceCPU]; ok {
+
+			effectiveMin := container.MinAllowed
+			if len(effectiveMin) == 0 && container.Requests != nil {
+				effectiveMin = container.Requests.MinAllowed
+			}
+			effectiveMax := container.MaxAllowed
+			if len(effectiveMax) == 0 && container.Requests != nil {
+				effectiveMax = container.Requests.MaxAllowed
+			}
+
+			if cpuMin, ok := effectiveMin[corev1.ResourceCPU]; ok {
 				metrics = append(metrics, metricsstore.StructuredMetric{
 					Name:  metricPrefix + ".vertical_scaling.constraints.container.cpu.request_min",
 					Type:  metricsstore.MetricTypeGauge,
@@ -246,7 +258,7 @@ func GeneratePodAutoscalerMetrics(obj interface{}) metricsstore.StructuredMetric
 					Tags:  containerTags,
 				})
 			}
-			if memMin, ok := container.MinAllowed[corev1.ResourceMemory]; ok {
+			if memMin, ok := effectiveMin[corev1.ResourceMemory]; ok {
 				metrics = append(metrics, metricsstore.StructuredMetric{
 					Name:  metricPrefix + ".vertical_scaling.constraints.container.memory.request_min",
 					Type:  metricsstore.MetricTypeGauge,
@@ -254,7 +266,7 @@ func GeneratePodAutoscalerMetrics(obj interface{}) metricsstore.StructuredMetric
 					Tags:  containerTags,
 				})
 			}
-			if cpuMax, ok := container.MaxAllowed[corev1.ResourceCPU]; ok {
+			if cpuMax, ok := effectiveMax[corev1.ResourceCPU]; ok {
 				metrics = append(metrics, metricsstore.StructuredMetric{
 					Name:  metricPrefix + ".vertical_scaling.constraints.container.cpu.request_max",
 					Type:  metricsstore.MetricTypeGauge,
@@ -262,7 +274,7 @@ func GeneratePodAutoscalerMetrics(obj interface{}) metricsstore.StructuredMetric
 					Tags:  containerTags,
 				})
 			}
-			if memMax, ok := container.MaxAllowed[corev1.ResourceMemory]; ok {
+			if memMax, ok := effectiveMax[corev1.ResourceMemory]; ok {
 				metrics = append(metrics, metricsstore.StructuredMetric{
 					Name:  metricPrefix + ".vertical_scaling.constraints.container.memory.request_max",
 					Type:  metricsstore.MetricTypeGauge,

--- a/pkg/clusteragent/autoscaling/workload/metrics/generator_test.go
+++ b/pkg/clusteragent/autoscaling/workload/metrics/generator_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload/model"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/metricsstore"
 	le "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/leaderelection/metrics"
+	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 )
 
 func TestBaseAutoscalerTags(t *testing.T) {
@@ -55,7 +56,7 @@ func TestAutoscalerTagsWithContainer(t *testing.T) {
 	assert.Contains(t, tags, "target_name:test-target")
 	assert.Contains(t, tags, "autoscaler_name:test-autoscaler")
 	assert.Contains(t, tags, "source:Autoscaling")
-	assert.Contains(t, tags, "container_name:app-container")
+	assert.Contains(t, tags, "kube_container_name:app-container")
 	assert.Contains(t, tags, "resource_name:cpu")
 	assert.Contains(t, tags, le.JoinLeaderLabel+":"+le.JoinLeaderValue)
 }
@@ -154,13 +155,13 @@ func TestGeneratePodAutoscalerMetrics(t *testing.T) {
 					if m.Name == metricPrefix+".vertical_scaling_received_requests" {
 						requestsCount++
 						assert.Equal(t, metricsstore.MetricTypeGauge, m.Type)
-						assert.Contains(t, m.Tags, "container_name:app-container")
+						assert.Contains(t, m.Tags, "kube_container_name:app-container")
 						assert.Contains(t, m.Tags, "source:Autoscaling")
 					}
 					if m.Name == metricPrefix+".vertical_scaling_received_limits" {
 						limitsCount++
 						assert.Equal(t, metricsstore.MetricTypeGauge, m.Type)
-						assert.Contains(t, m.Tags, "container_name:app-container")
+						assert.Contains(t, m.Tags, "kube_container_name:app-container")
 						assert.Contains(t, m.Tags, "source:Autoscaling")
 					}
 				}
@@ -459,6 +460,303 @@ func TestGeneratePodAutoscalerMetrics(t *testing.T) {
 				}
 				assert.True(t, foundOk, "vertical_rollout_triggered status:ok metric not found")
 				assert.True(t, foundError, "vertical_rollout_triggered status:error metric not found")
+			},
+		},
+		{
+			name: "horizontal scaling constraints both min and max",
+			setupFunc: func() *model.PodAutoscalerInternal {
+				internal := model.FakePodAutoscalerInternal{
+					Namespace: "test-ns",
+					Name:      "test-dpa",
+					Spec: &datadoghq.DatadogPodAutoscalerSpec{
+						TargetRef: v2.CrossVersionObjectReference{
+							Name: "test-deployment",
+						},
+						Constraints: &datadoghqcommon.DatadogPodAutoscalerConstraints{
+							MinReplicas: pointer.Ptr(int32(2)),
+							MaxReplicas: pointer.Ptr(int32(10)),
+						},
+					},
+				}.Build()
+				return &internal
+			},
+			expectedCount: 3, // horizontal_scaling_constraints_max_replicas + horizontal_scaling_constraints_min_replicas + local_fallback_enabled
+			validateMetric: func(t *testing.T, metrics metricsstore.StructuredMetrics) {
+				var maxFound, minFound bool
+				for _, m := range metrics {
+					if m.Name == metricPrefix+".horizontal_scaling.constraints.max_replicas" {
+						maxFound = true
+						assert.Equal(t, metricsstore.MetricTypeGauge, m.Type)
+						assert.Equal(t, 10.0, m.Value)
+						assert.Contains(t, m.Tags, "namespace:test-ns")
+						assert.Contains(t, m.Tags, "target_name:test-deployment")
+						assert.Contains(t, m.Tags, "autoscaler_name:test-dpa")
+					}
+					if m.Name == metricPrefix+".horizontal_scaling.constraints.min_replicas" {
+						minFound = true
+						assert.Equal(t, metricsstore.MetricTypeGauge, m.Type)
+						assert.Equal(t, 2.0, m.Value)
+						assert.Contains(t, m.Tags, "namespace:test-ns")
+						assert.Contains(t, m.Tags, "target_name:test-deployment")
+						assert.Contains(t, m.Tags, "autoscaler_name:test-dpa")
+					}
+				}
+				assert.True(t, maxFound, "horizontal_scaling.constraints.max_replicas metric not found")
+				assert.True(t, minFound, "horizontal_scaling.constraints.min_replicas metric not found")
+			},
+		},
+		{
+			name: "horizontal scaling constraints max only (no min set)",
+			setupFunc: func() *model.PodAutoscalerInternal {
+				internal := model.FakePodAutoscalerInternal{
+					Namespace: "test-ns",
+					Name:      "test-dpa",
+					Spec: &datadoghq.DatadogPodAutoscalerSpec{
+						TargetRef: v2.CrossVersionObjectReference{
+							Name: "test-deployment",
+						},
+						Constraints: &datadoghqcommon.DatadogPodAutoscalerConstraints{
+							MaxReplicas: pointer.Ptr(int32(20)),
+						},
+					},
+				}.Build()
+				return &internal
+			},
+			expectedCount: 2, // horizontal_scaling_constraints_max_replicas + local_fallback_enabled
+			validateMetric: func(t *testing.T, metrics metricsstore.StructuredMetrics) {
+				var maxFound bool
+				for _, m := range metrics {
+					if m.Name == metricPrefix+".horizontal_scaling.constraints.max_replicas" {
+						maxFound = true
+						assert.Equal(t, 20.0, m.Value)
+					}
+					assert.NotEqual(t, metricPrefix+".horizontal_scaling.constraints.min_replicas", m.Name,
+						"min_replicas metric should not be emitted when MinReplicas is not set")
+				}
+				assert.True(t, maxFound, "horizontal_scaling.constraints.max_replicas metric not found")
+			},
+		},
+		{
+			name: "vertical scaling container constraints",
+			setupFunc: func() *model.PodAutoscalerInternal {
+				internal := model.FakePodAutoscalerInternal{
+					Namespace: "test-ns",
+					Name:      "test-dpa",
+					Spec: &datadoghq.DatadogPodAutoscalerSpec{
+						TargetRef: v2.CrossVersionObjectReference{
+							Name: "test-deployment",
+						},
+						Constraints: &datadoghqcommon.DatadogPodAutoscalerConstraints{
+							Containers: []datadoghqcommon.DatadogPodAutoscalerContainerConstraints{
+								{
+									Name: "app",
+									MinAllowed: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("100m"),
+										corev1.ResourceMemory: resource.MustParse("128Mi"),
+									},
+									MaxAllowed: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("2"),
+										corev1.ResourceMemory: resource.MustParse("1Gi"),
+									},
+								},
+							},
+						},
+					},
+				}.Build()
+				return &internal
+			},
+			expectedCount: 5, // 4 container constraint metrics + local_fallback_enabled
+			validateMetric: func(t *testing.T, metrics metricsstore.StructuredMetrics) {
+				var cpuMinFound, memMinFound, cpuMaxFound, memMaxFound bool
+				for _, m := range metrics {
+					if !slices.Contains(m.Tags, "kube_container_name:app") {
+						continue
+					}
+					switch m.Name {
+					case metricPrefix + ".vertical_scaling.constraints.container.cpu.request_min":
+						cpuMinFound = true
+						assert.Equal(t, metricsstore.MetricTypeGauge, m.Type)
+						assert.Equal(t, 100.0, m.Value, "100m = 100 millicores")
+						assert.Contains(t, m.Tags, "namespace:test-ns")
+						assert.Contains(t, m.Tags, "autoscaler_name:test-dpa")
+					case metricPrefix + ".vertical_scaling.constraints.container.memory.request_min":
+						memMinFound = true
+						assert.Equal(t, metricsstore.MetricTypeGauge, m.Type)
+						assert.Equal(t, float64(128*1024*1024), m.Value, "128Mi in bytes")
+					case metricPrefix + ".vertical_scaling.constraints.container.cpu.request_max":
+						cpuMaxFound = true
+						assert.Equal(t, metricsstore.MetricTypeGauge, m.Type)
+						assert.Equal(t, 2000.0, m.Value, "2 cores = 2000 millicores")
+					case metricPrefix + ".vertical_scaling.constraints.container.memory.request_max":
+						memMaxFound = true
+						assert.Equal(t, metricsstore.MetricTypeGauge, m.Type)
+						assert.Equal(t, float64(1024*1024*1024), m.Value, "1Gi in bytes")
+					}
+				}
+				assert.True(t, cpuMinFound, "vertical_scaling.constraints.container.cpu.request_min not found")
+				assert.True(t, memMinFound, "vertical_scaling.constraints.container.memory.request_min not found")
+				assert.True(t, cpuMaxFound, "vertical_scaling.constraints.container.cpu.request_max not found")
+				assert.True(t, memMaxFound, "vertical_scaling.constraints.container.memory.request_max not found")
+			},
+		},
+		{
+			name: "vertical scaling container constraints partial (only cpu min set)",
+			setupFunc: func() *model.PodAutoscalerInternal {
+				internal := model.FakePodAutoscalerInternal{
+					Namespace: "test-ns",
+					Name:      "test-dpa",
+					Spec: &datadoghq.DatadogPodAutoscalerSpec{
+						TargetRef: v2.CrossVersionObjectReference{
+							Name: "test-deployment",
+						},
+						Constraints: &datadoghqcommon.DatadogPodAutoscalerConstraints{
+							Containers: []datadoghqcommon.DatadogPodAutoscalerContainerConstraints{
+								{
+									Name: "sidecar",
+									MinAllowed: corev1.ResourceList{
+										corev1.ResourceCPU: resource.MustParse("50m"),
+									},
+								},
+							},
+						},
+					},
+				}.Build()
+				return &internal
+			},
+			expectedCount: 2, // vertical_scaling_constraints_container_cpu_request_min + local_fallback_enabled
+			validateMetric: func(t *testing.T, metrics metricsstore.StructuredMetrics) {
+				var cpuMinFound bool
+				for _, m := range metrics {
+					switch m.Name {
+					case metricPrefix + ".vertical_scaling.constraints.container.cpu.request_min":
+						cpuMinFound = true
+						assert.Equal(t, 50.0, m.Value, "50m = 50 millicores")
+						assert.Contains(t, m.Tags, "kube_container_name:sidecar")
+					case metricPrefix + ".vertical_scaling.constraints.container.memory.request_min",
+						metricPrefix + ".vertical_scaling.constraints.container.cpu.request_max",
+						metricPrefix + ".vertical_scaling.constraints.container.memory.request_max":
+						t.Errorf("unexpected metric %s emitted", m.Name)
+					}
+				}
+				assert.True(t, cpuMinFound, "vertical_scaling.constraints.container.cpu.request_min not found")
+			},
+		},
+		{
+			name: "horizontal desired replicas from status",
+			setupFunc: func() *model.PodAutoscalerInternal {
+				crd := &datadoghq.DatadogPodAutoscaler{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-dpa",
+						Namespace: "test-ns",
+					},
+					Spec: datadoghq.DatadogPodAutoscalerSpec{
+						TargetRef: v2.CrossVersionObjectReference{
+							Name: "test-deployment",
+						},
+					},
+					Status: datadoghqcommon.DatadogPodAutoscalerStatus{
+						Horizontal: &datadoghqcommon.DatadogPodAutoscalerHorizontalStatus{
+							Target: &datadoghqcommon.DatadogPodAutoscalerHorizontalRecommendation{
+								Replicas: 7,
+							},
+						},
+					},
+				}
+				internal := model.FakePodAutoscalerInternal{
+					Namespace:  "test-ns",
+					Name:       "test-dpa",
+					UpstreamCR: crd,
+				}.Build()
+				return &internal
+			},
+			expectedCount: 2, // status.desired.replicas + local_fallback_enabled
+			validateMetric: func(t *testing.T, metrics metricsstore.StructuredMetrics) {
+				var found bool
+				for _, m := range metrics {
+					if m.Name == metricPrefix+".status.desired.replicas" {
+						found = true
+						assert.Equal(t, metricsstore.MetricTypeGauge, m.Type)
+						assert.Equal(t, 7.0, m.Value)
+						assert.Contains(t, m.Tags, "namespace:test-ns")
+						assert.Contains(t, m.Tags, "target_name:test-deployment")
+						assert.Contains(t, m.Tags, "autoscaler_name:test-dpa")
+					}
+				}
+				assert.True(t, found, "status.desired.replicas metric not found")
+			},
+		},
+		{
+			name: "vertical desired resources from status",
+			setupFunc: func() *model.PodAutoscalerInternal {
+				crd := &datadoghq.DatadogPodAutoscaler{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-dpa",
+						Namespace: "test-ns",
+					},
+					Status: datadoghqcommon.DatadogPodAutoscalerStatus{
+						Vertical: &datadoghqcommon.DatadogPodAutoscalerVerticalStatus{
+							Target: &datadoghqcommon.DatadogPodAutoscalerVerticalTargetStatus{
+								DesiredResources: []datadoghqcommon.DatadogPodAutoscalerContainerResources{
+									{
+										Name: "app",
+										Requests: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("250m"),
+											corev1.ResourceMemory: resource.MustParse("256Mi"),
+										},
+										Limits: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("1"),
+											corev1.ResourceMemory: resource.MustParse("512Mi"),
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+				internal := model.FakePodAutoscalerInternal{
+					Namespace: "test-ns",
+					Name:      "test-dpa",
+					Spec: &datadoghq.DatadogPodAutoscalerSpec{
+						TargetRef: v2.CrossVersionObjectReference{
+							Name: "test-deployment",
+						},
+					},
+					UpstreamCR: crd,
+				}.Build()
+				return &internal
+			},
+			expectedCount: 5, // 4 desired resource metrics + local_fallback_enabled
+			validateMetric: func(t *testing.T, metrics metricsstore.StructuredMetrics) {
+				var cpuReqFound, memReqFound, cpuLimFound, memLimFound bool
+				for _, m := range metrics {
+					if !slices.Contains(m.Tags, "kube_container_name:app") {
+						continue
+					}
+					switch m.Name {
+					case metricPrefix + ".status.vertical.desired.container.cpu.request":
+						cpuReqFound = true
+						assert.Equal(t, metricsstore.MetricTypeGauge, m.Type)
+						assert.Equal(t, 250.0, m.Value, "250m = 250 millicores")
+						assert.Contains(t, m.Tags, "namespace:test-ns")
+						assert.Contains(t, m.Tags, "autoscaler_name:test-dpa")
+					case metricPrefix + ".status.vertical.desired.container.memory.request":
+						memReqFound = true
+						assert.Equal(t, metricsstore.MetricTypeGauge, m.Type)
+						assert.Equal(t, float64(256*1024*1024), m.Value, "256Mi in bytes")
+					case metricPrefix + ".status.vertical.desired.container.cpu.limit":
+						cpuLimFound = true
+						assert.Equal(t, metricsstore.MetricTypeGauge, m.Type)
+						assert.Equal(t, 1000.0, m.Value, "1 core = 1000 millicores")
+					case metricPrefix + ".status.vertical.desired.container.memory.limit":
+						memLimFound = true
+						assert.Equal(t, metricsstore.MetricTypeGauge, m.Type)
+						assert.Equal(t, float64(512*1024*1024), m.Value, "512Mi in bytes")
+					}
+				}
+				assert.True(t, cpuReqFound, "status.vertical.desired.container.cpu.request not found")
+				assert.True(t, memReqFound, "status.vertical.desired.container.memory.request not found")
+				assert.True(t, cpuLimFound, "status.vertical.desired.container.cpu.limit not found")
+				assert.True(t, memLimFound, "status.vertical.desired.container.memory.limit not found")
 			},
 		},
 		{

--- a/pkg/clusteragent/autoscaling/workload/metrics/generator_test.go
+++ b/pkg/clusteragent/autoscaling/workload/metrics/generator_test.go
@@ -642,6 +642,65 @@ func TestGeneratePodAutoscalerMetrics(t *testing.T) {
 			},
 		},
 		{
+			name: "vertical scaling container constraints via deprecated Requests field",
+			setupFunc: func() *model.PodAutoscalerInternal {
+				internal := model.FakePodAutoscalerInternal{
+					Namespace: "test-ns",
+					Name:      "test-dpa",
+					Spec: &datadoghq.DatadogPodAutoscalerSpec{
+						TargetRef: v2.CrossVersionObjectReference{
+							Name: "test-deployment",
+						},
+						Constraints: &datadoghqcommon.DatadogPodAutoscalerConstraints{
+							Containers: []datadoghqcommon.DatadogPodAutoscalerContainerConstraints{
+								{
+									Name: "app",
+									Requests: &datadoghqcommon.DatadogPodAutoscalerContainerResourceConstraints{
+										MinAllowed: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("100m"),
+											corev1.ResourceMemory: resource.MustParse("128Mi"),
+										},
+										MaxAllowed: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("2"),
+											corev1.ResourceMemory: resource.MustParse("1Gi"),
+										},
+									},
+								},
+							},
+						},
+					},
+				}.Build()
+				return &internal
+			},
+			expectedCount: 5, // 4 container constraint metrics + local_fallback_enabled
+			validateMetric: func(t *testing.T, metrics metricsstore.StructuredMetrics) {
+				var cpuMinFound, memMinFound, cpuMaxFound, memMaxFound bool
+				for _, m := range metrics {
+					if !slices.Contains(m.Tags, "kube_container_name:app") {
+						continue
+					}
+					switch m.Name {
+					case metricPrefix + ".vertical_scaling.constraints.container.cpu.request_min":
+						cpuMinFound = true
+						assert.Equal(t, 100.0, m.Value, "100m = 100 millicores")
+					case metricPrefix + ".vertical_scaling.constraints.container.memory.request_min":
+						memMinFound = true
+						assert.Equal(t, float64(128*1024*1024), m.Value, "128Mi in bytes")
+					case metricPrefix + ".vertical_scaling.constraints.container.cpu.request_max":
+						cpuMaxFound = true
+						assert.Equal(t, 2000.0, m.Value, "2 cores = 2000 millicores")
+					case metricPrefix + ".vertical_scaling.constraints.container.memory.request_max":
+						memMaxFound = true
+						assert.Equal(t, float64(1024*1024*1024), m.Value, "1Gi in bytes")
+					}
+				}
+				assert.True(t, cpuMinFound, "vertical_scaling.constraints.container.cpu.request_min not found")
+				assert.True(t, memMinFound, "vertical_scaling.constraints.container.memory.request_min not found")
+				assert.True(t, cpuMaxFound, "vertical_scaling.constraints.container.cpu.request_max not found")
+				assert.True(t, memMaxFound, "vertical_scaling.constraints.container.memory.request_max not found")
+			},
+		},
+		{
 			name: "horizontal desired replicas from status",
 			setupFunc: func() *model.PodAutoscalerInternal {
 				crd := &datadoghq.DatadogPodAutoscaler{


### PR DESCRIPTION
## Summary

- Add new structured metrics to `GeneratePodAutoscalerMetrics` for `DatadogPodAutoscaler` constraints and status fields
- Horizontal replica constraints: `horizontal_scaling.constraints.{max,min}_replicas`
- Vertical container constraints (per container): `vertical_scaling.constraints.container.{cpu,memory}.request_{min,max}`
- Horizontal desired replicas from status: `status.desired.replicas`
- Vertical desired resources from status (per container): `status.vertical.desired.container.{cpu,memory}.{request,limit}`
- Container-level metrics use `kube_container_name` tag for OOTB Kubernetes tag compatibility

Jira: [CASCL-623](https://datadoghq.atlassian.net/browse/CASCL-623)

## Test plan

- [x] Unit tests added for all new metrics in `generator_test.go`
- [x] Tests cover both full and partial constraint configurations (only emitted when values are set)
- [x] Linter passes (`dda inv linter.go --targets=./pkg/clusteragent/autoscaling/...`)
- [x] All tests pass (`go test -tags "kubeapiserver test" ./pkg/clusteragent/autoscaling/...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CASCL-623]: https://datadoghq.atlassian.net/browse/CASCL-623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ