### PR TITLE
[ABLD-317] Bump `gazelle` for maintained `proto_library`

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -52,9 +52,11 @@ bazel_dep(name = "supply_chain_tools", version = "0.0.1")
 bazel_dep(name = "rules_testing", version = "0.9.0", dev_dependency = True)
 
 # Temporary until gazelle > 0.47.0 with Go 1.24+ fixes is in BCR
+# and until a release includes bazel-contrib/bazel-gazelle#2284
+# (switch from deprecated rules_proto to protobuf module)
 git_override(
     module_name = "gazelle",
-    commit = "6b2aeccd77d2668a21202f5b60e10b035419c61a",  # master as of Feb 13, 2026
+    commit = "a3e63b06e1e5c4c7a7849874fadf7ccda8868870",  # master as of Feb 26, 2026
     remote = "https://github.com/bazel-contrib/bazel-gazelle.git",
 )
 


### PR DESCRIPTION
### What does this PR do?
Advance  `git_override` for `gazelle` from Feb 13 to Feb 26, 2026.

### Motivation
This eliminates a source of discrepancy when generating `BUILD.bazel` files dealing with code generation.

bazel-contrib/bazel-gazelle#2284 indeed switches the proto language extension from the _deprecated_ `rules_proto` module to the `protobuf` module when generating `load` statements for `proto_library`.

Without this, generated `BUILD.bazel` files carry a dependency on `rules_proto` that should no longer be required.