### PR TITLE
[INCIDENT-50372] fix(kmt): Increase memory limit on `test_kmt_local_setup` job

### DIFF
--- a/.gitlab/build/source_test/kmt_tasks.yml
+++ b/.gitlab/build/source_test/kmt_tasks.yml
@@ -30,6 +30,11 @@ test_kmt_local_setup_linux:
     # - AWSConfig: no AWS config in the CI yet
     KMT_EXCLUDE_REQUIREMENTS: "Docker,Compiler,UserInDockerGroup,AWSConfig"
 
+    # The `go mod download` step executed during the pulumi plugin install uses a lot of memory.
+    # This can lead to memory thrashing which causes the job to fail.
+    KUBERNETES_MEMORY_REQUEST: 12Gi
+    KUBERNETES_MEMORY_LIMIT: 16Gi
+
 test_kmt_local_setup_macos:
   extends: .test_kmt_local_setup
   before_script:


### PR DESCRIPTION
### What does this PR do?
Increases the Kubernetes memory request on `test_kmt_local_setup_linux` up from the default.

### Motivation
It seems that memory thrashing might be the reason for the failures when running `go mod download`:
- The job runners show a sawtooth pattern of memory usage when executing this job, getting very close to the limit
- The timing of the job is suspicious - Gitlab reports the command taking 30mn before failing when the timeout is set at 10mn. This suggest maybe the kernel is intervening in the process lifecycle, throwing off the calculation.
- Running the command locally _does_ consume a significant amount of memory, around 15G
- There is already a memory limit increase on our main `go_deps` job which is the only other big `go mod download` in the CI

### Describe how you validated your changes

### Additional Notes
