### PR TITLE
refactor(collector): introduce LoaderError type to replace ad-hoc string accumulation

### DIFF
--- a/pkg/collector/loader_error.go
+++ b/pkg/collector/loader_error.go
@@ -1,0 +1,32 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package collector
+
+import "strings"
+
+// LoaderError holds the per-loader errors encountered while trying to load a
+// single check instance. The Config field identifies the check configuration
+// that failed to load, and Errors maps each loader name to the error message
+// it produced.
+type LoaderError struct {
+	Config string
+	Errors map[string]string // loader name -> error message
+}
+
+// Error returns a human-readable summary of all loader errors, preserving the
+// format previously produced by the ad-hoc strings.Builder accumulation:
+//
+//	"loaderA: err1; loaderB: err2; "
+func (e *LoaderError) Error() string {
+	var b strings.Builder
+	for loaderName, errMsg := range e.Errors {
+		b.WriteString(loaderName)
+		b.WriteString(": ")
+		b.WriteString(errMsg)
+		b.WriteString("; ")
+	}
+	return b.String()
+}

--- a/pkg/collector/scheduler.go
+++ b/pkg/collector/scheduler.go
@@ -10,7 +10,6 @@ import (
 	"expvar"
 	"fmt"
 	"slices"
-	"strings"
 	"sync"
 
 	yaml "go.yaml.in/yaml/v2"
@@ -199,7 +198,10 @@ func (s *CheckScheduler) getChecks(config integration.Config) ([]check.Check, er
 			log.Debugf("Loading check instance for check '%s' using default loaders", config.Name)
 		}
 
-		loaderErrors := make(map[string]error, len(s.loaders))
+		loaderErr := &LoaderError{
+			Config: config.Name,
+			Errors: make(map[string]string, len(s.loaders)),
+		}
 		for _, loader := range s.loaders {
 			// the loader is skipped if the loader name is set and does not match
 			if (selectedInstanceLoader != "") && (selectedInstanceLoader != loader.Name()) {
@@ -212,21 +214,14 @@ func (s *CheckScheduler) getChecks(config integration.Config) ([]check.Check, er
 				checks = append(checks, c)
 				break
 			}
-			loaderErrors[fmt.Sprintf("%v", loader)] = err
+			loaderErr.Errors[fmt.Sprintf("%v", loader)] = err.Error()
 		}
 
-		if len(loaderErrors) == numLoaders {
-			var concatErr strings.Builder
-			for loaderName, err := range loaderErrors {
-				errMsg := err.Error()
+		if len(loaderErr.Errors) == numLoaders {
+			for loaderName, errMsg := range loaderErr.Errors {
 				errorStats.setLoaderError(config.Name, loaderName, errMsg)
-
-				concatErr.WriteString(loaderName)
-				concatErr.WriteString(": ")
-				concatErr.WriteString(errMsg)
-				concatErr.WriteString("; ")
 			}
-			log.Errorf("Unable to load a check from instance of config '%s': %s", config.Name, concatErr.String())
+			log.Errorf("Unable to load a check from instance of config '%s': %s", config.Name, loaderErr.Error())
 		} else {
 			errorStats.removeLoaderErrors(config.Name)
 		}


### PR DESCRIPTION
### What does this PR do?
Introduces a structured `LoaderError` type in `pkg/collector` to replace the ad-hoc `map[string]string` + `fmt.Sprintf` accumulation used in `getChecks()` to track which loaders failed for a check instance.

### Motivation
The loader error handling in `getChecks()` mixed parsing, string formatting, and error tracking in one method using untyped string maps. This made the code hard to test and the error structure impossible to inspect programmatically. A dedicated `LoaderError` type makes the error information structured, testable, and clearly typed.

### Describe how you validated your changes
- `go build ./pkg/collector/...` passes
- `go test ./pkg/collector/...` passes
- Error messages emitted to logs and expvars are unchanged

### Additional Notes
The `LoaderError` type also enables future improvements such as per-loader retry policies or structured logging of loader failures.