### PR TITLE
pkg/aggregator: use safe SerieSink in noAggregationStreamWorker

### DIFF
--- a/pkg/aggregator/no_aggregation_stream_worker.go
+++ b/pkg/aggregator/no_aggregation_stream_worker.go
@@ -166,7 +166,7 @@ func (w *noAggregationStreamWorker) run() {
 		metrics.Serialize(
 			w.seriesSink,
 			w.sketchesSink,
-			func(_ metrics.SerieSink, _ metrics.SketchesSink) {
+			func(seriesSink metrics.SerieSink, _ metrics.SketchesSink) {
 			mainloop:
 				for {
 					select {
@@ -220,7 +220,7 @@ func (w *noAggregationStreamWorker) run() {
 							serie.Host = sample.Host
 							serie.MType = mtype
 							serie.Interval = bucketSize
-							w.seriesSink.Append(&serie)
+							seriesSink.Append(&serie)
 
 							w.taggerBuffer.Reset()
 							w.metricBuffer.Reset()

--- a/pkg/aggregator/no_aggregation_stream_worker_test.go
+++ b/pkg/aggregator/no_aggregation_stream_worker_test.go
@@ -1,0 +1,44 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test
+
+package aggregator
+
+import (
+	"testing"
+	"time"
+)
+
+// TestNoAggStreamWorkerSeriesDisabled is a regression test for a nil pointer
+// dereference that occurs when AreSeriesEnabled() returns false. In that case,
+// createIterableMetrics returns a nil *IterableSeries, and the worker's
+// producer callback was calling w.seriesSink.Append() directly instead of
+// using the nil-safe SerieSink parameter provided by Serialize().
+func TestNoAggStreamWorkerSeriesDisabled(t *testing.T) {
+	noAggWorkerStreamCheckFrequency = 100 * time.Millisecond
+
+	opts := demuxTestOptions()
+	opts.EnableNoAggregationPipeline = true
+
+	mockSerializer := &MockSerializerIterableSerie{}
+	mockSerializer.On("AreSeriesEnabled").Return(false)
+	mockSerializer.On("AreSketchesEnabled").Return(false)
+
+	deps := createDemultiplexerAgentTestDeps(t)
+	demux := initAgentDemultiplexer(deps.Log, NewForwarderTest(deps.Log), deps.OrchestratorFwd, opts, deps.EventPlatform, deps.HaAgent, deps.Compressor, deps.Tagger, deps.FilterList, "")
+	demux.statsd.noAggStreamWorker.serializer = mockSerializer
+
+	go demux.run()
+
+	batch := testDemuxSamples(t)
+	demux.SendSamplesWithoutAggregation(batch)
+
+	// Give time for the worker to process the samples. If the bug is present,
+	// the worker goroutine will panic with a nil pointer dereference, crashing
+	// the test process.
+	time.Sleep(200 * time.Millisecond)
+	demux.Stop(true)
+}


### PR DESCRIPTION
### What does this PR do?
When DD_CORE_AGENT_ENABLED=false, all payload types are disabled (enable_payloads.series=false), causing createIterableMetrics to return nil sinks. The current code uses these directly without checking for nil, resulting in a nil pointer panic.

The Serialize function handles this by passing a noOpSerieSink to the producer callback. We must use the SerieSink parameter provided by Serialize instead of the struct field, consistent with how demultiplexer_agent.go handles the same callback.



### Motivation
Customer was hitting the NPE described above.

### Describe how you validated your changes
I validated with an actual build of the agent run locally in minikube, and also through the provided regression test.

### Additional Notes
