### PR TITLE
[WINA-2414] fix the powershell script path

### DIFF
--- a/pkg/privateactionrunner/autoconnections/conf/BUILD.bazel
+++ b/pkg/privateactionrunner/autoconnections/conf/BUILD.bazel
@@ -14,10 +14,7 @@ pkg_files(
         mode = "0400",
         owner = "root",
     ),
-    prefix = select({
-        "@platforms//os:windows": "ProgramData/Datadog/private-action-runner",
-        "//conditions:default": "etc/datadog-agent/private-action-runner",
-    }),
+    prefix = "etc/datadog-agent/private-action-runner",
 )
 
 pkg_install(

--- a/pkg/privateactionrunner/autoconnections/conf/powershell-script-config.yaml
+++ b/pkg/privateactionrunner/autoconnections/conf/powershell-script-config.yaml
@@ -14,3 +14,10 @@ runPredefinedPowershellScript:
           type: string
       required:
         - name
+
+  # Example showing environment variable
+  showEnv:
+    script: |
+      Write-Output "This vm name is $env:COMPUTERNAME"
+    allowedEnvVars:
+      - COMPUTERNAME

--- a/pkg/privateactionrunner/autoconnections/constants.go
+++ b/pkg/privateactionrunner/autoconnections/constants.go
@@ -7,13 +7,13 @@ package autoconnections
 
 import (
 	"path/filepath"
+	"runtime"
 
 	"github.com/DataDog/datadog-agent/pkg/util/defaultpaths"
 )
 
 const (
 	privateActionRunnerRelativeDir = "private-action-runner"
-	scriptConfigFileName           = "script-config.yaml"
 
 	createConnectionEndpoint = "/api/v2/actions/connections"
 	apiKeyHeader             = "DD-API-KEY"
@@ -27,5 +27,9 @@ func getPrivateActionRunnerDir() string {
 	return filepath.Join(defaultpaths.ConfPath, privateActionRunnerRelativeDir)
 }
 func getScriptConfigPath() string {
-	return filepath.Join(getPrivateActionRunnerDir(), scriptConfigFileName)
+	filename := "script-config.yaml"
+	if runtime.GOOS == "windows" {
+		filename = "powershell-script-config.yaml"
+	}
+	return filepath.Join(getPrivateActionRunnerDir(), filename)
 }

--- a/releasenotes/notes/private-action-runner-windows-config-install-fix.yaml
+++ b/releasenotes/notes/private-action-runner-windows-config-install-fix.yaml
@@ -1,0 +1,4 @@
+bug_fixes:
+  - |
+    Fix the private action runner PowerShell example config not being installed on Windows.
+    The file is now correctly placed at ``C:\ProgramData\Datadog\private-action-runner\powershell-script-config.yaml``.

--- a/releasenotes/notes/private-action-runner-windows-config-install-fix.yaml
+++ b/releasenotes/notes/private-action-runner-windows-config-install-fix.yaml
@@ -1,4 +1,4 @@
-bug_fixes:
+fixes:
   - |
     Fix the private action runner PowerShell example config not being installed on Windows.
     The file is now correctly placed at ``C:\ProgramData\Datadog\private-action-runner\powershell-script-config.yaml``.

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentInstaller.cs
@@ -730,6 +730,10 @@ namespace WixSetup.Datadog_Agent
                        new Files($@"{EtcSource}\runtime-security.d\*.*")
             ));
 
+            appData.AddDir(new Dir("private-action-runner",
+                       new Files($@"{EtcSource}\private-action-runner\*.*")
+            ));
+
             return new Dir(new Id("%CommonAppData%"), appData)
             {
                 Attributes = { { "Name", "CommonAppData" } }


### PR DESCRIPTION
### What does this PR do?
This PR fixes path for the template `powershell-script-config.yaml` at installation of the PAR in Windows Agent.

### Motivation
At installation, the path prefix for the `powershell-script-config.yaml` was assigned in the wrong place, which resulted in a dead-end path and the file was never packaged.

### Describe how you validated your changes
Install msi from the artefact from this PR pipeline and confirm the `powershell-script-config.yaml` lands under `C:\ProgramData\Datadog\private-action-runner\` after installation. Confirm that the auto-created scrip connection points to this path.

### Additional Notes
