### PR TITLE
Optimize ddot-ebpf Dockerfile to reduce image size

### DIFF
--- a/Dockerfiles/ddot-ebpf/Dockerfile
+++ b/Dockerfiles/ddot-ebpf/Dockerfile
@@ -43,7 +43,9 @@ COPY --from=builder /workspace/datadog-agent/bin/full-host-profiler/dist/host-pr
 # Find all directories and files in /etc with world-writable permissions and remove write permissions for group and others
 RUN find /etc -type d,f -perm -o+w -print0 | xargs -r -0 chmod g-w,o-w
 # Host profiler requires objcopy
-RUN apt-get update && apt-get install -y binutils
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends binutils && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
 ENTRYPOINT ["/opt/datadog-agent/embedded/bin/full-host-profiler"]
 CMD ["run", "--config", "/etc/datadog-agent/host-profiler-config.yaml"]


### PR DESCRIPTION
## Summary
- Optimize apt-get installation in ddot-ebpf Dockerfile to reduce final image size
- Add `--no-install-recommends` flag to avoid installing unnecessary recommended packages
- Clean up apt cache and package lists in the same RUN layer

## Impact

- Before with `datadog/ddot-ebpf-dev:nightly-latest`: Total Image size: 366 MB
- This PR with `registry.ddbuild.io/ci/datadog-agent/ddot-ebpf:v99953657-17703723-7-amd64`: Total Image size: 288 MB 
