### PR TITLE
[observer] Add custom telemetry support

### DIFF
--- a/cmd/observer-testbench/ui/src/components/ChartWithAnomalyDetails.tsx
+++ b/cmd/observer-testbench/ui/src/components/ChartWithAnomalyDetails.tsx
@@ -27,6 +27,7 @@ interface ChartWithAnomalyDetailsProps {
   onTimeRangeChange?: (range: TimeRange | null) => void;
   smoothLines?: boolean;
   seriesVariants?: SeriesVariant[];
+  isTelemetry?: boolean;
 }
 
 function buildSeriesIDSet(seriesVariants?: SeriesVariant[]): Set<SeriesID> {
@@ -81,6 +82,7 @@ export function ChartWithAnomalyDetails({
   onTimeRangeChange,
   smoothLines = true,
   seriesVariants,
+  isTelemetry = false,
 }: ChartWithAnomalyDetailsProps) {
   const [expandedIndex, setExpandedIndex] = useState<number | null>(null);
   const [hoveredAnomalyId, setHoveredAnomalyId] = useState<string | null>(null);
@@ -197,6 +199,7 @@ export function ChartWithAnomalyDetails({
         highlightedMarkerId={activeAnomalyId}
         onMarkerHover={setHoveredAnomalyId}
         onMarkerClick={handleMarkerClick}
+        isTelemetry={isTelemetry}
       />
 
       {/* Anomaly details - compact list below chart */}

--- a/cmd/observer-testbench/ui/src/components/LogView.tsx
+++ b/cmd/observer-testbench/ui/src/components/LogView.tsx
@@ -157,9 +157,10 @@ interface LogEntryRowProps {
   entry: LogEntry;
   isExpanded: boolean;
   onToggle: () => void;
+  isTelemetry?: boolean;
 }
 
-function LogEntryRow({ entry, isExpanded, onToggle }: LogEntryRowProps) {
+function LogEntryRow({ entry, isExpanded, onToggle, isTelemetry = false }: LogEntryRowProps) {
   const contentPreview = entry.content.length > 120 && !isExpanded
     ? entry.content.slice(0, 120) + '…'
     : entry.content;
@@ -177,6 +178,9 @@ function LogEntryRow({ entry, isExpanded, onToggle }: LogEntryRowProps) {
           <span className={`flex-shrink-0 text-xs px-1.5 py-0.5 rounded font-medium uppercase ${levelBadgeColor(entry.status)}`}>
             {entry.status}
           </span>
+          {isTelemetry && (
+            <span className="flex-shrink-0 inline-flex items-center justify-center w-4 h-4 rounded-full bg-purple-600 text-white text-[9px] font-bold mt-0.5" title="Telemetry log">T</span>
+          )}
           <span className="text-xs text-slate-300 font-mono leading-relaxed break-all flex-1">
             {contentPreview}
           </span>
@@ -321,6 +325,9 @@ export function LogView({ state, actions, sidebarWidth }: LogViewProps) {
   const [anomaliesExpanded, setAnomaliesExpanded] = useState(true);
   const [logsExpanded, setLogsExpanded] = useState(true);
   const [logPage, setLogPage] = useState(1);
+  const [telemetryLogsExpanded, setTelemetryLogsExpanded] = useState(true);
+  const [telemetryLogPage, setTelemetryLogPage] = useState(1);
+  const [expandedTelemetryLogIndex, setExpandedTelemetryLogIndex] = useState<number | null>(null);
   const initializedScenarioRef = useRef<string | null>(null);
 
   // Reset state when scenario changes
@@ -332,6 +339,8 @@ export function LogView({ state, actions, sidebarWidth }: LogViewProps) {
       setExpandedLogIndex(null);
       setExpandedAnomalyIndex(null);
       setLogPage(1);
+      setTelemetryLogPage(1);
+      setExpandedTelemetryLogIndex(null);
     }
   }, [state.activeScenario]);
 
@@ -350,6 +359,16 @@ export function LogView({ state, actions, sidebarWidth }: LogViewProps) {
       })
       .sort((a, b) => a.timestamp - b.timestamp);
   }, [allLogs, enabledLevels, tagFilterInput]);
+
+  const regularLogs = useMemo(
+    () => filteredLogs.filter((l) => !(l.tags ?? []).includes('telemetry:true')),
+    [filteredLogs]
+  );
+
+  const telemetryLogs = useMemo(
+    () => filteredLogs.filter((l) => (l.tags ?? []).includes('telemetry:true')),
+    [filteredLogs]
+  );
 
   const countByLevel = useMemo(() => {
     const counts = new Map<string, number>();
@@ -496,8 +515,14 @@ export function LogView({ state, actions, sidebarWidth }: LogViewProps) {
           </h2>
           <div className="space-y-1.5">
             <div className="text-sm text-slate-300">
-              {allLogs.length} log{allLogs.length !== 1 ? 's' : ''} total
+              {allLogs.filter((l) => !(l.tags ?? []).includes('telemetry:true')).length} log{allLogs.filter((l) => !(l.tags ?? []).includes('telemetry:true')).length !== 1 ? 's' : ''} total
             </div>
+            {allLogs.some((l) => (l.tags ?? []).includes('telemetry:true')) && (
+              <div className="text-sm text-purple-400 flex items-center gap-1.5">
+                <span className="inline-flex items-center justify-center w-3.5 h-3.5 rounded-full bg-purple-600 text-white text-[8px] font-bold">T</span>
+                {allLogs.filter((l) => (l.tags ?? []).includes('telemetry:true')).length} telemetry log{allLogs.filter((l) => (l.tags ?? []).includes('telemetry:true')).length !== 1 ? 's' : ''}
+              </div>
+            )}
             <div className="text-sm text-slate-300">
               {allLogAnomalies.length} anomal{allLogAnomalies.length !== 1 ? 'ies' : 'y'} detected
             </div>
@@ -535,7 +560,7 @@ export function LogView({ state, actions, sidebarWidth }: LogViewProps) {
           <div>
             {/* Log rate + anomaly timeline */}
             <LogRateChart
-              logs={allLogs}
+              logs={allLogs.filter((l) => !(l.tags ?? []).includes('telemetry:true'))}
               anomalies={sortedAnomalies}
               scenarioStart={scenarioStart ?? null}
               scenarioEnd={scenarioEnd ?? null}
@@ -568,29 +593,29 @@ export function LogView({ state, actions, sidebarWidth }: LogViewProps) {
               </div>
             )}
 
-            {/* Raw log entries */}
+            {/* Raw log entries (regular only) */}
             <div>
               <button
                 onClick={() => setLogsExpanded(!logsExpanded)}
                 className="flex items-center gap-2 text-sm font-medium text-slate-300 hover:text-white mb-3 transition-colors"
               >
                 <span className="text-slate-500">{logsExpanded ? '▼' : '▶'}</span>
-                Raw Logs ({filteredLogs.length}{filteredLogs.length !== allLogs.length ? ` of ${allLogs.length}` : ''})
+                Raw Logs ({regularLogs.length}{regularLogs.length !== allLogs.length - telemetryLogs.length ? ` of ${allLogs.length - telemetryLogs.length}` : ''})
               </button>
 
               {logsExpanded && (
-                allLogs.length === 0 ? (
+                allLogs.filter((l) => !(l.tags ?? []).includes('telemetry:true')).length === 0 ? (
                   <div className="text-center py-8 text-slate-500 text-sm">
                     No log entries. Load a scenario with log files or the demo scenario.
                   </div>
-                ) : filteredLogs.length === 0 ? (
+                ) : regularLogs.length === 0 ? (
                   <div className="text-center py-8 text-slate-500 text-sm">
                     No logs match the selected levels.
                   </div>
                 ) : (
                   <>
                     <div className="overflow-y-auto max-h-[480px] space-y-0.5 pr-1">
-                      {filteredLogs.slice(0, logPage * LOG_PAGE_SIZE).map((entry, idx) => (
+                      {regularLogs.slice(0, logPage * LOG_PAGE_SIZE).map((entry, idx) => (
                         <LogEntryRow
                           key={`${entry.timestamp}-${idx}`}
                           entry={entry}
@@ -599,18 +624,66 @@ export function LogView({ state, actions, sidebarWidth }: LogViewProps) {
                         />
                       ))}
                     </div>
-                    {filteredLogs.length > logPage * LOG_PAGE_SIZE && (
+                    {regularLogs.length > logPage * LOG_PAGE_SIZE && (
                       <button
                         onClick={() => setLogPage((p) => p + 1)}
                         className="mt-2 w-full py-1.5 text-xs text-slate-400 hover:text-slate-200 bg-slate-700/40 hover:bg-slate-700/70 rounded transition-colors"
                       >
-                        Show more ({filteredLogs.length - logPage * LOG_PAGE_SIZE} remaining)
+                        Show more ({regularLogs.length - logPage * LOG_PAGE_SIZE} remaining)
                       </button>
                     )}
                   </>
                 )
               )}
             </div>
+
+            {/* Telemetry log entries */}
+            {(allLogs.some((l) => (l.tags ?? []).includes('telemetry:true')) || telemetryLogs.length > 0) && (
+              <div>
+                <div className="flex items-center gap-3 mb-3">
+                  <div className="flex-1 border-t border-purple-800/50" />
+                  <button
+                    onClick={() => setTelemetryLogsExpanded(!telemetryLogsExpanded)}
+                    className="flex items-center gap-1.5 text-xs text-purple-400 font-medium hover:text-purple-300 transition-colors"
+                  >
+                    <span className="text-purple-600">{telemetryLogsExpanded ? '▼' : '▶'}</span>
+                    <span className="inline-flex items-center justify-center w-4 h-4 rounded-full bg-purple-600 text-white text-[9px] font-bold">T</span>
+                    Telemetry Logs ({telemetryLogs.length})
+                  </button>
+                  <div className="flex-1 border-t border-purple-800/50" />
+                </div>
+
+                {telemetryLogsExpanded && (
+                  telemetryLogs.length === 0 ? (
+                    <div className="text-center py-8 text-slate-500 text-sm">
+                      No telemetry logs match the current filters.
+                    </div>
+                  ) : (
+                    <>
+                      <div className="overflow-y-auto max-h-[480px] space-y-0.5 pr-1">
+                        {telemetryLogs.slice(0, telemetryLogPage * LOG_PAGE_SIZE).map((entry, idx) => (
+                          <LogEntryRow
+                            key={`telem-${entry.timestamp}-${idx}`}
+                            entry={entry}
+                            isExpanded={expandedTelemetryLogIndex === idx}
+                            onToggle={() => setExpandedTelemetryLogIndex(expandedTelemetryLogIndex === idx ? null : idx)}
+                            isTelemetry
+                          />
+                        ))}
+                      </div>
+                      {telemetryLogs.length > telemetryLogPage * LOG_PAGE_SIZE && (
+                        <button
+                          onClick={() => setTelemetryLogPage((p) => p + 1)}
+                          className="mt-2 w-full py-1.5 text-xs text-purple-400 hover:text-purple-200 bg-purple-900/20 hover:bg-purple-900/40 rounded transition-colors"
+                        >
+                          Show more ({telemetryLogs.length - telemetryLogPage * LOG_PAGE_SIZE} remaining)
+                        </button>
+                      )}
+                    </>
+                  )
+                )}
+              </div>
+            )}
           </div>
         )}
       </main>

--- a/cmd/observer-testbench/ui/src/components/TSAnalysisView.tsx
+++ b/cmd/observer-testbench/ui/src/components/TSAnalysisView.tsx
@@ -156,6 +156,11 @@ export function TSAnalysisView({
     return metricGroups.filter((g) => (anomalyCountByGroup.get(g.key) ?? 0) > 0);
   }, [metricGroups, showAnomalyOnlyGroups, anomalyCountByGroup]);
 
+  const telemetryGroups = useMemo(
+    () => visibleGroups.filter((g) => g.namespace === 'telemetry'),
+    [visibleGroups]
+  );
+
   const displayGroups = useMemo(
     () => visibleGroups.map((g) => ({ key: g.key, name: g.baseName, displayName: g.baseName })),
     [visibleGroups]
@@ -175,13 +180,17 @@ export function TSAnalysisView({
     if (!state.activeScenario || state.connectionState !== 'ready') return;
     if (autoSelectedScenario === state.activeScenario) return;
 
-    const ranked = [...visibleGroups].sort((a, b) => {
-      const countDiff = (anomalyCountByGroup.get(b.key) ?? 0) - (anomalyCountByGroup.get(a.key) ?? 0);
-      if (countDiff !== 0) return countDiff;
-      return a.baseName.localeCompare(b.baseName);
-    });
+    const telKeys = visibleGroups.filter((g) => g.namespace === 'telemetry').map((g) => g.key);
 
-    setSelectedGroups(new Set(ranked.slice(0, 6).map((g) => g.key)));
+    const ranked = [...visibleGroups]
+      .filter((g) => g.namespace !== 'telemetry')
+      .sort((a, b) => {
+        const countDiff = (anomalyCountByGroup.get(b.key) ?? 0) - (anomalyCountByGroup.get(a.key) ?? 0);
+        if (countDiff !== 0) return countDiff;
+        return a.baseName.localeCompare(b.baseName);
+      });
+
+    setSelectedGroups(new Set([...ranked.slice(0, 6).map((g) => g.key), ...telKeys]));
     setAutoSelectedScenario(state.activeScenario);
     onTimeRangeChange(null);
   }, [state.activeScenario, state.connectionState, visibleGroups, anomalyCountByGroup, autoSelectedScenario, onTimeRangeChange]);
@@ -394,6 +403,29 @@ export function TSAnalysisView({
             <div className="flex gap-1">
               <button
                 onClick={() => {
+                  const telKeys = telemetryGroups.map((g) => g.key);
+                  const anySelected = telKeys.some((k) => selectedGroups.has(k));
+                  setSelectedGroups((prev) => {
+                    const next = new Set(prev);
+                    if (anySelected) {
+                      telKeys.forEach((k) => next.delete(k));
+                    } else {
+                      telKeys.forEach((k) => next.add(k));
+                    }
+                    return next;
+                  });
+                }}
+                className={`text-xs px-1.5 py-0.5 rounded font-bold transition-colors ${
+                  telemetryGroups.some((g) => selectedGroups.has(g.key))
+                    ? 'bg-purple-600 text-white'
+                    : 'bg-slate-700 text-slate-400 hover:bg-slate-600'
+                }`}
+                title={telemetryGroups.some((g) => selectedGroups.has(g.key)) ? 'Deselect telemetry groups' : 'Select telemetry groups'}
+              >
+                T
+              </button>
+              <button
+                onClick={() => {
                   const anomalousKeys = displayGroups
                     .filter((g) => anomalousGroupKeys.has(g.key))
                     .map((g) => g.key);
@@ -466,47 +498,106 @@ export function TSAnalysisView({
             ) : groupSeriesData.size === 0 ? (
               <div className="text-center py-10 text-slate-500">Loading series data...</div>
             ) : (
-              <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-                {Array.from(selectedGroups).map((groupKey) => {
-                  const group = groupByKey.get(groupKey);
-                  if (!group) return null;
-                  const dataList = groupSeriesData.get(groupKey) ?? [];
-                  if (dataList.length === 0) return null;
+              <>
+                {/* Regular metric groups */}
+                {(() => {
+                  const cards = Array.from(selectedGroups)
+                    .filter((key) => {
+                      const g = groupByKey.get(key);
+                      return g && g.namespace !== 'telemetry';
+                    })
+                    .map((groupKey) => {
+                      const dataList = groupSeriesData.get(groupKey) ?? [];
+                      if (dataList.length === 0) return null;
+                      const chartSeries = showAnomalyOnlySeriesLines
+                        ? dataList.filter((d) => (anomalyCountBySeriesID.get(d.id) ?? 0) > 0)
+                        : dataList;
+                      if (chartSeries.length === 0) return null;
+                      const seriesIDs = new Set(chartSeries.map((d) => d.id));
+                      const seriesAnomalies = anomalies.filter((a) => a.sourceSeriesId && seriesIDs.has(a.sourceSeriesId));
+                      const anomalyMarkers = chartSeries.flatMap((d) => d.anomalies);
+                      const seriesVariants: SeriesVariant[] = chartSeries.map((d) => ({
+                        label: formatSeriesLabel(d.tags),
+                        points: d.points,
+                        seriesId: d.id,
+                      }));
+                      const primary = chartSeries[0];
+                      return (
+                        <ChartWithAnomalyDetails
+                          key={groupKey}
+                          name={primary.name}
+                          points={primary.points}
+                          anomalyMarkers={anomalyMarkers}
+                          anomalies={seriesAnomalies}
+                          correlationRanges={[]}
+                          enabledAnalyzers={enabledAnalyzers}
+                          timeRange={timeRange}
+                          onTimeRangeChange={onTimeRangeChange}
+                          smoothLines={smoothLines}
+                          seriesVariants={seriesVariants}
+                        />
+                      );
+                    })
+                    .filter(Boolean);
+                  return cards.length > 0 ? (
+                    <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">{cards}</div>
+                  ) : null;
+                })()}
 
-                  const chartSeries = showAnomalyOnlySeriesLines
-                    ? dataList.filter((d) => (anomalyCountBySeriesID.get(d.id) ?? 0) > 0)
-                    : dataList;
-                  if (chartSeries.length === 0) return null;
-
-                  const seriesIDs = new Set(chartSeries.map((d) => d.id));
-                  const seriesAnomalies = anomalies.filter((a) => a.sourceSeriesId && seriesIDs.has(a.sourceSeriesId));
-                  const anomalyMarkers = chartSeries.flatMap((d) => d.anomalies);
-
-                  const seriesVariants: SeriesVariant[] = chartSeries.map((d) => ({
-                    label: formatSeriesLabel(d.tags),
-                    points: d.points,
-                    seriesId: d.id,
-                  }));
-
-                  const primary = chartSeries[0];
-
-                  return (
-                    <ChartWithAnomalyDetails
-                      key={groupKey}
-                      name={primary.name}
-                      points={primary.points}
-                      anomalyMarkers={anomalyMarkers}
-                      anomalies={seriesAnomalies}
-                      correlationRanges={[]}
-                      enabledAnalyzers={enabledAnalyzers}
-                      timeRange={timeRange}
-                      onTimeRangeChange={onTimeRangeChange}
-                      smoothLines={smoothLines}
-                      seriesVariants={seriesVariants}
-                    />
-                  );
-                })}
-              </div>
+                {/* Telemetry metric groups — shown after a separator */}
+                {telemetryGroups.some((g) => selectedGroups.has(g.key)) && (
+                  <>
+                    <div className="flex items-center gap-3">
+                      <div className="flex-1 border-t border-purple-800/50" />
+                      <div className="flex items-center gap-1.5 text-xs text-purple-400 font-medium">
+                        <span className="inline-flex items-center justify-center w-4 h-4 rounded-full bg-purple-600 text-white text-[9px] font-bold">T</span>
+                        Telemetry Metrics
+                      </div>
+                      <div className="flex-1 border-t border-purple-800/50" />
+                    </div>
+                    <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+                      {Array.from(selectedGroups)
+                        .filter((key) => {
+                          const g = groupByKey.get(key);
+                          return g && g.namespace === 'telemetry';
+                        })
+                        .map((groupKey) => {
+                          const dataList = groupSeriesData.get(groupKey) ?? [];
+                          if (dataList.length === 0) return null;
+                          const chartSeries = showAnomalyOnlySeriesLines
+                            ? dataList.filter((d) => (anomalyCountBySeriesID.get(d.id) ?? 0) > 0)
+                            : dataList;
+                          if (chartSeries.length === 0) return null;
+                          const seriesIDs = new Set(chartSeries.map((d) => d.id));
+                          const seriesAnomalies = anomalies.filter((a) => a.sourceSeriesId && seriesIDs.has(a.sourceSeriesId));
+                          const anomalyMarkers = chartSeries.flatMap((d) => d.anomalies);
+                          const seriesVariants: SeriesVariant[] = chartSeries.map((d) => ({
+                            label: formatSeriesLabel(d.tags),
+                            points: d.points,
+                            seriesId: d.id,
+                          }));
+                          const primary = chartSeries[0];
+                          return (
+                            <ChartWithAnomalyDetails
+                              key={groupKey}
+                              name={primary.name}
+                              points={primary.points}
+                              anomalyMarkers={anomalyMarkers}
+                              anomalies={seriesAnomalies}
+                              correlationRanges={[]}
+                              enabledAnalyzers={enabledAnalyzers}
+                              timeRange={timeRange}
+                              onTimeRangeChange={onTimeRangeChange}
+                              smoothLines={smoothLines}
+                              seriesVariants={seriesVariants}
+                              isTelemetry
+                            />
+                          );
+                        })}
+                    </div>
+                  </>
+                )}
+              </>
             )}
           </div>
         )}

--- a/cmd/observer-testbench/ui/src/components/TimeSeriesChart.tsx
+++ b/cmd/observer-testbench/ui/src/components/TimeSeriesChart.tsx
@@ -86,6 +86,7 @@ interface TimeSeriesChartProps {
   highlightedMarkerId?: string | null;
   onMarkerHover?: (markerId: string | null) => void;
   onMarkerClick?: (markerId: string) => void;
+  isTelemetry?: boolean;
 }
 
 export function TimeSeriesChart({
@@ -105,6 +106,7 @@ export function TimeSeriesChart({
   highlightedMarkerId = null,
   onMarkerHover,
   onMarkerClick,
+  isTelemetry = false,
 }: TimeSeriesChartProps) {
   const [showCorrelationLegend, setShowCorrelationLegend] = useState(false);
   const [showSeriesLegend, setShowSeriesLegend] = useState(false);
@@ -586,7 +588,12 @@ export function TimeSeriesChart({
   if (points.length === 0) {
     return (
       <div className="bg-slate-800 rounded-lg p-4">
-        <div className="text-sm text-slate-400 mb-2 font-mono">{name}</div>
+        <div className="text-sm text-slate-400 mb-2 font-mono flex items-center gap-1.5">
+          {isTelemetry && (
+            <span className="inline-flex items-center justify-center w-4 h-4 rounded-full bg-purple-600 text-white text-[9px] font-bold flex-shrink-0" title="Telemetry metric">T</span>
+          )}
+          {name}
+        </div>
         <div className="text-slate-500 text-center py-8">No data</div>
       </div>
     );
@@ -595,7 +602,12 @@ export function TimeSeriesChart({
   return (
     <div className="bg-slate-800 rounded-lg p-4">
       <div className="flex justify-between items-center mb-2 gap-2">
-        <div className="text-sm text-slate-300 font-mono truncate">{name}</div>
+        <div className="text-sm text-slate-300 font-mono truncate flex items-center gap-1.5">
+          {isTelemetry && (
+            <span className="inline-flex items-center justify-center w-4 h-4 rounded-full bg-purple-600 text-white text-[9px] font-bold flex-shrink-0" title="Telemetry metric">T</span>
+          )}
+          {name}
+        </div>
         <div className="flex gap-2 items-center flex-shrink-0">
           {/* Detector legend - only show if there are anomalies */}
           {filteredAnomalies.length > 0 && Array.from(new Set(filteredAnomalies.map((a) => a.analyzerName))).map((analyzer) => {

--- a/comp/observer/def/component.go
+++ b/comp/observer/def/component.go
@@ -74,6 +74,8 @@ type LogProcessorResult struct {
 	Metrics []MetricOutput
 	// Anomalies are directly detected anomalies (bypassing the metrics→TSAnalysis path).
 	Anomalies []AnomalyOutput
+	// Used to debug anomaly detectors
+	Telemetry []ObserverTelemetry
 }
 
 // MetricOutput is a timeseries value derived from log analysis.
@@ -183,6 +185,14 @@ type Point struct {
 	Value     float64
 }
 
+// Describes a telemetry event that is emitted by the observer.
+// This could be a metric or a log for instance.
+type ObserverTelemetry struct {
+	AnalyzerName string
+	Metric       MetricView
+	Log          LogView
+}
+
 // TimeSeriesAnalysis analyzes a time series for anomalies.
 // Implementations should be stateless and just do math on the points.
 type TimeSeriesAnalysis interface {
@@ -195,6 +205,8 @@ type TimeSeriesAnalysis interface {
 // TimeSeriesAnalysisResult contains outputs from time series analysis.
 type TimeSeriesAnalysisResult struct {
 	Anomalies []AnomalyOutput
+	// Used to debug anomaly detectors
+	Telemetry []ObserverTelemetry
 }
 
 // AnomalyProcessor accumulates anomaly events and produces reports.

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -51,7 +51,7 @@ type observation struct {
 	log    *logObs
 }
 
-// metricObs contains copied metric data.
+// metricObs contains copied metric data and implements observerdef.MetricView.
 type metricObs struct {
 	name      string
 	value     float64
@@ -59,13 +59,61 @@ type metricObs struct {
 	timestamp int64
 }
 
-// logObs contains copied log data.
+// Ensure metricObs implements observerdef.MetricView
+var _ observerdef.MetricView = (*metricObs)(nil)
+
+func (m *metricObs) GetName() string {
+	return m.name
+}
+
+func (m *metricObs) GetValue() float64 {
+	return m.value
+}
+
+func (m *metricObs) GetRawTags() []string {
+	return m.tags
+}
+
+func (m *metricObs) GetTimestamp() float64 {
+	return float64(m.timestamp)
+}
+
+// Observer does not store samplerate; just return 1.0
+func (m *metricObs) GetSampleRate() float64 {
+	return 1.0
+}
+
+// logObs contains copied log data and implements observerdef.LogView.
 type logObs struct {
 	content   []byte
 	status    string
 	tags      []string
 	hostname  string
 	timestamp int64
+}
+
+// Ensure logObs implements observerdef.LogView
+var _ observerdef.LogView = (*logObs)(nil)
+
+func (l *logObs) GetContent() []byte {
+	return l.content
+}
+
+func (l *logObs) GetStatus() string {
+	return l.status
+}
+
+func (l *logObs) GetTags() []string {
+	return l.tags
+}
+
+func (l *logObs) GetHostname() string {
+	return l.hostname
+}
+
+// Optionally, for logs that provide timestamp interface (if needed elsewhere)
+func (l *logObs) GetTimestamp() int64 {
+	return l.timestamp
 }
 
 // NewComponent creates an observer.Component.
@@ -337,6 +385,8 @@ func (o *observerImpl) processLog(source string, l *logObs) {
 			o.captureRawAnomaly(anomaly)
 			o.processAnomaly(anomaly)
 		}
+
+		o.handleTelemetry(result.Telemetry, processor.Name())
 	}
 
 	o.flushAndReport()
@@ -399,6 +449,36 @@ func (o *observerImpl) runTSAnalyses(series observerdef.Series, agg Aggregate) {
 			// Capture raw anomaly before passing to processors
 			o.captureRawAnomaly(anomaly)
 			o.processAnomaly(anomaly)
+		}
+		// Custom telemetry
+		o.handleTelemetry(result.Telemetry, tsAnalysis.Name())
+	}
+}
+
+// This will register custom telemetry sent by the anomaly detectors.
+func (o *observerImpl) handleTelemetry(telemetry []observerdef.ObserverTelemetry, analyzerName string) {
+	now := time.Now().Unix()
+	for _, telemetryEvent := range telemetry {
+		// Generate missing fields if needed
+		if telemetryEvent.Metric != nil {
+			metric := &metricObs{
+				name:      telemetryEvent.Metric.GetName(),
+				value:     telemetryEvent.Metric.GetValue(),
+				tags:      telemetryEvent.Metric.GetRawTags(),
+				timestamp: int64(telemetryEvent.Metric.GetTimestamp()),
+			}
+			if metric.timestamp == 0 {
+				metric.timestamp = now
+			}
+			if telemetryEvent.AnalyzerName == "" {
+				telemetryEvent.AnalyzerName = analyzerName
+			}
+			// Save this for UI
+			o.storage.Add("telemetry", "telemetry."+telemetryEvent.AnalyzerName+"."+metric.name, metric.value, metric.timestamp, metric.tags)
+		}
+
+		// TODO A(celian): Handle log telemetry
+		if telemetryEvent.Log != nil {
 		}
 	}
 }

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -385,8 +385,6 @@ func (o *observerImpl) processLog(source string, l *logObs) {
 			o.captureRawAnomaly(anomaly)
 			o.processAnomaly(anomaly)
 		}
-
-		o.handleTelemetry(result.Telemetry, processor.Name())
 	}
 
 	o.flushAndReport()
@@ -449,36 +447,6 @@ func (o *observerImpl) runTSAnalyses(series observerdef.Series, agg Aggregate) {
 			// Capture raw anomaly before passing to processors
 			o.captureRawAnomaly(anomaly)
 			o.processAnomaly(anomaly)
-		}
-		// Custom telemetry
-		o.handleTelemetry(result.Telemetry, tsAnalysis.Name())
-	}
-}
-
-// This will register custom telemetry sent by the anomaly detectors.
-func (o *observerImpl) handleTelemetry(telemetry []observerdef.ObserverTelemetry, analyzerName string) {
-	now := time.Now().Unix()
-	for _, telemetryEvent := range telemetry {
-		// Generate missing fields if needed
-		if telemetryEvent.Metric != nil {
-			metric := &metricObs{
-				name:      telemetryEvent.Metric.GetName(),
-				value:     telemetryEvent.Metric.GetValue(),
-				tags:      telemetryEvent.Metric.GetRawTags(),
-				timestamp: int64(telemetryEvent.Metric.GetTimestamp()),
-			}
-			if metric.timestamp == 0 {
-				metric.timestamp = now
-			}
-			if telemetryEvent.AnalyzerName == "" {
-				telemetryEvent.AnalyzerName = analyzerName
-			}
-			// Save this for UI
-			o.storage.Add("telemetry", "telemetry."+telemetryEvent.AnalyzerName+"."+metric.name, metric.value, metric.timestamp, metric.tags)
-		}
-
-		// TODO A(celian): Handle log telemetry
-		if telemetryEvent.Log != nil {
 		}
 	}
 }

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -734,7 +734,6 @@ func (tb *TestBench) handleTelemetry(telemetry []observerdef.ObserverTelemetry, 
 			tb.storage.Add("telemetry", "telemetry."+telemetryEvent.AnalyzerName+"."+metric.name, metric.value, metric.timestamp, metric.tags)
 		}
 
-		// TODO A(celian): Handle log telemetry
 		if telemetryEvent.Log != nil {
 			timestamp := int64(0)
 			if tlv, ok := telemetryEvent.Log.(logTimestamper); ok {

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -309,7 +309,7 @@ func (tb *TestBench) LoadScenario(name string) error {
 	tb.rerunAnalysesLocked()
 	fmt.Printf("  Analyzer phase took %s\n", time.Since(analysisStart))
 	fmt.Printf("  Total scenario load took %s (correlators running in background)\n", time.Since(scenarioStart))
-	fmt.Printf("Scenario loaded: %d series, %d metric anomalies, %d log anomalies\n", tb.seriesCount(), len(tb.metricsAnomalies), len(tb.logAnomalies))
+	fmt.Printf("Scenario loaded: %d series, %d metric anomalies,  %d log entries, %d log anomalies\n", tb.seriesCount(), len(tb.metricsAnomalies), len(tb.rawLogs), len(tb.logAnomalies))
 
 	return nil
 }
@@ -417,6 +417,7 @@ func (tb *TestBench) loadLogsDir(dir string) error {
 					tb.logAnomaliesByProcessor[anomaly.AnalyzerName] = append(
 						tb.logAnomaliesByProcessor[anomaly.AnalyzerName], anomaly)
 				}
+				tb.handleTelemetry(result.Telemetry, processor.Name(), timestamp)
 			}
 		}
 		totalLogs += len(logs)
@@ -711,8 +712,9 @@ func (tb *TestBench) rerunAnalysesLocked() {
 	}()
 }
 
+// This will handle custom telemetry created by the anomaly detectors.
+// It includes metrics and logs.
 func (tb *TestBench) handleTelemetry(telemetry []observerdef.ObserverTelemetry, analyzerName string, baseTimestamp int64) {
-	// TODO: Use a single method for that, this is duplicated from observer.go
 	for _, telemetryEvent := range telemetry {
 		// Generate missing fields if needed
 		if telemetryEvent.Metric != nil {
@@ -741,17 +743,25 @@ func (tb *TestBench) handleTelemetry(telemetry []observerdef.ObserverTelemetry, 
 			if timestamp == 0 {
 				timestamp = baseTimestamp
 			}
-			log := &logObs{
-				content:   telemetryEvent.Log.GetContent(),
-				status:    telemetryEvent.Log.GetStatus(),
-				tags:      telemetryEvent.Log.GetTags(),
-				hostname:  telemetryEvent.Log.GetHostname(),
-				timestamp: timestamp,
+			logTags := telemetryEvent.Log.GetTags()
+			tagsCopy := make([]string, 0, len(logTags)+2)
+			copy(tagsCopy, logTags)
+			tagsCopy = append(tagsCopy, "analyzer:"+analyzerName)
+			tagsCopy = append(tagsCopy, "telemetry:true")
+			log := storedLogEntry{
+				Content:   string(telemetryEvent.Log.GetContent()),
+				Status:    telemetryEvent.Log.GetStatus(),
+				Tags:      tagsCopy,
+				Timestamp: timestamp,
+			}
+			if log.Status == "" {
+				log.Status = "info"
 			}
 			if telemetryEvent.AnalyzerName == "" {
 				telemetryEvent.AnalyzerName = analyzerName
 			}
 			// Save this for UI
+			tb.rawLogs = append(tb.rawLogs, log)
 		}
 	}
 }

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -734,6 +734,24 @@ func (tb *TestBench) handleTelemetry(telemetry []observerdef.ObserverTelemetry, 
 
 		// TODO A(celian): Handle log telemetry
 		if telemetryEvent.Log != nil {
+			timestamp := int64(0)
+			if tlv, ok := telemetryEvent.Log.(logTimestamper); ok {
+				timestamp = tlv.GetTimestamp()
+			}
+			if timestamp == 0 {
+				timestamp = baseTimestamp
+			}
+			log := &logObs{
+				content:   telemetryEvent.Log.GetContent(),
+				status:    telemetryEvent.Log.GetStatus(),
+				tags:      telemetryEvent.Log.GetTags(),
+				hostname:  telemetryEvent.Log.GetHostname(),
+				timestamp: timestamp,
+			}
+			if telemetryEvent.AnalyzerName == "" {
+				telemetryEvent.AnalyzerName = analyzerName
+			}
+			// Save this for UI
 		}
 	}
 }

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -617,6 +617,12 @@ func (tb *TestBench) rerunAnalysesLocked() {
 							tb.metricsBySeriesID[anomaly.SourceSeriesID] = append(tb.metricsBySeriesID[anomaly.SourceSeriesID], anomaly)
 						}
 					}
+
+					baseTimestamp := time.Now().Unix()
+					if len(seriesCopy.Points) > 0 {
+						baseTimestamp = seriesCopy.Points[0].Timestamp
+					}
+					tb.handleTelemetry(result.Telemetry, analyzer.Name(), baseTimestamp)
 				}
 			}
 		}
@@ -703,6 +709,33 @@ func (tb *TestBench) rerunAnalysesLocked() {
 
 		tb.correlatorsProcessing = false
 	}()
+}
+
+func (tb *TestBench) handleTelemetry(telemetry []observerdef.ObserverTelemetry, analyzerName string, baseTimestamp int64) {
+	// TODO: Use a single method for that, this is duplicated from observer.go
+	for _, telemetryEvent := range telemetry {
+		// Generate missing fields if needed
+		if telemetryEvent.Metric != nil {
+			metric := &metricObs{
+				name:      telemetryEvent.Metric.GetName(),
+				value:     telemetryEvent.Metric.GetValue(),
+				tags:      telemetryEvent.Metric.GetRawTags(),
+				timestamp: int64(telemetryEvent.Metric.GetTimestamp()),
+			}
+			if metric.timestamp == 0 {
+				metric.timestamp = baseTimestamp
+			}
+			if telemetryEvent.AnalyzerName == "" {
+				telemetryEvent.AnalyzerName = analyzerName
+			}
+			// Save this for UI
+			tb.storage.Add("telemetry", "telemetry."+telemetryEvent.AnalyzerName+"."+metric.name, metric.value, metric.timestamp, metric.tags)
+		}
+
+		// TODO A(celian): Handle log telemetry
+		if telemetryEvent.Log != nil {
+		}
+	}
 }
 
 // GetComponents returns all registered components.

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -309,7 +309,7 @@ func (tb *TestBench) LoadScenario(name string) error {
 	tb.rerunAnalysesLocked()
 	fmt.Printf("  Analyzer phase took %s\n", time.Since(analysisStart))
 	fmt.Printf("  Total scenario load took %s (correlators running in background)\n", time.Since(scenarioStart))
-	fmt.Printf("Scenario loaded: %d series, %d metric anomalies,  %d log entries, %d log anomalies\n", tb.seriesCount(), len(tb.metricsAnomalies), len(tb.rawLogs), len(tb.logAnomalies))
+	fmt.Printf("Scenario loaded: %d series, %d metric anomalies, %d log entries, %d log anomalies\n", tb.seriesCount(), len(tb.metricsAnomalies), len(tb.rawLogs), len(tb.logAnomalies))
 
 	return nil
 }
@@ -1180,7 +1180,7 @@ func (tb *TestBench) loadDemoScenario() error {
 
 	// Run analyses on all loaded data (analyzers sync, correlators async)
 	tb.rerunAnalysesLocked()
-	fmt.Printf("Demo scenario loaded: %d series, %d metric anomalies, %d log anomalies (correlators running in background)\n", tb.seriesCount(), len(tb.metricsAnomalies), len(tb.logAnomalies))
+	fmt.Printf("Demo scenario loaded: %d series, %d metric anomalies, %d log entries, %d log anomalies (correlators running in background)\n", tb.seriesCount(), len(tb.metricsAnomalies), len(tb.rawLogs), len(tb.logAnomalies))
 
 	return nil
 }

--- a/comp/observer/impl/ts_analysis_cusum.go
+++ b/comp/observer/impl/ts_analysis_cusum.go
@@ -74,10 +74,15 @@ func (c *CUSUMDetector) Name() string {
 // Analyze runs CUSUM on the series and returns an anomaly if a shift is detected.
 // The anomaly's Timestamp indicates when the shift was first detected (threshold crossing).
 func (c *CUSUMDetector) Analyze(series observer.Series) observer.TimeSeriesAnalysisResult {
+	telemetry := []observer.ObserverTelemetry{}
+	for _, p := range series.Points {
+		telemetry = append(telemetry, observer.ObserverTelemetry{Metric: &metricObs{name: "cusum_baseline_eval", value: p.Value, tags: []string{"series:" + series.Name}, timestamp: p.Timestamp}})
+	}
+
 	// Skip :count metrics - these are cardinality counts that create noise
 	// when container counts change (e.g., 1 -> 2 pods)
 	if c.SkipCountMetrics && strings.HasSuffix(series.Name, ":count") {
-		return observer.TimeSeriesAnalysisResult{}
+		return observer.TimeSeriesAnalysisResult{Telemetry: telemetry}
 	}
 
 	minPoints := c.MinPoints
@@ -99,7 +104,7 @@ func (c *CUSUMDetector) Analyze(series observer.Series) observer.TimeSeriesAnaly
 
 	n := len(series.Points)
 	if n < minPoints {
-		return observer.TimeSeriesAnalysisResult{}
+		return observer.TimeSeriesAnalysisResult{Telemetry: telemetry}
 	}
 
 	// Estimate baseline from first portion of data
@@ -124,7 +129,7 @@ func (c *CUSUMDetector) Analyze(series observer.Series) observer.TimeSeriesAnaly
 			baselineStddev = baselineMean * 0.1
 		} else {
 			// Can't establish meaningful baseline
-			return observer.TimeSeriesAnalysisResult{}
+			return observer.TimeSeriesAnalysisResult{Telemetry: telemetry}
 		}
 	}
 
@@ -145,10 +150,10 @@ func (c *CUSUMDetector) Analyze(series observer.Series) observer.TimeSeriesAnaly
 	// Run CUSUM and detect threshold crossing
 	anomaly := runCUSUM(series, baselineMean, baselineStddev, k, h, debugInfo)
 	if anomaly == nil {
-		return observer.TimeSeriesAnalysisResult{}
+		return observer.TimeSeriesAnalysisResult{Telemetry: telemetry}
 	}
 
-	return observer.TimeSeriesAnalysisResult{Anomalies: []observer.AnomalyOutput{*anomaly}}
+	return observer.TimeSeriesAnalysisResult{Anomalies: []observer.AnomalyOutput{*anomaly}, Telemetry: telemetry}
 }
 
 // runCUSUM executes a two-sided CUSUM algorithm and returns an anomaly at the first threshold crossing.

--- a/comp/observer/impl/ts_analysis_cusum.go
+++ b/comp/observer/impl/ts_analysis_cusum.go
@@ -74,17 +74,10 @@ func (c *CUSUMDetector) Name() string {
 // Analyze runs CUSUM on the series and returns an anomaly if a shift is detected.
 // The anomaly's Timestamp indicates when the shift was first detected (threshold crossing).
 func (c *CUSUMDetector) Analyze(series observer.Series) observer.TimeSeriesAnalysisResult {
-	telemetry := []observer.ObserverTelemetry{}
-	for _, p := range series.Points {
-		telemetry = append(telemetry, observer.ObserverTelemetry{Metric: &metricObs{name: "cusum_baseline_eval", value: p.Value, tags: []string{"series:" + series.Name}, timestamp: p.Timestamp}})
-	}
-	telemetry = append(telemetry, observer.ObserverTelemetry{Log: &logObs{content: []byte(fmt.Sprintf("CUSUMDetector: analyzing series %s start", series.Name)), timestamp: series.Points[0].Timestamp}})
-	telemetry = append(telemetry, observer.ObserverTelemetry{Log: &logObs{content: []byte(fmt.Sprintf("CUSUMDetector: analyzing series %s end", series.Name)), timestamp: series.Points[len(series.Points)-1].Timestamp}})
-
 	// Skip :count metrics - these are cardinality counts that create noise
 	// when container counts change (e.g., 1 -> 2 pods)
 	if c.SkipCountMetrics && strings.HasSuffix(series.Name, ":count") {
-		return observer.TimeSeriesAnalysisResult{Telemetry: telemetry}
+		return observer.TimeSeriesAnalysisResult{}
 	}
 
 	minPoints := c.MinPoints
@@ -106,7 +99,7 @@ func (c *CUSUMDetector) Analyze(series observer.Series) observer.TimeSeriesAnaly
 
 	n := len(series.Points)
 	if n < minPoints {
-		return observer.TimeSeriesAnalysisResult{Telemetry: telemetry}
+		return observer.TimeSeriesAnalysisResult{}
 	}
 
 	// Estimate baseline from first portion of data
@@ -131,7 +124,7 @@ func (c *CUSUMDetector) Analyze(series observer.Series) observer.TimeSeriesAnaly
 			baselineStddev = baselineMean * 0.1
 		} else {
 			// Can't establish meaningful baseline
-			return observer.TimeSeriesAnalysisResult{Telemetry: telemetry}
+			return observer.TimeSeriesAnalysisResult{}
 		}
 	}
 
@@ -152,10 +145,10 @@ func (c *CUSUMDetector) Analyze(series observer.Series) observer.TimeSeriesAnaly
 	// Run CUSUM and detect threshold crossing
 	anomaly := runCUSUM(series, baselineMean, baselineStddev, k, h, debugInfo)
 	if anomaly == nil {
-		return observer.TimeSeriesAnalysisResult{Telemetry: telemetry}
+		return observer.TimeSeriesAnalysisResult{}
 	}
 
-	return observer.TimeSeriesAnalysisResult{Anomalies: []observer.AnomalyOutput{*anomaly}, Telemetry: telemetry}
+	return observer.TimeSeriesAnalysisResult{Anomalies: []observer.AnomalyOutput{*anomaly}}
 }
 
 // runCUSUM executes a two-sided CUSUM algorithm and returns an anomaly at the first threshold crossing.

--- a/comp/observer/impl/ts_analysis_cusum.go
+++ b/comp/observer/impl/ts_analysis_cusum.go
@@ -78,6 +78,8 @@ func (c *CUSUMDetector) Analyze(series observer.Series) observer.TimeSeriesAnaly
 	for _, p := range series.Points {
 		telemetry = append(telemetry, observer.ObserverTelemetry{Metric: &metricObs{name: "cusum_baseline_eval", value: p.Value, tags: []string{"series:" + series.Name}, timestamp: p.Timestamp}})
 	}
+	telemetry = append(telemetry, observer.ObserverTelemetry{Log: &logObs{content: []byte(fmt.Sprintf("CUSUMDetector: analyzing series %s start", series.Name)), timestamp: series.Points[0].Timestamp}})
+	telemetry = append(telemetry, observer.ObserverTelemetry{Log: &logObs{content: []byte(fmt.Sprintf("CUSUMDetector: analyzing series %s end", series.Name)), timestamp: series.Points[len(series.Points)-1].Timestamp}})
 
 	// Skip :count metrics - these are cardinality counts that create noise
 	// when container counts change (e.g., 1 -> 2 pods)


### PR DESCRIPTION
### What does this PR do?

This adds support for custom telemetry (metrics / logs) generated from metrics and log anomaly detectors.
To do so, there is a new Telemetry field inside the metrics / logs AD process result.
It also updates the UI to show these as separate metrics / logs.

<img width="2175" height="304" alt="Screenshot 2026-03-02 at 15 53 54" src="https://github.com/user-attachments/assets/f7dc1d22-2804-4c1c-871c-d84d01454f67" />

<img width="2193" height="178" alt="Screenshot 2026-03-02 at 15 53 40" src="https://github.com/user-attachments/assets/f9e36449-75a0-4b25-aa19-b6d38736c43e" />

### Motivation

### Describe how you validated your changes

### Additional Notes
