### PR TITLE
chore: bump DataDog/datadog-traceroute to 1.0.12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -170,7 +170,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/version v0.77.0-devel.0.20260213154712-e02b9359151a
 	github.com/DataDog/datadog-go/v5 v5.8.3
 	github.com/DataDog/datadog-operator/api v0.0.0-20260218132256-6fb0dc76eec6
-	github.com/DataDog/datadog-traceroute v1.0.11
+	github.com/DataDog/datadog-traceroute v1.0.12
 	github.com/DataDog/ebpf-manager v0.7.15
 	github.com/DataDog/go-sqllexer v0.1.13
 	github.com/DataDog/gopsutil v1.2.3

--- a/go.sum
+++ b/go.sum
@@ -198,8 +198,8 @@ github.com/DataDog/datadog-go/v5 v5.8.3 h1:s58CUJ9s8lezjhTNJO/SxkPBv2qZjS3ktpRSq
 github.com/DataDog/datadog-go/v5 v5.8.3/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
 github.com/DataDog/datadog-operator/api v0.0.0-20260218132256-6fb0dc76eec6 h1:UXO2N0ElAkDMRwMSX1aurYLCRbr1rYtT2ta/f7O9Hdg=
 github.com/DataDog/datadog-operator/api v0.0.0-20260218132256-6fb0dc76eec6/go.mod h1:lejC6AK61CXsAj6kfQI8/ByZly9xvsdBNODJfC+EutQ=
-github.com/DataDog/datadog-traceroute v1.0.11 h1:71/l7M977vuBH/E4MGtuodNAQvdxihILYiR8tcxOtLc=
-github.com/DataDog/datadog-traceroute v1.0.11/go.mod h1:ywOVt342keSUAzy1Aa47td4+2yl8WJsYQ+m7PlEDy8o=
+github.com/DataDog/datadog-traceroute v1.0.12 h1:RlYQMZgzzR0kxMHOcN2SerBEJWieLRY4EOKWjUoFlEI=
+github.com/DataDog/datadog-traceroute v1.0.12/go.mod h1:ywOVt342keSUAzy1Aa47td4+2yl8WJsYQ+m7PlEDy8o=
 github.com/DataDog/ddtrivy v0.0.0-20260115083325-07614fb0b8d5 h1:R6uhWnfvq23xRAoV3vK9sc6D5pDHxEEDYBgs2YbcX8s=
 github.com/DataDog/ddtrivy v0.0.0-20260115083325-07614fb0b8d5/go.mod h1:oz6zVBIVeK9I/AFP9k7TljSGtA9Opslmay0FcXg0fuQ=
 github.com/DataDog/ebpf-manager v0.7.15 h1:14PbnvXFQccV3zexENfNuADAxCuwHNori7sK55CP0SU=


### PR DESCRIPTION
### What does this PR do?
- Bumps `github.com/DataDog/datadog-traceroute` from `v1.0.11` to `v1.0.12`.
- Updates the corresponding module checksums in `go.sum`.
- - Updates the corresponding licenses.

### Motivation
- Solving an issue regarding mismatched checksum.

### Describe how you validated your changes
N/A

### Additional Notes
- Dependency-only change (no functional code changes in this PR), limited to Go module/versioning updates.