### PR TITLE
Rename getNetworkPath to runNetworkPath

### DIFF
--- a/pkg/privateactionrunner/bundles/ddagent/networkpath/entrypoint.go
+++ b/pkg/privateactionrunner/bundles/ddagent/networkpath/entrypoint.go
@@ -18,7 +18,7 @@ type NetworkPathBundle struct {
 func NewNetworkPath(traceroute traceroute.Component, eventPlatform eventplatform.Component) types.Bundle {
 	return &NetworkPathBundle{
 		actions: map[string]types.Action{
-			"getNetworkPath": NewGetNetworkPathHandler(traceroute, eventPlatform),
+			"runNetworkPath": NewRunNetworkPathHandler(traceroute, eventPlatform),
 		},
 	}
 }

--- a/pkg/privateactionrunner/bundles/ddagent/networkpath/run_network_path.go
+++ b/pkg/privateactionrunner/bundles/ddagent/networkpath/run_network_path.go
@@ -22,19 +22,19 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/types"
 )
 
-type GetNetworkPathHandler struct {
+type RunNetworkPathHandler struct {
 	traceroute    traceroute.Component
 	eventPlatform eventplatform.Component
 }
 
-func NewGetNetworkPathHandler(traceroute traceroute.Component, eventPlatform eventplatform.Component) *GetNetworkPathHandler {
-	return &GetNetworkPathHandler{
+func NewRunNetworkPathHandler(traceroute traceroute.Component, eventPlatform eventplatform.Component) *RunNetworkPathHandler {
+	return &RunNetworkPathHandler{
 		traceroute:    traceroute,
 		eventPlatform: eventPlatform,
 	}
 }
 
-type GetNetworkPathInputs struct {
+type RunNetworkPathInputs struct {
 	Hostname           string            `json:"hostname"`
 	Port               uint16            `json:"port"`
 	SourceService      string            `json:"sourceService,omitempty"`
@@ -50,7 +50,7 @@ type GetNetworkPathInputs struct {
 	SendToBackend bool `json:"sendToBackend,omitempty"`
 }
 
-func (h *GetNetworkPathHandler) Run(
+func (h *RunNetworkPathHandler) Run(
 	ctx context.Context,
 	task *types.Task,
 	_ *privateconnection.PrivateCredentials,
@@ -59,7 +59,7 @@ func (h *GetNetworkPathHandler) Run(
 		return nil, errors.New("traceroute component is not available")
 	}
 
-	inputs, err := types.ExtractInputs[GetNetworkPathInputs](task)
+	inputs, err := types.ExtractInputs[RunNetworkPathInputs](task)
 	if err != nil {
 		return nil, err
 	}
@@ -129,7 +129,7 @@ func (h *GetNetworkPathHandler) Run(
 	return &path, nil
 }
 
-func (h *GetNetworkPathHandler) sendToBackend(path payload.NetworkPath) error {
+func (h *RunNetworkPathHandler) sendToBackend(path payload.NetworkPath) error {
 	if h.eventPlatform == nil {
 		return errors.New("event platform forwarder is not available")
 	}

--- a/pkg/privateactionrunner/bundles/ddagent/networkpath/run_network_path_test.go
+++ b/pkg/privateactionrunner/bundles/ddagent/networkpath/run_network_path_test.go
@@ -56,7 +56,7 @@ func (m *mockEventPlatformForwarder) Purge() map[string][]*message.Message {
 	return nil
 }
 
-func TestGetNetworkPathHandlerRun(t *testing.T) {
+func TestRunNetworkPathHandlerRun(t *testing.T) {
 	tracerouteStub := &mockTraceroute{
 		path: payload.NetworkPath{
 			Source: payload.NetworkPathSource{Service: "old-source"},
@@ -77,7 +77,7 @@ func TestGetNetworkPathHandlerRun(t *testing.T) {
 			},
 		},
 	}
-	handler := NewGetNetworkPathHandler(tracerouteStub, option.NonePtr[eventplatform.Forwarder]())
+	handler := NewRunNetworkPathHandler(tracerouteStub, option.NonePtr[eventplatform.Forwarder]())
 
 	task := &types.Task{}
 	task.Data.Attributes = &types.Attributes{
@@ -125,7 +125,7 @@ func TestGetNetworkPathHandlerRun(t *testing.T) {
 	require.Equal(t, expectedCfg, tracerouteStub.cfg)
 }
 
-func TestGetNetworkPathHandlerRunDefaults(t *testing.T) {
+func TestRunNetworkPathHandlerRunDefaults(t *testing.T) {
 	tracerouteStub := &mockTraceroute{
 		path: payload.NetworkPath{
 			Source: payload.NetworkPathSource{Service: "old-source"},
@@ -146,7 +146,7 @@ func TestGetNetworkPathHandlerRunDefaults(t *testing.T) {
 			},
 		},
 	}
-	handler := NewGetNetworkPathHandler(tracerouteStub, option.NonePtr[eventplatform.Forwarder]())
+	handler := NewRunNetworkPathHandler(tracerouteStub, option.NonePtr[eventplatform.Forwarder]())
 
 	task := &types.Task{}
 	task.Data.Attributes = &types.Attributes{
@@ -172,7 +172,7 @@ func TestGetNetworkPathHandlerRunDefaults(t *testing.T) {
 	require.Equal(t, expectedCfg, tracerouteStub.cfg)
 }
 
-func TestGetNetworkPathHandlerRunInvalidPath(t *testing.T) {
+func TestRunNetworkPathHandlerRunInvalidPath(t *testing.T) {
 	tracerouteStub := &mockTraceroute{
 		path: payload.NetworkPath{
 			Destination: payload.NetworkPathDestination{
@@ -188,7 +188,7 @@ func TestGetNetworkPathHandlerRunInvalidPath(t *testing.T) {
 			},
 		},
 	}
-	handler := NewGetNetworkPathHandler(tracerouteStub, option.NonePtr[eventplatform.Forwarder]())
+	handler := NewRunNetworkPathHandler(tracerouteStub, option.NonePtr[eventplatform.Forwarder]())
 
 	task := &types.Task{}
 	task.Data.Attributes = &types.Attributes{
@@ -202,7 +202,7 @@ func TestGetNetworkPathHandlerRunInvalidPath(t *testing.T) {
 	require.ErrorContains(t, err, "invalid destination IP address")
 }
 
-func TestGetNetworkPathHandlerRunSendToBackend(t *testing.T) {
+func TestRunNetworkPathHandlerRunSendToBackend(t *testing.T) {
 	tracerouteStub := &mockTraceroute{
 		path: payload.NetworkPath{
 			Destination: payload.NetworkPathDestination{
@@ -223,7 +223,7 @@ func TestGetNetworkPathHandlerRunSendToBackend(t *testing.T) {
 	}
 	forwarder := &mockEventPlatformForwarder{}
 	eventPlatform := option.NewPtr[eventplatform.Forwarder](forwarder)
-	handler := NewGetNetworkPathHandler(tracerouteStub, eventPlatform)
+	handler := NewRunNetworkPathHandler(tracerouteStub, eventPlatform)
 
 	task := &types.Task{}
 	task.Data.Attributes = &types.Attributes{

--- a/releasenotes/notes/add-networkpath-private-action-73e8c5fa4f7a6d6c.yaml
+++ b/releasenotes/notes/add-networkpath-private-action-73e8c5fa4f7a6d6c.yaml
@@ -9,4 +9,4 @@
 enhancements:
   - |
     Added a private action runner bundle that exposes the Network Path
-    traceroute functionality through the ``getNetworkPath`` action.
+    traceroute functionality through the ``runNetworkPath`` action.


### PR DESCRIPTION
Motivation: `run_network_path` since we are doing traceroute active probing, meaning, we are not just "getting" existing data, but we are actually "running" traceroute and fetching the results

---

<!-- dd-meta {"pullId":"98bc66aa-62a6-47f2-8f4e-75900c3022db","source":"chat","resourceId":"e54d72b6-2d07-4003-ba9e-df1e2fe30d35","workflowId":"0c998144-ed79-4d25-be63-76aeff763cb3","codeChangeId":"0c998144-ed79-4d25-be63-76aeff763cb3","sourceType":"chat"} -->
PR by Bits
[View session in Datadog](https://app.datadoghq.com/code/e54d72b6-2d07-4003-ba9e-df1e2fe30d35)

Comment @datadog to request changes

Feedback (especially what can be better) welcome in [#code-gen-aka-bits-dev-feedback](https://dd.enterprise.slack.com/archives/C07JA5N2D25)!

---

### What does this PR do?

Renames the `getNetworkPath` private action runner action to `runNetworkPath`, including all related Go types, constructors, and file names.

### Motivation

Align the action name with the `run` verb convention used for private action runners.

### Describe how you validated your changes

Verified no remaining references to the old `getNetworkPath` / `GetNetworkPath` names exist in the codebase.

### Additional Notes

Renamed files:
- `get_network_path.go` → `run_network_path.go`
- `get_network_path_test.go` → `run_network_path_test.go`

Renamed symbols:
- `GetNetworkPathHandler` → `RunNetworkPathHandler`
- `NewGetNetworkPathHandler` → `NewRunNetworkPathHandler`
- `GetNetworkPathInputs` → `RunNetworkPathInputs`
- Action key `"getNetworkPath"` → `"runNetworkPath"`
- Updated release note reference