### PR TITLE
Update rules to skip Windows entirely when not needed

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,21 +36,17 @@
   - pkg/logs/util/windowsevent/**/*
   - pkg/network/driver/**/*
 
-  # cmd/ - run subcommands and Windows-specific directories
-  # Excludes serverless-init and cluster-agent (not built on Windows)
-  - cmd/agent/subcommands/run/**/*
-  - cmd/agent/subcommands/controlsvc/**/*
-  - cmd/agent/windows/**/*
-  - cmd/agent/windows_resources/**/*
-  - cmd/agent/dist/conf.d/win32_event_log.d/**/*
-  - cmd/agent/dist/conf.d/windows_certificate.d/**/*
-  - cmd/system-probe/subcommands/run/**/*
-  - cmd/system-probe/windows/**/*
-  - cmd/system-probe/windows_resources/**/*
-  - cmd/trace-agent/subcommands/run/**/*
+  # cmd/ 
+  - cmd/agent/**/*
+  - cmd/process-agent/**/*
+  - cmd/security-agent/**/*
+  - cmd/otel-agent/**/*
+  - cmd/privateactionrunner/**/*
+  - cmd/system-probe/**/*
+  - cmd/trace-agent/**/*
   - cmd/installer/**/*
   - cmd/systray/**/*
-  - cmd/otel-agent/subcommands/run/**/*
+  - cmd/otel-agent/**/*
 
 # Windows-specific comp/, tools, omnibus, containers, tasks, and cross-cutting (27 paths)
 .windows_path_2: &windows_path_2

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,22 @@
 ---
 
-# Windows-specific Go source files, pkg/, and cmd/ (27 paths)
+# Condition mixins for simplification of rules, needed in the include rules so must be defined first
+.if_run_all_e2e_tests: &if_run_all_e2e_tests
+  if: $RUN_E2E_TESTS == "on"
+
+.if_triggered_pipeline: &if_triggered_pipeline
+  if: $CI_PIPELINE_SOURCE == "trigger" || $CI_PIPELINE_SOURCE == "pipeline"
+
+.if_main_branch: &if_main_branch
+  if: $CI_COMMIT_BRANCH == "main"
+
+.if_release_branch: &if_release_branch
+  if: $CI_COMMIT_BRANCH =~ /^[0-9]+\.[0-9]+\.x$/
+
+.if_mergequeue: &if_mergequeue
+  if: $CI_COMMIT_BRANCH =~ /^mq-working-branch-/
+
+# Windows-specific Go source files, pkg/, and cmd/ (27 paths), need to be splitted because Gitlab has a limit to 50 paths in a single rule
 .windows_path: &windows_path
   # Windows-specific Go source files (by filename convention)
   - "**/*_windows.go"
