### PR TITLE
[EBPF] gpu: emit activity fallback metrics without global device stats

### DIFF
--- a/pkg/collector/corechecks/gpu/nvidia/ebpf.go
+++ b/pkg/collector/corechecks/gpu/nvidia/ebpf.go
@@ -239,27 +239,30 @@ func (c *ebpfCollector) Collect() ([]Metric, error) {
 
 	// Emit device-level utilization metrics as a fallback when no other
 	// sources are available (mainly Ampere MIG devices)
+	activeTimePct := 0.0
 	for _, deviceMetric := range stats.DeviceMetrics {
 		if deviceMetric.DeviceUUID == deviceUUID {
-			deviceMetrics = append(deviceMetrics,
-				Metric{
-					Name:     "sm_active",
-					Value:    deviceMetric.Metrics.ActiveTimePct,
-					Type:     ddmetrics.GaugeType,
-					Priority: Low,
-					// No AssociatedWorkloads - device-wide metric
-				},
-				Metric{
-					Name:     "gr_engine_active",
-					Value:    deviceMetric.Metrics.ActiveTimePct,
-					Type:     ddmetrics.GaugeType,
-					Priority: Low,
-					// No AssociatedWorkloads - device-wide metric
-				},
-			)
+			activeTimePct = deviceMetric.Metrics.ActiveTimePct
 			break
 		}
 	}
+
+	deviceMetrics = append(deviceMetrics,
+		Metric{
+			Name:     "sm_active",
+			Value:    activeTimePct,
+			Type:     ddmetrics.GaugeType,
+			Priority: Low,
+			// No AssociatedWorkloads - device-wide metric
+		},
+		Metric{
+			Name:     "gr_engine_active",
+			Value:    activeTimePct,
+			Type:     ddmetrics.GaugeType,
+			Priority: Low,
+			// No AssociatedWorkloads - device-wide metric
+		},
+	)
 
 	return deviceMetrics, nil
 }

