### PR TITLE
Fix `go_mod_tidy` GH workflow wrt XDG cache

### DIFF
--- a/.github/workflows/go_mod_tidy.yml
+++ b/.github/workflows/go_mod_tidy.yml
@@ -12,11 +12,28 @@ jobs:
     permissions:
       contents: write
     runs-on: ubuntu-latest
+    env:
+      XDG_CACHE_HOME: ${{ github.workspace }}/.cache
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
+      - name: Restore Bazel installation
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          key: bazelisk-${{ hashFiles('.bazelversion') }}
+          path: |
+            .cache/bazelisk
+            .cache/bazel/*/install
+      - name: Restore Bazel repositories
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          key: bazel-${{ hashFiles('.go-version', '.python-version') }}
+          path: |
+            .cache/bazel/*/cache
+            .cache/go*
+            .cache/pip
       - name: Install go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:


### PR DESCRIPTION
### What does this PR do?
Set `XDG_CACHE_HOME` and add two `actions/cache@v5.0.3` steps:
- Bazel installation cache: `bazelisk`-managed `bazel` binary and `bazel` own install tree, keyed on `.bazelversion`,
- Bazel repository cache: `bazel`-managed repositories as well as `rules_go`'s and `rules_python`'s caches (`.cache/go*`, `.cache/pip`), keyed on `.go-version` and `.python-version`.

### Motivation
The `tools/bazel` wrapper requires `XDG_CACHE_HOME` to point to a directory in CI.
(https://dd.slack.com/archives/C078N61DRK9/p1772500795310519)

### Additional Notes
actions/cache@v5 requires runner >= v2.327.1, already implied by actions/setup-go@v6 being in use.

Since GitHub might evict caches after a period without access, and this workflow only runs on dependabot PRs, Bazel caches might be cold at times => best effort for the time being.