### PR TITLE
Log error from HTTP server Serve goroutine instead of silently discarding it

### DIFF
--- a/comp/api/api/apiimpl/api.go
+++ b/comp/api/api/apiimpl/api.go
@@ -9,6 +9,7 @@ package apiimpl
 import (
 	"context"
 	"net"
+	"net/http"
 
 	"go.uber.org/fx"
 
@@ -29,8 +30,10 @@ func Module() fxutil.Module {
 type apiServer struct {
 	cfg               config.Component
 	ipc               ipc.Component
-	cmdListener       net.Listener
-	ipcListener       net.Listener
+	cmdAddr           *net.TCPAddr
+	ipcAddr           *net.TCPAddr
+	cmdServer         *http.Server
+	ipcServer         *http.Server
 	telemetry         telemetry.Component
 	endpointProviders []api.EndpointProvider
 	grpcComponent     grpc.Component
@@ -70,12 +73,12 @@ func newAPIServer(deps dependencies) api.Component {
 	return &server
 }
 
-// ServerAddress returns the server address.
+// CMDServerAddress returns the CMD server address.
 func (server *apiServer) CMDServerAddress() *net.TCPAddr {
-	return server.cmdListener.Addr().(*net.TCPAddr)
+	return server.cmdAddr
 }
 
-// ServerAddress returns the server address.
+// IPCServerAddress returns the IPC server address.
 func (server *apiServer) IPCServerAddress() *net.TCPAddr {
-	return server.ipcListener.Addr().(*net.TCPAddr)
+	return server.ipcAddr
 }

--- a/comp/api/api/apiimpl/server.go
+++ b/comp/api/api/apiimpl/server.go
@@ -28,7 +28,11 @@ func startServer(listener net.Listener, srv *http.Server, name string) {
 
 	tlsListener := tls.NewListener(listener, srv.TLSConfig)
 
-	go srv.Serve(tlsListener) //nolint:errcheck
+	go func() {
+		if err := srv.Serve(tlsListener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Errorf("HTTP server '%s' exited with error: %s", name, err)
+		}
+	}()
 
 	log.Infof("Started HTTP server '%s' on %s", name, listener.Addr().String())
 }

--- a/comp/api/api/apiimpl/server.go
+++ b/comp/api/api/apiimpl/server.go
@@ -37,9 +37,9 @@ func startServer(listener net.Listener, srv *http.Server, name string) {
 	log.Infof("Started HTTP server '%s' on %s", name, listener.Addr().String())
 }
 
-func stopServer(listener net.Listener, name string) {
-	if listener != nil {
-		if err := listener.Close(); err != nil {
+func stopServer(srv *http.Server, name string) {
+	if srv != nil {
+		if err := srv.Close(); err != nil {
 			log.Errorf("Error stopping HTTP server '%s': %s", name, err)
 		} else {
 			log.Infof("Stopped HTTP server '%s'", name)
@@ -84,8 +84,8 @@ func (server *apiServer) startServers() error {
 
 // StopServers closes the connections and the servers
 func (server *apiServer) stopServers() {
-	stopServer(server.cmdListener, cmdServerName)
-	stopServer(server.ipcListener, ipcServerName)
+	stopServer(server.cmdServer, cmdServerName)
+	stopServer(server.ipcServer, ipcServerName)
 }
 
 // authTagGetter returns a function that returns the auth tag for the given request

--- a/comp/api/api/apiimpl/server_cmd.go
+++ b/comp/api/api/apiimpl/server_cmd.go
@@ -7,6 +7,7 @@ package apiimpl
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 	"time"
 
@@ -26,12 +27,13 @@ func (server *apiServer) startCMDServer(
 	tmf observability.TelemetryMiddlewareFactory,
 ) (err error) {
 	// get the transport we're going to use under HTTP
-	server.cmdListener, err = listener.GetListener(cmdAddr)
+	cmdListener, err := listener.GetListener(cmdAddr)
 	if err != nil {
 		// we use the listener to handle commands for the Agent, there's
 		// no way we can recover from this error
 		return fmt.Errorf("unable to listen to address %s: %v", cmdAddr, err)
 	}
+	server.cmdAddr = cmdListener.Addr().(*net.TCPAddr)
 
 	// gRPC server
 	grpcServer := server.grpcComponent.BuildServer()
@@ -68,7 +70,8 @@ func (server *apiServer) startCMDServer(
 		srv = helpers.NewMuxedGRPCServer(cmdAddr, tlsConfig, grpcServer, cmdMuxHandler, time.Duration(server.cfg.GetInt64("server_timeout"))*time.Second)
 	}
 
-	startServer(server.cmdListener, srv, cmdServerName)
+	server.cmdServer = srv
+	startServer(cmdListener, srv, cmdServerName)
 
 	return nil
 }

--- a/comp/api/api/apiimpl/server_ipc.go
+++ b/comp/api/api/apiimpl/server_ipc.go
@@ -7,6 +7,7 @@ package apiimpl
 
 import (
 	"crypto/tls"
+	"net"
 	"net/http"
 	"time"
 
@@ -20,10 +21,11 @@ const ipcServerName string = "IPC API Server"
 const ipcServerShortName string = "IPC"
 
 func (server *apiServer) startIPCServer(ipcServerAddr string, tmf observability.TelemetryMiddlewareFactory) (err error) {
-	server.ipcListener, err = listener.GetListener(ipcServerAddr)
+	ipcListener, err := listener.GetListener(ipcServerAddr)
 	if err != nil {
 		return err
 	}
+	server.ipcAddr = ipcListener.Addr().(*net.TCPAddr)
 
 	configEndpointMux := configendpoint.GetConfigEndpointMuxCore(server.cfg)
 
@@ -45,7 +47,8 @@ func (server *apiServer) startIPCServer(ipcServerAddr string, tmf observability.
 		TLSConfig: serverTLSConfig,
 	}
 
-	startServer(server.ipcListener, ipcServer, ipcServerName)
+	server.ipcServer = ipcServer
+	startServer(ipcListener, ipcServer, ipcServerName)
 
 	return nil
 }

--- a/comp/api/api/apiimpl/server_ipc.go
+++ b/comp/api/api/apiimpl/server_ipc.go
@@ -25,7 +25,9 @@ func (server *apiServer) startIPCServer(ipcServerAddr string, tmf observability.
 	if err != nil {
 		return err
 	}
-	server.ipcAddr = ipcListener.Addr().(*net.TCPAddr)
+	if tcpAddr, ok := ipcListener.Addr().(*net.TCPAddr); ok {
+		server.ipcAddr = tcpAddr
+	}
 
 	configEndpointMux := configendpoint.GetConfigEndpointMuxCore(server.cfg)
 

--- a/releasenotes/notes/log-api-server-serve-error-e70a1760fb8a.yaml
+++ b/releasenotes/notes/log-api-server-serve-error-e70a1760fb8a.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    The API server now logs errors from ``srv.Serve`` that were previously silently discarded.


### PR DESCRIPTION
### What does this PR do?

Logs the error returned by `srv.Serve` in the API server startup goroutine, instead of silently discarding it with `//nolint:errcheck`.

### Motivation

The `startServer` function in `comp/api/api/apiimpl/server.go` launches `srv.Serve` in a detached goroutine and immediately logs "Started HTTP server". If `Serve` fails after launch, the error is silently dropped and the agent continues running with a dead API server and no indication of the failure.

This was observed in a support case where the IPC API Server logged "Started" on port 5009, but `ss -lntp` showed nothing listening. The agent appeared healthy while the IPC server was silently dead. No other log path (`srv.ErrorLog`, `LogResponseHandler`) surfaces this type of failure because they only fire during active request handling.

### Changes

- Replace `go srv.Serve(tlsListener) //nolint:errcheck` with a goroutine that checks the error and logs it at error level
- Filter `http.ErrServerClosed` since it is the expected return on graceful shutdown

### Describe how you validated your changes

- Verified the file compiles and lints cleanly
- Confirmed `http.ErrServerClosed` is correctly filtered (graceful shutdown path unchanged)
- Traced the code path to confirm no other mechanism logs the `Serve` return error
