### PR TITLE
pkg/trace: skip already consumed log files from tracer

### DIFF
--- a/comp/trace/config/setup.go
+++ b/comp/trace/config/setup.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -25,6 +26,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/tagger/origindetection"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	dsdconfig "github.com/DataDog/datadog-agent/comp/dogstatsd/config"
+	logsconfig "github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	"github.com/DataDog/datadog-agent/comp/otelcol/otlp/configcheck"
 	"github.com/DataDog/datadog-agent/pkg/config/env"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
@@ -687,7 +689,77 @@ func applyDatadogConfig(c *config.AgentConfig, core corecompcfg.Component) error
 	c.DebugServerPort = core.GetInt("apm_config.debug.port")
 	c.ContainerTagsBuffer = core.GetBool("apm_config.enable_container_tags_buffer")
 	c.AdditionalProfileTags = core.GetStringMapString("apm_config.additional_profile_tags")
+	c.ConsumedLogFiles = loadConsumedLogFiles(core)
 	return nil
+}
+
+// loadConsumedLogFiles scans the agent's log configuration in conf.d/ integration
+// files and returns the list of file path patterns already being tailed by the
+// log agent. Patterns may be exact paths or glob patterns (e.g. /var/log/*.log).
+// It follows the same directory layout as the autodiscovery config reader:
+// only *.d/ subdirectories are scanned, and only .yaml/.yml files are read.
+func loadConsumedLogFiles(core corecompcfg.Component) []string {
+	confdPath := core.GetString("confd_path")
+	if confdPath == "" {
+		return nil
+	}
+	entries, err := os.ReadDir(confdPath)
+	if err != nil {
+		log.Debugf("Could not read confd_path %q: %v", confdPath, err)
+		return nil
+	}
+	seen := make(map[string]struct{})
+	var consumed []string
+	for _, entry := range entries {
+		if !entry.IsDir() || filepath.Ext(entry.Name()) != ".d" {
+			continue
+		}
+		paths := collectLogFilePaths(filepath.Join(confdPath, entry.Name()))
+		for _, p := range paths {
+			if _, ok := seen[p]; ok {
+				continue
+			}
+			seen[p] = struct{}{}
+			consumed = append(consumed, p)
+		}
+	}
+	return consumed
+}
+
+// collectLogFilePaths reads all .yaml/.yml files in dir, parses their logs
+// sections, and returns the file paths for any file-type log source.
+func collectLogFilePaths(dir string) []string {
+	files, err := os.ReadDir(dir)
+	if err != nil {
+		log.Debugf("Could not read directory %q: %v", dir, err)
+		return nil
+	}
+	var paths []string
+	for _, f := range files {
+		if f.IsDir() {
+			continue
+		}
+		ext := filepath.Ext(f.Name())
+		if ext != ".yaml" && ext != ".yml" {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, f.Name()))
+		if err != nil {
+			continue
+		}
+		configs, err := logsconfig.ParseYAML(data)
+		if err != nil {
+			log.Debugf("Could not parse logs config from %s: %v", filepath.Join(dir, f.Name()), err)
+			continue
+		}
+		for _, cfg := range configs {
+			if cfg.Type != logsconfig.FileType || cfg.Path == "" {
+				continue
+			}
+			paths = append(paths, filepath.Clean(cfg.Path))
+		}
+	}
+	return paths
 }
 
 // loadDeprecatedValues loads a set of deprecated values which are kept for

