### PR TITLE
[CWS] normalize extension patterns instead of stripping dot from field value

### DIFF
--- a/pkg/security/probe/field_handlers.go
+++ b/pkg/security/probe/field_handlers.go
@@ -156,7 +156,7 @@ func (bfh *BaseFieldHandlers) ResolveService(ev *model.Event, e *model.BaseEvent
 func (bfh *BaseFieldHandlers) ResolveFileExtension(ev *model.Event, f *model.FileEvent) string {
 	if f.Extension == "" {
 		if baseName := ev.FieldHandlers.ResolveFileBasename(ev, f); baseName != "" {
-			f.Extension = strings.TrimPrefix(filepath.Ext(baseName), ".")
+			f.Extension = filepath.Ext(baseName)
 		}
 	}
 	return f.Extension

--- a/pkg/security/secl/compiler/eval/oo_extension.go
+++ b/pkg/security/secl/compiler/eval/oo_extension.go
@@ -9,11 +9,7 @@ import "strings"
 
 var (
 	extensionSanitizer = func(kind FieldValueType, pattern string) (string, error) {
-		if kind == RegexpValueType {
-			return pattern, nil
-		}
-
-		if strings.HasPrefix(pattern, ".") {
+		if kind == RegexpValueType || strings.HasPrefix(pattern, ".") {
 			return pattern, nil
 		}
 

--- a/pkg/security/secl/compiler/eval/oo_extension.go
+++ b/pkg/security/secl/compiler/eval/oo_extension.go
@@ -5,38 +5,52 @@
 
 package eval
 
+import "strings"
+
 var (
+	extensionSanitizer = func(kind FieldValueType, pattern string) (string, error) {
+		if kind == RegexpValueType {
+			return pattern, nil
+		}
+
+		if strings.HasPrefix(pattern, ".") {
+			return pattern, nil
+		}
+
+		return "." + pattern, nil
+	}
+
 	// ExtensionCmp normalizes file extension values by stripping a leading dot,
 	// allowing rules to use either ".txt" or "txt" to match the same extension.
 	ExtensionCmp = &OpOverrides{
 		StringEquals: func(a *StringEvaluator, b *StringEvaluator, state *State) (*BoolEvaluator, error) {
 			if a.Field != "" {
-				a.StringCmpOpts.TrimLeadingDot = true
+				a.StringCmpOpts.Sanitize = extensionSanitizer
 			} else if b.Field != "" {
-				b.StringCmpOpts.TrimLeadingDot = true
+				b.StringCmpOpts.Sanitize = extensionSanitizer
 			}
 
 			return StringEquals(a, b, state)
 		},
 		StringValuesContains: func(a *StringEvaluator, b *StringValuesEvaluator, state *State) (*BoolEvaluator, error) {
 			if a.Field != "" {
-				a.StringCmpOpts.TrimLeadingDot = true
+				a.StringCmpOpts.Sanitize = extensionSanitizer
 			}
 
 			return StringValuesContains(a, b, state)
 		},
 		StringArrayContains: func(a *StringEvaluator, b *StringArrayEvaluator, state *State) (*BoolEvaluator, error) {
 			if a.Field != "" {
-				a.StringCmpOpts.TrimLeadingDot = true
+				a.StringCmpOpts.Sanitize = extensionSanitizer
 			} else if b.Field != "" {
-				b.StringCmpOpts.TrimLeadingDot = true
+				b.StringCmpOpts.Sanitize = extensionSanitizer
 			}
 
 			return StringArrayContains(a, b, state)
 		},
 		StringArrayMatches: func(a *StringArrayEvaluator, b *StringValuesEvaluator, state *State) (*BoolEvaluator, error) {
 			if a.Field != "" {
-				a.StringCmpOpts.TrimLeadingDot = true
+				a.StringCmpOpts.Sanitize = extensionSanitizer
 			}
 
 			return StringArrayMatches(a, b, state)

--- a/pkg/security/secl/compiler/eval/strings.go
+++ b/pkg/security/secl/compiler/eval/strings.go
@@ -18,7 +18,11 @@ import (
 type StringCmpOpts struct {
 	CaseInsensitive        bool
 	PathSeparatorNormalize bool
-	TrimLeadingDot         bool
+	Sanitize               func(kind FieldValueType, pattern string) (string, error)
+}
+
+func (o StringCmpOpts) IsDefault() bool {
+	return o.Sanitize == nil && !o.CaseInsensitive && !o.PathSeparatorNormalize
 }
 
 // DefaultStringCmpOpts defines the default comparison options
@@ -51,7 +55,7 @@ func (s *StringValues) AppendFieldValue(value FieldValue) {
 func (s *StringValues) Compile(opts StringCmpOpts) error {
 	for _, value := range s.fieldValues {
 		// fast path for scalar value without specific comparison behavior
-		if opts == DefaultStringCmpOpts && value.Type == ScalarValueType {
+		if opts.IsDefault() && value.Type == ScalarValueType {
 			str := value.Value.(string)
 			s.scalars = append(s.scalars, str)
 		} else {
@@ -266,8 +270,12 @@ func (s *ScalarStringMatcher) Matches(value string) bool {
 
 // NewStringMatcher returns a new string matcher
 func NewStringMatcher(kind FieldValueType, pattern string, opts StringCmpOpts) (StringMatcher, error) {
-	if opts.TrimLeadingDot {
-		pattern = strings.TrimPrefix(pattern, ".")
+	if opts.Sanitize != nil {
+		var err error
+		pattern, err = opts.Sanitize(kind, pattern)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	switch kind {

--- a/pkg/security/tests/fields_test.go
+++ b/pkg/security/tests/fields_test.go
@@ -36,6 +36,10 @@ func TestFieldsResolver(t *testing.T) {
 			ID:         "test_fields_extension_no_dot",
 			Expression: `open.file.extension == "csv" && open.flags & O_CREAT != 0`,
 		},
+		{
+			ID:         "test_fields_extension_in",
+			Expression: `open.file.extension in [".mp3", "mp4"] && open.flags & O_CREAT != 0`,
+		},
 	}
 
 	test, err := newTestModule(t, nil, ruleDefs)
@@ -89,5 +93,14 @@ func TestFieldsResolver(t *testing.T) {
 		}, func(_ *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_fields_extension_no_dot")
 		}, "test_fields_extension_no_dot")
+	})
+
+	t.Run("extension-in", func(t *testing.T) {
+		test.WaitSignalFromRule(t, func() error {
+			_, _, err = test.Create("test-fields.mp3")
+			return err
+		}, func(_ *model.Event, rule *rules.Rule) {
+			assertTriggeredRule(t, rule, "test_fields_extension_in")
+		}, "test_fields_extension_in")
 	})
 }


### PR DESCRIPTION
Replace the TrimLeadingDot bool option in StringCmpOpts with a generic Sanitize callback, and flip the normalization strategy: instead of stripping the leading dot from the resolved extension value in the field handler, keep the dot there and normalize SECL rule patterns to always include a leading dot via the sanitizer.

This allows rules to use either ".txt" or "txt" while the field value consistently retains the dot (matching filepath.Ext behavior). Also adds a test covering the `in` operator with mixed dot/no-dot patterns.

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
