### PR TITLE
Patch install_name at the source instead of after build

### DIFF
--- a/deps/cpython/0002-Set-the-install-name-to-use-rpath-instead-of-absolut.patch
+++ b/deps/cpython/0002-Set-the-install-name-to-use-rpath-instead-of-absolut.patch
@@ -1,0 +1,32 @@
+From 9878f08ef7b05a770902c72eda9d6da24f72bf94 Mon Sep 17 00:00:00 2001
+From: Alex Lopez <alex.lopez@datadoghq.com>
+Date: Mon, 2 Mar 2026 13:10:18 +0100
+Subject: [PATCH] Set the install name to use @rpath instead of absolute path
+ on darwin.
+
+This determines linker references to this library for other binaries
+that may link against it.
+
+In bazel, the absolute path points at a sandbox, causing "broken"
+links. Libraries built with rules_cc rules also make this relative to
+@rpath.
+---
+ Makefile.pre.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile.pre.in b/Makefile.pre.in
+index ecf77bdc41c..4cf7552f3c8 100644
+--- a/Makefile.pre.in
++++ b/Makefile.pre.in
+@@ -924,7 +924,7 @@ libpython3.so:	libpython$(LDVERSION).so
+ 	$(BLDSHARED) $(NO_AS_NEEDED) -o $@ -Wl,-h$@ $^
+ 
+ libpython$(LDVERSION).dylib: $(LIBRARY_OBJS)
+-	 $(CC) -dynamiclib $(PY_CORE_LDFLAGS) -undefined dynamic_lookup -Wl,-install_name,$(prefix)/lib/libpython$(LDVERSION).dylib -Wl,-compatibility_version,$(VERSION) -Wl,-current_version,$(VERSION) -o $@ $(LIBRARY_OBJS) $(DTRACE_OBJS) $(SHLIBS) $(LIBC) $(LIBM); \
++	 $(CC) -dynamiclib $(PY_CORE_LDFLAGS) -undefined dynamic_lookup -Wl,-install_name,@rpath/libpython$(LDVERSION).dylib -Wl,-compatibility_version,$(VERSION) -Wl,-current_version,$(VERSION) -o $@ $(LIBRARY_OBJS) $(DTRACE_OBJS) $(SHLIBS) $(LIBC) $(LIBM); \
+ 
+ 
+ libpython$(VERSION).sl: $(LIBRARY_OBJS)
+-- 
+2.52.0
+

