### PR TITLE
[ACTP] Add agent_flavor tag to autoconnections

### DIFF
--- a/pkg/privateactionrunner/autoconnections/tags_provider.go
+++ b/pkg/privateactionrunner/autoconnections/tags_provider.go
@@ -12,6 +12,7 @@ import (
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	tagNames "github.com/DataDog/datadog-agent/comp/core/tagger/tags"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
+	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -44,6 +45,7 @@ func (p *taggerBasedTagsProvider) GetTags(ctx context.Context, runnerID, hostnam
 	tags := []string{
 		"runner-id:" + runnerID,
 		"hostname:" + hostname,
+		"agent_flavor:" + flavor.GetFlavor(),
 	}
 
 	// Only attempt to get cluster tags if cluster_agent is enabled

--- a/pkg/privateactionrunner/autoconnections/tags_provider_test.go
+++ b/pkg/privateactionrunner/autoconnections/tags_provider_test.go
@@ -22,11 +22,13 @@ func TestTagsProvider_WithClusterTags(t *testing.T) {
 
 	tags := provider.GetTags(context.Background(), "runner-abc", "host-01")
 
-	require.Len(t, tags, 4)
+	require.Len(t, tags, 5)
 	assert.Contains(t, tags, "runner-id:runner-abc")
 	assert.Contains(t, tags, "hostname:host-01")
 	assert.Contains(t, tags, "orch_cluster_id:abc-123-def")
 	assert.Contains(t, tags, "kube_cluster_name:production")
+	// agent_flavor tag is added automatically (defaults to "agent")
+	assert.Contains(t, tags, "agent_flavor:agent")
 }
 
 func TestTagsProvider_WithEnvTag(t *testing.T) {
@@ -40,9 +42,10 @@ func TestTagsProvider_WithEnvTag(t *testing.T) {
 
 	tags := provider.GetTags(context.Background(), "runner-xyz", "host-02")
 
-	require.Len(t, tags, 4)
+	require.Len(t, tags, 5)
 	assert.Contains(t, tags, "runner-id:runner-xyz")
 	assert.Contains(t, tags, "hostname:host-02")
+	assert.Contains(t, tags, "agent_flavor:agent")
 	assert.Contains(t, tags, "env:production")
 	assert.Contains(t, tags, "kube_cluster_name:my-cluster")
 	assert.NotContains(t, tags, "team:platform") // Filtered out
@@ -54,9 +57,10 @@ func TestTagsProvider_NoClusterTagsAvailable(t *testing.T) {
 
 	tags := provider.GetTags(context.Background(), "runner-abc", "host-01")
 
-	require.Len(t, tags, 2)
+	require.Len(t, tags, 3)
 	assert.Contains(t, tags, "runner-id:runner-abc")
 	assert.Contains(t, tags, "hostname:host-01")
+	assert.Contains(t, tags, "agent_flavor:agent")
 }
 
 func TestTagsProvider_AllWhitelistedTags(t *testing.T) {
@@ -74,10 +78,11 @@ func TestTagsProvider_AllWhitelistedTags(t *testing.T) {
 
 	tags := provider.GetTags(context.Background(), "runner-abc", "host-01")
 
-	// Should have: runner-id, hostname + 5 whitelisted tags
-	require.Len(t, tags, 7)
+	// Should have: runner-id, hostname, agent_flavor + 5 whitelisted tags
+	require.Len(t, tags, 8)
 	assert.Contains(t, tags, "runner-id:runner-abc")
 	assert.Contains(t, tags, "hostname:host-01")
+	assert.Contains(t, tags, "agent_flavor:agent")
 	assert.Contains(t, tags, "env:staging")
 	assert.Contains(t, tags, "cluster_name:my-cluster")
 	assert.Contains(t, tags, "kube_cluster_name:k8s-cluster")


### PR DESCRIPTION
### What does this PR do?

Adds the `agent_flavor` tag to automatic connections created during privateactionrunner self-enrollment to distinguish between DCA (Cluster Agent) and other agent flavors.

### Motivation

When automatically creating connections, we need to identify whether the connection was created by a regular agent or DCA (Datadog Cluster Agent). The `agent_flavor` tag enables this distinction.

### Describe how you validated your changes

- Updated `tags_provider.go` to include `agent_flavor` tag from `flavor.GetFlavor()`
- Updated all test cases in `tags_provider_test.go` to verify the tag is present
- All tests pass: `go test -tags test ./pkg/privateactionrunner/autoconnections/... -v`

### Additional Notes

The tag will contain values like:
- `agent_flavor:agent` - Regular Agent
- `agent_flavor:cluster_agent` - DCA
- `agent_flavor:iot_agent` - IoT Agent
- Other flavors as defined in `pkg/util/flavor/flavor.go`