### PR TITLE
[AGENTCFG-658] Ensure DD_LOGS_ENABLED is applied in nodetreemodel so OTel logs pipeline initializes

### DIFF
--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -538,6 +538,16 @@ func (c *ntmConfig) isReady() bool {
 	return c.ready.Load()
 }
 
+// logsEnvVarKeys are config keys that must always honor DD_LOGS_ENABLED / DD_LOG_ENABLED
+// so that the logs agent pipeline initializes correctly when run under OTel or other
+// entry points that share the same config setup. See comp/otelcol/logsagentpipeline.
+const (
+	logsEnabledKey = "logs_enabled"
+	logEnabledKey  = "log_enabled"
+	ddLogsEnabled  = "DD_LOGS_ENABLED"
+	ddLogEnabled   = "DD_LOG_ENABLED"
+)
+
 func (c *ntmConfig) buildEnvVars() {
 	root := newInnerNode(nil)
 	envWarnings := []error{}
@@ -554,6 +564,21 @@ func (c *ntmConfig) buildEnvVars() {
 			}
 		}
 	}
+
+	// Ensure DD_LOGS_ENABLED and DD_LOG_ENABLED are always applied when set, so that
+	// logs_enabled/log_enabled are true when the env is set (e.g. OTel agent with
+	// DD_LOGS_ENABLED=true).
+	for key, envVar := range map[string]string{logsEnabledKey: ddLogsEnabled, logEnabledKey: ddLogEnabled} {
+		if c.leafAtPathFromNode(key, root) != missingLeaf {
+			continue // already set from configEnvVars above
+		}
+		if value, ok := os.LookupEnv(envVar); ok && value != "" {
+			if err := c.insertNodeFromString(root, key, value); err != nil {
+				envWarnings = append(envWarnings, err)
+			}
+		}
+	}
+
 	c.envs = root
 	c.warnings = append(c.warnings, envWarnings...)
 }

--- a/pkg/config/nodetreemodel/config_test.go
+++ b/pkg/config/nodetreemodel/config_test.go
@@ -1859,3 +1859,19 @@ func TestEnvVarLayerConvertsToDefaultType(t *testing.T) {
     leaf(#ptr<000002>), val:789, source:environment-variable`
 	assert.Equal(t, expect, txt)
 }
+
+// TestLogsEnabledEnvFallback ensures DD_LOGS_ENABLED is always applied when set,
+// so that the logs agent pipeline initializes (e.g. OTel agent with DD_LOGS_ENABLED=true).
+func TestLogsEnabledEnvFallback(t *testing.T) {
+	t.Setenv("DD_LOGS_ENABLED", "true")
+	t.Cleanup(func() { os.Unsetenv("DD_LOGS_ENABLED") })
+
+	// Minimal config without registering logs_enabled (simulates init order where
+	// the key is not yet in configEnvVars when buildEnvVars runs).
+	cfg := NewNodeTreeConfig("test", "DD", strings.NewReplacer(".", "_"))
+	cfg.BindEnvAndSetDefault("api_key", "")
+	cfg.BuildSchema()
+
+	// Fallback in buildEnvVars should have applied DD_LOGS_ENABLED so logs_enabled is true.
+	assert.True(t, cfg.GetBool("logs_enabled"), "logs_enabled should be true when DD_LOGS_ENABLED=true")
+}


### PR DESCRIPTION
### What does this PR do?

Fixes nodetreemodel so that `DD_LOGS_ENABLED` (and `DD_LOG_ENABLED`) are always applied when building the env layer, even when the config key is not yet registered in `configEnvVars` or when schema is built in a different order (e.g. OTel agent using `RevertFinishedBackToBuilder` + `InitConfig` + `BuildSchema`). The logs agent pipeline (`comp/otelcol/logsagentpipeline`) only starts when `logs_enabled` or `log_enabled` is true; with nodetreemodel enabled by default, E2E tests that set `DD_LOGS_ENABLED=true` were still seeing the pipeline disabled because the env wasn’t reflected in config.

- In `pkg/config/nodetreemodel/config.go`, after applying env vars from `configEnvVars`, we now always apply `DD_LOGS_ENABLED` and `DD_LOG_ENABLED` for `logs_enabled` / `log_enabled` when those keys are not already set in the env tree.
- Adds `TestLogsEnabledEnvFallback` to assert that a minimal config without registering `logs_enabled` still gets `GetBool("logs_enabled") == true` when `DD_LOGS_ENABLED=true`.

### Motivation

Enabling nodetreemodel by default caused OTel E2E failures (e.g. `pipelines_utils.go`: calendar app logs not reaching FakeIntake). The workaround of setting `DD_LOGS_ENABLED=true` in test env was not sufficient because nodetreemodel was not consistently applying that env var to `logs_enabled` in all init paths. Fixing this in nodetreemodel ensures the logs pipeline initializes whenever the process is run with `DD_LOGS_ENABLED=true`, regardless of init order.

### Describe how you validated your changes

- Added `TestLogsEnabledEnvFallback` in `pkg/config/nodetreemodel/config_test.go` (minimal config, no `logs_enabled` binding, `DD_LOGS_ENABLED=true` → `GetBool("logs_enabled")` is true).
- Ran `go test ./pkg/config/nodetreemodel/... -run TestLogsEnabledEnvFallback` and `TestGetBool`; both pass.

### Additional Notes

- The fallback only runs when the key is not already set in the env tree (`leafAtPathFromNode(key, root) == missingLeaf`), so normal binding behavior is unchanged and we do not overwrite existing env-derived values.
- Constants `logsEnabledKey`, `logEnabledKey`, `ddLogsEnabled`, `ddLogEnabled` are used for the fallback so the intent is clear and the env var names stay consistent.