### PR TITLE
Add extra gazelle:exclude's that are causing problems in local dev

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -16,10 +16,11 @@ package(default_visibility = ["//visibility:public"])
 # gazelle:exclude internal/tools/independent-lint
 # gazelle:exclude internal/tools/modformatter
 # gazelle:exclude pkg
-# gazelle:exclude rtloader/test
+# gazelle:exclude rtloader
 # gazelle:exclude tasks
 # gazelle:exclude test
 # gazelle:exclude tools
+# gazelle:exclude .gitlab
 # gazelle:prefix github.com/DataDog/datadog-agent
 gazelle(
     name = "gazelle",


### PR DESCRIPTION
### What does this PR do?

Adds extra gazelle:exclude's that are causing problems in local dev.

### Motivation

Directories named "build" on case-insensitive host OSes cause issues:

```
gazelle: open /home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/build: no such file or directory
```

This `build` folder is created by `inv rtloader.make`, which many developers use direct or indirectly to build the Agent.

Additionally, there's been a report of `/home/datadog/go/src/github.com/DataDog/datadog-agent/.gitlab/build` causing similar issues in the devcontainer (I didn't get to reproduce this one myself).

Given that `gazelle` is hooked to `dda inv tidy`, this is something that contributors may easily encounter.

### Describe how you validated your changes

Running `dda inv rtloader.cmake` followed by `dda inv tidy`.

### Additional Notes

This is a quick fix for the issue, to be followed up later on a few possible fronts.