### PR TITLE
Fix depth limit formatting in dynamic instrumentation log messages

### DIFF
--- a/pkg/dyninst/decode/template_test.go
+++ b/pkg/dyninst/decode/template_test.go
@@ -227,6 +227,31 @@ func TestReadUint(t *testing.T) {
 	}
 }
 
+func TestFormatUnresolvedPointeeType(t *testing.T) {
+	typ := &ir.UnresolvedPointeeType{
+		TypeCommon: ir.TypeCommon{ID: 1, Name: "unresolved"},
+	}
+
+	ctx := &encodingContext{
+		typesByID: map[ir.TypeID]decoderType{
+			typ.GetID(): (*unresolvedPointeeType)(typ),
+		},
+		typesByGoRuntimeType: make(map[uint32]ir.TypeID),
+		currentlyEncoding:    make(map[typeAndAddr]struct{}),
+		dataItems:            make(map[typeAndAddr]output.DataItem),
+	}
+
+	var buf bytes.Buffer
+	limits := &formatLimits{
+		maxBytes:           maxLogLineBytes,
+		maxCollectionItems: maxLogCollectionItems,
+		maxFields:          maxLogFieldCount,
+	}
+	err := formatType(ctx, &buf, typ, nil, limits)
+	assert.NoError(t, err)
+	assert.Equal(t, "{...}", buf.String())
+}
+
 // Helper functions - use NativeEndian for consistency with code
 
 func int64ToBytes(v int64) []byte {

--- a/pkg/dyninst/decode/types.go
+++ b/pkg/dyninst/decode/types.go
@@ -2095,9 +2095,10 @@ func (u *unresolvedPointeeType) encodeValueFields(
 }
 
 func (u *unresolvedPointeeType) formatValueFields(
-	*encodingContext, *bytes.Buffer, []byte, *formatLimits,
+	_ *encodingContext, buf *bytes.Buffer, _ []byte, limits *formatLimits,
 ) error {
-	return errors.New("depth limit reached")
+	writeBoundedString(buf, limits, "{...}")
+	return nil
 }
 
 func getFieldByName(fields []ir.Field, name string) (*ir.Field, error) {


### PR DESCRIPTION
When depth limits are reached during expression evaluation, output "{...}" instead of "{error: error formatting expression: depth limit reached}" to conform to the log probe configuration spec. Depth limits are truncation behavior, not errors, and should use ellipsis notation consistent with other limit handling (arrays, maps, fields).

### What does this PR do?

Changes the dynamic instrumentation log message formatting to output `{...}` instead of `{error: error formatting expression: depth limit reached}` when a capture depth limit is hit. This aligns the string formatting path with the JSON encoding path, which already correctly uses notCapturedReason: "depth".

### Motivation

The log probe configuration spec defines that truncation due to limits (depth, collection size, field count) should use ellipsis notation (...), not error messages. Depth limits are expected truncation behavior, not errors. The current output violates the spec and is confusing to users who see what appears to be an error when the system is working as designed.

### Describe how you validated your changes

Added unit test TestFormatUnresolvedPointeeType to verify the new output format. Ran existing tests.

### Additional Notes

[DEBUG-5243](https://datadoghq.atlassian.net/browse/DEBUG-5243)

[DEBUG-5243]: https://datadoghq.atlassian.net/browse/DEBUG-5243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