--- a/deps/cpython/cpython.MODULE.bazel
+++ b/deps/cpython/cpython.MODULE.bazel
@@ -11,6 +11,7 @@ http_archive(
     patch_strip = 1,
     patches = [
         "//deps/cpython:0001-customize-windows-build-script.patch",
+        "//deps/cpython:0002-Set-the-install-name-to-use-rpath-instead-of-absolut.patch",
     ],
     sha256 = "12e7cb170ad2d1a69aee96a1cc7fc8de5b1e97a2bdac51683a3db016ec9a2996",
     strip_prefix = "Python-{}".format(PYTHON_VERSION),

--- a/deps/openssl.BUILD.bazel
+++ b/deps/openssl.BUILD.bazel
@@ -210,13 +210,6 @@ configure_make(
     # to link
     postfix_script = select({
         "@platforms//os:macos": """
-            # Fix install names
-            for lib in libcrypto.dylib libssl.dylib; do
-                install_name_tool -id @rpath/$$lib $$INSTALLDIR/lib/$$lib
-                for dep in $$(otool -L $$INSTALLDIR/lib/$$lib | grep 'sandbox.*execroot' | awk '{print $$1}'); do
-                    install_name_tool -change $$dep "@loader_path/$$(basename $$dep)" $$INSTALLDIR/lib/$$lib
-                done
-            done
             LIBS="$$INSTALLDIR/lib/libcrypto.dylib $$INSTALLDIR/lib/libssl.dylib"
         """ + FIX_OPENSSL_PATHS + """
         codesign -s - -f $$INSTALLDIR/lib/libcrypto.dylib $$INSTALLDIR/lib/libssl.dylib

--- a/deps/openssl/0001-Set-the-install-name-to-use-rpath-instead-of-absolut.patch
+++ b/deps/openssl/0001-Set-the-install-name-to-use-rpath-instead-of-absolut.patch
@@ -1,0 +1,32 @@
+From 84ccd4cbef7c89cdc560606e3eb3c696b4759ffd Mon Sep 17 00:00:00 2001
+From: Alex Lopez <alex.lopez@datadoghq.com>
+Date: Mon, 2 Mar 2026 11:45:42 +0100
+Subject: [PATCH] Set the install name to use @rpath instead of absolute path
+ on darwin.
+
+This determines linker references to this library for other binaries
+that may link against it.
+
+In bazel, the absolute path points at a sandbox, causing "broken"
+links. Libraries built with rules_cc rules also make this relative to
+@rpath.
+---
+ Configurations/shared-info.pl | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Configurations/shared-info.pl b/Configurations/shared-info.pl
+index caf6f90126..17c1987944 100644
+--- a/Configurations/shared-info.pl
++++ b/Configurations/shared-info.pl
+@@ -49,7 +49,7 @@ my %shared_info;
+     'darwin-shared' => {
+         module_ldflags        => '-bundle',
+         shared_ldflag         => '-dynamiclib -current_version $(SHLIB_VERSION_NUMBER) -compatibility_version $(SHLIB_VERSION_NUMBER)',
+-        shared_sonameflag     => '-install_name $(libdir)/',
++        shared_sonameflag     => '-install_name @rpath/',
+     },
+     'cygwin-shared' => {
+         shared_ldflag         => '-shared -Wl,--enable-auto-image-base',
+-- 
+2.52.0
+

--- a/deps/repos.MODULE.bazel
+++ b/deps/repos.MODULE.bazel
@@ -96,6 +96,10 @@ register_toolchains(
 http_archive(
     name = "openssl",
     build_file = "//deps:openssl.BUILD.bazel",
+    patch_strip = 1,
+    patches = [
+        "//deps/openssl:0001-Set-the-install-name-to-use-rpath-instead-of-absolut.patch",
+    ],
     sha256 = "b28c91532a8b65a1f983b4c28b7488174e4a01008e29ce8e69bd789f28bc2a89",
     strip_prefix = "openssl-3.5.5",
     urls = [

--- a/omnibus/config/software/openssl3.rb
+++ b/omnibus/config/software/openssl3.rb
@@ -50,7 +50,7 @@ build do
 
     files_to_patch = files_to_patch.map { |path| "#{install_dir}/embedded/#{path}" }
 
-    command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix #{real_install_dir}/embedded #{files_to_patch.join(' ')}"
+    command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix #{install_dir}/embedded #{files_to_patch.join(' ')}"
 
     command_on_repo_root "bazelisk run -- //deps/openssl:fix_openssl_paths --destdir #{real_install_dir}/embedded" \
       " #{install_dir}/embedded/lib/libssl#{lib_extension}" \


### PR DESCRIPTION
### What does this PR do?

Reinstate #47157, which was reverted due to a health check issue.

> Patch macos install_name at the source instead of after build for configure_make targets.

### Motivation

> While working on migrating the rtloader build to Bazel ([ABLD-323](https://datadoghq.atlassian.net/browse/ABLD-323)), I realized that in macos, the rtloader lib (three) would get an absolute path reference to the Python dylib file, which would be in the sandbox. Even if we post-process all these libraries before packaging, any other intermediate use of these libraries – in my case it happened attempting to run go-based rtloader tests – would fail due to this.
> 
> This is caused by the install_name assigned to binaries at build time, which is later used to populate the references when linking dynamically. This is similar to what happened when trying to build python against openssl, which we fixed with some ad-hoc post-build fix.
> 
> Digging into the details of how this path gets set, I found that it comes from each projects' build systems (and not rules_foreign_cc, for example). Rather than add another similar post-build fix script, it seemed cleaner to me to fix it at the source, as the changes needed are really small.

### Describe how you validated your changes

Running the macos builds (I won't forget this time around).

### Additional Notes

See https://github.com/DataDog/datadog-agent/pull/47206#discussion_r2876862488 for the explanation of what broke the original change and how it's being fixed in this PR.


[ABLD-323]: https://datadoghq.atlassian.net/browse/ABLD-323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