### PR TITLE
otlp/metrics: reduce hot-path allocations in Dimensions and key-hash cache

### DIFF
--- a/pkg/opentelemetry-mapping-go/otlp/metrics/dimensions.go
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/dimensions.go
@@ -15,17 +15,12 @@
 package metrics
 
 import (
-	"fmt"
 	"sort"
 	"strings"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 
 	"github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/metrics/internal/utils"
-)
-
-const (
-	dimensionSeparator = string(byte(0))
 )
 
 // Dimensions of a metric that identify a timeseries uniquely.
@@ -77,17 +72,6 @@ func (d *Dimensions) OriginProductDetail() OriginProductDetail {
 	return d.originProductDetail
 }
 
-// getTags maps an attributeMap into a slice of Datadog tags
-func getTags(labels pcommon.Map) []string {
-	tags := make([]string, 0, labels.Len())
-	labels.Range(func(key string, value pcommon.Value) bool {
-		v := value.AsString()
-		tags = append(tags, utils.FormatKeyValueTag(key, v))
-		return true
-	})
-	return tags
-}
-
 // AddTags to metrics dimensions.
 func (d *Dimensions) AddTags(tags ...string) *Dimensions {
 	// defensively copy the tags
@@ -107,13 +91,32 @@ func (d *Dimensions) AddTags(tags ...string) *Dimensions {
 
 // WithAttributeMap creates a new metricDimensions struct with additional tags from attributes.
 func (d *Dimensions) WithAttributeMap(labels pcommon.Map) *Dimensions {
-	return d.AddTags(getTags(labels)...)
+	n := labels.Len()
+	if n == 0 {
+		return d
+	}
+	newTags := make([]string, 0, n+len(d.tags))
+	labels.Range(func(key string, value pcommon.Value) bool {
+		newTags = append(newTags, utils.FormatKeyValueTag(key, value.AsString()))
+		return true
+	})
+	newTags = append(newTags, d.tags...)
+	return &Dimensions{
+		name:                d.name,
+		tags:                newTags,
+		host:                d.host,
+		originID:            d.originID,
+		originProduct:       d.originProduct,
+		originSubProduct:    d.originSubProduct,
+		originProductDetail: d.originProductDetail,
+	}
 }
 
 // WithSuffix creates a new dimensions struct with an extra name suffix.
 func (d *Dimensions) WithSuffix(suffix string) *Dimensions {
+	name := d.name + "." + suffix
 	return &Dimensions{
-		name:                fmt.Sprintf("%s.%s", d.name, suffix),
+		name:                name,
 		host:                d.host,
 		tags:                d.tags,
 		originID:            d.originID,
@@ -123,29 +126,28 @@ func (d *Dimensions) WithSuffix(suffix string) *Dimensions {
 	}
 }
 
-// Uses a logic similar to what is done in the span processor to build metric keys:
-// https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/b2327211df976e0a57ef0425493448988772a16b/processor/spanmetricsprocessor/processor.go#L353-L387
-// TODO: make this a public util function?
-func concatDimensionValue(metricKeyBuilder *strings.Builder, value string) {
-	metricKeyBuilder.WriteString(value)
-	metricKeyBuilder.WriteString(dimensionSeparator)
-}
-
 // String maps dimensions to a string to use as an identifier.
 // The tags order does not matter.
 func (d *Dimensions) String() string {
-	var metricKeyBuilder strings.Builder
-
-	dimensions := make([]string, len(d.tags))
+	// Pre-compute fixed suffixes: "name:<n>\x00host:<h>\x00originID:<o>\x00"
+	// and sort tags in place on a temporary copy.
+	dimensions := make([]string, len(d.tags), len(d.tags)+3)
 	copy(dimensions, d.tags)
-
 	dimensions = append(dimensions, "name:"+d.name)
 	dimensions = append(dimensions, "host:"+d.host)
 	dimensions = append(dimensions, "originID:"+d.originID)
 	sort.Strings(dimensions)
 
+	// Compute total capacity to avoid Builder re-allocations.
+	total := 0
 	for _, dim := range dimensions {
-		concatDimensionValue(&metricKeyBuilder, dim)
+		total += len(dim) + 1 // +1 for dimensionSeparator (single byte 0)
+	}
+	var metricKeyBuilder strings.Builder
+	metricKeyBuilder.Grow(total)
+	for _, dim := range dimensions {
+		metricKeyBuilder.WriteString(dim)
+		metricKeyBuilder.WriteByte(0)
 	}
 	return metricKeyBuilder.String()
 }

--- a/pkg/opentelemetry-mapping-go/otlp/metrics/dimensions_test.go
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/dimensions_test.go
@@ -36,6 +36,17 @@ func TestWithAttributeMap(t *testing.T) {
 	)
 }
 
+func TestWithAttributeMapEmptyReturnsOriginal(t *testing.T) {
+	dims := &Dimensions{
+		name: "metric.name",
+		tags: []string{"key:val"},
+		host: "host",
+	}
+	result := dims.WithAttributeMap(pcommon.NewMap())
+	// Empty map must return the same pointer (no unnecessary allocation).
+	assert.Same(t, dims, result)
+}
+
 func TestMetricDimensionsString(t *testing.T) {
 	getKey := func(name string, tags []string, host string) string {
 		dims := Dimensions{name: name, tags: tags, host: host}

--- a/pkg/opentelemetry-mapping-go/otlp/metrics/internal/utils/tags.go
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/internal/utils/tags.go
@@ -15,15 +15,15 @@
 // Package utils provides utilities for the OpenTelemetry Collector.
 package utils
 
-import (
-	"fmt"
-)
-
 // FormatKeyValueTag takes a key-value pair, and creates a tag string out of it
 // Tags can't end with ":" so we replace empty values with "n/a"
 func FormatKeyValueTag(key, value string) string {
 	if value == "" {
 		value = "n/a"
 	}
-	return fmt.Sprintf("%s:%s", key, value)
+	b := make([]byte, 0, len(key)+1+len(value))
+	b = append(b, key...)
+	b = append(b, ':')
+	b = append(b, value...)
+	return string(b)
 }

--- a/pkg/opentelemetry-mapping-go/otlp/metrics/key_hash_cache.go
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/key_hash_cache.go
@@ -49,13 +49,17 @@ func (m *keyHashCache) set(s keyHashCacheKey, v interface{}, expiration time.Dur
 	m.cache.Set(string(s), v, expiration)
 }
 
+// ascii85EncodedLen16 is the ascii85 encoded length for a 16-byte input:
+// ascii85.MaxEncodedLen(16) = (16+3)/4*5 = 20
+const ascii85EncodedLen16 = 20
+
 func (m *keyHashCache) computeKey(s string) keyHashCacheKey {
 	h1, h2 := murmur3.StringSum128(s)
-	var bytes [16]byte
-	binary.LittleEndian.PutUint64(bytes[0:], h1)
-	binary.LittleEndian.PutUint64(bytes[8:], h2)
+	var hashBytes [16]byte
+	binary.LittleEndian.PutUint64(hashBytes[0:], h1)
+	binary.LittleEndian.PutUint64(hashBytes[8:], h2)
 
-	buf := make([]byte, ascii85.MaxEncodedLen(len(bytes)))
-	n := ascii85.Encode(buf, bytes[:])
+	var buf [ascii85EncodedLen16]byte
+	n := ascii85.Encode(buf[:], hashBytes[:])
 	return keyHashCacheKey(buf[:n])
 }


### PR DESCRIPTION
### What does this PR do?

Optimizes hot-path memory allocations in the OpenTelemetry metrics mapping layer:

- `WithAttributeMap`: inlines the tag-building loop, pre-allocates a single slice for both new attribute tags and existing tags, and returns the original `*Dimensions` pointer unchanged when the attribute map is empty (avoiding a heap allocation entirely).
- `Dimensions.String`: pre-computes the total string length and calls `strings.Builder.Grow` once, removing repeated re-allocations during key construction. Inlines `concatDimensionValue` and removes the now-unused `dimensionSeparator` constant.
- `WithSuffix`: replaces `fmt.Sprintf` with a plain string concatenation.
- `FormatKeyValueTag`: replaces `fmt.Sprintf` with a manual byte-slice append, eliminating `fmt` reflection overhead.
- `keyHashCache.computeKey`: stack-allocates the ascii85 output buffer using the pre-computed constant `ascii85EncodedLen16` instead of a heap `make`.
- Removes the now-unused `getTags` helper and the `fmt` imports in both `dimensions.go` and `tags.go`.

### Motivation

These functions sit on the critical path for every OTLP metric point processed by the Datadog exporter. Reducing allocations and avoiding `fmt.Sprintf` in tight loops lowers GC pressure and improves throughput.

### Describe how you validated your changes

Run unit test

### Additional Notes