@@ -87,6 +103,12 @@ include:
   # Windows jobs - set SKIP_WINDOWS=true to exclude all Windows-related jobs
   - local: .gitlab/windows/**.yml
     rules:
+      - if: $SKIP_WINDOWS == "true"
+        when: never
+      - <<: *if_main_branch
+      - <<: *if_release_branch
+      - <<: *if_triggered_pipeline
+      - <<: *if_mergequeue
       # - !reference [.except_skip_windows] Should be the rule but it is not working so we need to explicitly write the rule. See https://gitlab.com/gitlab-org/gitlab/-/issues/434157
       - changes:
           paths: *windows_path
@@ -333,14 +355,9 @@ variables:
 #
 # Condition mixins for simplification of rules
 #
-.if_main_branch: &if_main_branch
-  if: $CI_COMMIT_BRANCH == "main"
 
 .if_not_main_branch: &if_not_main_branch
   if: $CI_COMMIT_BRANCH != "main"
-
-.if_release_branch: &if_release_branch
-  if: $CI_COMMIT_BRANCH =~ /^[0-9]+\.[0-9]+\.x$/
 
 .if_deploy: &if_deploy
   if: $DEPLOY_AGENT == "true" || $DDR_WORKFLOW_ID != null
@@ -362,8 +379,6 @@ variables:
 
 # CI_PIPELINE_SOURCE can be set to "trigger" or "pipeline" depending on how the trigger was done.
 # See https://docs.gitlab.com/ee/ci/triggers/index.html#configure-cicd-jobs-to-run-in-triggered-pipelines.
-.if_triggered_pipeline: &if_triggered_pipeline
-  if: $CI_PIPELINE_SOURCE == "trigger" || $CI_PIPELINE_SOURCE == "pipeline"
 
 # Rule to trigger all builds conditionally.
 # By default:
@@ -387,8 +402,6 @@ variables:
 .if_installer_tests: &if_installer_tests
   if: ($CI_COMMIT_BRANCH == "main"  || $DEPLOY_AGENT == "true" || $RUN_E2E_TESTS == "on" || $DDR_WORKFLOW_ID != null) && $RUN_E2E_TESTS != "off"
 
-.if_run_all_e2e_tests: &if_run_all_e2e_tests
-  if: $RUN_E2E_TESTS == "on"
 
 # When RUN_E2E_TESTS is set to "auto". We do not enforce a behavior for the tests.
 # The behavior of each test will be defined by its rules.
@@ -413,10 +426,6 @@ variables:
 # Schedule on main branch come from conductor, pipeline source is `pipeline`, we use the conductor env variable for identification
 .if_scheduled_main: &if_scheduled_main
   if: $DDR_WORKFLOW_ID != null && $CI_COMMIT_BRANCH == "main"
-
-# Rule to trigger jobs only when a branch matches the mergequeue pattern.
-.if_mergequeue: &if_mergequeue
-  if: $CI_COMMIT_BRANCH =~ /^mq-working-branch-/
 
 .fakeintake_paths: &fakeintake_paths
   paths:
@@ -475,7 +484,9 @@ workflow:
         GO_TEST_SKIP_FLAKE: "false"
     - <<: *if_release_branch
     - <<: *if_deploy
+    - <<: *if_run_all_e2e_tests
     - !reference [.if_deploy_installer]
+    - <<: *if_mergequeue
     - changes:
         paths: *windows_path
         compare_to: main

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,82 @@
 ---
+
+# Windows-specific Go source files, pkg/, and cmd/ (27 paths)
+.windows_path: &windows_path
+  # Windows-specific Go source files (by filename convention)
+  - "**/*_windows.go"
+
+  # Windows-specific packages in pkg/
+  - pkg/util/winutil/**/*
+  - pkg/windowsdriver/**/*
+  - pkg/util/pdhutil/**/*
+  - pkg/util/crashreport/**/*
+  - pkg/collector/corechecks/system/wincrashdetect/**/*
+  - pkg/collector/corechecks/system/windowscertificate/**/*
+  - pkg/collector/corechecks/system/winkmem/**/*
+  - pkg/collector/corechecks/system/winproc/**/*
+  - pkg/collector/corechecks/net/wlan/**/*
+  - pkg/logs/launchers/windowsevent/**/*
+  - pkg/logs/tailers/windowsevent/**/*
+  - pkg/logs/util/windowsevent/**/*
+  - pkg/network/driver/**/*
+
+  # cmd/ - run subcommands and Windows-specific directories
+  # Excludes serverless-init and cluster-agent (not built on Windows)
+  - cmd/agent/subcommands/run/**/*
+  - cmd/agent/subcommands/controlsvc/**/*
+  - cmd/agent/windows/**/*
+  - cmd/agent/windows_resources/**/*
+  - cmd/agent/dist/conf.d/win32_event_log.d/**/*
+  - cmd/agent/dist/conf.d/windows_certificate.d/**/*
+  - cmd/system-probe/subcommands/run/**/*
+  - cmd/system-probe/windows/**/*
+  - cmd/system-probe/windows_resources/**/*
+  - cmd/trace-agent/subcommands/run/**/*
+  - cmd/installer/**/*
+  - cmd/systray/**/*
+  - cmd/otel-agent/subcommands/run/**/*
+
+# Windows-specific comp/, tools, omnibus, containers, tasks, and cross-cutting (27 paths)
+.windows_path_2: &windows_path_2
+  # Windows-specific comp/ components
+  - comp/systray/**/*
+  - comp/updater/**/*
+  - comp/checks/agentcrashdetect/**/*
+  - comp/checks/windowseventlog/**/*
+  - comp/checks/winregistry/**/*
+  - comp/metadata/hostsysteminfo/**/*
+  - comp/trace/etwtracer/**/*
+  - comp/etw/**/*
+  - comp/notableevents/**/*
+  - comp/publishermetadatacache/**/*
+  - comp/softwareinventory/**/*
+
+  # MSI installer and Windows tooling
+  - tools/windows/**/*
+
+  # Omnibus packaging
+  - omnibus/**/*
+
+  # Windows containers
+  - Dockerfiles/agent/windows/**/*
+  - Dockerfiles/agent/entrypoint.ps1
+  - Dockerfiles/agent/entrypoint.d.windows/**/*
+
+  # Chocolatey package
+  - chocolatey/**/*
+
+  # Build and release tasks
+  - tasks/msi.py
+  - tasks/winbuild.py
+  - tasks/winbuildscripts/**/*
+  - tasks/windows_resources.py
+  - tasks/systray.py
+
+  # Cross-cutting: these affect all platforms including Windows
+  - release.json
+  - .gitlab-ci.yml
+  - .gitlab/**/*
+
 include:
   - local: .adms/**/*.yaml
   - local: .gitlab/.pre/**.yml
@@ -10,9 +88,13 @@ include:
   - local: .gitlab/windows/**.yml
     rules:
       # - !reference [.except_skip_windows] Should be the rule but it is not working so we need to explicitly write the rule. See https://gitlab.com/gitlab-org/gitlab/-/issues/434157
-      - if: $SKIP_WINDOWS == "true"
-        when: never
-      - when: always
+      - changes:
+          paths: *windows_path
+          compare_to: main
+      - changes:
+          paths: *windows_path_2
+          compare_to: main
+      - when: never
 
 default:
   retry:
@@ -394,7 +476,19 @@ workflow:
     - <<: *if_release_branch
     - <<: *if_deploy
     - !reference [.if_deploy_installer]
+    - changes:
+        paths: *windows_path
+        compare_to: main
+      variables:
+        SKIP_WINDOWS: "false"
+    - changes:
+        paths: *windows_path_2
+        compare_to: main
+      variables:
+        SKIP_WINDOWS: "false"
     - if: $CI_COMMIT_TAG == null
+      variables:
+        SKIP_WINDOWS: "true"
 
 #
 # List of rule blocks used in the pipeline

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -856,9 +856,14 @@ def create_release_branches(
         with open(".gitlab-ci.yml") as f:
             content = f.read()
         with open(".gitlab-ci.yml", "w") as f:
-            f.write(
-                content.replace(f'COMPARE_TO_BRANCH: {get_default_branch()}', f'COMPARE_TO_BRANCH: {release_branch}')
+            updated_content = content.replace(
+                f'COMPARE_TO_BRANCH: {get_default_branch()}', f'COMPARE_TO_BRANCH: {release_branch}'
             )
+            # Workaround for Gitlab not supporting the use of `COMPARE_TO_BRANCH` variable in `includes: rules` so we need to manually update the compare_to value
+            updated_content = updated_content.replace(
+                f'compare_to: {get_default_branch()}', f'compare_to: {release_branch}'
+            )
+            f.write(updated_content)
 
         # Step 1.3 - Commit new changes
         ctx.run("git add release.json .gitlab-ci.yml")


### PR DESCRIPTION
### What does this PR do?

Skip the Windows part of the CI when it is likely that the changes done should not impact windows. The list was generated from the following instructions given by Windows folks:

```
windows specific go files
- `//go:build windows` and `_windows.go`
- `pkg/util/winutil`
probably most changes in `cmd/`
- since this impacts what binaries include/run
- maybe could limit it to the `run` subcommand?
- could limit it to the binaries that are built on Windows (e.g. not `serverless-init` or `cluster-agent`)
check the gitlab path filters we have on the e2e tests
- MSI path `tools/windows`
- most things under `omnibus/`, unless it's something excluded for Windows
cross-platform things
- release.json as a whole impacts a lot
- most gitlab config changes, could change env vars and impact build
- `omnibus/python-scripts`
- rtloader?
unit tests already only include modified packages, if those skip, and other paths don't match, maybe we can skip the windows build tooI wonder if you could go by what paths `team/windows-products` owns/co-ownsIf PR only edits files with `//go:build linux` or similar, could skip windows jobsI'm not familiar with what's in the `internal/`  directory. can maybe skip windows for some things in there. except golangci-lint bumps?windows container related things
- `Dockerfiles/agent/windows/`
- `Dockerfiles/agent/install.ps1` etc.
- can exclude windows for changes to other containers
`chocolatey/` directory has choco package stuffThere are some windows specific components under `comp`, like `comp/checks/winregistry`
- if there are non-windows specific components could exclude them
```

The list of paths that should trigger windows can evolve with time if we realize that some paths need to be added or removed


Note: The way it is done in the Gitlab configuration is not ideal because of several limitations in `include: rules`
- We cannot use `$COMPARE_TO_BRANCH` variable
- We cannot use `[!reference]` so we need to use yaml anchor directly.
That should be easier to handle once we land CI units and we have more leverages to dynamically generate the pipeline.

### Motivation

Try to make the pipeline as fast as possible on most PRs.


### Describe how you validated your changes

### Additional Notes