--- a/comp/trace/config/setup_test.go
+++ b/comp/trace/config/setup_test.go
@@ -1,0 +1,274 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	coreconfig "github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadConsumedLogFiles(t *testing.T) {
+	t.Run("empty_confd_path", func(t *testing.T) {
+		cfg := coreconfig.NewMockWithOverrides(t, map[string]interface{}{
+			"confd_path": "",
+		})
+		result := loadConsumedLogFiles(cfg)
+		assert.Nil(t, result)
+	})
+
+	t.Run("nonexistent_confd_path", func(t *testing.T) {
+		cfg := coreconfig.NewMockWithOverrides(t, map[string]interface{}{
+			"confd_path": "/nonexistent/path/that/does/not/exist",
+		})
+		result := loadConsumedLogFiles(cfg)
+		assert.Nil(t, result)
+	})
+
+	t.Run("empty_confd_directory", func(t *testing.T) {
+		dir := t.TempDir()
+		cfg := coreconfig.NewMockWithOverrides(t, map[string]interface{}{
+			"confd_path": dir,
+		})
+		result := loadConsumedLogFiles(cfg)
+		assert.Nil(t, result)
+	})
+
+	t.Run("exact_file_paths", func(t *testing.T) {
+		dir := t.TempDir()
+		integDir := filepath.Join(dir, "myapp.d")
+		require.NoError(t, os.MkdirAll(integDir, 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(integDir, "conf.yaml"), []byte(`
+logs:
+  - type: file
+    path: /var/log/myapp.log
+    service: myapp
+    source: myapp
+`), 0644))
+
+		cfg := coreconfig.NewMockWithOverrides(t, map[string]interface{}{
+			"confd_path": dir,
+		})
+		result := loadConsumedLogFiles(cfg)
+		assert.Equal(t, []string{"/var/log/myapp.log"}, result)
+	})
+
+	t.Run("glob_pattern", func(t *testing.T) {
+		dir := t.TempDir()
+		integDir := filepath.Join(dir, "myapp.d")
+		require.NoError(t, os.MkdirAll(integDir, 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(integDir, "conf.yaml"), []byte(`
+logs:
+  - type: file
+    path: /var/log/*.log
+    service: myapp
+    source: myapp
+`), 0644))
+
+		cfg := coreconfig.NewMockWithOverrides(t, map[string]interface{}{
+			"confd_path": dir,
+		})
+		result := loadConsumedLogFiles(cfg)
+		assert.Equal(t, []string{"/var/log/*.log"}, result)
+	})
+
+	t.Run("directory_path_cleaned", func(t *testing.T) {
+		dir := t.TempDir()
+		integDir := filepath.Join(dir, "myapp.d")
+		require.NoError(t, os.MkdirAll(integDir, 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(integDir, "conf.yaml"), []byte(`
+logs:
+  - type: file
+    path: /var/log/myapp/
+    service: myapp
+    source: myapp
+`), 0644))
+
+		cfg := coreconfig.NewMockWithOverrides(t, map[string]interface{}{
+			"confd_path": dir,
+		})
+		result := loadConsumedLogFiles(cfg)
+		assert.Equal(t, []string{"/var/log/myapp"}, result)
+	})
+
+	t.Run("multiple_integrations", func(t *testing.T) {
+		dir := t.TempDir()
+
+		app1Dir := filepath.Join(dir, "app1.d")
+		require.NoError(t, os.MkdirAll(app1Dir, 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(app1Dir, "conf.yaml"), []byte(`
+logs:
+  - type: file
+    path: /var/log/app1.log
+    service: app1
+`), 0644))
+
+		app2Dir := filepath.Join(dir, "app2.d")
+		require.NoError(t, os.MkdirAll(app2Dir, 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(app2Dir, "conf.yaml"), []byte(`
+logs:
+  - type: file
+    path: /var/log/app2/*.log
+    service: app2
+`), 0644))
+
+		cfg := coreconfig.NewMockWithOverrides(t, map[string]interface{}{
+			"confd_path": dir,
+		})
+		result := loadConsumedLogFiles(cfg)
+		sort.Strings(result)
+		assert.Equal(t, []string{"/var/log/app1.log", "/var/log/app2/*.log"}, result)
+	})
+
+	t.Run("skips_non_file_types", func(t *testing.T) {
+		dir := t.TempDir()
+		integDir := filepath.Join(dir, "myapp.d")
+		require.NoError(t, os.MkdirAll(integDir, 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(integDir, "conf.yaml"), []byte(`
+logs:
+  - type: tcp
+    port: 10514
+    service: myapp
+  - type: file
+    path: /var/log/myapp.log
+    service: myapp
+`), 0644))
+
+		cfg := coreconfig.NewMockWithOverrides(t, map[string]interface{}{
+			"confd_path": dir,
+		})
+		result := loadConsumedLogFiles(cfg)
+		assert.Equal(t, []string{"/var/log/myapp.log"}, result)
+	})
+
+	t.Run("yml_extension", func(t *testing.T) {
+		dir := t.TempDir()
+		integDir := filepath.Join(dir, "myapp.d")
+		require.NoError(t, os.MkdirAll(integDir, 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(integDir, "conf.yml"), []byte(`
+logs:
+  - type: file
+    path: /var/log/myapp.log
+    service: myapp
+`), 0644))
+
+		cfg := coreconfig.NewMockWithOverrides(t, map[string]interface{}{
+			"confd_path": dir,
+		})
+		result := loadConsumedLogFiles(cfg)
+		assert.Equal(t, []string{"/var/log/myapp.log"}, result)
+	})
+
+	t.Run("custom_filename", func(t *testing.T) {
+		dir := t.TempDir()
+		integDir := filepath.Join(dir, "myapp.d")
+		require.NoError(t, os.MkdirAll(integDir, 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(integDir, "custom_name.yaml"), []byte(`
+logs:
+  - type: file
+    path: /var/log/custom.log
+    service: myapp
+`), 0644))
+
+		cfg := coreconfig.NewMockWithOverrides(t, map[string]interface{}{
+			"confd_path": dir,
+		})
+		result := loadConsumedLogFiles(cfg)
+		assert.Equal(t, []string{"/var/log/custom.log"}, result)
+	})
+
+	t.Run("deduplicates_paths", func(t *testing.T) {
+		dir := t.TempDir()
+		integDir := filepath.Join(dir, "myapp.d")
+		require.NoError(t, os.MkdirAll(integDir, 0755))
+		// Two yaml files with the same log path
+		content := []byte(`
+logs:
+  - type: file
+    path: /var/log/myapp.log
+    service: myapp
+`)
+		require.NoError(t, os.WriteFile(filepath.Join(integDir, "conf.yaml"), content, 0644))
+		require.NoError(t, os.WriteFile(filepath.Join(integDir, "other.yaml"), content, 0644))
+
+		cfg := coreconfig.NewMockWithOverrides(t, map[string]interface{}{
+			"confd_path": dir,
+		})
+		result := loadConsumedLogFiles(cfg)
+		assert.Equal(t, []string{"/var/log/myapp.log"}, result)
+	})
+
+	t.Run("invalid_yaml_is_skipped", func(t *testing.T) {
+		dir := t.TempDir()
+		integDir := filepath.Join(dir, "myapp.d")
+		require.NoError(t, os.MkdirAll(integDir, 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(integDir, "conf.yaml"), []byte(`not: [valid: yaml: for: logs`), 0644))
+
+		cfg := coreconfig.NewMockWithOverrides(t, map[string]interface{}{
+			"confd_path": dir,
+		})
+		result := loadConsumedLogFiles(cfg)
+		assert.Nil(t, result)
+	})
+
+	t.Run("skips_plain_files_in_confd", func(t *testing.T) {
+		dir := t.TempDir()
+		// Create a regular file (not a directory) in confd_path
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "not_a_dir.yaml"), []byte(`
+logs:
+  - type: file
+    path: /var/log/app.log
+`), 0644))
+
+		cfg := coreconfig.NewMockWithOverrides(t, map[string]interface{}{
+			"confd_path": dir,
+		})
+		result := loadConsumedLogFiles(cfg)
+		assert.Nil(t, result)
+	})
+
+	t.Run("skips_dirs_without_d_suffix", func(t *testing.T) {
+		dir := t.TempDir()
+		// Directory without .d suffix should be ignored
+		plainDir := filepath.Join(dir, "myapp")
+		require.NoError(t, os.MkdirAll(plainDir, 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(plainDir, "conf.yaml"), []byte(`
+logs:
+  - type: file
+    path: /var/log/app.log
+`), 0644))
+
+		cfg := coreconfig.NewMockWithOverrides(t, map[string]interface{}{
+			"confd_path": dir,
+		})
+		result := loadConsumedLogFiles(cfg)
+		assert.Nil(t, result)
+	})
+
+	t.Run("skips_non_yaml_files", func(t *testing.T) {
+		dir := t.TempDir()
+		integDir := filepath.Join(dir, "myapp.d")
+		require.NoError(t, os.MkdirAll(integDir, 0755))
+		// .json and .default files should be ignored
+		require.NoError(t, os.WriteFile(filepath.Join(integDir, "conf.json"), []byte(`{"logs":[{"type":"file","path":"/var/log/app.log"}]}`), 0644))
+		require.NoError(t, os.WriteFile(filepath.Join(integDir, "conf.yaml.default"), []byte(`
+logs:
+  - type: file
+    path: /var/log/default.log
+`), 0644))
+
+		cfg := coreconfig.NewMockWithOverrides(t, map[string]interface{}{
+			"confd_path": dir,
+		})
+		result := loadConsumedLogFiles(cfg)
+		assert.Nil(t, result)
+	})
+}

