### PR TITLE
perf(e2e): Speed up OpenShift CRC cluster initialization

### DIFF
--- a/test/e2e-framework/components/kubernetes/openshift.go
+++ b/test/e2e-framework/components/kubernetes/openshift.go
@@ -82,9 +82,8 @@ func NewOpenShiftCluster(env config.Env, vm *remote.Host, name string, pullSecre
 			return err
 		}
 
-		installLibvirt, err := runner.Command(commonEnvironment.CommonNamer().ResourceName("install-libvirt"), &command.Args{
-			Create: pulumi.String(`
-		sudo dnf install -y libvirt NetworkManager`),
+		installDeps, err := runner.Command(commonEnvironment.CommonNamer().ResourceName("install-deps"), &command.Args{
+			Create: pulumi.String(`sudo dnf install -y libvirt NetworkManager socat`),
 		}, utils.MergeOptions(opts, utils.PulumiDependsOn(openShiftInstallBinary))...)
 		if err != nil {
 			return err
@@ -92,13 +91,13 @@ func NewOpenShiftCluster(env config.Env, vm *remote.Host, name string, pullSecre
 		// To avoid the crc-daemon.service being stopped when the user session ends, we enable linger for the user
 		enableLinger, err := runner.Command(commonEnvironment.CommonNamer().ResourceName("enable-linger"), &command.Args{
 			Create: pulumi.String("loginctl enable-linger"),
-		}, utils.MergeOptions(opts, utils.PulumiDependsOn(installLibvirt))...)
+		}, utils.MergeOptions(opts, utils.PulumiDependsOn(installDeps))...)
 		if err != nil {
 			return err
 		}
 
 		setupCRC, err := runner.Command(commonEnvironment.CommonNamer().ResourceName("crc-setup"), &command.Args{
-			Create: pulumi.String("crc config set disk-size 100 && crc config set cpus 6 && crc config set memory 16384 && crc setup"),
+			Create: pulumi.String("crc config set disk-size 100 && crc config set cpus 12 && crc config set memory 32768 && crc setup"),
 		}, utils.MergeOptions(opts, utils.PulumiDependsOn(pullSecretFile, enableLinger))...)
 		if err != nil {
 			return err
@@ -114,18 +113,12 @@ func NewOpenShiftCluster(env config.Env, vm *remote.Host, name string, pullSecre
 		if err != nil {
 			return err
 		}
-		socatInstall, err := runner.Command(commonEnvironment.CommonNamer().ResourceName("install-socat"), &command.Args{
-			Create: pulumi.String("sudo dnf install -y socat"),
-		}, utils.MergeOptions(opts, utils.PulumiDependsOn(startCRC))...)
-		if err != nil {
-			return err
-		}
 
 		socatForwarding, err := runner.Command(commonEnvironment.CommonNamer().ResourceName("socat-kubeapi-proxy"), &command.Args{
 			Create: pulumi.String(`
                 sudo nohup socat TCP-LISTEN:8443,bind=0.0.0.0,fork TCP:127.0.0.1:6443 > /tmp/socat.log 2>&1 &
             `),
-		}, utils.MergeOptions(opts, utils.PulumiDependsOn(socatInstall))...)
+		}, utils.MergeOptions(opts, utils.PulumiDependsOn(startCRC))...)
 		if err != nil {
 			return err
 		}
@@ -141,43 +134,41 @@ func NewOpenShiftCluster(env config.Env, vm *remote.Host, name string, pullSecre
 		waitControlPlane, err := runner.Command(commonEnvironment.CommonNamer().ResourceName("wait-control-plane-ready"), &command.Args{
 			Create: pulumi.String(`
 # Wait for API server to be responsive
-for i in {1..30}; do
+for i in {1..15}; do
   if curl -sk https://127.0.0.1:6443/healthz 2>/dev/null | grep -q ok; then
     echo "API server responsive"
     break
   fi
-  echo "Waiting for API server (attempt $i/30)..."
-  sleep 10
+  echo "Waiting for API server (attempt $i/15)..."
+  sleep 5
 done
 
 export KUBECONFIG=~/.crc/machines/crc/kubeconfig
 
 # Wait for nodes to be ready
 echo "Waiting for nodes to be Ready..."
-for i in {1..60}; do
+for i in {1..30}; do
   ready_nodes=$(kubectl get nodes --no-headers 2>/dev/null | grep -c ' Ready ')
   if [ "$ready_nodes" -gt 0 ]; then
     echo "Found $ready_nodes Ready nodes"
     break
   fi
-  echo "Waiting for nodes (attempt $i/60)..."
+  echo "Waiting for nodes (attempt $i/30)..."
   sleep 5
 done
 
-# Wait for some system pods to be running
+# Wait for system pods to be running (check both namespaces in one pass)
 echo "Waiting for system pods to be running..."
-for namespace in openshift-kube-apiserver openshift-kube-controller-manager; do
-  for i in {1..60}; do
-    running_pods=$(kubectl get pods -n "$namespace" --field-selector=status.phase=Running --no-headers 2>/dev/null | wc -l)
-    if [ "$running_pods" -gt 0 ]; then
-      echo "Namespace $namespace has $running_pods running pod(s)"
-      break
-    fi
-    if [ $i -lt 60 ]; then
-      echo "Waiting for $namespace pods (attempt $i/60)..."
-      sleep 5
-    fi
-  done
+for i in {1..30}; do
+  apiserver_pods=$(kubectl get pods -n openshift-kube-apiserver --field-selector=status.phase=Running --no-headers 2>/dev/null | wc -l)
+  controller_pods=$(kubectl get pods -n openshift-kube-controller-manager --field-selector=status.phase=Running --no-headers 2>/dev/null | wc -l)
+  if [ "$apiserver_pods" -gt 0 ] && [ "$controller_pods" -gt 0 ]; then
+    echo "openshift-kube-apiserver has $apiserver_pods running pod(s)"
+    echo "openshift-kube-controller-manager has $controller_pods running pod(s)"
+    break
+  fi
+  echo "Waiting for system pods (attempt $i/30, apiserver=$apiserver_pods, controller=$controller_pods)..."
+  sleep 5
 done
 
 echo "Control plane is ready"


### PR DESCRIPTION
### What does this PR do?

Optimizes the OpenShift CRC (CodeReady Containers) cluster initialization in e2e tests with three changes:

1. **Merge socat install into the initial dependency install step**: socat was installed as a separate Pulumi resource that unnecessarily depended on `startCRC`. It now installs alongside `libvirt` and `NetworkManager` in a single `dnf` call, removing one sequential step from the critical path.

2. **Increase CRC resource allocation**: CRC was configured with only 6 CPUs and 16GB RAM on an `n2-standard-16` host (16 vCPUs, 64GB RAM). Doubled to 12 CPUs and 32GB RAM to speed up both `crc start` and control plane boot.

3. **Tighten health check wait loops**:
   - API server wait: 30×10s (5 min max) → 15×5s (75s max)
   - Node readiness: 60×5s (5 min max) → 30×5s (2.5 min max)
   - System pods: now checks both namespaces in parallel per iteration instead of sequentially, reduced from 60×5s to 30×5s

### Motivation

OpenShift init (`new-e2e-containers-openshift-init`) has a P50 duration of ~49 min on main, nearly 2x slower than EKS init (~26 min). The bulk of the time is spent on CRC startup with nested virtualization, but several easy optimizations in the provisioning flow were left on the table:
- An unnecessary sequential Pulumi step (socat install after CRC start)
- Under-provisioned CRC VM (6 CPUs out of 16 available)
- Very generous health check timeouts that in practice never need the full wait window

### Describe how you validated your changes

These changes only affect the OpenShift e2e init path. Will validate via CI pipeline execution that the OpenShift init job completes successfully with reduced duration.

### Additional Notes

Further optimization is possible via pre-baked GCP images with CRC pre-installed (similar to the ami-builder pattern for AWS), which could save an additional ~15 min by eliminating the CRC binary download and `crc setup` bundle download. That's a larger effort tracked separately.