### PR TITLE
Reinstate XDG_CACHE_HOME abspath check in tools/bazel*

### DIFF
--- a/tools/bazel
+++ b/tools/bazel
@@ -18,8 +18,16 @@ if [ ! -d "${XDG_CACHE_HOME:-}" ]; then
     # shellcheck disable=SC2016
     >&2 echo '    docker run --env=XDG_CACHE_HOME=/cache --volume="$HOME/.cache:/cache" ...'
   fi
-elif [ -n "${CI:-}" ]; then
-  exec "$BAZEL_REAL" ${1:+"$1" --config=ci} "${@:2}"
+fi
+
+# Ensure `bazel` & managed toolchains honor `XDG_CACHE_HOME` as per https://wiki.archlinux.org/title/XDG_Base_Directory
+if [ -n "${XDG_CACHE_HOME:-}" ]; then
+  if [[ "$XDG_CACHE_HOME" != /* ]]; then
+    >&2 echo "🔴 XDG_CACHE_HOME ($XDG_CACHE_HOME) must denote an absolute path!"
+    exit 2
+  fi
+
+  [ -n "${CI:-}" ] && exec "$BAZEL_REAL" ${1:+"$1" --config=ci} "${@:2}"
 fi
 
 exec "$BAZEL_REAL" "$@"

--- a/tools/bazel.bat
+++ b/tools/bazel.bat
@@ -21,8 +21,13 @@ if not exist "%XDG_CACHE_HOME%" (
   )
 )
 
-:: Make `bazel` honor $XDG_CACHE_HOME if set as it does on POSIX OSes: https://github.com/bazelbuild/bazel/issues/27808
+:: Ensure `bazel` & managed toolchains honor `XDG_CACHE_HOME` if set: https://github.com/bazelbuild/bazel/issues/27808
 if defined XDG_CACHE_HOME (
+  set "XDG_CACHE_HOME=!XDG_CACHE_HOME:/=\!"
+  if "!XDG_CACHE_HOME:~1,2!" neq ":\" if "!XDG_CACHE_HOME:~0,2!" neq "\\" (
+    >&2 echo 🔴 XDG_CACHE_HOME ^(!XDG_CACHE_HOME!^) must denote an absolute path!
+    exit /b 2
+  )
   set "bazel_home=%XDG_CACHE_HOME%\bazel"
   set bazel_home_startup_option="--output_user_root=!bazel_home!"
 ) else (


### PR DESCRIPTION
### What does this PR do?
Very partially restores #47007, which was fully reverted in #47083 due to #incident-50242:
- only the absolute-path validation on XDG_CACHE_HOME is reinstated,
- in particular, the GOCACHE wiring that caused the incident is left out.

### Motivation
A relative XDG_CACHE_HOME is silently accepted by the existing directory-existence check and would be used as-is, leading to cache misses or wrong paths depending on the working directory (see #47007)..