--- a/pkg/trace/api/debugger.go
+++ b/pkg/trace/api/debugger.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -30,12 +31,72 @@ const (
 	// This limit is not imposed by the event platform intake, it's a safeguard we've added to guarantee an upper
 	// bound for the tags.
 	ddTagsQueryStringMaxLen = 4001
+
+	// logFilesHeader is the HTTP header containing file paths sent by the debugger.
+	logFilesHeader = "LOG_FILES"
+
+	// logFilesSeparator is the separator used between file paths in the LOG_FILES header.
+	logFilesSeparator = "\x1F"
 )
 
 // debuggerLogsProxyHandler returns an http.Handler proxying Dynamic Instrumentation dynamic logs
-// to the logs intake.
+// to the logs intake. It wraps the proxy with a conflict check that rejects requests for files
+// already being consumed by log integrations.
 func (r *HTTPReceiver) debuggerLogsProxyHandler() http.Handler {
-	return r.debuggerProxyHandler(logsIntakeURLTemplate, r.conf.DebuggerProxy)
+	proxy := r.debuggerProxyHandler(logsIntakeURLTemplate, r.conf.DebuggerProxy)
+	return r.withLogFileConflictCheck(proxy)
+}
+
+// withLogFileConflictCheck wraps an http.Handler with a check that rejects requests
+// containing log file paths already consumed by log integrations.
+func (r *HTTPReceiver) withLogFileConflictCheck(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if header := req.Header.Get(logFilesHeader); header != "" {
+			files := strings.Split(header, logFilesSeparator)
+			var conflicts []string
+			for _, f := range files {
+				f = filepath.Clean(strings.TrimSpace(f))
+				if f == "" || f == "." {
+					continue
+				}
+				if matchesConsumedLogFile(f, r.conf.ConsumedLogFiles) {
+					conflicts = append(conflicts, f)
+				}
+			}
+			if len(conflicts) > 0 {
+				http.Error(w, fmt.Sprintf("log files already consumed: %s", strings.Join(conflicts, ", ")), http.StatusConflict)
+				return
+			}
+		}
+		next.ServeHTTP(w, req)
+	})
+}
+
+// matchesConsumedLogFile checks whether file matches any of the consumed log
+// file patterns. This follows the same matching approach as the log agent's
+// FileProvider: exact path comparison for non-wildcard patterns and filepath.Match
+// for glob patterns.
+func matchesConsumedLogFile(file string, patterns []string) bool {
+	for _, pattern := range patterns {
+		if !containsWildcard(pattern) {
+			// Exact match (same as FileProvider.CollectFiles for non-wildcard paths)
+			if file == pattern {
+				return true
+			}
+			continue
+		}
+		// Glob pattern matching (same as FileProvider.filesMatchingSource)
+		if matched, _ := filepath.Match(pattern, file); matched {
+			return true
+		}
+	}
+	return false
+}
+
+// containsWildcard returns true if the path contains any wildcard character.
+// This mirrors logsconfig.ContainsWildcard.
+func containsWildcard(path string) bool {
+	return strings.ContainsAny(path, "*?[")
 }
 
 // debuggerDiagnosticsProxyHandler returns an http.Handler proxying Dynamic Instrumentation diagnostic messages

