### PR TITLE
Lift openscap directly into a package build

### DIFF
--- a/deps/libxml2/overlay.BUILD.bazel
+++ b/deps/libxml2/overlay.BUILD.bazel
@@ -175,6 +175,7 @@ pkg_filegroup(
         ":lib_files",
     ],
     prefix = "embedded",
+    visibility = ["@@//deps/openscap:__pkg__"],
 )
 
 pkg_install(

--- a/deps/openscap/BUILD.bazel
+++ b/deps/openscap/BUILD.bazel
@@ -1,61 +1,43 @@
 # openscap
 
-load(
-    "@rules_pkg//pkg:mappings.bzl",
-    "pkg_filegroup",
-)
+load("@rules_pkg//pkg:install.bzl", "pkg_install")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup")
 
-# Things we depend on. This is used to gather liceneses
-alias(
-    name = "all_deps",
-    actual = "@openscap//:all_deps",
-    target_compatible_with = [
-        "@platforms//os:linux",
-    ],
-    visibility = [
-        "//compliance:__pkg__",
-        "//packages:__subpackages__",
-    ],
-)
-
-# Files to install in the distro. This is distinct from all_deps.
-# In the future, we should merge the two by being able to designate
-# that individual build targets, like a .so file, should be packaged
-# for distribution IFF the top level binary actually depends on them.
-# That needs design w.r.t. stripping debug symbols and rpath fixes.
+# Files to install in the distro.
+# In the future PR, we will introduce global install and rpath
+# rewrite, so that this block just becomes @openscap, and all
+# the needed .so and .h files follow along.
 pkg_filegroup(
     name = "all_files",
     srcs = [
-        ":all_embedded",
         "@acl//:all_files",
         "@attr//:all_files",
         "@bzip2//:all_files",
-    ],
-    # Do not pick up with ... expansion.
-    tags = ["manual"],
-    visibility = ["//packages:__subpackages__"],
-)
-
-# TODO: Fix all of these packages so that embedded is part of the prefix they
-# know about. Right now, we rely on the pkg_install dest_dir to put it into
-# embedded.
-pkg_filegroup(
-    name = "all_embedded",
-    srcs = [
         "@dbus//:all_files",
         "@gcrypt//:all_files",
         "@libselinux//:all_files",
         "@libsepol//:all_files",
+        "@libxml2//:all_files",
         "@libxslt//:all_files",
         "@libyaml//:all_files",
+        "@openscap//:all_files",
         "@pcre2//:all_files",
         "@popt//:all_files",
         "@rpm//:all_files",
         "@util-linux//:all_files",
         "@xmlsec//:all_files",
     ],
-    prefix = "embedded",
     # Do not pick up with ... expansion.
     tags = ["manual"],
+    target_compatible_with = [
+        "@platforms//os:linux",
+    ],
     visibility = ["//packages:__subpackages__"],
+)
+
+pkg_install(
+    name = "install",
+    srcs = [
+        ":all_files",
+    ],
 )

--- a/omnibus/config/software/datadog-agent-dependencies.rb
+++ b/omnibus/config/software/datadog-agent-dependencies.rb
@@ -1,4 +1,4 @@
-name 'datadog-agent-d-ependencies'
+name 'datadog-agent-dependencies'
 
 description "Enforce building dependencies as soon as possible so they can be cached"
 

--- a/omnibus/config/software/datadog-agent-dependencies.rb
+++ b/omnibus/config/software/datadog-agent-dependencies.rb
@@ -1,9 +1,11 @@
-name 'datadog-agent-dependencies'
+name 'datadog-agent-d-ependencies'
 
 description "Enforce building dependencies as soon as possible so they can be cached"
 
 if heroku_target?
   flavor_flag = "--//packages/agent:flavor=heroku"
+elif ENV['AGENT_FLAVOR'] == 'iot'
+  flavor_flag = "--//packages/agent:flavor=iot"
 else
   flavor_flag = fips_mode? ? "--//packages/agent:flavor=fips" : ""
 end

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -13,6 +13,8 @@ name 'datadog-agent'
 # Flavor flag for bazel actions
 if heroku_target?
   flavor_flag = "--//packages/agent:flavor=heroku"
+elif ENV['AGENT_FLAVOR'] == 'iot'
+  flavor_flag = "--//packages/agent:flavor=iot"
 else
   flavor_flag = fips_mode? ? "--//packages/agent:flavor=fips" : ""
 end
@@ -24,8 +26,6 @@ unless do_repackage?
   dependency 'datadog-agent-prepare'
 
   dependency "python3"
-
-  dependency "openscap" if linux_target? and !arm7l_target? and !heroku_target? # Security-agent dependency, not needed for Heroku
 
   dependency 'datadog-agent-dependencies'
 end

--- a/omnibus/config/software/openscap.rb
+++ b/omnibus/config/software/openscap.rb
@@ -7,39 +7,31 @@ name 'openscap'
 default_version '1.4.3'
 
 build do
-  command_on_repo_root "bazelisk run -- @acl//:install --destdir='#{install_dir}'"
+  command_on_repo_root "bazelisk run -- //deps/openscap:install --destdir='#{install_dir}'"
+
   command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
     " #{install_dir}/embedded/lib/libacl.so"
 
-  command_on_repo_root "bazelisk run -- @attr//:install --destdir='#{install_dir}'"
   command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
     " #{install_dir}/embedded/lib/libattr.so"
 
-  command_on_repo_root "bazelisk run -- @dbus//:install --destdir='#{install_dir}'"
-
-  command_on_repo_root "bazelisk run -- @libselinux//:install --destdir='#{install_dir}'"
   command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
     " #{install_dir}/embedded/lib/libselinux.so"
 
-  command_on_repo_root "bazelisk run -- @libsepol//:install --destdir='#{install_dir}'"
   command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
     " #{install_dir}/embedded/lib/libsepol.so"
 
-  command_on_repo_root "bazelisk run -- @libyaml//:install --destdir='#{install_dir}'"
   sh_lib = if linux_target? then "libyaml.so" else "libyaml.dylib" end
   command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded' " \
     "#{install_dir}/embedded/lib/#{sh_lib}"
 
-  command_on_repo_root "bazelisk run -- @pcre2//:install --destdir=#{install_dir}"
   command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix " \
     "--prefix #{install_dir}/embedded " \
     "#{install_dir}/embedded/lib/libpcre2*.so"
 
-  command_on_repo_root "bazelisk run -- @popt//:install --destdir='#{install_dir}'"
   command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
     " #{install_dir}/embedded/lib/libpopt.so"
 
-  command_on_repo_root "bazelisk run -- @rpm//:install --destdir='#{install_dir}'"
   command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
     " #{install_dir}/embedded/lib/librpm.so" \
     " #{install_dir}/embedded/lib/librpmio.so"
@@ -48,26 +40,20 @@ build do
   command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
     " #{install_dir}/embedded/lib/libblkid.so"
 
-  command_on_repo_root "bazelisk run -- @gpg-error//:install --destdir='#{install_dir}'"
-  command_on_repo_root "bazelisk run -- @gcrypt//:install --destdir='#{install_dir}'"
   command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
     " #{install_dir}/embedded/lib/libgcrypt.so" \
     " #{install_dir}/embedded/lib/libgpg-error.so" \
 
-  command_on_repo_root "bazelisk run -- @libxml2//:install --destdir='#{install_dir}'"
   command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
     " #{install_dir}/embedded/lib/libxml2.so"
 
-  command_on_repo_root "bazelisk run -- @libxslt//:install --destdir='#{install_dir}'"
   command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
     " #{install_dir}/embedded/lib/libxslt.so" \
     " #{install_dir}/embedded/lib/libexslt.so"
 
-  command_on_repo_root "bazelisk run -- @xmlsec//:install --destdir='#{install_dir}'"
   command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
     " #{install_dir}/embedded/lib/libxmlsec1*.so" \
 
-  command_on_repo_root "bazelisk run -- @openscap//:install --destdir='#{install_dir}'"
   command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
     " #{install_dir}/embedded/lib/libopenscap.so" \
     " #{install_dir}/embedded/lib/libopenscap_sce.so" \

--- a/packages/agent/BUILD.bazel
+++ b/packages/agent/BUILD.bazel
@@ -13,6 +13,7 @@ string_flag(
         "base",
         "fips",
         "heroku",
+        "iot",
     ],
 )
 
