### PR TITLE
[INCIDENT-50276] fix(kmt): Bump timeout used when downloading pulumi plugins

### DIFF
--- a/tasks/kernel_matrix_testing/setup/common.py
+++ b/tasks/kernel_matrix_testing/setup/common.py
@@ -114,7 +114,9 @@ class PulumiPlugin(Requirement):
             try:
                 # https://github.com/golang/go/issues/63758: downloading dependencies stuck when git tag signature [...]
                 ctx.run(
-                    "go mod download", timeout=timedelta(minutes=10).total_seconds(), env={"GIT_TERMINAL_PROMPT": "0"}
+                    "go mod download -x",
+                    timeout=timedelta(minutes=10).total_seconds(),
+                    env={"GIT_TERMINAL_PROMPT": "0"},
                 )
                 ctx.run("PULUMI_CONFIG_PASSPHRASE=dummy pulumi --non-interactive plugin install")
             except Exception as e:

--- a/tasks/kernel_matrix_testing/setup/common.py
+++ b/tasks/kernel_matrix_testing/setup/common.py
@@ -113,7 +113,7 @@ class PulumiPlugin(Requirement):
 
             try:
                 # https://github.com/golang/go/issues/63758: downloading dependencies stuck when git tag signature [...]
-                ctx.run("GIT_TERMINAL_PROMPT=0 go mod download", timeout=timedelta(minutes=5).total_seconds())
+                ctx.run("GIT_TERMINAL_PROMPT=0 go mod download", timeout=timedelta(minutes=10).total_seconds())
                 ctx.run("PULUMI_CONFIG_PASSPHRASE=dummy pulumi --non-interactive plugin install")
             except Exception as e:
                 return RequirementState(Status.FAIL, f"pulumi plugins installation failed: {e}")

--- a/tasks/kernel_matrix_testing/setup/common.py
+++ b/tasks/kernel_matrix_testing/setup/common.py
@@ -113,7 +113,9 @@ class PulumiPlugin(Requirement):
 
             try:
                 # https://github.com/golang/go/issues/63758: downloading dependencies stuck when git tag signature [...]
-                ctx.run("GIT_TERMINAL_PROMPT=0 go mod download", timeout=timedelta(minutes=10).total_seconds())
+                ctx.run(
+                    "go mod download", timeout=timedelta(minutes=10).total_seconds(), env={"GIT_TERMINAL_PROMPT": "0"}
+                )
                 ctx.run("PULUMI_CONFIG_PASSPHRASE=dummy pulumi --non-interactive plugin install")
             except Exception as e:
                 return RequirementState(Status.FAIL, f"pulumi plugins installation failed: {e}")


### PR DESCRIPTION
### What does this PR do?
Bumps the timeout used when running `go mod download` while installing Pulumi plugins in KMT setup + add a verbose flag.

### Motivation
incident-50276 - using ADMS as a GOPROXY, the `go mod download` can take more than 5mn, which causes the job to fail.

### Describe how you validated your changes
Running CI

### Additional Notes
Follow-up to #46178 