--- a/pkg/trace/api/debugger_test.go
+++ b/pkg/trace/api/debugger_test.go
@@ -300,3 +300,193 @@ func getConf() *traceconfig.AgentConfig {
 	conf.AgentVersion = "v1"
 	return conf
 }
+
+func TestDebuggerLogsProxyLogFileConflict(t *testing.T) {
+	t.Run("no_header", func(t *testing.T) {
+		var called bool
+		srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			called = true
+		}))
+		defer srv.Close()
+		conf := getConf()
+		conf.DebuggerProxy.DDURL = srv.URL
+		conf.ConsumedLogFiles = []string{"/var/log/app.log"}
+		receiver := newTestReceiverFromConfig(conf)
+		req, err := http.NewRequest("POST", "/some/path", nil)
+		assert.NoError(t, err)
+		rec := httptest.NewRecorder()
+		receiver.debuggerLogsProxyHandler().ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusOK, rec.Result().StatusCode)
+		assert.True(t, called, "request should be proxied when no LOG_FILES header")
+	})
+
+	t.Run("empty_header", func(t *testing.T) {
+		var called bool
+		srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			called = true
+		}))
+		defer srv.Close()
+		conf := getConf()
+		conf.DebuggerProxy.DDURL = srv.URL
+		conf.ConsumedLogFiles = []string{"/var/log/app.log"}
+		receiver := newTestReceiverFromConfig(conf)
+		req, err := http.NewRequest("POST", "/some/path", nil)
+		assert.NoError(t, err)
+		req.Header.Set("LOG_FILES", "")
+		rec := httptest.NewRecorder()
+		receiver.debuggerLogsProxyHandler().ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusOK, rec.Result().StatusCode)
+		assert.True(t, called, "request should be proxied when LOG_FILES header is empty")
+	})
+
+	t.Run("no_conflict", func(t *testing.T) {
+		var called bool
+		srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			called = true
+		}))
+		defer srv.Close()
+		conf := getConf()
+		conf.DebuggerProxy.DDURL = srv.URL
+		conf.ConsumedLogFiles = []string{"/var/log/app.log"}
+		receiver := newTestReceiverFromConfig(conf)
+		req, err := http.NewRequest("POST", "/some/path", nil)
+		assert.NoError(t, err)
+		req.Header.Set("LOG_FILES", "/var/log/other.log")
+		rec := httptest.NewRecorder()
+		receiver.debuggerLogsProxyHandler().ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusOK, rec.Result().StatusCode)
+		assert.True(t, called, "request should be proxied when no conflict")
+	})
+
+	t.Run("conflict_exact", func(t *testing.T) {
+		var called bool
+		srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			called = true
+		}))
+		defer srv.Close()
+		conf := getConf()
+		conf.DebuggerProxy.DDURL = srv.URL
+		conf.ConsumedLogFiles = []string{"/var/log/app.log"}
+		receiver := newTestReceiverFromConfig(conf)
+		req, err := http.NewRequest("POST", "/some/path", nil)
+		assert.NoError(t, err)
+		req.Header.Set("LOG_FILES", "/var/log/app.log")
+		rec := httptest.NewRecorder()
+		receiver.debuggerLogsProxyHandler().ServeHTTP(rec, req)
+		res := rec.Result()
+		assert.Equal(t, http.StatusConflict, res.StatusCode)
+		slurp, err := io.ReadAll(res.Body)
+		res.Body.Close()
+		assert.NoError(t, err)
+		assert.Contains(t, string(slurp), "/var/log/app.log")
+		assert.False(t, called, "backend should NOT be called on conflict")
+	})
+
+	t.Run("conflict_glob", func(t *testing.T) {
+		var called bool
+		srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			called = true
+		}))
+		defer srv.Close()
+		conf := getConf()
+		conf.DebuggerProxy.DDURL = srv.URL
+		conf.ConsumedLogFiles = []string{"/var/log/*.log"}
+		receiver := newTestReceiverFromConfig(conf)
+		req, err := http.NewRequest("POST", "/some/path", nil)
+		assert.NoError(t, err)
+		req.Header.Set("LOG_FILES", "/var/log/app.log")
+		rec := httptest.NewRecorder()
+		receiver.debuggerLogsProxyHandler().ServeHTTP(rec, req)
+		res := rec.Result()
+		assert.Equal(t, http.StatusConflict, res.StatusCode)
+		assert.False(t, called, "backend should NOT be called on glob conflict")
+	})
+
+	t.Run("no_conflict_glob_no_match", func(t *testing.T) {
+		var called bool
+		srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			called = true
+		}))
+		defer srv.Close()
+		conf := getConf()
+		conf.DebuggerProxy.DDURL = srv.URL
+		conf.ConsumedLogFiles = []string{"/var/log/*.log"}
+		receiver := newTestReceiverFromConfig(conf)
+		req, err := http.NewRequest("POST", "/some/path", nil)
+		assert.NoError(t, err)
+		req.Header.Set("LOG_FILES", "/var/log/sub/app.log")
+		rec := httptest.NewRecorder()
+		receiver.debuggerLogsProxyHandler().ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusOK, rec.Result().StatusCode)
+		assert.True(t, called, "glob *.log should not match files in subdirectories")
+	})
+
+	t.Run("partial_conflict", func(t *testing.T) {
+		var called bool
+		srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			called = true
+		}))
+		defer srv.Close()
+		conf := getConf()
+		conf.DebuggerProxy.DDURL = srv.URL
+		conf.ConsumedLogFiles = []string{"/var/log/app.log"}
+		receiver := newTestReceiverFromConfig(conf)
+		req, err := http.NewRequest("POST", "/some/path", nil)
+		assert.NoError(t, err)
+		req.Header.Set("LOG_FILES", "/var/log/other.log\x1F/var/log/app.log")
+		rec := httptest.NewRecorder()
+		receiver.debuggerLogsProxyHandler().ServeHTTP(rec, req)
+		res := rec.Result()
+		assert.Equal(t, http.StatusConflict, res.StatusCode)
+		slurp, err := io.ReadAll(res.Body)
+		res.Body.Close()
+		assert.NoError(t, err)
+		assert.Contains(t, string(slurp), "/var/log/app.log")
+		assert.NotContains(t, string(slurp), "/var/log/other.log")
+		assert.False(t, called, "backend should NOT be called on conflict")
+	})
+
+	t.Run("diagnostics_not_affected", func(t *testing.T) {
+		var called bool
+		srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			called = true
+		}))
+		defer srv.Close()
+		conf := getConf()
+		conf.DebuggerIntakeProxy.DDURL = srv.URL
+		conf.ConsumedLogFiles = []string{"/var/log/app.log"}
+		receiver := newTestReceiverFromConfig(conf)
+		req, err := http.NewRequest("POST", "/some/path", nil)
+		assert.NoError(t, err)
+		req.Header.Set("LOG_FILES", "/var/log/app.log")
+		rec := httptest.NewRecorder()
+		receiver.debuggerDiagnosticsProxyHandler().ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusOK, rec.Result().StatusCode)
+		assert.True(t, called, "diagnostics endpoint should not have conflict check")
+	})
+}
+
+func TestMatchesConsumedLogFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		file     string
+		patterns []string
+		expected bool
+	}{
+		{"exact_match", "/var/log/app.log", []string{"/var/log/app.log"}, true},
+		{"no_match", "/var/log/other.log", []string{"/var/log/app.log"}, false},
+		{"glob_star_match", "/var/log/app.log", []string{"/var/log/*.log"}, true},
+		{"glob_star_no_subdir", "/var/log/sub/app.log", []string{"/var/log/*.log"}, false},
+		{"glob_question_match", "/var/log/app1.log", []string{"/var/log/app?.log"}, true},
+		{"glob_question_no_match", "/var/log/app12.log", []string{"/var/log/app?.log"}, false},
+		{"glob_no_cross_dir", "/var/log/sub/app.log", []string{"/var/log/*.log"}, false},
+		{"glob_bracket_match", "/var/log/app1.log", []string{"/var/log/app[0-9].log"}, true},
+		{"empty_patterns", "/var/log/app.log", nil, false},
+		{"multiple_patterns_match_second", "/var/log/app.log", []string{"/tmp/*.log", "/var/log/app.log"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, matchesConsumedLogFile(tt.file, tt.patterns))
+		})
+	}
+}

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -501,6 +501,11 @@ type AgentConfig struct {
 	// DebuggerIntakeProxy contains the settings for the Live Debugger intake proxy.
 	DebuggerIntakeProxy DebuggerProxyConfig
 
+	// ConsumedLogFiles is the list of log file path patterns already consumed by log integrations.
+	// Patterns may be exact paths or glob patterns (e.g. /var/log/*.log).
+	// Used by the debugger logs proxy to reject requests for files already being tailed.
+	ConsumedLogFiles []string
+
 	// SymDBProxy contains the settings for the Symbol Database proxy.
 	SymDBProxy SymDBProxyConfig
 


### PR DESCRIPTION
To avoid double processing, if any file is already tailed by the datadog-agent, this debugger handler drops logs forwarded by the tracer. 

TODO - add config tests!
