### PR TITLE
[CONTP-1218] Propagate Autodiscovery CEL Config Errors

### DIFF
--- a/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go
@@ -492,6 +492,7 @@ func (ac *AutoConfig) processNewConfig(config integration.Config) integration.Co
 	err := ac.initializeConfiguration(&config)
 	if err != nil {
 		log.Errorf("Config %s (source %s) could not initialize: %v", config.Name, config.Source, err)
+		errorStats.setConfigError(config.Name, err.Error())
 		return integration.ConfigChanges{}
 	}
 

--- a/comp/core/autodiscovery/autodiscoveryimpl/autoconfig_cel_test.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/autoconfig_cel_test.go
@@ -1,0 +1,41 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build clusterchecks && kubeapiserver && cel && test
+
+package autodiscoveryimpl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
+)
+
+func TestProcessNewConfigCELCompileErrorStoredInStats(t *testing.T) {
+	_, ac := getResolveTestConfig(t)
+
+	// Reset errorStats to ensure a clean state
+	errorStats = newAcErrorStats()
+
+	invalidTpl := integration.Config{
+		Name: "bad-cel-check",
+		CELSelector: workloadfilter.Rules{
+			Containers: []string{`this is not valid CEL !!!`},
+		},
+	}
+
+	changes := ac.processNewConfig(invalidTpl)
+
+	// processNewConfig should return empty changes when config cannot be initialized
+	assert.Empty(t, changes.Schedule)
+	assert.Empty(t, changes.Unschedule)
+
+	// The CEL compile error should be stored in errorStats
+	errors := GetConfigErrors()
+	assert.Contains(t, errors, "bad-cel-check")
+}

