### PR TITLE
[PROF-13842] Extract DD_VERSION and DD_ENV from process env var and add as version tag in prof-analyzer metadata

### DIFF
--- a/comp/host-profiler/collector/impl/receiver/config.go
+++ b/comp/host-profiler/collector/impl/receiver/config.go
@@ -28,9 +28,10 @@ type Config struct {
 	CollectContext      bool                                `mapstructure:"collect_context"`
 }
 
-// ServiceNameEnvVars is the list of environment variables used to determine the service name.
+// defaultEnvVars lists environment variables read from profiled processes to populate
+// unified service tags (service, env, version) in OTLP resource attributes.
 // The order indicates which environment variable takes precedence.
-var serviceNameEnvVars = []string{"DD_SERVICE", "OTEL_SERVICE_NAME"}
+var defaultEnvVars = []string{"DD_SERVICE", "OTEL_SERVICE_NAME", "DD_ENV", "DD_VERSION"}
 
 var _ xconfmap.Validator = (*Config)(nil)
 
@@ -59,7 +60,7 @@ func (c *Config) Validate() error {
 		c.EbpfCollectorConfig.Tracers = includeTracers.String()
 	}
 
-	includeEnvVars := append([]string{}, serviceNameEnvVars...)
+	includeEnvVars := append([]string{}, defaultEnvVars...)
 	if c.EbpfCollectorConfig.IncludeEnvVars != "" {
 		includeEnvVars = append(includeEnvVars, c.EbpfCollectorConfig.IncludeEnvVars)
 	}

--- a/comp/host-profiler/collector/impl/receiver/config_test.go
+++ b/comp/host-profiler/collector/impl/receiver/config_test.go
@@ -41,14 +41,14 @@ func TestTracers(t *testing.T) {
 	require.Contains(t, cfg.EbpfCollectorConfig.Tracers, "labels")
 }
 
-func TestServiceNameEnvVars(t *testing.T) {
+func TestDefaultEnvVars(t *testing.T) {
 	config := defaultConfig()
 	cfg := config.(Config)
 	cfg.SymbolUploader.Enabled = false
 	require.Equal(t, "", cfg.EbpfCollectorConfig.IncludeEnvVars)
 
 	require.NoError(t, cfg.Validate())
-	require.Equal(t, strings.Join(serviceNameEnvVars, ","), cfg.EbpfCollectorConfig.IncludeEnvVars)
+	require.Equal(t, strings.Join(defaultEnvVars, ","), cfg.EbpfCollectorConfig.IncludeEnvVars)
 }
 
 func TestSymbolUploader(t *testing.T) {
@@ -86,7 +86,7 @@ func TestFlatConfigParsingIsAccepted(t *testing.T) {
 	require.False(t, cfg.SymbolUploader.Enabled)
 
 	require.NoError(t, cfg.Validate())
-	require.Equal(t, strings.Join(serviceNameEnvVars, ","), cfg.EbpfCollectorConfig.IncludeEnvVars)
+	require.Equal(t, strings.Join(defaultEnvVars, ","), cfg.EbpfCollectorConfig.IncludeEnvVars)
 }
 
 func TestNestedConfigIsRejected(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Add `DD_VERSION` and `DD_ENV` to the environment variables sent by the collector.

### Motivation

Full host profiles are missing the `version` and `env` tag, which represents the deployment version of the service. This tag is required by the deployment tracking panel, which compares two deployments across various dimensions/metrics from different products including profiling.

The profiling collector already sends process environment variables as OTLP resource attributes (e.g. `process.environment_variable.DD_SERVICE`).

### Describe how you validated your changes

- Fixed the existing unary test to match the changes.

### Additional Notes