### PR TITLE
fix(fleet): default DD_SITE to datadoghq.com in OTel config when not set

### DIFF
--- a/pkg/fleet/installer/packages/otel_config_common.go
+++ b/pkg/fleet/installer/packages/otel_config_common.go
@@ -94,8 +94,10 @@ func writeOTelConfigCommon(ctx HookContext, datadogYamlPath, templatePath, outPa
 	if apiKey != "" {
 		content = strings.ReplaceAll(content, "${env:DD_API_KEY}", apiKey)
 	}
-	if site != "" {
-		content = strings.ReplaceAll(content, "${env:DD_SITE}", site)
+	// Set default site if unset
+	if site == "" {
+		site = "datadoghq.com"
 	}
+	content = strings.ReplaceAll(content, "${env:DD_SITE}", site)
 	return os.WriteFile(outPath, []byte(content), mode)
 }

--- a/pkg/fleet/installer/packages/otel_config_common_test.go
+++ b/pkg/fleet/installer/packages/otel_config_common_test.go
@@ -1,0 +1,59 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package packages
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteOTelConfigCommonSiteSubstitution(t *testing.T) {
+	const template = "endpoint: ${env:DD_SITE}\napi_key: ${env:DD_API_KEY}\n"
+
+	tests := []struct {
+		name         string
+		datadogYAML  string
+		expectedSite string
+	}{
+		{
+			name:         "defaults to datadoghq.com when site is not set",
+			datadogYAML:  "api_key: testapikey\n",
+			expectedSite: "datadoghq.com",
+		},
+		{
+			name:         "uses explicit site when set",
+			datadogYAML:  "api_key: testapikey\nsite: datadoghq.eu\n",
+			expectedSite: "datadoghq.eu",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+
+			datadogYamlPath := filepath.Join(dir, "datadog.yaml")
+			require.NoError(t, os.WriteFile(datadogYamlPath, []byte(tc.datadogYAML), 0o644))
+
+			templatePath := filepath.Join(dir, "otel-config.yaml.tmpl")
+			require.NoError(t, os.WriteFile(templatePath, []byte(template), 0o644))
+
+			outPath := filepath.Join(dir, "otel-config.yaml")
+			ctx := HookContext{Context: context.Background()}
+			require.NoError(t, writeOTelConfigCommon(ctx, datadogYamlPath, templatePath, outPath, false, 0o644))
+
+			content, err := os.ReadFile(outPath)
+			require.NoError(t, err)
+
+			assert.Contains(t, string(content), tc.expectedSite)
+			assert.NotContains(t, string(content), "${env:DD_SITE}")
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

When `site` is not explicitly set in `datadog.yaml`, the `${env:DD_SITE}` placeholder was left unreplaced in the OTel collector config template, resulting in a runtime error.

This PR defaults `site` to `datadoghq.com` when it is empty so the placeholder is always substituted.

### Motivation

If `site` isn't explicitly set in the install script, `${env:DD_SITE}` is not replaced in the OTel config, causing a runtime error.

### Describe how you validated your changes

Added unit tests covering both cases:
- `site` absent from `datadog.yaml` → placeholder replaced with `datadoghq.com`
- `site` explicitly set → placeholder replaced with the provided value

### Additional Notes

_None_