@@ -36,6 +37,11 @@ config_setting(
     flag_values = {"@@//packages/agent:flavor": "heroku"},
 )
 
+config_setting(
+    name = "iot_flavor",
+    flag_values = {"@@//packages/agent:flavor": "iot"},
+)
+
 selects.config_setting_group(
     name = "linux_default",
     match_all = [
@@ -56,6 +62,14 @@ selects.config_setting_group(
     name = "linux_heroku",
     match_all = [
         ":heroku_flavor",
+        "@platforms//os:linux",
+    ],
+)
+
+selects.config_setting_group(
+    name = "linux_iot",
+    match_all = [
+        ":iot_flavor",
         "@platforms//os:linux",
     ],
 )

--- a/packages/agent/dependencies/BUILD.bazel
+++ b/packages/agent/dependencies/BUILD.bazel
@@ -26,31 +26,24 @@ pkg_filegroup(
         ],
         "//conditions:default": [],
     }) + select({
-        # if linux_target? and !heroku_target?
         "//packages/agent:linux_default": [
             # dependency datadog_agent_data_plane
+            "//deps/compile_policy:all_files",
+            "//deps/openscap:all_files",  # for security-agent
             # This is really part of system-probe
             "@libpcap//:all_files",
         ],
         "//packages/agent:linux_fips": [
+            "//deps/compile_policy:all_files",
+            "//deps/openscap:all_files",  # for security-agent
             "@libpcap//:all_files",
         ],
         "//packages/agent:linux_heroku": [],
-        "//conditions:default": [],
-    }) + select({
-        "//packages/agent:linux_default": [
-            "//deps/compile_policy:all_files",
-        ],
-        "//packages/agent:linux_fips": [
-            "//deps/compile_policy:all_files",
-        ],
-        "//packages/agent:linux_heroku": [],
-        "@platforms//os:windows": [
-            "//deps/compile_policy:all_files",
-        ],
+        "//packages/agent:linux_iot": [],
         "//conditions:default": [],
     }) + select({
         "@platforms//os:windows": [
+            "//deps/compile_policy:all_files",
             "//packages/windows:all_files",
         ],
         "//conditions:default": [],

--- a/packages/install_dir/BUILD.bazel
+++ b/packages/install_dir/BUILD.bazel
@@ -31,16 +31,10 @@ filegroup(
         "//deps:all_deps",
         "//deps/jmxfetch:all_files",
     ] + select({
-        "//packages/agent:linux_heroku": [],
         "//packages/agent:linux_default": [
-            "//deps/nfsiostat:all_files",
-            "//deps/openscap:all_deps",
             "@freetds//:all_files",
         ],
-        "//conditions:default": [
-            # This will become "//deps/openscap:all_deps" in the future
-            "@popt",
-        ],
+        "//conditions:default": [],
     }),
 )
 


### PR DESCRIPTION
Lift openscap into //packages/agent/dependencies/BUILD.

- but... it's not really useful until we have rpath rewrite magic.