### PR TITLE
(fleet) add operator client type to remote config proto

### DIFF
--- a/pkg/config/remote/service/service.go
+++ b/pkg/config/remote/service/service.go
@@ -1478,12 +1478,23 @@ func validateRequest(request *pbgo.ClientGetConfigsRequest) error {
 		return status.Error(codes.InvalidArgument, "client.client_updater is a required field for updater client config update requests")
 	}
 
-	if (request.Client.IsTracer && request.Client.IsAgent) || (request.Client.IsTracer && request.Client.IsUpdater) || (request.Client.IsAgent && request.Client.IsUpdater) {
-		return status.Error(codes.InvalidArgument, "client.is_tracer, client.is_agent, and client.is_updater are mutually exclusive")
+	if request.Client.IsOperator && request.Client.ClientOperator == nil {
+		return status.Error(codes.InvalidArgument, "client.client_operator is a required field for operator client config update requests")
 	}
 
-	if !request.Client.IsTracer && !request.Client.IsAgent && !request.Client.IsUpdater {
-		return status.Error(codes.InvalidArgument, "agents only support remote config updates from tracer or agent or updater at this time")
+	isTracer, isAgent, isUpdater, isOperator := request.Client.IsTracer, request.Client.IsAgent, request.Client.IsUpdater, request.Client.IsOperator
+	typeCount := 0
+	for _, b := range []bool{isTracer, isAgent, isUpdater, isOperator} {
+		if b {
+			typeCount++
+		}
+	}
+	if typeCount > 1 {
+		return status.Error(codes.InvalidArgument, "client.is_tracer, client.is_agent, client.is_updater, and client.is_operator are mutually exclusive")
+	}
+
+	if typeCount == 0 {
+		return status.Error(codes.InvalidArgument, "agents only support remote config updates from tracer or agent or updater or operator at this time")
 	}
 
 	if request.Client.Id == "" {

--- a/pkg/fleet/daemon/daemon.go
+++ b/pkg/fleet/daemon/daemon.go
@@ -869,7 +869,7 @@ func (d *daemonImpl) refreshState(ctx context.Context) {
 					Message: requestState.Err,
 				}
 			}
-			p.Task = &pbgo.PackageStateTask{
+			p.Task = &pbgo.Task{
 				Id:    requestState.ID,
 				State: requestState.State,
 				Error: taskErr,

--- a/pkg/fleet/daemon/local_api_test.go
+++ b/pkg/fleet/daemon/local_api_test.go
@@ -136,7 +136,7 @@ func TestAPIStatus(t *testing.T) {
 		Packages: []*pbgo.PackageState{
 			{
 				Package: "test-package",
-				Task: &pbgo.PackageStateTask{
+				Task: &pbgo.Task{
 					State: pbgo.TaskState_DONE,
 				},
 			},

--- a/pkg/proto/datadog/remoteconfig/remoteconfig.proto
+++ b/pkg/proto/datadog/remoteconfig/remoteconfig.proto
@@ -89,6 +89,8 @@ message Client {
   reserved 12, 13;
   bool is_updater = 14;
   ClientUpdater client_updater = 15;
+  bool is_operator = 16;
+  ClientOperator client_operator = 17;
 }
 
 message ClientTracer {
@@ -123,7 +125,7 @@ message PackageState {
   string package = 1;
   string stable_version = 2;
   string experiment_version = 3;
-  PackageStateTask task = 4;
+  Task task = 4;
   reserved 5, 6, 7, 8, 9, 10;
   string stable_config_version = 11;
   string experiment_config_version = 12;
@@ -131,10 +133,21 @@ message PackageState {
   string running_config_version = 14;
 }
 
-message PackageStateTask {
+message Task {
   string id = 1;
   TaskState state = 2;
   TaskError error = 3;
+}
+
+message FleetState {
+  string config_version = 1;
+  bool experiment = 2;
+  Task task = 3;
+  string secret_pub_key = 4;
+}
+
+message ClientOperator {
+  repeated FleetState fleet_states = 1;
 }
 
 enum TaskState {

--- a/pkg/proto/datadog/remoteconfig/remoteconfig.proto
+++ b/pkg/proto/datadog/remoteconfig/remoteconfig.proto
@@ -168,10 +168,10 @@ message Rollout {
 
 message FleetState {
   string config_version = 1;
-  Task config_task = 5;
-  bool config_experiment = 2;
-  Rollout config_rollout = 3;
-  string secret_pub_key = 4;
+  Task config_task = 2;
+  bool config_experiment = 3;
+  Rollout config_rollout = 4;
+  string secret_pub_key = 5;
 }
 
 message ClientOperator {

--- a/pkg/proto/datadog/remoteconfig/remoteconfig.proto
+++ b/pkg/proto/datadog/remoteconfig/remoteconfig.proto
@@ -139,10 +139,37 @@ message Task {
   TaskError error = 3;
 }
 
+message DeploymentStatus {
+  string name = 1;
+  int64 observed_generation = 2;
+  int32 replicas = 3;
+  int32 updated_replicas = 4;
+  int32 ready_replicas = 5;
+  int32 available_replicas = 6;
+  int32 unavailable_replicas = 7;
+}
+
+message DaemonSetStatus {
+  string name = 1;
+  int32 current_number_scheduled = 2;
+  int32 number_misscheduled = 3;
+  int32 desired_number_scheduled = 4;
+  int32 number_ready = 5;
+  int64 observed_generation = 6;
+  int32 updated_number_scheduled = 7;
+  int32 number_available = 8;
+  int32 number_unavailable = 9;
+}
+
+message Rollout {
+  repeated DeploymentStatus deployments = 1;
+  repeated DaemonSetStatus daemon_sets = 2;
+}
+
 message FleetState {
   string config_version = 1;
-  bool experiment = 2;
-  Task task = 3;
+  bool config_experiment = 2;
+  Rollout config_rollout = 3;
   string secret_pub_key = 4;
 }
 

--- a/pkg/proto/datadog/remoteconfig/remoteconfig.proto
+++ b/pkg/proto/datadog/remoteconfig/remoteconfig.proto
@@ -168,6 +168,7 @@ message Rollout {
 
 message FleetState {
   string config_version = 1;
+  Task config_task = 5;
   bool config_experiment = 2;
   Rollout config_rollout = 3;
   string secret_pub_key = 4;

--- a/pkg/proto/pbgo/core/remoteconfig.pb.go
+++ b/pkg/proto/pbgo/core/remoteconfig.pb.go
@@ -218,7 +218,7 @@ func (x ConfigSubscriptionRequest_Action) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use ConfigSubscriptionRequest_Action.Descriptor instead.
 func (ConfigSubscriptionRequest_Action) EnumDescriptor() ([]byte, []int) {
-	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{20, 0}
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{22, 0}
 }
 
 type ConfigMetas struct {
@@ -843,20 +843,22 @@ func (x *OrgStatusResponse) GetAuthorized() bool {
 }
 
 type Client struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	State         *ClientState           `protobuf:"bytes,1,opt,name=state,proto3" json:"state,omitempty"`
-	Id            string                 `protobuf:"bytes,2,opt,name=id,proto3" json:"id,omitempty"`
-	Products      []string               `protobuf:"bytes,3,rep,name=products,proto3" json:"products,omitempty"`
-	IsTracer      bool                   `protobuf:"varint,6,opt,name=is_tracer,json=isTracer,proto3" json:"is_tracer,omitempty"`
-	ClientTracer  *ClientTracer          `protobuf:"bytes,7,opt,name=client_tracer,json=clientTracer,proto3" json:"client_tracer,omitempty"`
-	IsAgent       bool                   `protobuf:"varint,8,opt,name=is_agent,json=isAgent,proto3" json:"is_agent,omitempty"`
-	ClientAgent   *ClientAgent           `protobuf:"bytes,9,opt,name=client_agent,json=clientAgent,proto3" json:"client_agent,omitempty"`
-	LastSeen      uint64                 `protobuf:"varint,10,opt,name=last_seen,json=lastSeen,proto3" json:"last_seen,omitempty"`
-	Capabilities  []byte                 `protobuf:"bytes,11,opt,name=capabilities,proto3" json:"capabilities,omitempty"`
-	IsUpdater     bool                   `protobuf:"varint,14,opt,name=is_updater,json=isUpdater,proto3" json:"is_updater,omitempty"`
-	ClientUpdater *ClientUpdater         `protobuf:"bytes,15,opt,name=client_updater,json=clientUpdater,proto3" json:"client_updater,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	State          *ClientState           `protobuf:"bytes,1,opt,name=state,proto3" json:"state,omitempty"`
+	Id             string                 `protobuf:"bytes,2,opt,name=id,proto3" json:"id,omitempty"`
+	Products       []string               `protobuf:"bytes,3,rep,name=products,proto3" json:"products,omitempty"`
+	IsTracer       bool                   `protobuf:"varint,6,opt,name=is_tracer,json=isTracer,proto3" json:"is_tracer,omitempty"`
+	ClientTracer   *ClientTracer          `protobuf:"bytes,7,opt,name=client_tracer,json=clientTracer,proto3" json:"client_tracer,omitempty"`
+	IsAgent        bool                   `protobuf:"varint,8,opt,name=is_agent,json=isAgent,proto3" json:"is_agent,omitempty"`
+	ClientAgent    *ClientAgent           `protobuf:"bytes,9,opt,name=client_agent,json=clientAgent,proto3" json:"client_agent,omitempty"`
+	LastSeen       uint64                 `protobuf:"varint,10,opt,name=last_seen,json=lastSeen,proto3" json:"last_seen,omitempty"`
+	Capabilities   []byte                 `protobuf:"bytes,11,opt,name=capabilities,proto3" json:"capabilities,omitempty"`
+	IsUpdater      bool                   `protobuf:"varint,14,opt,name=is_updater,json=isUpdater,proto3" json:"is_updater,omitempty"`
+	ClientUpdater  *ClientUpdater         `protobuf:"bytes,15,opt,name=client_updater,json=clientUpdater,proto3" json:"client_updater,omitempty"`
+	IsOperator     bool                   `protobuf:"varint,16,opt,name=is_operator,json=isOperator,proto3" json:"is_operator,omitempty"`
+	ClientOperator *ClientOperator        `protobuf:"bytes,17,opt,name=client_operator,json=clientOperator,proto3" json:"client_operator,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *Client) Reset() {
@@ -962,6 +964,20 @@ func (x *Client) GetIsUpdater() bool {
 func (x *Client) GetClientUpdater() *ClientUpdater {
 	if x != nil {
 		return x.ClientUpdater
+	}
+	return nil
+}
+
+func (x *Client) GetIsOperator() bool {
+	if x != nil {
+		return x.IsOperator
+	}
+	return false
+}
+
+func (x *Client) GetClientOperator() *ClientOperator {
+	if x != nil {
+		return x.ClientOperator
 	}
 	return nil
 }
@@ -1231,7 +1247,7 @@ type PackageState struct {
 	Package                 string                 `protobuf:"bytes,1,opt,name=package,proto3" json:"package,omitempty"`
 	StableVersion           string                 `protobuf:"bytes,2,opt,name=stable_version,json=stableVersion,proto3" json:"stable_version,omitempty"`
 	ExperimentVersion       string                 `protobuf:"bytes,3,opt,name=experiment_version,json=experimentVersion,proto3" json:"experiment_version,omitempty"`
-	Task                    *PackageStateTask      `protobuf:"bytes,4,opt,name=task,proto3" json:"task,omitempty"`
+	Task                    *Task                  `protobuf:"bytes,4,opt,name=task,proto3" json:"task,omitempty"`
 	StableConfigVersion     string                 `protobuf:"bytes,11,opt,name=stable_config_version,json=stableConfigVersion,proto3" json:"stable_config_version,omitempty"`
 	ExperimentConfigVersion string                 `protobuf:"bytes,12,opt,name=experiment_config_version,json=experimentConfigVersion,proto3" json:"experiment_config_version,omitempty"`
 	RunningVersion          string                 `protobuf:"bytes,13,opt,name=running_version,json=runningVersion,proto3" json:"running_version,omitempty"`
@@ -1291,7 +1307,7 @@ func (x *PackageState) GetExperimentVersion() string {
 	return ""
 }
 
-func (x *PackageState) GetTask() *PackageStateTask {
+func (x *PackageState) GetTask() *Task {
 	if x != nil {
 		return x.Task
 	}
@@ -1326,7 +1342,7 @@ func (x *PackageState) GetRunningConfigVersion() string {
 	return ""
 }
 
-type PackageStateTask struct {
+type Task struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	State         TaskState              `protobuf:"varint,2,opt,name=state,proto3,enum=datadog.config.TaskState" json:"state,omitempty"`
@@ -1335,20 +1351,20 @@ type PackageStateTask struct {
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *PackageStateTask) Reset() {
-	*x = PackageStateTask{}
+func (x *Task) Reset() {
+	*x = Task{}
 	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *PackageStateTask) String() string {
+func (x *Task) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*PackageStateTask) ProtoMessage() {}
+func (*Task) ProtoMessage() {}
 
-func (x *PackageStateTask) ProtoReflect() protoreflect.Message {
+func (x *Task) ProtoReflect() protoreflect.Message {
 	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1360,28 +1376,140 @@ func (x *PackageStateTask) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use PackageStateTask.ProtoReflect.Descriptor instead.
-func (*PackageStateTask) Descriptor() ([]byte, []int) {
+// Deprecated: Use Task.ProtoReflect.Descriptor instead.
+func (*Task) Descriptor() ([]byte, []int) {
 	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{14}
 }
 
-func (x *PackageStateTask) GetId() string {
+func (x *Task) GetId() string {
 	if x != nil {
 		return x.Id
 	}
 	return ""
 }
 
-func (x *PackageStateTask) GetState() TaskState {
+func (x *Task) GetState() TaskState {
 	if x != nil {
 		return x.State
 	}
 	return TaskState_IDLE
 }
 
-func (x *PackageStateTask) GetError() *TaskError {
+func (x *Task) GetError() *TaskError {
 	if x != nil {
 		return x.Error
+	}
+	return nil
+}
+
+type FleetState struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ConfigVersion string                 `protobuf:"bytes,1,opt,name=config_version,json=configVersion,proto3" json:"config_version,omitempty"`
+	Experiment    bool                   `protobuf:"varint,2,opt,name=experiment,proto3" json:"experiment,omitempty"`
+	Task          *Task                  `protobuf:"bytes,3,opt,name=task,proto3" json:"task,omitempty"`
+	SecretPubKey  string                 `protobuf:"bytes,4,opt,name=secret_pub_key,json=secretPubKey,proto3" json:"secret_pub_key,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *FleetState) Reset() {
+	*x = FleetState{}
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *FleetState) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*FleetState) ProtoMessage() {}
+
+func (x *FleetState) ProtoReflect() protoreflect.Message {
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use FleetState.ProtoReflect.Descriptor instead.
+func (*FleetState) Descriptor() ([]byte, []int) {
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *FleetState) GetConfigVersion() string {
+	if x != nil {
+		return x.ConfigVersion
+	}
+	return ""
+}
+
+func (x *FleetState) GetExperiment() bool {
+	if x != nil {
+		return x.Experiment
+	}
+	return false
+}
+
+func (x *FleetState) GetTask() *Task {
+	if x != nil {
+		return x.Task
+	}
+	return nil
+}
+
+func (x *FleetState) GetSecretPubKey() string {
+	if x != nil {
+		return x.SecretPubKey
+	}
+	return ""
+}
+
+type ClientOperator struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	FleetStates   []*FleetState          `protobuf:"bytes,1,rep,name=fleet_states,json=fleetStates,proto3" json:"fleet_states,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ClientOperator) Reset() {
+	*x = ClientOperator{}
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ClientOperator) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ClientOperator) ProtoMessage() {}
+
+func (x *ClientOperator) ProtoReflect() protoreflect.Message {
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ClientOperator.ProtoReflect.Descriptor instead.
+func (*ClientOperator) Descriptor() ([]byte, []int) {
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *ClientOperator) GetFleetStates() []*FleetState {
+	if x != nil {
+		return x.FleetStates
 	}
 	return nil
 }
@@ -1396,7 +1524,7 @@ type TaskError struct {
 
 func (x *TaskError) Reset() {
 	*x = TaskError{}
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[15]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1408,7 +1536,7 @@ func (x *TaskError) String() string {
 func (*TaskError) ProtoMessage() {}
 
 func (x *TaskError) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[15]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1421,7 +1549,7 @@ func (x *TaskError) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TaskError.ProtoReflect.Descriptor instead.
 func (*TaskError) Descriptor() ([]byte, []int) {
-	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{15}
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *TaskError) GetCode() uint64 {
@@ -1451,7 +1579,7 @@ type ConfigState struct {
 
 func (x *ConfigState) Reset() {
 	*x = ConfigState{}
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[16]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1463,7 +1591,7 @@ func (x *ConfigState) String() string {
 func (*ConfigState) ProtoMessage() {}
 
 func (x *ConfigState) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[16]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1476,7 +1604,7 @@ func (x *ConfigState) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConfigState.ProtoReflect.Descriptor instead.
 func (*ConfigState) Descriptor() ([]byte, []int) {
-	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{16}
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *ConfigState) GetId() string {
@@ -1528,7 +1656,7 @@ type ClientState struct {
 
 func (x *ClientState) Reset() {
 	*x = ClientState{}
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[17]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1540,7 +1668,7 @@ func (x *ClientState) String() string {
 func (*ClientState) ProtoMessage() {}
 
 func (x *ClientState) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[17]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1553,7 +1681,7 @@ func (x *ClientState) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClientState.ProtoReflect.Descriptor instead.
 func (*ClientState) Descriptor() ([]byte, []int) {
-	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{17}
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *ClientState) GetRootVersion() uint64 {
@@ -1608,7 +1736,7 @@ type TargetFileHash struct {
 
 func (x *TargetFileHash) Reset() {
 	*x = TargetFileHash{}
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[18]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1620,7 +1748,7 @@ func (x *TargetFileHash) String() string {
 func (*TargetFileHash) ProtoMessage() {}
 
 func (x *TargetFileHash) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[18]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1633,7 +1761,7 @@ func (x *TargetFileHash) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TargetFileHash.ProtoReflect.Descriptor instead.
 func (*TargetFileHash) Descriptor() ([]byte, []int) {
-	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{18}
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *TargetFileHash) GetAlgorithm() string {
@@ -1661,7 +1789,7 @@ type TargetFileMeta struct {
 
 func (x *TargetFileMeta) Reset() {
 	*x = TargetFileMeta{}
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[19]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1673,7 +1801,7 @@ func (x *TargetFileMeta) String() string {
 func (*TargetFileMeta) ProtoMessage() {}
 
 func (x *TargetFileMeta) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[19]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1686,7 +1814,7 @@ func (x *TargetFileMeta) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TargetFileMeta.ProtoReflect.Descriptor instead.
 func (*TargetFileMeta) Descriptor() ([]byte, []int) {
-	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{19}
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *TargetFileMeta) GetPath() string {
@@ -1728,7 +1856,7 @@ type ConfigSubscriptionRequest struct {
 
 func (x *ConfigSubscriptionRequest) Reset() {
 	*x = ConfigSubscriptionRequest{}
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[20]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1740,7 +1868,7 @@ func (x *ConfigSubscriptionRequest) String() string {
 func (*ConfigSubscriptionRequest) ProtoMessage() {}
 
 func (x *ConfigSubscriptionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[20]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1753,7 +1881,7 @@ func (x *ConfigSubscriptionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConfigSubscriptionRequest.ProtoReflect.Descriptor instead.
 func (*ConfigSubscriptionRequest) Descriptor() ([]byte, []int) {
-	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{20}
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *ConfigSubscriptionRequest) GetRuntimeId() string {
@@ -1797,7 +1925,7 @@ type ConfigSubscriptionResponse struct {
 
 func (x *ConfigSubscriptionResponse) Reset() {
 	*x = ConfigSubscriptionResponse{}
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[21]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1809,7 +1937,7 @@ func (x *ConfigSubscriptionResponse) String() string {
 func (*ConfigSubscriptionResponse) ProtoMessage() {}
 
 func (x *ConfigSubscriptionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[21]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1822,7 +1950,7 @@ func (x *ConfigSubscriptionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConfigSubscriptionResponse.ProtoReflect.Descriptor instead.
 func (*ConfigSubscriptionResponse) Descriptor() ([]byte, []int) {
-	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{21}
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *ConfigSubscriptionResponse) GetClient() *Client {
@@ -1856,7 +1984,7 @@ type ClientGetConfigsRequest struct {
 
 func (x *ClientGetConfigsRequest) Reset() {
 	*x = ClientGetConfigsRequest{}
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[22]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1868,7 +1996,7 @@ func (x *ClientGetConfigsRequest) String() string {
 func (*ClientGetConfigsRequest) ProtoMessage() {}
 
 func (x *ClientGetConfigsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[22]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1881,7 +2009,7 @@ func (x *ClientGetConfigsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClientGetConfigsRequest.ProtoReflect.Descriptor instead.
 func (*ClientGetConfigsRequest) Descriptor() ([]byte, []int) {
-	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{22}
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *ClientGetConfigsRequest) GetClient() *Client {
@@ -1911,7 +2039,7 @@ type ClientGetConfigsResponse struct {
 
 func (x *ClientGetConfigsResponse) Reset() {
 	*x = ClientGetConfigsResponse{}
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[23]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1923,7 +2051,7 @@ func (x *ClientGetConfigsResponse) String() string {
 func (*ClientGetConfigsResponse) ProtoMessage() {}
 
 func (x *ClientGetConfigsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[23]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1936,7 +2064,7 @@ func (x *ClientGetConfigsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClientGetConfigsResponse.ProtoReflect.Descriptor instead.
 func (*ClientGetConfigsResponse) Descriptor() ([]byte, []int) {
-	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{23}
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *ClientGetConfigsResponse) GetRoots() [][]byte {
@@ -1984,7 +2112,7 @@ type FileMetaState struct {
 
 func (x *FileMetaState) Reset() {
 	*x = FileMetaState{}
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[24]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1996,7 +2124,7 @@ func (x *FileMetaState) String() string {
 func (*FileMetaState) ProtoMessage() {}
 
 func (x *FileMetaState) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[24]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2009,7 +2137,7 @@ func (x *FileMetaState) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FileMetaState.ProtoReflect.Descriptor instead.
 func (*FileMetaState) Descriptor() ([]byte, []int) {
-	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{24}
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *FileMetaState) GetVersion() uint64 {
@@ -2039,7 +2167,7 @@ type GetStateConfigResponse struct {
 
 func (x *GetStateConfigResponse) Reset() {
 	*x = GetStateConfigResponse{}
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[25]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2051,7 +2179,7 @@ func (x *GetStateConfigResponse) String() string {
 func (*GetStateConfigResponse) ProtoMessage() {}
 
 func (x *GetStateConfigResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[25]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2064,7 +2192,7 @@ func (x *GetStateConfigResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetStateConfigResponse.ProtoReflect.Descriptor instead.
 func (*GetStateConfigResponse) Descriptor() ([]byte, []int) {
-	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{25}
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *GetStateConfigResponse) GetConfigState() map[string]*FileMetaState {
@@ -2116,7 +2244,7 @@ type ConfigSubscriptionState struct {
 
 func (x *ConfigSubscriptionState) Reset() {
 	*x = ConfigSubscriptionState{}
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[26]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2128,7 +2256,7 @@ func (x *ConfigSubscriptionState) String() string {
 func (*ConfigSubscriptionState) ProtoMessage() {}
 
 func (x *ConfigSubscriptionState) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[26]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2141,7 +2269,7 @@ func (x *ConfigSubscriptionState) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConfigSubscriptionState.ProtoReflect.Descriptor instead.
 func (*ConfigSubscriptionState) Descriptor() ([]byte, []int) {
-	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{26}
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *ConfigSubscriptionState) GetSubscriptionId() uint64 {
@@ -2166,7 +2294,7 @@ type ResetStateConfigResponse struct {
 
 func (x *ResetStateConfigResponse) Reset() {
 	*x = ResetStateConfigResponse{}
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[27]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2178,7 +2306,7 @@ func (x *ResetStateConfigResponse) String() string {
 func (*ResetStateConfigResponse) ProtoMessage() {}
 
 func (x *ResetStateConfigResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[27]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2191,7 +2319,7 @@ func (x *ResetStateConfigResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResetStateConfigResponse.ProtoReflect.Descriptor instead.
 func (*ResetStateConfigResponse) Descriptor() ([]byte, []int) {
-	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{27}
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{29}
 }
 
 type TracerPredicateV1 struct {
@@ -2209,7 +2337,7 @@ type TracerPredicateV1 struct {
 
 func (x *TracerPredicateV1) Reset() {
 	*x = TracerPredicateV1{}
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[28]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2221,7 +2349,7 @@ func (x *TracerPredicateV1) String() string {
 func (*TracerPredicateV1) ProtoMessage() {}
 
 func (x *TracerPredicateV1) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[28]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2234,7 +2362,7 @@ func (x *TracerPredicateV1) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TracerPredicateV1.ProtoReflect.Descriptor instead.
 func (*TracerPredicateV1) Descriptor() ([]byte, []int) {
-	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{28}
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *TracerPredicateV1) GetClientID() string {
@@ -2295,7 +2423,7 @@ type TracerPredicates struct {
 
 func (x *TracerPredicates) Reset() {
 	*x = TracerPredicates{}
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[29]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2307,7 +2435,7 @@ func (x *TracerPredicates) String() string {
 func (*TracerPredicates) ProtoMessage() {}
 
 func (x *TracerPredicates) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[29]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2320,7 +2448,7 @@ func (x *TracerPredicates) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TracerPredicates.ProtoReflect.Descriptor instead.
 func (*TracerPredicates) Descriptor() ([]byte, []int) {
-	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{29}
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *TracerPredicates) GetTracerPredicatesV1() []*TracerPredicateV1 {
@@ -2341,7 +2469,7 @@ type ConfigSubscriptionState_TrackedClient struct {
 
 func (x *ConfigSubscriptionState_TrackedClient) Reset() {
 	*x = ConfigSubscriptionState_TrackedClient{}
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[33]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2353,7 +2481,7 @@ func (x *ConfigSubscriptionState_TrackedClient) String() string {
 func (*ConfigSubscriptionState_TrackedClient) ProtoMessage() {}
 
 func (x *ConfigSubscriptionState_TrackedClient) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[33]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2366,7 +2494,7 @@ func (x *ConfigSubscriptionState_TrackedClient) ProtoReflect() protoreflect.Mess
 
 // Deprecated: Use ConfigSubscriptionState_TrackedClient.ProtoReflect.Descriptor instead.
 func (*ConfigSubscriptionState_TrackedClient) Descriptor() ([]byte, []int) {
-	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{26, 0}
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{28, 0}
 }
 
 func (x *ConfigSubscriptionState_TrackedClient) GetRuntimeId() string {
@@ -2446,7 +2574,7 @@ const file_datadog_remoteconfig_remoteconfig_proto_rawDesc = "" +
 	"\aenabled\x18\x01 \x01(\bR\aenabled\x12\x1e\n" +
 	"\n" +
 	"authorized\x18\x02 \x01(\bR\n" +
-	"authorized\"\xe0\x03\n" +
+	"authorized\"\xca\x04\n" +
 	"\x06Client\x121\n" +
 	"\x05state\x18\x01 \x01(\v2\x1b.datadog.config.ClientStateR\x05state\x12\x0e\n" +
 	"\x02id\x18\x02 \x01(\tR\x02id\x12\x1a\n" +
@@ -2460,7 +2588,10 @@ const file_datadog_remoteconfig_remoteconfig_proto_rawDesc = "" +
 	"\fcapabilities\x18\v \x01(\fR\fcapabilities\x12\x1d\n" +
 	"\n" +
 	"is_updater\x18\x0e \x01(\bR\tisUpdater\x12D\n" +
-	"\x0eclient_updater\x18\x0f \x01(\v2\x1d.datadog.config.ClientUpdaterR\rclientUpdaterJ\x04\b\x04\x10\x05J\x04\b\x05\x10\x06J\x04\b\f\x10\rJ\x04\b\r\x10\x0e\"\xc2\x02\n" +
+	"\x0eclient_updater\x18\x0f \x01(\v2\x1d.datadog.config.ClientUpdaterR\rclientUpdater\x12\x1f\n" +
+	"\vis_operator\x18\x10 \x01(\bR\n" +
+	"isOperator\x12G\n" +
+	"\x0fclient_operator\x18\x11 \x01(\v2\x1e.datadog.config.ClientOperatorR\x0eclientOperatorJ\x04\b\x04\x10\x05J\x04\b\x05\x10\x06J\x04\b\f\x10\rJ\x04\b\r\x10\x0e\"\xc2\x02\n" +
 	"\fClientTracer\x12\x1d\n" +
 	"\n" +
 	"runtime_id\x18\x01 \x01(\tR\truntimeId\x12\x1a\n" +
@@ -2486,22 +2617,32 @@ const file_datadog_remoteconfig_remoteconfig_proto_rawDesc = "" +
 	"\x04tags\x18\x01 \x03(\tR\x04tags\x128\n" +
 	"\bpackages\x18\x02 \x03(\v2\x1c.datadog.config.PackageStateR\bpackages\x120\n" +
 	"\x14available_disk_space\x18\x03 \x01(\x04R\x12availableDiskSpace\x12&\n" +
-	"\x0fsecrets_pub_key\x18\x04 \x01(\tR\rsecretsPubKey\"\xa7\x03\n" +
+	"\x0fsecrets_pub_key\x18\x04 \x01(\tR\rsecretsPubKey\"\x9b\x03\n" +
 	"\fPackageState\x12\x18\n" +
 	"\apackage\x18\x01 \x01(\tR\apackage\x12%\n" +
 	"\x0estable_version\x18\x02 \x01(\tR\rstableVersion\x12-\n" +
-	"\x12experiment_version\x18\x03 \x01(\tR\x11experimentVersion\x124\n" +
-	"\x04task\x18\x04 \x01(\v2 .datadog.config.PackageStateTaskR\x04task\x122\n" +
+	"\x12experiment_version\x18\x03 \x01(\tR\x11experimentVersion\x12(\n" +
+	"\x04task\x18\x04 \x01(\v2\x14.datadog.config.TaskR\x04task\x122\n" +
 	"\x15stable_config_version\x18\v \x01(\tR\x13stableConfigVersion\x12:\n" +
 	"\x19experiment_config_version\x18\f \x01(\tR\x17experimentConfigVersion\x12'\n" +
 	"\x0frunning_version\x18\r \x01(\tR\x0erunningVersion\x124\n" +
 	"\x16running_config_version\x18\x0e \x01(\tR\x14runningConfigVersionJ\x04\b\x05\x10\x06J\x04\b\x06\x10\aJ\x04\b\a\x10\bJ\x04\b\b\x10\tJ\x04\b\t\x10\n" +
 	"J\x04\b\n" +
-	"\x10\v\"\x84\x01\n" +
-	"\x10PackageStateTask\x12\x0e\n" +
+	"\x10\v\"x\n" +
+	"\x04Task\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12/\n" +
 	"\x05state\x18\x02 \x01(\x0e2\x19.datadog.config.TaskStateR\x05state\x12/\n" +
-	"\x05error\x18\x03 \x01(\v2\x19.datadog.config.TaskErrorR\x05error\"9\n" +
+	"\x05error\x18\x03 \x01(\v2\x19.datadog.config.TaskErrorR\x05error\"\xa3\x01\n" +
+	"\n" +
+	"FleetState\x12%\n" +
+	"\x0econfig_version\x18\x01 \x01(\tR\rconfigVersion\x12\x1e\n" +
+	"\n" +
+	"experiment\x18\x02 \x01(\bR\n" +
+	"experiment\x12(\n" +
+	"\x04task\x18\x03 \x01(\v2\x14.datadog.config.TaskR\x04task\x12$\n" +
+	"\x0esecret_pub_key\x18\x04 \x01(\tR\fsecretPubKey\"O\n" +
+	"\x0eClientOperator\x12=\n" +
+	"\ffleet_states\x18\x01 \x03(\v2\x1a.datadog.config.FleetStateR\vfleetStates\"9\n" +
 	"\tTaskError\x12\x12\n" +
 	"\x04code\x18\x01 \x01(\x04R\x04code\x12\x18\n" +
 	"\amessage\x18\x02 \x01(\tR\amessage\"\x93\x01\n" +
@@ -2614,7 +2755,7 @@ func file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP() []byte {
 }
 
 var file_datadog_remoteconfig_remoteconfig_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_datadog_remoteconfig_remoteconfig_proto_msgTypes = make([]protoimpl.MessageInfo, 34)
+var file_datadog_remoteconfig_remoteconfig_proto_msgTypes = make([]protoimpl.MessageInfo, 36)
 var file_datadog_remoteconfig_remoteconfig_proto_goTypes = []any{
 	(TaskState)(0),                                // 0: datadog.config.TaskState
 	(ConfigSubscriptionProducts)(0),               // 1: datadog.config.ConfigSubscriptionProducts
@@ -2634,26 +2775,28 @@ var file_datadog_remoteconfig_remoteconfig_proto_goTypes = []any{
 	(*ClientAgent)(nil),                           // 15: datadog.config.ClientAgent
 	(*ClientUpdater)(nil),                         // 16: datadog.config.ClientUpdater
 	(*PackageState)(nil),                          // 17: datadog.config.PackageState
-	(*PackageStateTask)(nil),                      // 18: datadog.config.PackageStateTask
-	(*TaskError)(nil),                             // 19: datadog.config.TaskError
-	(*ConfigState)(nil),                           // 20: datadog.config.ConfigState
-	(*ClientState)(nil),                           // 21: datadog.config.ClientState
-	(*TargetFileHash)(nil),                        // 22: datadog.config.TargetFileHash
-	(*TargetFileMeta)(nil),                        // 23: datadog.config.TargetFileMeta
-	(*ConfigSubscriptionRequest)(nil),             // 24: datadog.config.ConfigSubscriptionRequest
-	(*ConfigSubscriptionResponse)(nil),            // 25: datadog.config.ConfigSubscriptionResponse
-	(*ClientGetConfigsRequest)(nil),               // 26: datadog.config.ClientGetConfigsRequest
-	(*ClientGetConfigsResponse)(nil),              // 27: datadog.config.ClientGetConfigsResponse
-	(*FileMetaState)(nil),                         // 28: datadog.config.FileMetaState
-	(*GetStateConfigResponse)(nil),                // 29: datadog.config.GetStateConfigResponse
-	(*ConfigSubscriptionState)(nil),               // 30: datadog.config.ConfigSubscriptionState
-	(*ResetStateConfigResponse)(nil),              // 31: datadog.config.ResetStateConfigResponse
-	(*TracerPredicateV1)(nil),                     // 32: datadog.config.TracerPredicateV1
-	(*TracerPredicates)(nil),                      // 33: datadog.config.TracerPredicates
-	nil,                                           // 34: datadog.config.GetStateConfigResponse.ConfigStateEntry
-	nil,                                           // 35: datadog.config.GetStateConfigResponse.DirectorStateEntry
-	nil,                                           // 36: datadog.config.GetStateConfigResponse.TargetFilenamesEntry
-	(*ConfigSubscriptionState_TrackedClient)(nil), // 37: datadog.config.ConfigSubscriptionState.TrackedClient
+	(*Task)(nil),                                  // 18: datadog.config.Task
+	(*FleetState)(nil),                            // 19: datadog.config.FleetState
+	(*ClientOperator)(nil),                        // 20: datadog.config.ClientOperator
+	(*TaskError)(nil),                             // 21: datadog.config.TaskError
+	(*ConfigState)(nil),                           // 22: datadog.config.ConfigState
+	(*ClientState)(nil),                           // 23: datadog.config.ClientState
+	(*TargetFileHash)(nil),                        // 24: datadog.config.TargetFileHash
+	(*TargetFileMeta)(nil),                        // 25: datadog.config.TargetFileMeta
+	(*ConfigSubscriptionRequest)(nil),             // 26: datadog.config.ConfigSubscriptionRequest
+	(*ConfigSubscriptionResponse)(nil),            // 27: datadog.config.ConfigSubscriptionResponse
+	(*ClientGetConfigsRequest)(nil),               // 28: datadog.config.ClientGetConfigsRequest
+	(*ClientGetConfigsResponse)(nil),              // 29: datadog.config.ClientGetConfigsResponse
+	(*FileMetaState)(nil),                         // 30: datadog.config.FileMetaState
+	(*GetStateConfigResponse)(nil),                // 31: datadog.config.GetStateConfigResponse
+	(*ConfigSubscriptionState)(nil),               // 32: datadog.config.ConfigSubscriptionState
+	(*ResetStateConfigResponse)(nil),              // 33: datadog.config.ResetStateConfigResponse
+	(*TracerPredicateV1)(nil),                     // 34: datadog.config.TracerPredicateV1
+	(*TracerPredicates)(nil),                      // 35: datadog.config.TracerPredicates
+	nil,                                           // 36: datadog.config.GetStateConfigResponse.ConfigStateEntry
+	nil,                                           // 37: datadog.config.GetStateConfigResponse.DirectorStateEntry
+	nil,                                           // 38: datadog.config.GetStateConfigResponse.TargetFilenamesEntry
+	(*ConfigSubscriptionState_TrackedClient)(nil), // 39: datadog.config.ConfigSubscriptionState.TrackedClient
 }
 var file_datadog_remoteconfig_remoteconfig_proto_depIdxs = []int32{
 	7,  // 0: datadog.config.ConfigMetas.roots:type_name -> datadog.config.TopMeta
@@ -2669,39 +2812,42 @@ var file_datadog_remoteconfig_remoteconfig_proto_depIdxs = []int32{
 	4,  // 10: datadog.config.LatestConfigsResponse.config_metas:type_name -> datadog.config.ConfigMetas
 	5,  // 11: datadog.config.LatestConfigsResponse.director_metas:type_name -> datadog.config.DirectorMetas
 	8,  // 12: datadog.config.LatestConfigsResponse.target_files:type_name -> datadog.config.File
-	21, // 13: datadog.config.Client.state:type_name -> datadog.config.ClientState
+	23, // 13: datadog.config.Client.state:type_name -> datadog.config.ClientState
 	14, // 14: datadog.config.Client.client_tracer:type_name -> datadog.config.ClientTracer
 	15, // 15: datadog.config.Client.client_agent:type_name -> datadog.config.ClientAgent
 	16, // 16: datadog.config.Client.client_updater:type_name -> datadog.config.ClientUpdater
-	17, // 17: datadog.config.ClientUpdater.packages:type_name -> datadog.config.PackageState
-	18, // 18: datadog.config.PackageState.task:type_name -> datadog.config.PackageStateTask
-	0,  // 19: datadog.config.PackageStateTask.state:type_name -> datadog.config.TaskState
-	19, // 20: datadog.config.PackageStateTask.error:type_name -> datadog.config.TaskError
-	20, // 21: datadog.config.ClientState.config_states:type_name -> datadog.config.ConfigState
-	22, // 22: datadog.config.TargetFileMeta.hashes:type_name -> datadog.config.TargetFileHash
-	3,  // 23: datadog.config.ConfigSubscriptionRequest.action:type_name -> datadog.config.ConfigSubscriptionRequest.Action
-	1,  // 24: datadog.config.ConfigSubscriptionRequest.products:type_name -> datadog.config.ConfigSubscriptionProducts
-	13, // 25: datadog.config.ConfigSubscriptionResponse.client:type_name -> datadog.config.Client
-	8,  // 26: datadog.config.ConfigSubscriptionResponse.target_files:type_name -> datadog.config.File
-	13, // 27: datadog.config.ClientGetConfigsRequest.client:type_name -> datadog.config.Client
-	23, // 28: datadog.config.ClientGetConfigsRequest.cached_target_files:type_name -> datadog.config.TargetFileMeta
-	8,  // 29: datadog.config.ClientGetConfigsResponse.target_files:type_name -> datadog.config.File
-	2,  // 30: datadog.config.ClientGetConfigsResponse.config_status:type_name -> datadog.config.ConfigStatus
-	34, // 31: datadog.config.GetStateConfigResponse.config_state:type_name -> datadog.config.GetStateConfigResponse.ConfigStateEntry
-	35, // 32: datadog.config.GetStateConfigResponse.director_state:type_name -> datadog.config.GetStateConfigResponse.DirectorStateEntry
-	36, // 33: datadog.config.GetStateConfigResponse.target_filenames:type_name -> datadog.config.GetStateConfigResponse.TargetFilenamesEntry
-	13, // 34: datadog.config.GetStateConfigResponse.active_clients:type_name -> datadog.config.Client
-	30, // 35: datadog.config.GetStateConfigResponse.config_subscription_states:type_name -> datadog.config.ConfigSubscriptionState
-	37, // 36: datadog.config.ConfigSubscriptionState.tracked_clients:type_name -> datadog.config.ConfigSubscriptionState.TrackedClient
-	32, // 37: datadog.config.TracerPredicates.tracer_predicates_v1:type_name -> datadog.config.TracerPredicateV1
-	28, // 38: datadog.config.GetStateConfigResponse.ConfigStateEntry.value:type_name -> datadog.config.FileMetaState
-	28, // 39: datadog.config.GetStateConfigResponse.DirectorStateEntry.value:type_name -> datadog.config.FileMetaState
-	1,  // 40: datadog.config.ConfigSubscriptionState.TrackedClient.products:type_name -> datadog.config.ConfigSubscriptionProducts
-	41, // [41:41] is the sub-list for method output_type
-	41, // [41:41] is the sub-list for method input_type
-	41, // [41:41] is the sub-list for extension type_name
-	41, // [41:41] is the sub-list for extension extendee
-	0,  // [0:41] is the sub-list for field type_name
+	20, // 17: datadog.config.Client.client_operator:type_name -> datadog.config.ClientOperator
+	17, // 18: datadog.config.ClientUpdater.packages:type_name -> datadog.config.PackageState
+	18, // 19: datadog.config.PackageState.task:type_name -> datadog.config.Task
+	0,  // 20: datadog.config.Task.state:type_name -> datadog.config.TaskState
+	21, // 21: datadog.config.Task.error:type_name -> datadog.config.TaskError
+	18, // 22: datadog.config.FleetState.task:type_name -> datadog.config.Task
+	19, // 23: datadog.config.ClientOperator.fleet_states:type_name -> datadog.config.FleetState
+	22, // 24: datadog.config.ClientState.config_states:type_name -> datadog.config.ConfigState
+	24, // 25: datadog.config.TargetFileMeta.hashes:type_name -> datadog.config.TargetFileHash
+	3,  // 26: datadog.config.ConfigSubscriptionRequest.action:type_name -> datadog.config.ConfigSubscriptionRequest.Action
+	1,  // 27: datadog.config.ConfigSubscriptionRequest.products:type_name -> datadog.config.ConfigSubscriptionProducts
+	13, // 28: datadog.config.ConfigSubscriptionResponse.client:type_name -> datadog.config.Client
+	8,  // 29: datadog.config.ConfigSubscriptionResponse.target_files:type_name -> datadog.config.File
+	13, // 30: datadog.config.ClientGetConfigsRequest.client:type_name -> datadog.config.Client
+	25, // 31: datadog.config.ClientGetConfigsRequest.cached_target_files:type_name -> datadog.config.TargetFileMeta
+	8,  // 32: datadog.config.ClientGetConfigsResponse.target_files:type_name -> datadog.config.File
+	2,  // 33: datadog.config.ClientGetConfigsResponse.config_status:type_name -> datadog.config.ConfigStatus
+	36, // 34: datadog.config.GetStateConfigResponse.config_state:type_name -> datadog.config.GetStateConfigResponse.ConfigStateEntry
+	37, // 35: datadog.config.GetStateConfigResponse.director_state:type_name -> datadog.config.GetStateConfigResponse.DirectorStateEntry
+	38, // 36: datadog.config.GetStateConfigResponse.target_filenames:type_name -> datadog.config.GetStateConfigResponse.TargetFilenamesEntry
+	13, // 37: datadog.config.GetStateConfigResponse.active_clients:type_name -> datadog.config.Client
+	32, // 38: datadog.config.GetStateConfigResponse.config_subscription_states:type_name -> datadog.config.ConfigSubscriptionState
+	39, // 39: datadog.config.ConfigSubscriptionState.tracked_clients:type_name -> datadog.config.ConfigSubscriptionState.TrackedClient
+	34, // 40: datadog.config.TracerPredicates.tracer_predicates_v1:type_name -> datadog.config.TracerPredicateV1
+	30, // 41: datadog.config.GetStateConfigResponse.ConfigStateEntry.value:type_name -> datadog.config.FileMetaState
+	30, // 42: datadog.config.GetStateConfigResponse.DirectorStateEntry.value:type_name -> datadog.config.FileMetaState
+	1,  // 43: datadog.config.ConfigSubscriptionState.TrackedClient.products:type_name -> datadog.config.ConfigSubscriptionProducts
+	44, // [44:44] is the sub-list for method output_type
+	44, // [44:44] is the sub-list for method input_type
+	44, // [44:44] is the sub-list for extension type_name
+	44, // [44:44] is the sub-list for extension extendee
+	0,  // [0:44] is the sub-list for field type_name
 }
 
 func init() { file_datadog_remoteconfig_remoteconfig_proto_init() }
@@ -2715,7 +2861,7 @@ func file_datadog_remoteconfig_remoteconfig_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_datadog_remoteconfig_remoteconfig_proto_rawDesc), len(file_datadog_remoteconfig_remoteconfig_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   34,
+			NumMessages:   36,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/pkg/proto/pbgo/core/remoteconfig.pb.go
+++ b/pkg/proto/pbgo/core/remoteconfig.pb.go
@@ -1657,6 +1657,7 @@ func (x *Rollout) GetDaemonSets() []*DaemonSetStatus {
 type FleetState struct {
 	state            protoimpl.MessageState `protogen:"open.v1"`
 	ConfigVersion    string                 `protobuf:"bytes,1,opt,name=config_version,json=configVersion,proto3" json:"config_version,omitempty"`
+	ConfigTask       *Task                  `protobuf:"bytes,5,opt,name=config_task,json=configTask,proto3" json:"config_task,omitempty"`
 	ConfigExperiment bool                   `protobuf:"varint,2,opt,name=config_experiment,json=configExperiment,proto3" json:"config_experiment,omitempty"`
 	ConfigRollout    *Rollout               `protobuf:"bytes,3,opt,name=config_rollout,json=configRollout,proto3" json:"config_rollout,omitempty"`
 	SecretPubKey     string                 `protobuf:"bytes,4,opt,name=secret_pub_key,json=secretPubKey,proto3" json:"secret_pub_key,omitempty"`
@@ -1699,6 +1700,13 @@ func (x *FleetState) GetConfigVersion() string {
 		return x.ConfigVersion
 	}
 	return ""
+}
+
+func (x *FleetState) GetConfigTask() *Task {
+	if x != nil {
+		return x.ConfigTask
+	}
+	return nil
 }
 
 func (x *FleetState) GetConfigExperiment() bool {
@@ -2906,10 +2914,12 @@ const file_datadog_remoteconfig_remoteconfig_proto_rawDesc = "" +
 	"\aRollout\x12B\n" +
 	"\vdeployments\x18\x01 \x03(\v2 .datadog.config.DeploymentStatusR\vdeployments\x12@\n" +
 	"\vdaemon_sets\x18\x02 \x03(\v2\x1f.datadog.config.DaemonSetStatusR\n" +
-	"daemonSets\"\xc6\x01\n" +
+	"daemonSets\"\xfd\x01\n" +
 	"\n" +
 	"FleetState\x12%\n" +
-	"\x0econfig_version\x18\x01 \x01(\tR\rconfigVersion\x12+\n" +
+	"\x0econfig_version\x18\x01 \x01(\tR\rconfigVersion\x125\n" +
+	"\vconfig_task\x18\x05 \x01(\v2\x14.datadog.config.TaskR\n" +
+	"configTask\x12+\n" +
 	"\x11config_experiment\x18\x02 \x01(\bR\x10configExperiment\x12>\n" +
 	"\x0econfig_rollout\x18\x03 \x01(\v2\x17.datadog.config.RolloutR\rconfigRollout\x12$\n" +
 	"\x0esecret_pub_key\x18\x04 \x01(\tR\fsecretPubKey\"O\n" +
@@ -3098,33 +3108,34 @@ var file_datadog_remoteconfig_remoteconfig_proto_depIdxs = []int32{
 	24, // 21: datadog.config.Task.error:type_name -> datadog.config.TaskError
 	19, // 22: datadog.config.Rollout.deployments:type_name -> datadog.config.DeploymentStatus
 	20, // 23: datadog.config.Rollout.daemon_sets:type_name -> datadog.config.DaemonSetStatus
-	21, // 24: datadog.config.FleetState.config_rollout:type_name -> datadog.config.Rollout
-	22, // 25: datadog.config.ClientOperator.fleet_states:type_name -> datadog.config.FleetState
-	25, // 26: datadog.config.ClientState.config_states:type_name -> datadog.config.ConfigState
-	27, // 27: datadog.config.TargetFileMeta.hashes:type_name -> datadog.config.TargetFileHash
-	3,  // 28: datadog.config.ConfigSubscriptionRequest.action:type_name -> datadog.config.ConfigSubscriptionRequest.Action
-	1,  // 29: datadog.config.ConfigSubscriptionRequest.products:type_name -> datadog.config.ConfigSubscriptionProducts
-	13, // 30: datadog.config.ConfigSubscriptionResponse.client:type_name -> datadog.config.Client
-	8,  // 31: datadog.config.ConfigSubscriptionResponse.target_files:type_name -> datadog.config.File
-	13, // 32: datadog.config.ClientGetConfigsRequest.client:type_name -> datadog.config.Client
-	28, // 33: datadog.config.ClientGetConfigsRequest.cached_target_files:type_name -> datadog.config.TargetFileMeta
-	8,  // 34: datadog.config.ClientGetConfigsResponse.target_files:type_name -> datadog.config.File
-	2,  // 35: datadog.config.ClientGetConfigsResponse.config_status:type_name -> datadog.config.ConfigStatus
-	39, // 36: datadog.config.GetStateConfigResponse.config_state:type_name -> datadog.config.GetStateConfigResponse.ConfigStateEntry
-	40, // 37: datadog.config.GetStateConfigResponse.director_state:type_name -> datadog.config.GetStateConfigResponse.DirectorStateEntry
-	41, // 38: datadog.config.GetStateConfigResponse.target_filenames:type_name -> datadog.config.GetStateConfigResponse.TargetFilenamesEntry
-	13, // 39: datadog.config.GetStateConfigResponse.active_clients:type_name -> datadog.config.Client
-	35, // 40: datadog.config.GetStateConfigResponse.config_subscription_states:type_name -> datadog.config.ConfigSubscriptionState
-	42, // 41: datadog.config.ConfigSubscriptionState.tracked_clients:type_name -> datadog.config.ConfigSubscriptionState.TrackedClient
-	37, // 42: datadog.config.TracerPredicates.tracer_predicates_v1:type_name -> datadog.config.TracerPredicateV1
-	33, // 43: datadog.config.GetStateConfigResponse.ConfigStateEntry.value:type_name -> datadog.config.FileMetaState
-	33, // 44: datadog.config.GetStateConfigResponse.DirectorStateEntry.value:type_name -> datadog.config.FileMetaState
-	1,  // 45: datadog.config.ConfigSubscriptionState.TrackedClient.products:type_name -> datadog.config.ConfigSubscriptionProducts
-	46, // [46:46] is the sub-list for method output_type
-	46, // [46:46] is the sub-list for method input_type
-	46, // [46:46] is the sub-list for extension type_name
-	46, // [46:46] is the sub-list for extension extendee
-	0,  // [0:46] is the sub-list for field type_name
+	18, // 24: datadog.config.FleetState.config_task:type_name -> datadog.config.Task
+	21, // 25: datadog.config.FleetState.config_rollout:type_name -> datadog.config.Rollout
+	22, // 26: datadog.config.ClientOperator.fleet_states:type_name -> datadog.config.FleetState
+	25, // 27: datadog.config.ClientState.config_states:type_name -> datadog.config.ConfigState
+	27, // 28: datadog.config.TargetFileMeta.hashes:type_name -> datadog.config.TargetFileHash
+	3,  // 29: datadog.config.ConfigSubscriptionRequest.action:type_name -> datadog.config.ConfigSubscriptionRequest.Action
+	1,  // 30: datadog.config.ConfigSubscriptionRequest.products:type_name -> datadog.config.ConfigSubscriptionProducts
+	13, // 31: datadog.config.ConfigSubscriptionResponse.client:type_name -> datadog.config.Client
+	8,  // 32: datadog.config.ConfigSubscriptionResponse.target_files:type_name -> datadog.config.File
+	13, // 33: datadog.config.ClientGetConfigsRequest.client:type_name -> datadog.config.Client
+	28, // 34: datadog.config.ClientGetConfigsRequest.cached_target_files:type_name -> datadog.config.TargetFileMeta
+	8,  // 35: datadog.config.ClientGetConfigsResponse.target_files:type_name -> datadog.config.File
+	2,  // 36: datadog.config.ClientGetConfigsResponse.config_status:type_name -> datadog.config.ConfigStatus
+	39, // 37: datadog.config.GetStateConfigResponse.config_state:type_name -> datadog.config.GetStateConfigResponse.ConfigStateEntry
+	40, // 38: datadog.config.GetStateConfigResponse.director_state:type_name -> datadog.config.GetStateConfigResponse.DirectorStateEntry
+	41, // 39: datadog.config.GetStateConfigResponse.target_filenames:type_name -> datadog.config.GetStateConfigResponse.TargetFilenamesEntry
+	13, // 40: datadog.config.GetStateConfigResponse.active_clients:type_name -> datadog.config.Client
+	35, // 41: datadog.config.GetStateConfigResponse.config_subscription_states:type_name -> datadog.config.ConfigSubscriptionState
+	42, // 42: datadog.config.ConfigSubscriptionState.tracked_clients:type_name -> datadog.config.ConfigSubscriptionState.TrackedClient
+	37, // 43: datadog.config.TracerPredicates.tracer_predicates_v1:type_name -> datadog.config.TracerPredicateV1
+	33, // 44: datadog.config.GetStateConfigResponse.ConfigStateEntry.value:type_name -> datadog.config.FileMetaState
+	33, // 45: datadog.config.GetStateConfigResponse.DirectorStateEntry.value:type_name -> datadog.config.FileMetaState
+	1,  // 46: datadog.config.ConfigSubscriptionState.TrackedClient.products:type_name -> datadog.config.ConfigSubscriptionProducts
+	47, // [47:47] is the sub-list for method output_type
+	47, // [47:47] is the sub-list for method input_type
+	47, // [47:47] is the sub-list for extension type_name
+	47, // [47:47] is the sub-list for extension extendee
+	0,  // [0:47] is the sub-list for field type_name
 }
 
 func init() { file_datadog_remoteconfig_remoteconfig_proto_init() }

--- a/pkg/proto/pbgo/core/remoteconfig.pb.go
+++ b/pkg/proto/pbgo/core/remoteconfig.pb.go
@@ -218,7 +218,7 @@ func (x ConfigSubscriptionRequest_Action) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use ConfigSubscriptionRequest_Action.Descriptor instead.
 func (ConfigSubscriptionRequest_Action) EnumDescriptor() ([]byte, []int) {
-	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{22, 0}
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{25, 0}
 }
 
 type ConfigMetas struct {
@@ -1402,19 +1402,271 @@ func (x *Task) GetError() *TaskError {
 	return nil
 }
 
-type FleetState struct {
+type DeploymentStatus struct {
+	state               protoimpl.MessageState `protogen:"open.v1"`
+	Name                string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	ObservedGeneration  int64                  `protobuf:"varint,2,opt,name=observed_generation,json=observedGeneration,proto3" json:"observed_generation,omitempty"`
+	Replicas            int32                  `protobuf:"varint,3,opt,name=replicas,proto3" json:"replicas,omitempty"`
+	UpdatedReplicas     int32                  `protobuf:"varint,4,opt,name=updated_replicas,json=updatedReplicas,proto3" json:"updated_replicas,omitempty"`
+	ReadyReplicas       int32                  `protobuf:"varint,5,opt,name=ready_replicas,json=readyReplicas,proto3" json:"ready_replicas,omitempty"`
+	AvailableReplicas   int32                  `protobuf:"varint,6,opt,name=available_replicas,json=availableReplicas,proto3" json:"available_replicas,omitempty"`
+	UnavailableReplicas int32                  `protobuf:"varint,7,opt,name=unavailable_replicas,json=unavailableReplicas,proto3" json:"unavailable_replicas,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
+}
+
+func (x *DeploymentStatus) Reset() {
+	*x = DeploymentStatus{}
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeploymentStatus) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeploymentStatus) ProtoMessage() {}
+
+func (x *DeploymentStatus) ProtoReflect() protoreflect.Message {
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeploymentStatus.ProtoReflect.Descriptor instead.
+func (*DeploymentStatus) Descriptor() ([]byte, []int) {
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *DeploymentStatus) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *DeploymentStatus) GetObservedGeneration() int64 {
+	if x != nil {
+		return x.ObservedGeneration
+	}
+	return 0
+}
+
+func (x *DeploymentStatus) GetReplicas() int32 {
+	if x != nil {
+		return x.Replicas
+	}
+	return 0
+}
+
+func (x *DeploymentStatus) GetUpdatedReplicas() int32 {
+	if x != nil {
+		return x.UpdatedReplicas
+	}
+	return 0
+}
+
+func (x *DeploymentStatus) GetReadyReplicas() int32 {
+	if x != nil {
+		return x.ReadyReplicas
+	}
+	return 0
+}
+
+func (x *DeploymentStatus) GetAvailableReplicas() int32 {
+	if x != nil {
+		return x.AvailableReplicas
+	}
+	return 0
+}
+
+func (x *DeploymentStatus) GetUnavailableReplicas() int32 {
+	if x != nil {
+		return x.UnavailableReplicas
+	}
+	return 0
+}
+
+type DaemonSetStatus struct {
+	state                  protoimpl.MessageState `protogen:"open.v1"`
+	Name                   string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	CurrentNumberScheduled int32                  `protobuf:"varint,2,opt,name=current_number_scheduled,json=currentNumberScheduled,proto3" json:"current_number_scheduled,omitempty"`
+	NumberMisscheduled     int32                  `protobuf:"varint,3,opt,name=number_misscheduled,json=numberMisscheduled,proto3" json:"number_misscheduled,omitempty"`
+	DesiredNumberScheduled int32                  `protobuf:"varint,4,opt,name=desired_number_scheduled,json=desiredNumberScheduled,proto3" json:"desired_number_scheduled,omitempty"`
+	NumberReady            int32                  `protobuf:"varint,5,opt,name=number_ready,json=numberReady,proto3" json:"number_ready,omitempty"`
+	ObservedGeneration     int64                  `protobuf:"varint,6,opt,name=observed_generation,json=observedGeneration,proto3" json:"observed_generation,omitempty"`
+	UpdatedNumberScheduled int32                  `protobuf:"varint,7,opt,name=updated_number_scheduled,json=updatedNumberScheduled,proto3" json:"updated_number_scheduled,omitempty"`
+	NumberAvailable        int32                  `protobuf:"varint,8,opt,name=number_available,json=numberAvailable,proto3" json:"number_available,omitempty"`
+	NumberUnavailable      int32                  `protobuf:"varint,9,opt,name=number_unavailable,json=numberUnavailable,proto3" json:"number_unavailable,omitempty"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
+}
+
+func (x *DaemonSetStatus) Reset() {
+	*x = DaemonSetStatus{}
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DaemonSetStatus) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DaemonSetStatus) ProtoMessage() {}
+
+func (x *DaemonSetStatus) ProtoReflect() protoreflect.Message {
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DaemonSetStatus.ProtoReflect.Descriptor instead.
+func (*DaemonSetStatus) Descriptor() ([]byte, []int) {
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *DaemonSetStatus) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *DaemonSetStatus) GetCurrentNumberScheduled() int32 {
+	if x != nil {
+		return x.CurrentNumberScheduled
+	}
+	return 0
+}
+
+func (x *DaemonSetStatus) GetNumberMisscheduled() int32 {
+	if x != nil {
+		return x.NumberMisscheduled
+	}
+	return 0
+}
+
+func (x *DaemonSetStatus) GetDesiredNumberScheduled() int32 {
+	if x != nil {
+		return x.DesiredNumberScheduled
+	}
+	return 0
+}
+
+func (x *DaemonSetStatus) GetNumberReady() int32 {
+	if x != nil {
+		return x.NumberReady
+	}
+	return 0
+}
+
+func (x *DaemonSetStatus) GetObservedGeneration() int64 {
+	if x != nil {
+		return x.ObservedGeneration
+	}
+	return 0
+}
+
+func (x *DaemonSetStatus) GetUpdatedNumberScheduled() int32 {
+	if x != nil {
+		return x.UpdatedNumberScheduled
+	}
+	return 0
+}
+
+func (x *DaemonSetStatus) GetNumberAvailable() int32 {
+	if x != nil {
+		return x.NumberAvailable
+	}
+	return 0
+}
+
+func (x *DaemonSetStatus) GetNumberUnavailable() int32 {
+	if x != nil {
+		return x.NumberUnavailable
+	}
+	return 0
+}
+
+type Rollout struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	ConfigVersion string                 `protobuf:"bytes,1,opt,name=config_version,json=configVersion,proto3" json:"config_version,omitempty"`
-	Experiment    bool                   `protobuf:"varint,2,opt,name=experiment,proto3" json:"experiment,omitempty"`
-	Task          *Task                  `protobuf:"bytes,3,opt,name=task,proto3" json:"task,omitempty"`
-	SecretPubKey  string                 `protobuf:"bytes,4,opt,name=secret_pub_key,json=secretPubKey,proto3" json:"secret_pub_key,omitempty"`
+	Deployments   []*DeploymentStatus    `protobuf:"bytes,1,rep,name=deployments,proto3" json:"deployments,omitempty"`
+	DaemonSets    []*DaemonSetStatus     `protobuf:"bytes,2,rep,name=daemon_sets,json=daemonSets,proto3" json:"daemon_sets,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
+func (x *Rollout) Reset() {
+	*x = Rollout{}
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Rollout) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Rollout) ProtoMessage() {}
+
+func (x *Rollout) ProtoReflect() protoreflect.Message {
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Rollout.ProtoReflect.Descriptor instead.
+func (*Rollout) Descriptor() ([]byte, []int) {
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{17}
+}
+
+func (x *Rollout) GetDeployments() []*DeploymentStatus {
+	if x != nil {
+		return x.Deployments
+	}
+	return nil
+}
+
+func (x *Rollout) GetDaemonSets() []*DaemonSetStatus {
+	if x != nil {
+		return x.DaemonSets
+	}
+	return nil
+}
+
+type FleetState struct {
+	state            protoimpl.MessageState `protogen:"open.v1"`
+	ConfigVersion    string                 `protobuf:"bytes,1,opt,name=config_version,json=configVersion,proto3" json:"config_version,omitempty"`
+	ConfigExperiment bool                   `protobuf:"varint,2,opt,name=config_experiment,json=configExperiment,proto3" json:"config_experiment,omitempty"`
+	ConfigRollout    *Rollout               `protobuf:"bytes,3,opt,name=config_rollout,json=configRollout,proto3" json:"config_rollout,omitempty"`
+	SecretPubKey     string                 `protobuf:"bytes,4,opt,name=secret_pub_key,json=secretPubKey,proto3" json:"secret_pub_key,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
 func (x *FleetState) Reset() {
 	*x = FleetState{}
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[15]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1426,7 +1678,7 @@ func (x *FleetState) String() string {
 func (*FleetState) ProtoMessage() {}
 
 func (x *FleetState) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[15]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1439,7 +1691,7 @@ func (x *FleetState) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FleetState.ProtoReflect.Descriptor instead.
 func (*FleetState) Descriptor() ([]byte, []int) {
-	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{15}
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *FleetState) GetConfigVersion() string {
@@ -1449,16 +1701,16 @@ func (x *FleetState) GetConfigVersion() string {
 	return ""
 }
 
-func (x *FleetState) GetExperiment() bool {
+func (x *FleetState) GetConfigExperiment() bool {
 	if x != nil {
-		return x.Experiment
+		return x.ConfigExperiment
 	}
 	return false
 }
 
-func (x *FleetState) GetTask() *Task {
+func (x *FleetState) GetConfigRollout() *Rollout {
 	if x != nil {
-		return x.Task
+		return x.ConfigRollout
 	}
 	return nil
 }
@@ -1479,7 +1731,7 @@ type ClientOperator struct {
 
 func (x *ClientOperator) Reset() {
 	*x = ClientOperator{}
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[16]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1491,7 +1743,7 @@ func (x *ClientOperator) String() string {
 func (*ClientOperator) ProtoMessage() {}
 
 func (x *ClientOperator) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[16]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1504,7 +1756,7 @@ func (x *ClientOperator) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClientOperator.ProtoReflect.Descriptor instead.
 func (*ClientOperator) Descriptor() ([]byte, []int) {
-	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{16}
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *ClientOperator) GetFleetStates() []*FleetState {
@@ -1524,7 +1776,7 @@ type TaskError struct {
 
 func (x *TaskError) Reset() {
 	*x = TaskError{}
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[17]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1536,7 +1788,7 @@ func (x *TaskError) String() string {
 func (*TaskError) ProtoMessage() {}
 
 func (x *TaskError) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[17]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1549,7 +1801,7 @@ func (x *TaskError) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TaskError.ProtoReflect.Descriptor instead.
 func (*TaskError) Descriptor() ([]byte, []int) {
-	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{17}
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *TaskError) GetCode() uint64 {
@@ -1579,7 +1831,7 @@ type ConfigState struct {
 
 func (x *ConfigState) Reset() {
 	*x = ConfigState{}
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[18]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1591,7 +1843,7 @@ func (x *ConfigState) String() string {
 func (*ConfigState) ProtoMessage() {}
 
 func (x *ConfigState) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[18]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1604,7 +1856,7 @@ func (x *ConfigState) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConfigState.ProtoReflect.Descriptor instead.
 func (*ConfigState) Descriptor() ([]byte, []int) {
-	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{18}
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *ConfigState) GetId() string {
@@ -1656,7 +1908,7 @@ type ClientState struct {
 
 func (x *ClientState) Reset() {
 	*x = ClientState{}
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[19]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1668,7 +1920,7 @@ func (x *ClientState) String() string {
 func (*ClientState) ProtoMessage() {}
 
 func (x *ClientState) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[19]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1681,7 +1933,7 @@ func (x *ClientState) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClientState.ProtoReflect.Descriptor instead.
 func (*ClientState) Descriptor() ([]byte, []int) {
-	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{19}
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *ClientState) GetRootVersion() uint64 {
@@ -1736,7 +1988,7 @@ type TargetFileHash struct {
 
 func (x *TargetFileHash) Reset() {
 	*x = TargetFileHash{}
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[20]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1748,7 +2000,7 @@ func (x *TargetFileHash) String() string {
 func (*TargetFileHash) ProtoMessage() {}
 
 func (x *TargetFileHash) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[20]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1761,7 +2013,7 @@ func (x *TargetFileHash) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TargetFileHash.ProtoReflect.Descriptor instead.
 func (*TargetFileHash) Descriptor() ([]byte, []int) {
-	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{20}
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *TargetFileHash) GetAlgorithm() string {
@@ -1789,7 +2041,7 @@ type TargetFileMeta struct {
 
 func (x *TargetFileMeta) Reset() {
 	*x = TargetFileMeta{}
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[21]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1801,7 +2053,7 @@ func (x *TargetFileMeta) String() string {
 func (*TargetFileMeta) ProtoMessage() {}
 
 func (x *TargetFileMeta) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[21]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1814,7 +2066,7 @@ func (x *TargetFileMeta) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TargetFileMeta.ProtoReflect.Descriptor instead.
 func (*TargetFileMeta) Descriptor() ([]byte, []int) {
-	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{21}
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *TargetFileMeta) GetPath() string {
@@ -1856,7 +2108,7 @@ type ConfigSubscriptionRequest struct {
 
 func (x *ConfigSubscriptionRequest) Reset() {
 	*x = ConfigSubscriptionRequest{}
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[22]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1868,7 +2120,7 @@ func (x *ConfigSubscriptionRequest) String() string {
 func (*ConfigSubscriptionRequest) ProtoMessage() {}
 
 func (x *ConfigSubscriptionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[22]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1881,7 +2133,7 @@ func (x *ConfigSubscriptionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConfigSubscriptionRequest.ProtoReflect.Descriptor instead.
 func (*ConfigSubscriptionRequest) Descriptor() ([]byte, []int) {
-	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{22}
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *ConfigSubscriptionRequest) GetRuntimeId() string {
@@ -1925,7 +2177,7 @@ type ConfigSubscriptionResponse struct {
 
 func (x *ConfigSubscriptionResponse) Reset() {
 	*x = ConfigSubscriptionResponse{}
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[23]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1937,7 +2189,7 @@ func (x *ConfigSubscriptionResponse) String() string {
 func (*ConfigSubscriptionResponse) ProtoMessage() {}
 
 func (x *ConfigSubscriptionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[23]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1950,7 +2202,7 @@ func (x *ConfigSubscriptionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConfigSubscriptionResponse.ProtoReflect.Descriptor instead.
 func (*ConfigSubscriptionResponse) Descriptor() ([]byte, []int) {
-	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{23}
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *ConfigSubscriptionResponse) GetClient() *Client {
@@ -1984,7 +2236,7 @@ type ClientGetConfigsRequest struct {
 
 func (x *ClientGetConfigsRequest) Reset() {
 	*x = ClientGetConfigsRequest{}
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[24]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1996,7 +2248,7 @@ func (x *ClientGetConfigsRequest) String() string {
 func (*ClientGetConfigsRequest) ProtoMessage() {}
 
 func (x *ClientGetConfigsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[24]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2009,7 +2261,7 @@ func (x *ClientGetConfigsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClientGetConfigsRequest.ProtoReflect.Descriptor instead.
 func (*ClientGetConfigsRequest) Descriptor() ([]byte, []int) {
-	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{24}
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *ClientGetConfigsRequest) GetClient() *Client {
@@ -2039,7 +2291,7 @@ type ClientGetConfigsResponse struct {
 
 func (x *ClientGetConfigsResponse) Reset() {
 	*x = ClientGetConfigsResponse{}
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[25]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2051,7 +2303,7 @@ func (x *ClientGetConfigsResponse) String() string {
 func (*ClientGetConfigsResponse) ProtoMessage() {}
 
 func (x *ClientGetConfigsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[25]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2064,7 +2316,7 @@ func (x *ClientGetConfigsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClientGetConfigsResponse.ProtoReflect.Descriptor instead.
 func (*ClientGetConfigsResponse) Descriptor() ([]byte, []int) {
-	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{25}
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *ClientGetConfigsResponse) GetRoots() [][]byte {
@@ -2112,7 +2364,7 @@ type FileMetaState struct {
 
 func (x *FileMetaState) Reset() {
 	*x = FileMetaState{}
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[26]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2124,7 +2376,7 @@ func (x *FileMetaState) String() string {
 func (*FileMetaState) ProtoMessage() {}
 
 func (x *FileMetaState) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[26]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2137,7 +2389,7 @@ func (x *FileMetaState) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FileMetaState.ProtoReflect.Descriptor instead.
 func (*FileMetaState) Descriptor() ([]byte, []int) {
-	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{26}
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *FileMetaState) GetVersion() uint64 {
@@ -2167,7 +2419,7 @@ type GetStateConfigResponse struct {
 
 func (x *GetStateConfigResponse) Reset() {
 	*x = GetStateConfigResponse{}
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[27]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2179,7 +2431,7 @@ func (x *GetStateConfigResponse) String() string {
 func (*GetStateConfigResponse) ProtoMessage() {}
 
 func (x *GetStateConfigResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[27]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2192,7 +2444,7 @@ func (x *GetStateConfigResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetStateConfigResponse.ProtoReflect.Descriptor instead.
 func (*GetStateConfigResponse) Descriptor() ([]byte, []int) {
-	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{27}
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *GetStateConfigResponse) GetConfigState() map[string]*FileMetaState {
@@ -2244,7 +2496,7 @@ type ConfigSubscriptionState struct {
 
 func (x *ConfigSubscriptionState) Reset() {
 	*x = ConfigSubscriptionState{}
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[28]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2256,7 +2508,7 @@ func (x *ConfigSubscriptionState) String() string {
 func (*ConfigSubscriptionState) ProtoMessage() {}
 
 func (x *ConfigSubscriptionState) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[28]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2269,7 +2521,7 @@ func (x *ConfigSubscriptionState) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConfigSubscriptionState.ProtoReflect.Descriptor instead.
 func (*ConfigSubscriptionState) Descriptor() ([]byte, []int) {
-	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{28}
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *ConfigSubscriptionState) GetSubscriptionId() uint64 {
@@ -2294,7 +2546,7 @@ type ResetStateConfigResponse struct {
 
 func (x *ResetStateConfigResponse) Reset() {
 	*x = ResetStateConfigResponse{}
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[29]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2306,7 +2558,7 @@ func (x *ResetStateConfigResponse) String() string {
 func (*ResetStateConfigResponse) ProtoMessage() {}
 
 func (x *ResetStateConfigResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[29]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2319,7 +2571,7 @@ func (x *ResetStateConfigResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResetStateConfigResponse.ProtoReflect.Descriptor instead.
 func (*ResetStateConfigResponse) Descriptor() ([]byte, []int) {
-	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{29}
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{32}
 }
 
 type TracerPredicateV1 struct {
@@ -2337,7 +2589,7 @@ type TracerPredicateV1 struct {
 
 func (x *TracerPredicateV1) Reset() {
 	*x = TracerPredicateV1{}
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[30]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2349,7 +2601,7 @@ func (x *TracerPredicateV1) String() string {
 func (*TracerPredicateV1) ProtoMessage() {}
 
 func (x *TracerPredicateV1) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[30]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2362,7 +2614,7 @@ func (x *TracerPredicateV1) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TracerPredicateV1.ProtoReflect.Descriptor instead.
 func (*TracerPredicateV1) Descriptor() ([]byte, []int) {
-	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{30}
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *TracerPredicateV1) GetClientID() string {
@@ -2423,7 +2675,7 @@ type TracerPredicates struct {
 
 func (x *TracerPredicates) Reset() {
 	*x = TracerPredicates{}
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[31]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2435,7 +2687,7 @@ func (x *TracerPredicates) String() string {
 func (*TracerPredicates) ProtoMessage() {}
 
 func (x *TracerPredicates) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[31]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2448,7 +2700,7 @@ func (x *TracerPredicates) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TracerPredicates.ProtoReflect.Descriptor instead.
 func (*TracerPredicates) Descriptor() ([]byte, []int) {
-	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{31}
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *TracerPredicates) GetTracerPredicatesV1() []*TracerPredicateV1 {
@@ -2469,7 +2721,7 @@ type ConfigSubscriptionState_TrackedClient struct {
 
 func (x *ConfigSubscriptionState_TrackedClient) Reset() {
 	*x = ConfigSubscriptionState_TrackedClient{}
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[35]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2481,7 +2733,7 @@ func (x *ConfigSubscriptionState_TrackedClient) String() string {
 func (*ConfigSubscriptionState_TrackedClient) ProtoMessage() {}
 
 func (x *ConfigSubscriptionState_TrackedClient) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[35]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2494,7 +2746,7 @@ func (x *ConfigSubscriptionState_TrackedClient) ProtoReflect() protoreflect.Mess
 
 // Deprecated: Use ConfigSubscriptionState_TrackedClient.ProtoReflect.Descriptor instead.
 func (*ConfigSubscriptionState_TrackedClient) Descriptor() ([]byte, []int) {
-	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{28, 0}
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{31, 0}
 }
 
 func (x *ConfigSubscriptionState_TrackedClient) GetRuntimeId() string {
@@ -2632,14 +2884,34 @@ const file_datadog_remoteconfig_remoteconfig_proto_rawDesc = "" +
 	"\x04Task\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12/\n" +
 	"\x05state\x18\x02 \x01(\x0e2\x19.datadog.config.TaskStateR\x05state\x12/\n" +
-	"\x05error\x18\x03 \x01(\v2\x19.datadog.config.TaskErrorR\x05error\"\xa3\x01\n" +
+	"\x05error\x18\x03 \x01(\v2\x19.datadog.config.TaskErrorR\x05error\"\xa7\x02\n" +
+	"\x10DeploymentStatus\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12/\n" +
+	"\x13observed_generation\x18\x02 \x01(\x03R\x12observedGeneration\x12\x1a\n" +
+	"\breplicas\x18\x03 \x01(\x05R\breplicas\x12)\n" +
+	"\x10updated_replicas\x18\x04 \x01(\x05R\x0fupdatedReplicas\x12%\n" +
+	"\x0eready_replicas\x18\x05 \x01(\x05R\rreadyReplicas\x12-\n" +
+	"\x12available_replicas\x18\x06 \x01(\x05R\x11availableReplicas\x121\n" +
+	"\x14unavailable_replicas\x18\a \x01(\x05R\x13unavailableReplicas\"\xb2\x03\n" +
+	"\x0fDaemonSetStatus\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x128\n" +
+	"\x18current_number_scheduled\x18\x02 \x01(\x05R\x16currentNumberScheduled\x12/\n" +
+	"\x13number_misscheduled\x18\x03 \x01(\x05R\x12numberMisscheduled\x128\n" +
+	"\x18desired_number_scheduled\x18\x04 \x01(\x05R\x16desiredNumberScheduled\x12!\n" +
+	"\fnumber_ready\x18\x05 \x01(\x05R\vnumberReady\x12/\n" +
+	"\x13observed_generation\x18\x06 \x01(\x03R\x12observedGeneration\x128\n" +
+	"\x18updated_number_scheduled\x18\a \x01(\x05R\x16updatedNumberScheduled\x12)\n" +
+	"\x10number_available\x18\b \x01(\x05R\x0fnumberAvailable\x12-\n" +
+	"\x12number_unavailable\x18\t \x01(\x05R\x11numberUnavailable\"\x8f\x01\n" +
+	"\aRollout\x12B\n" +
+	"\vdeployments\x18\x01 \x03(\v2 .datadog.config.DeploymentStatusR\vdeployments\x12@\n" +
+	"\vdaemon_sets\x18\x02 \x03(\v2\x1f.datadog.config.DaemonSetStatusR\n" +
+	"daemonSets\"\xc6\x01\n" +
 	"\n" +
 	"FleetState\x12%\n" +
-	"\x0econfig_version\x18\x01 \x01(\tR\rconfigVersion\x12\x1e\n" +
-	"\n" +
-	"experiment\x18\x02 \x01(\bR\n" +
-	"experiment\x12(\n" +
-	"\x04task\x18\x03 \x01(\v2\x14.datadog.config.TaskR\x04task\x12$\n" +
+	"\x0econfig_version\x18\x01 \x01(\tR\rconfigVersion\x12+\n" +
+	"\x11config_experiment\x18\x02 \x01(\bR\x10configExperiment\x12>\n" +
+	"\x0econfig_rollout\x18\x03 \x01(\v2\x17.datadog.config.RolloutR\rconfigRollout\x12$\n" +
 	"\x0esecret_pub_key\x18\x04 \x01(\tR\fsecretPubKey\"O\n" +
 	"\x0eClientOperator\x12=\n" +
 	"\ffleet_states\x18\x01 \x03(\v2\x1a.datadog.config.FleetStateR\vfleetStates\"9\n" +
@@ -2755,7 +3027,7 @@ func file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP() []byte {
 }
 
 var file_datadog_remoteconfig_remoteconfig_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_datadog_remoteconfig_remoteconfig_proto_msgTypes = make([]protoimpl.MessageInfo, 36)
+var file_datadog_remoteconfig_remoteconfig_proto_msgTypes = make([]protoimpl.MessageInfo, 39)
 var file_datadog_remoteconfig_remoteconfig_proto_goTypes = []any{
 	(TaskState)(0),                                // 0: datadog.config.TaskState
 	(ConfigSubscriptionProducts)(0),               // 1: datadog.config.ConfigSubscriptionProducts
@@ -2776,27 +3048,30 @@ var file_datadog_remoteconfig_remoteconfig_proto_goTypes = []any{
 	(*ClientUpdater)(nil),                         // 16: datadog.config.ClientUpdater
 	(*PackageState)(nil),                          // 17: datadog.config.PackageState
 	(*Task)(nil),                                  // 18: datadog.config.Task
-	(*FleetState)(nil),                            // 19: datadog.config.FleetState
-	(*ClientOperator)(nil),                        // 20: datadog.config.ClientOperator
-	(*TaskError)(nil),                             // 21: datadog.config.TaskError
-	(*ConfigState)(nil),                           // 22: datadog.config.ConfigState
-	(*ClientState)(nil),                           // 23: datadog.config.ClientState
-	(*TargetFileHash)(nil),                        // 24: datadog.config.TargetFileHash
-	(*TargetFileMeta)(nil),                        // 25: datadog.config.TargetFileMeta
-	(*ConfigSubscriptionRequest)(nil),             // 26: datadog.config.ConfigSubscriptionRequest
-	(*ConfigSubscriptionResponse)(nil),            // 27: datadog.config.ConfigSubscriptionResponse
-	(*ClientGetConfigsRequest)(nil),               // 28: datadog.config.ClientGetConfigsRequest
-	(*ClientGetConfigsResponse)(nil),              // 29: datadog.config.ClientGetConfigsResponse
-	(*FileMetaState)(nil),                         // 30: datadog.config.FileMetaState
-	(*GetStateConfigResponse)(nil),                // 31: datadog.config.GetStateConfigResponse
-	(*ConfigSubscriptionState)(nil),               // 32: datadog.config.ConfigSubscriptionState
-	(*ResetStateConfigResponse)(nil),              // 33: datadog.config.ResetStateConfigResponse
-	(*TracerPredicateV1)(nil),                     // 34: datadog.config.TracerPredicateV1
-	(*TracerPredicates)(nil),                      // 35: datadog.config.TracerPredicates
-	nil,                                           // 36: datadog.config.GetStateConfigResponse.ConfigStateEntry
-	nil,                                           // 37: datadog.config.GetStateConfigResponse.DirectorStateEntry
-	nil,                                           // 38: datadog.config.GetStateConfigResponse.TargetFilenamesEntry
-	(*ConfigSubscriptionState_TrackedClient)(nil), // 39: datadog.config.ConfigSubscriptionState.TrackedClient
+	(*DeploymentStatus)(nil),                      // 19: datadog.config.DeploymentStatus
+	(*DaemonSetStatus)(nil),                       // 20: datadog.config.DaemonSetStatus
+	(*Rollout)(nil),                               // 21: datadog.config.Rollout
+	(*FleetState)(nil),                            // 22: datadog.config.FleetState
+	(*ClientOperator)(nil),                        // 23: datadog.config.ClientOperator
+	(*TaskError)(nil),                             // 24: datadog.config.TaskError
+	(*ConfigState)(nil),                           // 25: datadog.config.ConfigState
+	(*ClientState)(nil),                           // 26: datadog.config.ClientState
+	(*TargetFileHash)(nil),                        // 27: datadog.config.TargetFileHash
+	(*TargetFileMeta)(nil),                        // 28: datadog.config.TargetFileMeta
+	(*ConfigSubscriptionRequest)(nil),             // 29: datadog.config.ConfigSubscriptionRequest
+	(*ConfigSubscriptionResponse)(nil),            // 30: datadog.config.ConfigSubscriptionResponse
+	(*ClientGetConfigsRequest)(nil),               // 31: datadog.config.ClientGetConfigsRequest
+	(*ClientGetConfigsResponse)(nil),              // 32: datadog.config.ClientGetConfigsResponse
+	(*FileMetaState)(nil),                         // 33: datadog.config.FileMetaState
+	(*GetStateConfigResponse)(nil),                // 34: datadog.config.GetStateConfigResponse
+	(*ConfigSubscriptionState)(nil),               // 35: datadog.config.ConfigSubscriptionState
+	(*ResetStateConfigResponse)(nil),              // 36: datadog.config.ResetStateConfigResponse
+	(*TracerPredicateV1)(nil),                     // 37: datadog.config.TracerPredicateV1
+	(*TracerPredicates)(nil),                      // 38: datadog.config.TracerPredicates
+	nil,                                           // 39: datadog.config.GetStateConfigResponse.ConfigStateEntry
+	nil,                                           // 40: datadog.config.GetStateConfigResponse.DirectorStateEntry
+	nil,                                           // 41: datadog.config.GetStateConfigResponse.TargetFilenamesEntry
+	(*ConfigSubscriptionState_TrackedClient)(nil), // 42: datadog.config.ConfigSubscriptionState.TrackedClient
 }
 var file_datadog_remoteconfig_remoteconfig_proto_depIdxs = []int32{
 	7,  // 0: datadog.config.ConfigMetas.roots:type_name -> datadog.config.TopMeta
@@ -2812,42 +3087,44 @@ var file_datadog_remoteconfig_remoteconfig_proto_depIdxs = []int32{
 	4,  // 10: datadog.config.LatestConfigsResponse.config_metas:type_name -> datadog.config.ConfigMetas
 	5,  // 11: datadog.config.LatestConfigsResponse.director_metas:type_name -> datadog.config.DirectorMetas
 	8,  // 12: datadog.config.LatestConfigsResponse.target_files:type_name -> datadog.config.File
-	23, // 13: datadog.config.Client.state:type_name -> datadog.config.ClientState
+	26, // 13: datadog.config.Client.state:type_name -> datadog.config.ClientState
 	14, // 14: datadog.config.Client.client_tracer:type_name -> datadog.config.ClientTracer
 	15, // 15: datadog.config.Client.client_agent:type_name -> datadog.config.ClientAgent
 	16, // 16: datadog.config.Client.client_updater:type_name -> datadog.config.ClientUpdater
-	20, // 17: datadog.config.Client.client_operator:type_name -> datadog.config.ClientOperator
+	23, // 17: datadog.config.Client.client_operator:type_name -> datadog.config.ClientOperator
 	17, // 18: datadog.config.ClientUpdater.packages:type_name -> datadog.config.PackageState
 	18, // 19: datadog.config.PackageState.task:type_name -> datadog.config.Task
 	0,  // 20: datadog.config.Task.state:type_name -> datadog.config.TaskState
-	21, // 21: datadog.config.Task.error:type_name -> datadog.config.TaskError
-	18, // 22: datadog.config.FleetState.task:type_name -> datadog.config.Task
-	19, // 23: datadog.config.ClientOperator.fleet_states:type_name -> datadog.config.FleetState
-	22, // 24: datadog.config.ClientState.config_states:type_name -> datadog.config.ConfigState
-	24, // 25: datadog.config.TargetFileMeta.hashes:type_name -> datadog.config.TargetFileHash
-	3,  // 26: datadog.config.ConfigSubscriptionRequest.action:type_name -> datadog.config.ConfigSubscriptionRequest.Action
-	1,  // 27: datadog.config.ConfigSubscriptionRequest.products:type_name -> datadog.config.ConfigSubscriptionProducts
-	13, // 28: datadog.config.ConfigSubscriptionResponse.client:type_name -> datadog.config.Client
-	8,  // 29: datadog.config.ConfigSubscriptionResponse.target_files:type_name -> datadog.config.File
-	13, // 30: datadog.config.ClientGetConfigsRequest.client:type_name -> datadog.config.Client
-	25, // 31: datadog.config.ClientGetConfigsRequest.cached_target_files:type_name -> datadog.config.TargetFileMeta
-	8,  // 32: datadog.config.ClientGetConfigsResponse.target_files:type_name -> datadog.config.File
-	2,  // 33: datadog.config.ClientGetConfigsResponse.config_status:type_name -> datadog.config.ConfigStatus
-	36, // 34: datadog.config.GetStateConfigResponse.config_state:type_name -> datadog.config.GetStateConfigResponse.ConfigStateEntry
-	37, // 35: datadog.config.GetStateConfigResponse.director_state:type_name -> datadog.config.GetStateConfigResponse.DirectorStateEntry
-	38, // 36: datadog.config.GetStateConfigResponse.target_filenames:type_name -> datadog.config.GetStateConfigResponse.TargetFilenamesEntry
-	13, // 37: datadog.config.GetStateConfigResponse.active_clients:type_name -> datadog.config.Client
-	32, // 38: datadog.config.GetStateConfigResponse.config_subscription_states:type_name -> datadog.config.ConfigSubscriptionState
-	39, // 39: datadog.config.ConfigSubscriptionState.tracked_clients:type_name -> datadog.config.ConfigSubscriptionState.TrackedClient
-	34, // 40: datadog.config.TracerPredicates.tracer_predicates_v1:type_name -> datadog.config.TracerPredicateV1
-	30, // 41: datadog.config.GetStateConfigResponse.ConfigStateEntry.value:type_name -> datadog.config.FileMetaState
-	30, // 42: datadog.config.GetStateConfigResponse.DirectorStateEntry.value:type_name -> datadog.config.FileMetaState
-	1,  // 43: datadog.config.ConfigSubscriptionState.TrackedClient.products:type_name -> datadog.config.ConfigSubscriptionProducts
-	44, // [44:44] is the sub-list for method output_type
-	44, // [44:44] is the sub-list for method input_type
-	44, // [44:44] is the sub-list for extension type_name
-	44, // [44:44] is the sub-list for extension extendee
-	0,  // [0:44] is the sub-list for field type_name
+	24, // 21: datadog.config.Task.error:type_name -> datadog.config.TaskError
+	19, // 22: datadog.config.Rollout.deployments:type_name -> datadog.config.DeploymentStatus
+	20, // 23: datadog.config.Rollout.daemon_sets:type_name -> datadog.config.DaemonSetStatus
+	21, // 24: datadog.config.FleetState.config_rollout:type_name -> datadog.config.Rollout
+	22, // 25: datadog.config.ClientOperator.fleet_states:type_name -> datadog.config.FleetState
+	25, // 26: datadog.config.ClientState.config_states:type_name -> datadog.config.ConfigState
+	27, // 27: datadog.config.TargetFileMeta.hashes:type_name -> datadog.config.TargetFileHash
+	3,  // 28: datadog.config.ConfigSubscriptionRequest.action:type_name -> datadog.config.ConfigSubscriptionRequest.Action
+	1,  // 29: datadog.config.ConfigSubscriptionRequest.products:type_name -> datadog.config.ConfigSubscriptionProducts
+	13, // 30: datadog.config.ConfigSubscriptionResponse.client:type_name -> datadog.config.Client
+	8,  // 31: datadog.config.ConfigSubscriptionResponse.target_files:type_name -> datadog.config.File
+	13, // 32: datadog.config.ClientGetConfigsRequest.client:type_name -> datadog.config.Client
+	28, // 33: datadog.config.ClientGetConfigsRequest.cached_target_files:type_name -> datadog.config.TargetFileMeta
+	8,  // 34: datadog.config.ClientGetConfigsResponse.target_files:type_name -> datadog.config.File
+	2,  // 35: datadog.config.ClientGetConfigsResponse.config_status:type_name -> datadog.config.ConfigStatus
+	39, // 36: datadog.config.GetStateConfigResponse.config_state:type_name -> datadog.config.GetStateConfigResponse.ConfigStateEntry
+	40, // 37: datadog.config.GetStateConfigResponse.director_state:type_name -> datadog.config.GetStateConfigResponse.DirectorStateEntry
+	41, // 38: datadog.config.GetStateConfigResponse.target_filenames:type_name -> datadog.config.GetStateConfigResponse.TargetFilenamesEntry
+	13, // 39: datadog.config.GetStateConfigResponse.active_clients:type_name -> datadog.config.Client
+	35, // 40: datadog.config.GetStateConfigResponse.config_subscription_states:type_name -> datadog.config.ConfigSubscriptionState
+	42, // 41: datadog.config.ConfigSubscriptionState.tracked_clients:type_name -> datadog.config.ConfigSubscriptionState.TrackedClient
+	37, // 42: datadog.config.TracerPredicates.tracer_predicates_v1:type_name -> datadog.config.TracerPredicateV1
+	33, // 43: datadog.config.GetStateConfigResponse.ConfigStateEntry.value:type_name -> datadog.config.FileMetaState
+	33, // 44: datadog.config.GetStateConfigResponse.DirectorStateEntry.value:type_name -> datadog.config.FileMetaState
+	1,  // 45: datadog.config.ConfigSubscriptionState.TrackedClient.products:type_name -> datadog.config.ConfigSubscriptionProducts
+	46, // [46:46] is the sub-list for method output_type
+	46, // [46:46] is the sub-list for method input_type
+	46, // [46:46] is the sub-list for extension type_name
+	46, // [46:46] is the sub-list for extension extendee
+	0,  // [0:46] is the sub-list for field type_name
 }
 
 func init() { file_datadog_remoteconfig_remoteconfig_proto_init() }
@@ -2861,7 +3138,7 @@ func file_datadog_remoteconfig_remoteconfig_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_datadog_remoteconfig_remoteconfig_proto_rawDesc), len(file_datadog_remoteconfig_remoteconfig_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   36,
+			NumMessages:   39,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/pkg/proto/pbgo/core/remoteconfig.pb.go
+++ b/pkg/proto/pbgo/core/remoteconfig.pb.go
@@ -1657,10 +1657,10 @@ func (x *Rollout) GetDaemonSets() []*DaemonSetStatus {
 type FleetState struct {
 	state            protoimpl.MessageState `protogen:"open.v1"`
 	ConfigVersion    string                 `protobuf:"bytes,1,opt,name=config_version,json=configVersion,proto3" json:"config_version,omitempty"`
-	ConfigTask       *Task                  `protobuf:"bytes,5,opt,name=config_task,json=configTask,proto3" json:"config_task,omitempty"`
-	ConfigExperiment bool                   `protobuf:"varint,2,opt,name=config_experiment,json=configExperiment,proto3" json:"config_experiment,omitempty"`
-	ConfigRollout    *Rollout               `protobuf:"bytes,3,opt,name=config_rollout,json=configRollout,proto3" json:"config_rollout,omitempty"`
-	SecretPubKey     string                 `protobuf:"bytes,4,opt,name=secret_pub_key,json=secretPubKey,proto3" json:"secret_pub_key,omitempty"`
+	ConfigTask       *Task                  `protobuf:"bytes,2,opt,name=config_task,json=configTask,proto3" json:"config_task,omitempty"`
+	ConfigExperiment bool                   `protobuf:"varint,3,opt,name=config_experiment,json=configExperiment,proto3" json:"config_experiment,omitempty"`
+	ConfigRollout    *Rollout               `protobuf:"bytes,4,opt,name=config_rollout,json=configRollout,proto3" json:"config_rollout,omitempty"`
+	SecretPubKey     string                 `protobuf:"bytes,5,opt,name=secret_pub_key,json=secretPubKey,proto3" json:"secret_pub_key,omitempty"`
 	unknownFields    protoimpl.UnknownFields
 	sizeCache        protoimpl.SizeCache
 }
@@ -2918,11 +2918,11 @@ const file_datadog_remoteconfig_remoteconfig_proto_rawDesc = "" +
 	"\n" +
 	"FleetState\x12%\n" +
 	"\x0econfig_version\x18\x01 \x01(\tR\rconfigVersion\x125\n" +
-	"\vconfig_task\x18\x05 \x01(\v2\x14.datadog.config.TaskR\n" +
+	"\vconfig_task\x18\x02 \x01(\v2\x14.datadog.config.TaskR\n" +
 	"configTask\x12+\n" +
-	"\x11config_experiment\x18\x02 \x01(\bR\x10configExperiment\x12>\n" +
-	"\x0econfig_rollout\x18\x03 \x01(\v2\x17.datadog.config.RolloutR\rconfigRollout\x12$\n" +
-	"\x0esecret_pub_key\x18\x04 \x01(\tR\fsecretPubKey\"O\n" +
+	"\x11config_experiment\x18\x03 \x01(\bR\x10configExperiment\x12>\n" +
+	"\x0econfig_rollout\x18\x04 \x01(\v2\x17.datadog.config.RolloutR\rconfigRollout\x12$\n" +
+	"\x0esecret_pub_key\x18\x05 \x01(\tR\fsecretPubKey\"O\n" +
 	"\x0eClientOperator\x12=\n" +
 	"\ffleet_states\x18\x01 \x03(\v2\x1a.datadog.config.FleetStateR\vfleetStates\"9\n" +
 	"\tTaskError\x12\x12\n" +

--- a/pkg/proto/pbgo/core/remoteconfig_gen.go
+++ b/pkg/proto/pbgo/core/remoteconfig_gen.go
@@ -9,9 +9,9 @@ import (
 // MarshalMsg implements msgp.Marshaler
 func (z *Client) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
-	// map header, size 11
+	// map header, size 13
 	// string "State"
-	o = append(o, 0x8b, 0xa5, 0x53, 0x74, 0x61, 0x74, 0x65)
+	o = append(o, 0x8d, 0xa5, 0x53, 0x74, 0x61, 0x74, 0x65)
 	if z.State == nil {
 		o = msgp.AppendNil(o)
 	} else {
@@ -76,6 +76,30 @@ func (z *Client) MarshalMsg(b []byte) (o []byte, err error) {
 		if err != nil {
 			err = msgp.WrapError(err, "ClientUpdater")
 			return
+		}
+	}
+	// string "IsOperator"
+	o = append(o, 0xaa, 0x49, 0x73, 0x4f, 0x70, 0x65, 0x72, 0x61, 0x74, 0x6f, 0x72)
+	o = msgp.AppendBool(o, z.IsOperator)
+	// string "ClientOperator"
+	o = append(o, 0xae, 0x43, 0x6c, 0x69, 0x65, 0x6e, 0x74, 0x4f, 0x70, 0x65, 0x72, 0x61, 0x74, 0x6f, 0x72)
+	if z.ClientOperator == nil {
+		o = msgp.AppendNil(o)
+	} else {
+		// map header, size 1
+		// string "FleetStates"
+		o = append(o, 0x81, 0xab, 0x46, 0x6c, 0x65, 0x65, 0x74, 0x53, 0x74, 0x61, 0x74, 0x65, 0x73)
+		o = msgp.AppendArrayHeader(o, uint32(len(z.ClientOperator.FleetStates)))
+		for za0002 := range z.ClientOperator.FleetStates {
+			if z.ClientOperator.FleetStates[za0002] == nil {
+				o = msgp.AppendNil(o)
+			} else {
+				o, err = z.ClientOperator.FleetStates[za0002].MarshalMsg(o)
+				if err != nil {
+					err = msgp.WrapError(err, "ClientOperator", "FleetStates", za0002)
+					return
+				}
+			}
 		}
 	}
 	return
@@ -222,6 +246,76 @@ func (z *Client) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+		case "IsOperator":
+			z.IsOperator, bts, err = msgp.ReadBoolBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "IsOperator")
+				return
+			}
+		case "ClientOperator":
+			if msgp.IsNil(bts) {
+				bts, err = msgp.ReadNilBytes(bts)
+				if err != nil {
+					return
+				}
+				z.ClientOperator = nil
+			} else {
+				if z.ClientOperator == nil {
+					z.ClientOperator = new(ClientOperator)
+				}
+				var zb0003 uint32
+				zb0003, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "ClientOperator")
+					return
+				}
+				for zb0003 > 0 {
+					zb0003--
+					field, bts, err = msgp.ReadMapKeyZC(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "ClientOperator")
+						return
+					}
+					switch msgp.UnsafeString(field) {
+					case "FleetStates":
+						var zb0004 uint32
+						zb0004, bts, err = msgp.ReadArrayHeaderBytes(bts)
+						if err != nil {
+							err = msgp.WrapError(err, "ClientOperator", "FleetStates")
+							return
+						}
+						if cap(z.ClientOperator.FleetStates) >= int(zb0004) {
+							z.ClientOperator.FleetStates = (z.ClientOperator.FleetStates)[:zb0004]
+						} else {
+							z.ClientOperator.FleetStates = make([]*FleetState, zb0004)
+						}
+						for za0002 := range z.ClientOperator.FleetStates {
+							if msgp.IsNil(bts) {
+								bts, err = msgp.ReadNilBytes(bts)
+								if err != nil {
+									return
+								}
+								z.ClientOperator.FleetStates[za0002] = nil
+							} else {
+								if z.ClientOperator.FleetStates[za0002] == nil {
+									z.ClientOperator.FleetStates[za0002] = new(FleetState)
+								}
+								bts, err = z.ClientOperator.FleetStates[za0002].UnmarshalMsg(bts)
+								if err != nil {
+									err = msgp.WrapError(err, "ClientOperator", "FleetStates", za0002)
+									return
+								}
+							}
+						}
+					default:
+						bts, err = msgp.Skip(bts)
+						if err != nil {
+							err = msgp.WrapError(err, "ClientOperator")
+							return
+						}
+					}
+				}
+			}
 		default:
 			bts, err = msgp.Skip(bts)
 			if err != nil {
@@ -263,6 +357,19 @@ func (z *Client) Msgsize() (s int) {
 		s += msgp.NilSize
 	} else {
 		s += z.ClientUpdater.Msgsize()
+	}
+	s += 11 + msgp.BoolSize + 15
+	if z.ClientOperator == nil {
+		s += msgp.NilSize
+	} else {
+		s += 1 + 12 + msgp.ArrayHeaderSize
+		for za0002 := range z.ClientOperator.FleetStates {
+			if z.ClientOperator.FleetStates[za0002] == nil {
+				s += msgp.NilSize
+			} else {
+				s += z.ClientOperator.FleetStates[za0002].Msgsize()
+			}
+		}
 	}
 	return
 }
@@ -705,6 +812,100 @@ func (z *ClientGetConfigsResponse) Msgsize() (s int) {
 		s += msgp.StringPrefixSize + len(z.ClientConfigs[za0003])
 	}
 	s += 13 + msgp.Int32Size
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *ClientOperator) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 1
+	// string "FleetStates"
+	o = append(o, 0x81, 0xab, 0x46, 0x6c, 0x65, 0x65, 0x74, 0x53, 0x74, 0x61, 0x74, 0x65, 0x73)
+	o = msgp.AppendArrayHeader(o, uint32(len(z.FleetStates)))
+	for za0001 := range z.FleetStates {
+		if z.FleetStates[za0001] == nil {
+			o = msgp.AppendNil(o)
+		} else {
+			o, err = z.FleetStates[za0001].MarshalMsg(o)
+			if err != nil {
+				err = msgp.WrapError(err, "FleetStates", za0001)
+				return
+			}
+		}
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *ClientOperator) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "FleetStates":
+			var zb0002 uint32
+			zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "FleetStates")
+				return
+			}
+			if cap(z.FleetStates) >= int(zb0002) {
+				z.FleetStates = (z.FleetStates)[:zb0002]
+			} else {
+				z.FleetStates = make([]*FleetState, zb0002)
+			}
+			for za0001 := range z.FleetStates {
+				if msgp.IsNil(bts) {
+					bts, err = msgp.ReadNilBytes(bts)
+					if err != nil {
+						return
+					}
+					z.FleetStates[za0001] = nil
+				} else {
+					if z.FleetStates[za0001] == nil {
+						z.FleetStates[za0001] = new(FleetState)
+					}
+					bts, err = z.FleetStates[za0001].UnmarshalMsg(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "FleetStates", za0001)
+						return
+					}
+				}
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *ClientOperator) Msgsize() (s int) {
+	s = 1 + 12 + msgp.ArrayHeaderSize
+	for za0001 := range z.FleetStates {
+		if z.FleetStates[za0001] == nil {
+			s += msgp.NilSize
+		} else {
+			s += z.FleetStates[za0001].Msgsize()
+		}
+	}
 	return
 }
 
@@ -2786,6 +2987,110 @@ func (z FileMetaState) Msgsize() (s int) {
 }
 
 // MarshalMsg implements msgp.Marshaler
+func (z *FleetState) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 4
+	// string "ConfigVersion"
+	o = append(o, 0x84, 0xad, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x56, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e)
+	o = msgp.AppendString(o, z.ConfigVersion)
+	// string "Experiment"
+	o = append(o, 0xaa, 0x45, 0x78, 0x70, 0x65, 0x72, 0x69, 0x6d, 0x65, 0x6e, 0x74)
+	o = msgp.AppendBool(o, z.Experiment)
+	// string "Task"
+	o = append(o, 0xa4, 0x54, 0x61, 0x73, 0x6b)
+	if z.Task == nil {
+		o = msgp.AppendNil(o)
+	} else {
+		o, err = z.Task.MarshalMsg(o)
+		if err != nil {
+			err = msgp.WrapError(err, "Task")
+			return
+		}
+	}
+	// string "SecretPubKey"
+	o = append(o, 0xac, 0x53, 0x65, 0x63, 0x72, 0x65, 0x74, 0x50, 0x75, 0x62, 0x4b, 0x65, 0x79)
+	o = msgp.AppendString(o, z.SecretPubKey)
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *FleetState) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "ConfigVersion":
+			z.ConfigVersion, bts, err = msgp.ReadStringBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "ConfigVersion")
+				return
+			}
+		case "Experiment":
+			z.Experiment, bts, err = msgp.ReadBoolBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Experiment")
+				return
+			}
+		case "Task":
+			if msgp.IsNil(bts) {
+				bts, err = msgp.ReadNilBytes(bts)
+				if err != nil {
+					return
+				}
+				z.Task = nil
+			} else {
+				if z.Task == nil {
+					z.Task = new(Task)
+				}
+				bts, err = z.Task.UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Task")
+					return
+				}
+			}
+		case "SecretPubKey":
+			z.SecretPubKey, bts, err = msgp.ReadStringBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "SecretPubKey")
+				return
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *FleetState) Msgsize() (s int) {
+	s = 1 + 14 + msgp.StringPrefixSize + len(z.ConfigVersion) + 11 + msgp.BoolSize + 5
+	if z.Task == nil {
+		s += msgp.NilSize
+	} else {
+		s += z.Task.Msgsize()
+	}
+	s += 13 + msgp.StringPrefixSize + len(z.SecretPubKey)
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
 func (z *GetStateConfigResponse) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
 	// map header, size 5
@@ -3955,7 +4260,7 @@ func (z *PackageState) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				z.Task = nil
 			} else {
 				if z.Task == nil {
-					z.Task = new(PackageStateTask)
+					z.Task = new(Task)
 				}
 				bts, err = z.Task.UnmarshalMsg(bts)
 				if err != nil {
@@ -4008,135 +4313,6 @@ func (z *PackageState) Msgsize() (s int) {
 		s += z.Task.Msgsize()
 	}
 	s += 20 + msgp.StringPrefixSize + len(z.StableConfigVersion) + 24 + msgp.StringPrefixSize + len(z.ExperimentConfigVersion) + 15 + msgp.StringPrefixSize + len(z.RunningVersion) + 21 + msgp.StringPrefixSize + len(z.RunningConfigVersion)
-	return
-}
-
-// MarshalMsg implements msgp.Marshaler
-func (z *PackageStateTask) MarshalMsg(b []byte) (o []byte, err error) {
-	o = msgp.Require(b, z.Msgsize())
-	// map header, size 3
-	// string "Id"
-	o = append(o, 0x83, 0xa2, 0x49, 0x64)
-	o = msgp.AppendString(o, z.Id)
-	// string "State"
-	o = append(o, 0xa5, 0x53, 0x74, 0x61, 0x74, 0x65)
-	o = msgp.AppendInt32(o, int32(z.State))
-	// string "Error"
-	o = append(o, 0xa5, 0x45, 0x72, 0x72, 0x6f, 0x72)
-	if z.Error == nil {
-		o = msgp.AppendNil(o)
-	} else {
-		// map header, size 2
-		// string "Code"
-		o = append(o, 0x82, 0xa4, 0x43, 0x6f, 0x64, 0x65)
-		o = msgp.AppendUint64(o, z.Error.Code)
-		// string "Message"
-		o = append(o, 0xa7, 0x4d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65)
-		o = msgp.AppendString(o, z.Error.Message)
-	}
-	return
-}
-
-// UnmarshalMsg implements msgp.Unmarshaler
-func (z *PackageStateTask) UnmarshalMsg(bts []byte) (o []byte, err error) {
-	var field []byte
-	_ = field
-	var zb0001 uint32
-	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
-	if err != nil {
-		err = msgp.WrapError(err)
-		return
-	}
-	for zb0001 > 0 {
-		zb0001--
-		field, bts, err = msgp.ReadMapKeyZC(bts)
-		if err != nil {
-			err = msgp.WrapError(err)
-			return
-		}
-		switch msgp.UnsafeString(field) {
-		case "Id":
-			z.Id, bts, err = msgp.ReadStringBytes(bts)
-			if err != nil {
-				err = msgp.WrapError(err, "Id")
-				return
-			}
-		case "State":
-			{
-				var zb0002 int32
-				zb0002, bts, err = msgp.ReadInt32Bytes(bts)
-				if err != nil {
-					err = msgp.WrapError(err, "State")
-					return
-				}
-				z.State = TaskState(zb0002)
-			}
-		case "Error":
-			if msgp.IsNil(bts) {
-				bts, err = msgp.ReadNilBytes(bts)
-				if err != nil {
-					return
-				}
-				z.Error = nil
-			} else {
-				if z.Error == nil {
-					z.Error = new(TaskError)
-				}
-				var zb0003 uint32
-				zb0003, bts, err = msgp.ReadMapHeaderBytes(bts)
-				if err != nil {
-					err = msgp.WrapError(err, "Error")
-					return
-				}
-				for zb0003 > 0 {
-					zb0003--
-					field, bts, err = msgp.ReadMapKeyZC(bts)
-					if err != nil {
-						err = msgp.WrapError(err, "Error")
-						return
-					}
-					switch msgp.UnsafeString(field) {
-					case "Code":
-						z.Error.Code, bts, err = msgp.ReadUint64Bytes(bts)
-						if err != nil {
-							err = msgp.WrapError(err, "Error", "Code")
-							return
-						}
-					case "Message":
-						z.Error.Message, bts, err = msgp.ReadStringBytes(bts)
-						if err != nil {
-							err = msgp.WrapError(err, "Error", "Message")
-							return
-						}
-					default:
-						bts, err = msgp.Skip(bts)
-						if err != nil {
-							err = msgp.WrapError(err, "Error")
-							return
-						}
-					}
-				}
-			}
-		default:
-			bts, err = msgp.Skip(bts)
-			if err != nil {
-				err = msgp.WrapError(err)
-				return
-			}
-		}
-	}
-	o = bts
-	return
-}
-
-// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
-func (z *PackageStateTask) Msgsize() (s int) {
-	s = 1 + 3 + msgp.StringPrefixSize + len(z.Id) + 6 + msgp.Int32Size + 6
-	if z.Error == nil {
-		s += msgp.NilSize
-	} else {
-		s += 1 + 5 + msgp.Uint64Size + 8 + msgp.StringPrefixSize + len(z.Error.Message)
-	}
 	return
 }
 
@@ -4385,6 +4561,135 @@ func (z *TargetFileMeta) Msgsize() (s int) {
 		} else {
 			s += 1 + 10 + msgp.StringPrefixSize + len(z.Hashes[za0001].Algorithm) + 5 + msgp.StringPrefixSize + len(z.Hashes[za0001].Hash)
 		}
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *Task) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 3
+	// string "Id"
+	o = append(o, 0x83, 0xa2, 0x49, 0x64)
+	o = msgp.AppendString(o, z.Id)
+	// string "State"
+	o = append(o, 0xa5, 0x53, 0x74, 0x61, 0x74, 0x65)
+	o = msgp.AppendInt32(o, int32(z.State))
+	// string "Error"
+	o = append(o, 0xa5, 0x45, 0x72, 0x72, 0x6f, 0x72)
+	if z.Error == nil {
+		o = msgp.AppendNil(o)
+	} else {
+		// map header, size 2
+		// string "Code"
+		o = append(o, 0x82, 0xa4, 0x43, 0x6f, 0x64, 0x65)
+		o = msgp.AppendUint64(o, z.Error.Code)
+		// string "Message"
+		o = append(o, 0xa7, 0x4d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65)
+		o = msgp.AppendString(o, z.Error.Message)
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *Task) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Id":
+			z.Id, bts, err = msgp.ReadStringBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Id")
+				return
+			}
+		case "State":
+			{
+				var zb0002 int32
+				zb0002, bts, err = msgp.ReadInt32Bytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "State")
+					return
+				}
+				z.State = TaskState(zb0002)
+			}
+		case "Error":
+			if msgp.IsNil(bts) {
+				bts, err = msgp.ReadNilBytes(bts)
+				if err != nil {
+					return
+				}
+				z.Error = nil
+			} else {
+				if z.Error == nil {
+					z.Error = new(TaskError)
+				}
+				var zb0003 uint32
+				zb0003, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Error")
+					return
+				}
+				for zb0003 > 0 {
+					zb0003--
+					field, bts, err = msgp.ReadMapKeyZC(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Error")
+						return
+					}
+					switch msgp.UnsafeString(field) {
+					case "Code":
+						z.Error.Code, bts, err = msgp.ReadUint64Bytes(bts)
+						if err != nil {
+							err = msgp.WrapError(err, "Error", "Code")
+							return
+						}
+					case "Message":
+						z.Error.Message, bts, err = msgp.ReadStringBytes(bts)
+						if err != nil {
+							err = msgp.WrapError(err, "Error", "Message")
+							return
+						}
+					default:
+						bts, err = msgp.Skip(bts)
+						if err != nil {
+							err = msgp.WrapError(err, "Error")
+							return
+						}
+					}
+				}
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *Task) Msgsize() (s int) {
+	s = 1 + 3 + msgp.StringPrefixSize + len(z.Id) + 6 + msgp.Int32Size + 6
+	if z.Error == nil {
+		s += msgp.NilSize
+	} else {
+		s += 1 + 5 + msgp.Uint64Size + 8 + msgp.StringPrefixSize + len(z.Error.Message)
 	}
 	return
 }

--- a/pkg/proto/pbgo/core/remoteconfig_gen.go
+++ b/pkg/proto/pbgo/core/remoteconfig_gen.go
@@ -2475,6 +2475,130 @@ func (z ConfigSubscriptionState_TrackedClient) Msgsize() (s int) {
 }
 
 // MarshalMsg implements msgp.Marshaler
+func (z *DaemonSetStatus) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 9
+	// string "Name"
+	o = append(o, 0x89, 0xa4, 0x4e, 0x61, 0x6d, 0x65)
+	o = msgp.AppendString(o, z.Name)
+	// string "CurrentNumberScheduled"
+	o = append(o, 0xb6, 0x43, 0x75, 0x72, 0x72, 0x65, 0x6e, 0x74, 0x4e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x53, 0x63, 0x68, 0x65, 0x64, 0x75, 0x6c, 0x65, 0x64)
+	o = msgp.AppendInt32(o, z.CurrentNumberScheduled)
+	// string "NumberMisscheduled"
+	o = append(o, 0xb2, 0x4e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x4d, 0x69, 0x73, 0x73, 0x63, 0x68, 0x65, 0x64, 0x75, 0x6c, 0x65, 0x64)
+	o = msgp.AppendInt32(o, z.NumberMisscheduled)
+	// string "DesiredNumberScheduled"
+	o = append(o, 0xb6, 0x44, 0x65, 0x73, 0x69, 0x72, 0x65, 0x64, 0x4e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x53, 0x63, 0x68, 0x65, 0x64, 0x75, 0x6c, 0x65, 0x64)
+	o = msgp.AppendInt32(o, z.DesiredNumberScheduled)
+	// string "NumberReady"
+	o = append(o, 0xab, 0x4e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x52, 0x65, 0x61, 0x64, 0x79)
+	o = msgp.AppendInt32(o, z.NumberReady)
+	// string "ObservedGeneration"
+	o = append(o, 0xb2, 0x4f, 0x62, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x47, 0x65, 0x6e, 0x65, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e)
+	o = msgp.AppendInt64(o, z.ObservedGeneration)
+	// string "UpdatedNumberScheduled"
+	o = append(o, 0xb6, 0x55, 0x70, 0x64, 0x61, 0x74, 0x65, 0x64, 0x4e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x53, 0x63, 0x68, 0x65, 0x64, 0x75, 0x6c, 0x65, 0x64)
+	o = msgp.AppendInt32(o, z.UpdatedNumberScheduled)
+	// string "NumberAvailable"
+	o = append(o, 0xaf, 0x4e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x41, 0x76, 0x61, 0x69, 0x6c, 0x61, 0x62, 0x6c, 0x65)
+	o = msgp.AppendInt32(o, z.NumberAvailable)
+	// string "NumberUnavailable"
+	o = append(o, 0xb1, 0x4e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x55, 0x6e, 0x61, 0x76, 0x61, 0x69, 0x6c, 0x61, 0x62, 0x6c, 0x65)
+	o = msgp.AppendInt32(o, z.NumberUnavailable)
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *DaemonSetStatus) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Name":
+			z.Name, bts, err = msgp.ReadStringBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Name")
+				return
+			}
+		case "CurrentNumberScheduled":
+			z.CurrentNumberScheduled, bts, err = msgp.ReadInt32Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "CurrentNumberScheduled")
+				return
+			}
+		case "NumberMisscheduled":
+			z.NumberMisscheduled, bts, err = msgp.ReadInt32Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "NumberMisscheduled")
+				return
+			}
+		case "DesiredNumberScheduled":
+			z.DesiredNumberScheduled, bts, err = msgp.ReadInt32Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "DesiredNumberScheduled")
+				return
+			}
+		case "NumberReady":
+			z.NumberReady, bts, err = msgp.ReadInt32Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "NumberReady")
+				return
+			}
+		case "ObservedGeneration":
+			z.ObservedGeneration, bts, err = msgp.ReadInt64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "ObservedGeneration")
+				return
+			}
+		case "UpdatedNumberScheduled":
+			z.UpdatedNumberScheduled, bts, err = msgp.ReadInt32Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "UpdatedNumberScheduled")
+				return
+			}
+		case "NumberAvailable":
+			z.NumberAvailable, bts, err = msgp.ReadInt32Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "NumberAvailable")
+				return
+			}
+		case "NumberUnavailable":
+			z.NumberUnavailable, bts, err = msgp.ReadInt32Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "NumberUnavailable")
+				return
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *DaemonSetStatus) Msgsize() (s int) {
+	s = 1 + 5 + msgp.StringPrefixSize + len(z.Name) + 23 + msgp.Int32Size + 19 + msgp.Int32Size + 23 + msgp.Int32Size + 12 + msgp.Int32Size + 19 + msgp.Int64Size + 23 + msgp.Int32Size + 16 + msgp.Int32Size + 18 + msgp.Int32Size
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
 func (z *DelegatedMeta) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
 	// map header, size 3
@@ -2541,6 +2665,112 @@ func (z *DelegatedMeta) UnmarshalMsg(bts []byte) (o []byte, err error) {
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *DelegatedMeta) Msgsize() (s int) {
 	s = 1 + 8 + msgp.Uint64Size + 5 + msgp.StringPrefixSize + len(z.Role) + 4 + msgp.BytesPrefixSize + len(z.Raw)
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *DeploymentStatus) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 7
+	// string "Name"
+	o = append(o, 0x87, 0xa4, 0x4e, 0x61, 0x6d, 0x65)
+	o = msgp.AppendString(o, z.Name)
+	// string "ObservedGeneration"
+	o = append(o, 0xb2, 0x4f, 0x62, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x47, 0x65, 0x6e, 0x65, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e)
+	o = msgp.AppendInt64(o, z.ObservedGeneration)
+	// string "Replicas"
+	o = append(o, 0xa8, 0x52, 0x65, 0x70, 0x6c, 0x69, 0x63, 0x61, 0x73)
+	o = msgp.AppendInt32(o, z.Replicas)
+	// string "UpdatedReplicas"
+	o = append(o, 0xaf, 0x55, 0x70, 0x64, 0x61, 0x74, 0x65, 0x64, 0x52, 0x65, 0x70, 0x6c, 0x69, 0x63, 0x61, 0x73)
+	o = msgp.AppendInt32(o, z.UpdatedReplicas)
+	// string "ReadyReplicas"
+	o = append(o, 0xad, 0x52, 0x65, 0x61, 0x64, 0x79, 0x52, 0x65, 0x70, 0x6c, 0x69, 0x63, 0x61, 0x73)
+	o = msgp.AppendInt32(o, z.ReadyReplicas)
+	// string "AvailableReplicas"
+	o = append(o, 0xb1, 0x41, 0x76, 0x61, 0x69, 0x6c, 0x61, 0x62, 0x6c, 0x65, 0x52, 0x65, 0x70, 0x6c, 0x69, 0x63, 0x61, 0x73)
+	o = msgp.AppendInt32(o, z.AvailableReplicas)
+	// string "UnavailableReplicas"
+	o = append(o, 0xb3, 0x55, 0x6e, 0x61, 0x76, 0x61, 0x69, 0x6c, 0x61, 0x62, 0x6c, 0x65, 0x52, 0x65, 0x70, 0x6c, 0x69, 0x63, 0x61, 0x73)
+	o = msgp.AppendInt32(o, z.UnavailableReplicas)
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *DeploymentStatus) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Name":
+			z.Name, bts, err = msgp.ReadStringBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Name")
+				return
+			}
+		case "ObservedGeneration":
+			z.ObservedGeneration, bts, err = msgp.ReadInt64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "ObservedGeneration")
+				return
+			}
+		case "Replicas":
+			z.Replicas, bts, err = msgp.ReadInt32Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Replicas")
+				return
+			}
+		case "UpdatedReplicas":
+			z.UpdatedReplicas, bts, err = msgp.ReadInt32Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "UpdatedReplicas")
+				return
+			}
+		case "ReadyReplicas":
+			z.ReadyReplicas, bts, err = msgp.ReadInt32Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "ReadyReplicas")
+				return
+			}
+		case "AvailableReplicas":
+			z.AvailableReplicas, bts, err = msgp.ReadInt32Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "AvailableReplicas")
+				return
+			}
+		case "UnavailableReplicas":
+			z.UnavailableReplicas, bts, err = msgp.ReadInt32Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "UnavailableReplicas")
+				return
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *DeploymentStatus) Msgsize() (s int) {
+	s = 1 + 5 + msgp.StringPrefixSize + len(z.Name) + 19 + msgp.Int64Size + 9 + msgp.Int32Size + 16 + msgp.Int32Size + 14 + msgp.Int32Size + 18 + msgp.Int32Size + 20 + msgp.Int32Size
 	return
 }
 
@@ -2993,17 +3223,17 @@ func (z *FleetState) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "ConfigVersion"
 	o = append(o, 0x84, 0xad, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x56, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e)
 	o = msgp.AppendString(o, z.ConfigVersion)
-	// string "Experiment"
-	o = append(o, 0xaa, 0x45, 0x78, 0x70, 0x65, 0x72, 0x69, 0x6d, 0x65, 0x6e, 0x74)
-	o = msgp.AppendBool(o, z.Experiment)
-	// string "Task"
-	o = append(o, 0xa4, 0x54, 0x61, 0x73, 0x6b)
-	if z.Task == nil {
+	// string "ConfigExperiment"
+	o = append(o, 0xb0, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x45, 0x78, 0x70, 0x65, 0x72, 0x69, 0x6d, 0x65, 0x6e, 0x74)
+	o = msgp.AppendBool(o, z.ConfigExperiment)
+	// string "ConfigRollout"
+	o = append(o, 0xad, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x52, 0x6f, 0x6c, 0x6c, 0x6f, 0x75, 0x74)
+	if z.ConfigRollout == nil {
 		o = msgp.AppendNil(o)
 	} else {
-		o, err = z.Task.MarshalMsg(o)
+		o, err = z.ConfigRollout.MarshalMsg(o)
 		if err != nil {
-			err = msgp.WrapError(err, "Task")
+			err = msgp.WrapError(err, "ConfigRollout")
 			return
 		}
 	}
@@ -3037,26 +3267,26 @@ func (z *FleetState) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				err = msgp.WrapError(err, "ConfigVersion")
 				return
 			}
-		case "Experiment":
-			z.Experiment, bts, err = msgp.ReadBoolBytes(bts)
+		case "ConfigExperiment":
+			z.ConfigExperiment, bts, err = msgp.ReadBoolBytes(bts)
 			if err != nil {
-				err = msgp.WrapError(err, "Experiment")
+				err = msgp.WrapError(err, "ConfigExperiment")
 				return
 			}
-		case "Task":
+		case "ConfigRollout":
 			if msgp.IsNil(bts) {
 				bts, err = msgp.ReadNilBytes(bts)
 				if err != nil {
 					return
 				}
-				z.Task = nil
+				z.ConfigRollout = nil
 			} else {
-				if z.Task == nil {
-					z.Task = new(Task)
+				if z.ConfigRollout == nil {
+					z.ConfigRollout = new(Rollout)
 				}
-				bts, err = z.Task.UnmarshalMsg(bts)
+				bts, err = z.ConfigRollout.UnmarshalMsg(bts)
 				if err != nil {
-					err = msgp.WrapError(err, "Task")
+					err = msgp.WrapError(err, "ConfigRollout")
 					return
 				}
 			}
@@ -3080,11 +3310,11 @@ func (z *FleetState) UnmarshalMsg(bts []byte) (o []byte, err error) {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *FleetState) Msgsize() (s int) {
-	s = 1 + 14 + msgp.StringPrefixSize + len(z.ConfigVersion) + 11 + msgp.BoolSize + 5
-	if z.Task == nil {
+	s = 1 + 14 + msgp.StringPrefixSize + len(z.ConfigVersion) + 17 + msgp.BoolSize + 14
+	if z.ConfigRollout == nil {
 		s += msgp.NilSize
 	} else {
-		s += z.Task.Msgsize()
+		s += z.ConfigRollout.Msgsize()
 	}
 	s += 13 + msgp.StringPrefixSize + len(z.SecretPubKey)
 	return
@@ -4358,6 +4588,152 @@ func (z *ResetStateConfigResponse) UnmarshalMsg(bts []byte) (o []byte, err error
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z ResetStateConfigResponse) Msgsize() (s int) {
 	s = 1
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *Rollout) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 2
+	// string "Deployments"
+	o = append(o, 0x82, 0xab, 0x44, 0x65, 0x70, 0x6c, 0x6f, 0x79, 0x6d, 0x65, 0x6e, 0x74, 0x73)
+	o = msgp.AppendArrayHeader(o, uint32(len(z.Deployments)))
+	for za0001 := range z.Deployments {
+		if z.Deployments[za0001] == nil {
+			o = msgp.AppendNil(o)
+		} else {
+			o, err = z.Deployments[za0001].MarshalMsg(o)
+			if err != nil {
+				err = msgp.WrapError(err, "Deployments", za0001)
+				return
+			}
+		}
+	}
+	// string "DaemonSets"
+	o = append(o, 0xaa, 0x44, 0x61, 0x65, 0x6d, 0x6f, 0x6e, 0x53, 0x65, 0x74, 0x73)
+	o = msgp.AppendArrayHeader(o, uint32(len(z.DaemonSets)))
+	for za0002 := range z.DaemonSets {
+		if z.DaemonSets[za0002] == nil {
+			o = msgp.AppendNil(o)
+		} else {
+			o, err = z.DaemonSets[za0002].MarshalMsg(o)
+			if err != nil {
+				err = msgp.WrapError(err, "DaemonSets", za0002)
+				return
+			}
+		}
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *Rollout) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Deployments":
+			var zb0002 uint32
+			zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Deployments")
+				return
+			}
+			if cap(z.Deployments) >= int(zb0002) {
+				z.Deployments = (z.Deployments)[:zb0002]
+			} else {
+				z.Deployments = make([]*DeploymentStatus, zb0002)
+			}
+			for za0001 := range z.Deployments {
+				if msgp.IsNil(bts) {
+					bts, err = msgp.ReadNilBytes(bts)
+					if err != nil {
+						return
+					}
+					z.Deployments[za0001] = nil
+				} else {
+					if z.Deployments[za0001] == nil {
+						z.Deployments[za0001] = new(DeploymentStatus)
+					}
+					bts, err = z.Deployments[za0001].UnmarshalMsg(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Deployments", za0001)
+						return
+					}
+				}
+			}
+		case "DaemonSets":
+			var zb0003 uint32
+			zb0003, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "DaemonSets")
+				return
+			}
+			if cap(z.DaemonSets) >= int(zb0003) {
+				z.DaemonSets = (z.DaemonSets)[:zb0003]
+			} else {
+				z.DaemonSets = make([]*DaemonSetStatus, zb0003)
+			}
+			for za0002 := range z.DaemonSets {
+				if msgp.IsNil(bts) {
+					bts, err = msgp.ReadNilBytes(bts)
+					if err != nil {
+						return
+					}
+					z.DaemonSets[za0002] = nil
+				} else {
+					if z.DaemonSets[za0002] == nil {
+						z.DaemonSets[za0002] = new(DaemonSetStatus)
+					}
+					bts, err = z.DaemonSets[za0002].UnmarshalMsg(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "DaemonSets", za0002)
+						return
+					}
+				}
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *Rollout) Msgsize() (s int) {
+	s = 1 + 12 + msgp.ArrayHeaderSize
+	for za0001 := range z.Deployments {
+		if z.Deployments[za0001] == nil {
+			s += msgp.NilSize
+		} else {
+			s += z.Deployments[za0001].Msgsize()
+		}
+	}
+	s += 11 + msgp.ArrayHeaderSize
+	for za0002 := range z.DaemonSets {
+		if z.DaemonSets[za0002] == nil {
+			s += msgp.NilSize
+		} else {
+			s += z.DaemonSets[za0002].Msgsize()
+		}
+	}
 	return
 }
 

--- a/pkg/proto/pbgo/core/remoteconfig_gen.go
+++ b/pkg/proto/pbgo/core/remoteconfig_gen.go
@@ -3219,10 +3219,21 @@ func (z FileMetaState) Msgsize() (s int) {
 // MarshalMsg implements msgp.Marshaler
 func (z *FleetState) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
-	// map header, size 4
+	// map header, size 5
 	// string "ConfigVersion"
-	o = append(o, 0x84, 0xad, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x56, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e)
+	o = append(o, 0x85, 0xad, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x56, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e)
 	o = msgp.AppendString(o, z.ConfigVersion)
+	// string "ConfigTask"
+	o = append(o, 0xaa, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x54, 0x61, 0x73, 0x6b)
+	if z.ConfigTask == nil {
+		o = msgp.AppendNil(o)
+	} else {
+		o, err = z.ConfigTask.MarshalMsg(o)
+		if err != nil {
+			err = msgp.WrapError(err, "ConfigTask")
+			return
+		}
+	}
 	// string "ConfigExperiment"
 	o = append(o, 0xb0, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x45, 0x78, 0x70, 0x65, 0x72, 0x69, 0x6d, 0x65, 0x6e, 0x74)
 	o = msgp.AppendBool(o, z.ConfigExperiment)
@@ -3267,6 +3278,23 @@ func (z *FleetState) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				err = msgp.WrapError(err, "ConfigVersion")
 				return
 			}
+		case "ConfigTask":
+			if msgp.IsNil(bts) {
+				bts, err = msgp.ReadNilBytes(bts)
+				if err != nil {
+					return
+				}
+				z.ConfigTask = nil
+			} else {
+				if z.ConfigTask == nil {
+					z.ConfigTask = new(Task)
+				}
+				bts, err = z.ConfigTask.UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "ConfigTask")
+					return
+				}
+			}
 		case "ConfigExperiment":
 			z.ConfigExperiment, bts, err = msgp.ReadBoolBytes(bts)
 			if err != nil {
@@ -3310,7 +3338,13 @@ func (z *FleetState) UnmarshalMsg(bts []byte) (o []byte, err error) {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *FleetState) Msgsize() (s int) {
-	s = 1 + 14 + msgp.StringPrefixSize + len(z.ConfigVersion) + 17 + msgp.BoolSize + 14
+	s = 1 + 14 + msgp.StringPrefixSize + len(z.ConfigVersion) + 11
+	if z.ConfigTask == nil {
+		s += msgp.NilSize
+	} else {
+		s += z.ConfigTask.Msgsize()
+	}
+	s += 17 + msgp.BoolSize + 14
 	if z.ConfigRollout == nil {
 		s += msgp.NilSize
 	} else {

--- a/pkg/proto/pbgo/core/remoteconfig_gen_test.go
+++ b/pkg/proto/pbgo/core/remoteconfig_gen_test.go
@@ -240,6 +240,64 @@ func BenchmarkUnmarshalClientGetConfigsResponse(b *testing.B) {
 	}
 }
 
+func TestMarshalUnmarshalClientOperator(t *testing.T) {
+	v := ClientOperator{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgClientOperator(b *testing.B) {
+	v := ClientOperator{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgClientOperator(b *testing.B) {
+	v := ClientOperator{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalClientOperator(b *testing.B) {
+	v := ClientOperator{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestMarshalUnmarshalClientState(t *testing.T) {
 	v := ClientState{}
 	bts, err := v.MarshalMsg(nil)
@@ -994,6 +1052,64 @@ func BenchmarkUnmarshalFileMetaState(b *testing.B) {
 	}
 }
 
+func TestMarshalUnmarshalFleetState(t *testing.T) {
+	v := FleetState{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgFleetState(b *testing.B) {
+	v := FleetState{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgFleetState(b *testing.B) {
+	v := FleetState{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalFleetState(b *testing.B) {
+	v := FleetState{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestMarshalUnmarshalGetStateConfigResponse(t *testing.T) {
 	v := GetStateConfigResponse{}
 	bts, err := v.MarshalMsg(nil)
@@ -1342,64 +1458,6 @@ func BenchmarkUnmarshalPackageState(b *testing.B) {
 	}
 }
 
-func TestMarshalUnmarshalPackageStateTask(t *testing.T) {
-	v := PackageStateTask{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	left, err := v.UnmarshalMsg(bts)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(left) > 0 {
-		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
-	}
-
-	left, err = msgp.Skip(bts)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(left) > 0 {
-		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
-	}
-}
-
-func BenchmarkMarshalMsgPackageStateTask(b *testing.B) {
-	v := PackageStateTask{}
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		v.MarshalMsg(nil)
-	}
-}
-
-func BenchmarkAppendMsgPackageStateTask(b *testing.B) {
-	v := PackageStateTask{}
-	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
-	b.SetBytes(int64(len(bts)))
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
-	}
-}
-
-func BenchmarkUnmarshalPackageStateTask(b *testing.B) {
-	v := PackageStateTask{}
-	bts, _ := v.MarshalMsg(nil)
-	b.ReportAllocs()
-	b.SetBytes(int64(len(bts)))
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_, err := v.UnmarshalMsg(bts)
-		if err != nil {
-			b.Fatal(err)
-		}
-	}
-}
-
 func TestMarshalUnmarshalResetStateConfigResponse(t *testing.T) {
 	v := ResetStateConfigResponse{}
 	bts, err := v.MarshalMsg(nil)
@@ -1562,6 +1620,64 @@ func BenchmarkAppendMsgTargetFileMeta(b *testing.B) {
 
 func BenchmarkUnmarshalTargetFileMeta(b *testing.B) {
 	v := TargetFileMeta{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestMarshalUnmarshalTask(t *testing.T) {
+	v := Task{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgTask(b *testing.B) {
+	v := Task{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgTask(b *testing.B) {
+	v := Task{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalTask(b *testing.B) {
+	v := Task{}
 	bts, _ := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))

--- a/pkg/proto/pbgo/core/remoteconfig_gen_test.go
+++ b/pkg/proto/pbgo/core/remoteconfig_gen_test.go
@@ -820,6 +820,64 @@ func BenchmarkUnmarshalConfigSubscriptionState_TrackedClient(b *testing.B) {
 	}
 }
 
+func TestMarshalUnmarshalDaemonSetStatus(t *testing.T) {
+	v := DaemonSetStatus{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgDaemonSetStatus(b *testing.B) {
+	v := DaemonSetStatus{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgDaemonSetStatus(b *testing.B) {
+	v := DaemonSetStatus{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalDaemonSetStatus(b *testing.B) {
+	v := DaemonSetStatus{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestMarshalUnmarshalDelegatedMeta(t *testing.T) {
 	v := DelegatedMeta{}
 	bts, err := v.MarshalMsg(nil)
@@ -866,6 +924,64 @@ func BenchmarkAppendMsgDelegatedMeta(b *testing.B) {
 
 func BenchmarkUnmarshalDelegatedMeta(b *testing.B) {
 	v := DelegatedMeta{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestMarshalUnmarshalDeploymentStatus(t *testing.T) {
+	v := DeploymentStatus{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgDeploymentStatus(b *testing.B) {
+	v := DeploymentStatus{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgDeploymentStatus(b *testing.B) {
+	v := DeploymentStatus{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalDeploymentStatus(b *testing.B) {
+	v := DeploymentStatus{}
 	bts, _ := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
@@ -1504,6 +1620,64 @@ func BenchmarkAppendMsgResetStateConfigResponse(b *testing.B) {
 
 func BenchmarkUnmarshalResetStateConfigResponse(b *testing.B) {
 	v := ResetStateConfigResponse{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestMarshalUnmarshalRollout(t *testing.T) {
+	v := Rollout{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgRollout(b *testing.B) {
+	v := Rollout{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgRollout(b *testing.B) {
+	v := Rollout{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalRollout(b *testing.B) {
+	v := Rollout{}
 	bts, _ := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))


### PR DESCRIPTION
## Summary

This PR adds the Datadog Operator as a fourth client type in the remote config protobuf definition, alongside existing tracer, agent, and updater clients.

## Changes

- Rename `PackageStateTask` → `Task` to make the type generic and reusable across client types
- Add `FleetState` message representing the state of a fleet managed by the operator (config version, experiment flag, task state, secret pub key)
- Add `ClientOperator` message containing a list of `FleetState` entries
- Extend `Client` with `is_operator` (field 16) and `client_operator` (field 17)
- Update `pkg/fleet/daemon/daemon.go` and `local_api_test.go` to use the renamed `Task` type