### PR TITLE
CI: ensure we don't override file reports with child pipelines

### DIFF
--- a/.gitlab/build/packaging/common.yml
+++ b/.gitlab/build/packaging/common.yml
@@ -61,8 +61,8 @@
 
         # Ensure we don't corrupt our `main` measurements with a child pipeline.
         # The report would override the one generated post-merge
-        if [[ -n "$CI_UPSTREAM_PIPELINE_ID" ]]; then
-          echo "This pipeline is a child pipeline, we will not upload the files inventory"
+        if [[ "$CI_PIPELINE_SOURCE" != "push" ]]; then
+          echo "This pipeline wasn't created by a push event, skipping report upload"
           continue
         fi
 

--- a/.gitlab/build/packaging/common.yml
+++ b/.gitlab/build/packaging/common.yml
@@ -59,6 +59,13 @@
 
         echo "✅ Package measurement completed"
 
+        # Ensure we don't corrupt our `main` measurements with a child pipeline.
+        # The report would override the one generated post-merge
+        if [[ -n "$CI_UPSTREAM_PIPELINE_ID" ]]; then
+          echo "This pipeline is a child pipeline, we will not upload the files inventory"
+          continue
+        fi
+
         # Upload the report to S3
         BUCKET_BASE_PATH="s3://dd-ci-artefacts-build-stable/datadog-agent/static_quality_gates/GATE_REPORTS/${CI_COMMIT_SHA}"
         echo "Uploading report to ${BUCKET_BASE_PATH}"


### PR DESCRIPTION
### What does this PR do?

Ensure we don't upload file inventory reports when executing from a child pipeline

### Motivation

This would cause the base report to change, causing incoherent reports (https://github.com/DataDog/datadog-agent/pull/47217#issuecomment-3990031006 for instance)
In this case, the report was most likely generated by a test pipeline from `integrations-core`
We only want to compare against the ancestor report from main while sharing the same configuration/dependencies.

### Describe how you validated your changes

### Additional Notes