--- a/pkg/collector/corechecks/gpu/nvidia/ebpf_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/ebpf_test.go
@@ -429,7 +429,7 @@ func testCollectAggregatesPidTagsForLimits(t *testing.T) {
 	metrics, err := collector.Collect()
 	require.NoError(t, err)
 
-	// Should have 11 metrics: 9 usage (3 per process: core, memory, sm_active) + 2 limit + 2 device metrics (sm_active, gr_engine_active)
+	// Should have 13 metrics: 9 usage (3 per process: core, memory, sm_active) + 2 limit + 2 device metrics (sm_active, gr_engine_active)
 	assert.Len(t, metrics, 13)
 
 	// Verify limit metrics have all workloads aggregated

--- a/pkg/collector/corechecks/gpu/nvidia/ebpf_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/ebpf_test.go
@@ -160,8 +160,8 @@ func testCollectWithSingleActiveProcess(t *testing.T) {
 	metrics, err := collector.Collect()
 	require.NoError(t, err)
 
-	// Should have 5 metrics: 3 usage (core, memory, sm_active) + 2 limit
-	assert.Len(t, metrics, 5)
+	// Should have 7 metrics: 3 usage (core, memory, sm_active) + 2 limit + 2 global activity metrics (sm_active, gr_engine_active)
+	assert.Len(t, metrics, 7)
 
 	// Verify usage metrics
 	coreUsage := findMetric(metrics, "process.core.usage")
@@ -236,8 +236,8 @@ func testCollectWithMultipleActiveProcesses(t *testing.T) {
 	metrics, err := collector.Collect()
 	require.NoError(t, err)
 
-	// Should have 8 metrics: 6 usage (3 per process: core, memory, sm_active) + 2 limit
-	assert.Len(t, metrics, 8)
+	// Should have 8 metrics: 6 usage (3 per process: core, memory, sm_active) + 2 limit + 2 global activity metrics (sm_active, gr_engine_active)
+	assert.Len(t, metrics, 10)
 
 	// Verify limit metrics have aggregated workloads
 	coreLimit := findMetric(metrics, "core.limit")
@@ -280,7 +280,7 @@ func testCollectWithInactiveProcesses(t *testing.T) {
 	// First collect with process 123
 	metrics, err := collector.Collect()
 	require.NoError(t, err)
-	assert.Len(t, metrics, 5)
+	assert.Len(t, metrics, 7)
 
 	// Now collect with empty stats (process became inactive)
 	cache.stats = &model.GPUStats{ProcessMetrics: []model.ProcessStatsTuple{}}
@@ -288,8 +288,8 @@ func testCollectWithInactiveProcesses(t *testing.T) {
 	metrics, err = collector.Collect()
 	require.NoError(t, err)
 
-	// Should have 5 metrics: 3 zero usage (core, memory, sm_active) + 2 limit
-	assert.Len(t, metrics, 5)
+	// Should have 7 metrics: 3 zero usage (core, memory, sm_active) + 2 limit + 2 global activity metrics (sm_active, gr_engine_active)
+	assert.Len(t, metrics, 7)
 
 	// Verify zero usage metrics for inactive process
 	coreUsage := findMetric(metrics, "process.core.usage")
@@ -359,11 +359,15 @@ func testCollectFiltersByDeviceUUID(t *testing.T) {
 	metrics, err := collector.Collect()
 	require.NoError(t, err)
 
-	// Should only have metrics for device1UUID (5 metrics: 3 usage + 2 limit)
-	assert.Len(t, metrics, 5)
+	// Should only have metrics for device1UUID (5 metrics: 3 usage + 2 limit + 2 global activity metrics (sm_active, gr_engine_active))
+	assert.Len(t, metrics, 7)
 
 	// All metrics should be for PID 123 only
 	for _, metric := range metrics {
+		if metric.Name == "sm_active" || metric.Name == "gr_engine_active" {
+			continue
+		}
+
 		require.Len(t, metric.AssociatedWorkloads, 1)
 		assert.Equal(t, "process", string(metric.AssociatedWorkloads[0].Kind))
 		assert.Equal(t, "123", metric.AssociatedWorkloads[0].ID)
@@ -425,8 +429,8 @@ func testCollectAggregatesPidTagsForLimits(t *testing.T) {
 	metrics, err := collector.Collect()
 	require.NoError(t, err)
 
-	// Should have 11 metrics: 9 usage (3 per process: core, memory, sm_active) + 2 limit
-	assert.Len(t, metrics, 11)
+	// Should have 11 metrics: 9 usage (3 per process: core, memory, sm_active) + 2 limit + 2 device metrics (sm_active, gr_engine_active)
+	assert.Len(t, metrics, 13)
 
 	// Verify limit metrics have all workloads aggregated
 	coreLimit := findMetric(metrics, "core.limit")
@@ -486,8 +490,8 @@ func testCollectEmitsSmActiveMetrics(t *testing.T) {
 	metrics, err := collector.Collect()
 	require.NoError(t, err)
 
-	// Should have 5 metrics: 3 usage (core, memory, sm_active) + 2 limit
-	assert.Len(t, metrics, 5)
+	// Should have 7 metrics: 3 usage (core, memory, sm_active) + 2 limit + 2 global activity metrics (sm_active, gr_engine_active)
+	assert.Len(t, metrics, 7)
 
 	// Verify process.sm_active metric
 	smActive := findMetric(metrics, "process.sm_active")
@@ -600,9 +604,8 @@ func testCollectEmitsZeroDeviceActivityWhenIdle(t *testing.T) {
 	metrics, err := collector.Collect()
 	require.NoError(t, err)
 
-	// Should still have 10 metrics even without global device metrics:
-	// 6 usage (3 per process) + 2 limit + 2 device metrics (sm_active, gr_engine_active)
-	assert.Len(t, metrics, 10)
+	// Should have 2 limit metrics and 2 device metrics (sm_active, gr_engine_active)
+	assert.Len(t, metrics, 4)
 
 	deviceSmActive := findMetric(metrics, "sm_active")
 	require.NotNil(t, deviceSmActive, "sm_active metric not found")

--- a/pkg/collector/corechecks/gpu/nvidia/ebpf_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/ebpf_test.go
@@ -236,7 +236,7 @@ func testCollectWithMultipleActiveProcesses(t *testing.T) {
 	metrics, err := collector.Collect()
 	require.NoError(t, err)
 
-	// Should have 8 metrics: 6 usage (3 per process: core, memory, sm_active) + 2 limit + 2 global activity metrics (sm_active, gr_engine_active)
+	// Should have 10 metrics: 6 usage (3 per process: core, memory, sm_active) + 2 limit + 2 global activity metrics (sm_active, gr_engine_active)
 	assert.Len(t, metrics, 10)
 
 	// Verify limit metrics have aggregated workloads

--- a/pkg/collector/corechecks/gpu/nvidia/ebpf_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/ebpf_test.go
@@ -108,6 +108,10 @@ func TestEbpfCollectorCollect(t *testing.T) {
 			name:     "collect_emits_device_utilization_metrics",
 			testFunc: testCollectEmitsDeviceSmActiveMetric,
 		},
+		{
+			name:     "collect_emits_zero_device_activity_when_idle",
+			testFunc: testCollectEmitsZeroDeviceActivityWhenIdle,
+		},
 	}
 
 	for _, tt := range tests {
@@ -575,6 +579,42 @@ func testCollectEmitsDeviceSmActiveMetric(t *testing.T) {
 		assert.Equal(t, Low, metric.Priority)
 		require.Len(t, metric.AssociatedWorkloads, 1)
 	}
+}
+
+func testCollectEmitsZeroDeviceActivityWhenIdle(t *testing.T) {
+	exe := "/bin/test"
+	procRoot := kernel.CreateFakeProcFS(t, []kernel.FakeProcFSEntry{
+		{Pid: 123, NsPid: 3, Cmdline: exe, Command: exe, Exe: exe},
+		{Pid: 456, NsPid: 4, Cmdline: exe, Command: exe, Exe: exe},
+	})
+	kernel.WithFakeProcFS(t, procRoot)
+
+	device := createMockDevice(t, testutil.DefaultGpuUUID)
+	cache := &SystemProbeCache{
+		stats: &model.GPUStats{},
+	}
+
+	collector, err := newEbpfCollector(device, cache)
+	require.NoError(t, err)
+
+	metrics, err := collector.Collect()
+	require.NoError(t, err)
+
+	// Should still have 10 metrics even without global device metrics:
+	// 6 usage (3 per process) + 2 limit + 2 device metrics (sm_active, gr_engine_active)
+	assert.Len(t, metrics, 10)
+
+	deviceSmActive := findMetric(metrics, "sm_active")
+	require.NotNil(t, deviceSmActive, "sm_active metric not found")
+	assert.Equal(t, 0.0, deviceSmActive.Value)
+	assert.Equal(t, Low, deviceSmActive.Priority, "sm_active should have Low priority")
+	assert.Empty(t, deviceSmActive.AssociatedWorkloads, "device-level sm_active should not have associated workloads")
+
+	deviceGrEngineActive := findMetric(metrics, "gr_engine_active")
+	require.NotNil(t, deviceGrEngineActive, "gr_engine_active metric not found")
+	assert.Equal(t, 0.0, deviceGrEngineActive.Value)
+	assert.Equal(t, Low, deviceGrEngineActive.Priority, "gr_engine_active should have Low priority")
+	assert.Empty(t, deviceGrEngineActive.AssociatedWorkloads, "device-level gr_engine_active should not have associated workloads")
 }
 
 // Helper functions


### PR DESCRIPTION
### What does this PR do?

Ensures the eBPF collector always emits device-level `sm_active` and `gr_engine_active` even when there's no activity.

### Motivation

Without this change, the metric would not be emitted unless there was activity in the processes.

### Describe how you validated your changes

Added unit tests to validate the behavior.

### Additional Notes