--- a/comp/core/autodiscovery/providers/kube_endpoints_file.go
+++ b/comp/core/autodiscovery/providers/kube_endpoints_file.go
@@ -219,19 +219,19 @@ func (p *KubeEndpointsFileConfigProvider) buildConfigStore(templates []integrati
 			matchingProg, celADID, compileErr, recError := integration.CreateMatchingProgram(tpl.CELSelector)
 			if celADID != adtypes.CelEndpointIdentifier {
 				errMsg := fmt.Sprintf("CEL selector for template %s is not targeting endpoints", tpl.Name)
-				log.Errorf(errMsg)
+				log.Error(errMsg)
 				p.configErrors[tpl.Name] = types.ErrorMsgSet{errMsg: struct{}{}}
 				continue
 			}
 			if compileErr != nil {
 				errMsg := fmt.Sprintf("Failed to compile CEL selector for template %s: %v", tpl.Name, compileErr)
-				log.Errorf(errMsg)
+				log.Error(errMsg)
 				p.configErrors[tpl.Name] = types.ErrorMsgSet{errMsg: struct{}{}}
 				continue
 			}
 			if recError != nil {
 				errMsg := fmt.Sprintf("Failed to check rule recommendations for CEL selector for template %s: %v", tpl.Name, recError)
-				log.Errorf(errMsg)
+				log.Error(errMsg)
 				p.configErrors[tpl.Name] = types.ErrorMsgSet{errMsg: struct{}{}}
 				continue
 			}

--- a/comp/core/autodiscovery/providers/kube_endpoints_file.go
+++ b/comp/core/autodiscovery/providers/kube_endpoints_file.go
@@ -59,9 +59,10 @@ func newEpConfig() *epConfig {
 // KubeEndpointsFileConfigProvider generates endpoints checks from check configurations defined in files.
 type KubeEndpointsFileConfigProvider struct {
 	sync.RWMutex
-	epLister listersv1.EndpointsLister
-	upToDate bool
-	store    *store
+	epLister     listersv1.EndpointsLister
+	upToDate     bool
+	store        *store
+	configErrors map[string]types.ErrorMsgSet
 }
 
 // NewKubeEndpointsFileConfigProvider returns a new KubeEndpointsFileConfigProvider
@@ -121,9 +122,17 @@ func (p *KubeEndpointsFileConfigProvider) String() string {
 	return names.KubeEndpointsFile
 }
 
-// GetConfigErrors is not implemented for the KubeEndpointsFileConfigProvider.
+// GetConfigErrors returns a map of errors that occurred when building the config store,
+// indexed by the integration name that generated the error.
 func (p *KubeEndpointsFileConfigProvider) GetConfigErrors() map[string]types.ErrorMsgSet {
-	return make(map[string]types.ErrorMsgSet)
+	p.RLock()
+	defer p.RUnlock()
+
+	errors := make(map[string]types.ErrorMsgSet, len(p.configErrors))
+	for k, v := range p.configErrors {
+		errors[k] = v
+	}
+	return errors
 }
 
 func (p *KubeEndpointsFileConfigProvider) setUpToDate(v bool) {
@@ -189,6 +198,7 @@ func (p *KubeEndpointsFileConfigProvider) deleteHandler(obj interface{}) {
 // buildConfigStore initializes the config templates store.
 func (p *KubeEndpointsFileConfigProvider) buildConfigStore(templates []integration.Config) {
 	p.store = newStore()
+	p.configErrors = make(map[string]types.ErrorMsgSet)
 	for _, tpl := range templates {
 		for _, advancedAD := range tpl.AdvancedADIdentifiers {
 			if advancedAD.KubeEndpoints.IsEmpty() {
@@ -208,15 +218,21 @@ func (p *KubeEndpointsFileConfigProvider) buildConfigStore(templates []integrati
 			// Create matching program from CEL rules
 			matchingProg, celADID, compileErr, recError := integration.CreateMatchingProgram(tpl.CELSelector)
 			if celADID != adtypes.CelEndpointIdentifier {
-				log.Errorf("CEL selector for template %s is not targeting endpoints", tpl.Name)
+				errMsg := fmt.Sprintf("CEL selector for template %s is not targeting endpoints", tpl.Name)
+				log.Errorf(errMsg)
+				p.configErrors[tpl.Name] = types.ErrorMsgSet{errMsg: struct{}{}}
 				continue
 			}
 			if compileErr != nil {
-				log.Errorf("Failed to compile CEL selector for template %s: %v", tpl.Name, compileErr)
+				errMsg := fmt.Sprintf("Failed to compile CEL selector for template %s: %v", tpl.Name, compileErr)
+				log.Errorf(errMsg)
+				p.configErrors[tpl.Name] = types.ErrorMsgSet{errMsg: struct{}{}}
 				continue
 			}
 			if recError != nil {
-				log.Errorf("Failed to check rule recommendations for CEL selector for template %s: %v", tpl.Name, recError)
+				errMsg := fmt.Sprintf("Failed to check rule recommendations for CEL selector for template %s: %v", tpl.Name, recError)
+				log.Errorf(errMsg)
+				p.configErrors[tpl.Name] = types.ErrorMsgSet{errMsg: struct{}{}}
 				continue
 			}
 			tpl.SetMatchingProgram(matchingProg)

--- a/comp/core/autodiscovery/providers/kube_endpoints_file_test.go
+++ b/comp/core/autodiscovery/providers/kube_endpoints_file_test.go
@@ -527,6 +527,33 @@ func TestEndpointChecksFromTemplateWithResolveMode(t *testing.T) {
 	}
 }
 
+func TestKubeEndpointsFileConfigProviderGetConfigErrors(t *testing.T) {
+	validTpl := integration.Config{
+		Name: "valid-check",
+		CELSelector: workloadfilter.Rules{
+			KubeEndpoints: []string{`kube_endpoint.namespace == "default" && kube_endpoint.name.matches("")`},
+		},
+	}
+	invalidTpl := integration.Config{
+		Name: "invalid-check",
+		CELSelector: workloadfilter.Rules{
+			KubeEndpoints: []string{`this is not valid CEL !!!`},
+		},
+	}
+
+	p := &KubeEndpointsFileConfigProvider{}
+	p.buildConfigStore([]integration.Config{validTpl, invalidTpl})
+
+	errors := p.GetConfigErrors()
+
+	// The valid template should not produce any errors
+	assert.NotContains(t, errors, "valid-check")
+
+	// The invalid template should produce a compile error
+	assert.Contains(t, errors, "invalid-check")
+	assert.Len(t, errors["invalid-check"], 1)
+}
+
 func kubeEndpointIdentifier(ns string, name string, resolve string) integration.KubeEndpointsIdentifier {
 	return integration.KubeEndpointsIdentifier{
 		KubeNamespacedName: integration.KubeNamespacedName{

--- a/comp/core/autodiscovery/providers/kube_endpointslices_file.go
+++ b/comp/core/autodiscovery/providers/kube_endpointslices_file.go
@@ -226,19 +226,19 @@ func (p *KubeEndpointSlicesFileConfigProvider) buildConfigStore(templates []inte
 			matchingProg, celADID, compileErr, recError := integration.CreateMatchingProgram(tpl.CELSelector)
 			if celADID != adtypes.CelEndpointIdentifier {
 				errMsg := fmt.Sprintf("CEL selector for template %s is not targeting endpoints", tpl.Name)
-				log.Errorf(errMsg)
+				log.Error(errMsg)
 				p.configErrors[tpl.Name] = types.ErrorMsgSet{errMsg: struct{}{}}
 				continue
 			}
 			if compileErr != nil {
 				errMsg := fmt.Sprintf("Failed to compile CEL selector for template %s: %v", tpl.Name, compileErr)
-				log.Errorf(errMsg)
+				log.Error(errMsg)
 				p.configErrors[tpl.Name] = types.ErrorMsgSet{errMsg: struct{}{}}
 				continue
 			}
 			if recError != nil {
 				errMsg := fmt.Sprintf("Failed to check rule recommendations for CEL selector for template %s: %v", tpl.Name, recError)
-				log.Errorf(errMsg)
+				log.Error(errMsg)
 				p.configErrors[tpl.Name] = types.ErrorMsgSet{errMsg: struct{}{}}
 				continue
 			}

--- a/comp/core/autodiscovery/providers/kube_endpointslices_file.go
+++ b/comp/core/autodiscovery/providers/kube_endpointslices_file.go
@@ -68,8 +68,9 @@ func (s *epSliceConfig) shouldCollect() bool {
 // KubeEndpointSlicesFileConfigProvider generates endpoints checks from check configurations defined in files.
 type KubeEndpointSlicesFileConfigProvider struct {
 	sync.RWMutex
-	upToDate bool
-	store    *endpointSliceStore
+	upToDate     bool
+	store        *endpointSliceStore
+	configErrors map[string]types.ErrorMsgSet
 }
 
 // NewKubeEndpointSlicesFileConfigProvider returns a new KubeEndpointSlicesFileConfigProvider
@@ -128,9 +129,17 @@ func (p *KubeEndpointSlicesFileConfigProvider) String() string {
 	return names.KubeEndpointSlicesFile
 }
 
-// GetConfigErrors is not implemented for the KubeEndpointSlicesFileConfigProvider.
+// GetConfigErrors returns a map of errors that occurred when building the config store,
+// indexed by the integration name that generated the error.
 func (p *KubeEndpointSlicesFileConfigProvider) GetConfigErrors() map[string]types.ErrorMsgSet {
-	return make(map[string]types.ErrorMsgSet)
+	p.RLock()
+	defer p.RUnlock()
+
+	errors := make(map[string]types.ErrorMsgSet, len(p.configErrors))
+	for k, v := range p.configErrors {
+		errors[k] = v
+	}
+	return errors
 }
 
 func (p *KubeEndpointSlicesFileConfigProvider) setUpToDate(v bool) {
@@ -196,6 +205,7 @@ func (p *KubeEndpointSlicesFileConfigProvider) deleteHandler(obj interface{}) {
 // buildConfigStore initializes the config templates store.
 func (p *KubeEndpointSlicesFileConfigProvider) buildConfigStore(templates []integration.Config) {
 	p.store = newEndpointSliceStore()
+	p.configErrors = make(map[string]types.ErrorMsgSet)
 	for _, tpl := range templates {
 		for _, advancedAD := range tpl.AdvancedADIdentifiers {
 			if advancedAD.KubeEndpoints.IsEmpty() {
@@ -215,15 +225,21 @@ func (p *KubeEndpointSlicesFileConfigProvider) buildConfigStore(templates []inte
 			// Create matching program from CEL rules
 			matchingProg, celADID, compileErr, recError := integration.CreateMatchingProgram(tpl.CELSelector)
 			if celADID != adtypes.CelEndpointIdentifier {
-				log.Errorf("CEL selector for template %s is not targeting endpoints", tpl.Name)
+				errMsg := fmt.Sprintf("CEL selector for template %s is not targeting endpoints", tpl.Name)
+				log.Errorf(errMsg)
+				p.configErrors[tpl.Name] = types.ErrorMsgSet{errMsg: struct{}{}}
 				continue
 			}
 			if compileErr != nil {
-				log.Errorf("Failed to compile CEL selector for template %s: %v", tpl.Name, compileErr)
+				errMsg := fmt.Sprintf("Failed to compile CEL selector for template %s: %v", tpl.Name, compileErr)
+				log.Errorf(errMsg)
+				p.configErrors[tpl.Name] = types.ErrorMsgSet{errMsg: struct{}{}}
 				continue
 			}
 			if recError != nil {
-				log.Errorf("Failed to check rule recommendations for CEL selector for template %s: %v", tpl.Name, recError)
+				errMsg := fmt.Sprintf("Failed to check rule recommendations for CEL selector for template %s: %v", tpl.Name, recError)
+				log.Errorf(errMsg)
+				p.configErrors[tpl.Name] = types.ErrorMsgSet{errMsg: struct{}{}}
 				continue
 			}
 			tpl.SetMatchingProgram(matchingProg)

--- a/comp/core/autodiscovery/providers/kube_endpointslices_file_test.go
+++ b/comp/core/autodiscovery/providers/kube_endpointslices_file_test.go
@@ -637,3 +637,24 @@ func TestEndpointSliceChecksFromTemplateWithResolveMode(t *testing.T) {
 		})
 	}
 }
+
+func TestKubeEndpointSlicesFileConfigProviderGetConfigErrors(t *testing.T) {
+	// A CEL expression with invalid syntax should always produce an error,
+	// regardless of whether the cel build tag is present.
+	invalidTpl := integration.Config{
+		Name: "invalid-check",
+		CELSelector: workloadfilter.Rules{
+			KubeEndpoints: []string{`this is not valid CEL !!!`},
+		},
+	}
+
+	p := &KubeEndpointSlicesFileConfigProvider{}
+	p.buildConfigStore([]integration.Config{invalidTpl})
+
+	errors := p.GetConfigErrors()
+
+	// The invalid template should produce an error (either a CEL compile error
+	// or an identifier mismatch when cel build tag is not present).
+	assert.Contains(t, errors, "invalid-check")
+	assert.Len(t, errors["invalid-check"], 1)
+}


### PR DESCRIPTION
### What does this PR do?

Surfaces CEL config compilation errors in agent status by implementing `GetConfigErrors()` on `KubeEndpointsFileConfigProvider` and `KubeEndpointSlicesFileConfigProvider`, and storing CEL init errors in errorStats within `processNewConfig()`.

### Motivation

Surface configuration errors as a result from CEL configuration errors. CEL selector errors were silently logged and dropped. Users had no way to discover misconfigured `cel_selector` rules without grepping agent logs. This makes them visible in diagnostic tooling.

### Describe how you validated your changes

Unit Tests & CI

Deploy Agent with invalid confd:
```
datadog:
  kubelet:
    tlsVerify: false
  confd:
    postgres.yaml: |-
      cel_selector:
        containers:
          - container.invalid_attribute.matches("alpine")
      init_config:
      instances:
        - host: "localhost"
```

Check `agent status`
```
Config Errors
  ==============
    postgres
    --------
      ERROR: <input>:1:10: undefined field 'invalid_attribute'
 | container.invalid_attribute.matches("alpine")
 | .........^
```
