### PR TITLE
[inventoryagent] Accept 'none' as a valid value for infrastructure_mode

### DIFF
--- a/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
@@ -184,7 +184,7 @@ func (ia *inventoryagent) initData() {
 
 	infraMode := scrub(ia.conf.GetString("infrastructure_mode"))
 	// agent-configuration: This validation should be done by the Config once we have such mechanism
-	if !slices.Contains([]string{"full", "end_user_device", "basic"}, infraMode) {
+	if !slices.Contains([]string{"full", "end_user_device", "basic", "none"}, infraMode) {
 		ia.log.Warnf("invalid value for 'infrastructure_mode': '%s' (defaulting to 'full')", infraMode)
 		infraMode = "full"
 	}


### PR DESCRIPTION
### What does this PR do?

Adds `"none"` as a valid value for the `infrastructure_mode` configuration key in the inventory agent payload validation.

Previously, the validation in `initData()` only accepted `"full"`, `"end_user_device"`, and `"basic"` as valid values, causing any agent configured with `infrastructure_mode: none` to log a warning and silently fall back to `"full"`.

### Motivation

The `none` mode is a legitimate infrastructure mode that should be accepted without triggering a warning or being overridden.

### Describe how you validated your changes

The change is a one-line addition to the `slices.Contains` allowlist. Validated by inspection: the logic is straightforward and consistent with how the other valid values are handled.

### Additional Notes

Branch name references the internal ticket: `ASKU-none-mode-fix`.