### PR TITLE
[procmgrd] Add multi-process startup ordering and reverse shutdown

### DIFF
--- a/pkg/procmgr/rust/src/config.rs
+++ b/pkg/procmgr/rust/src/config.rs
@@ -10,6 +10,8 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+pub type NamedProcess = (String, ProcessConfig);
+
 const DEFAULT_CONFIG_DIR: &str = "/etc/datadog-agent/processes.d";
 
 fn default_true() -> bool {
@@ -144,7 +146,7 @@ pub fn config_dir() -> PathBuf {
 /// Scan a directory for `*.yaml` files and parse each into a ProcessConfig.
 /// The process name is derived from the filename (without extension).
 /// Files that fail to parse are logged and skipped.
-pub fn load_configs(dir: &Path) -> Result<Vec<(String, ProcessConfig)>> {
+pub fn load_configs(dir: &Path) -> Result<Vec<NamedProcess>> {
     let entries = std::fs::read_dir(dir)
         .with_context(|| format!("failed to read config directory: {}", dir.display()))?;
 

--- a/pkg/procmgr/rust/src/config.rs
+++ b/pkg/procmgr/rust/src/config.rs
@@ -62,6 +62,10 @@ pub struct ProcessConfig {
     pub start_limit_burst: Option<u32>,
     pub start_limit_interval_sec: Option<u64>,
     pub runtime_success_sec: Option<u64>,
+    #[serde(default)]
+    pub after: Vec<String>,
+    #[serde(default)]
+    pub before: Vec<String>,
 }
 
 const DEFAULT_STOP_TIMEOUT_SECS: u64 = 90;

--- a/pkg/procmgr/rust/src/config.rs
+++ b/pkg/procmgr/rust/src/config.rs
@@ -75,6 +75,33 @@ const DEFAULT_START_LIMIT_BURST: u32 = 5;
 const DEFAULT_START_LIMIT_INTERVAL_SEC: u64 = 10;
 const DEFAULT_RUNTIME_SUCCESS_SEC: u64 = 1;
 
+impl Default for ProcessConfig {
+    fn default() -> Self {
+        Self {
+            description: None,
+            command: String::new(),
+            args: vec![],
+            env: HashMap::new(),
+            environment_file: None,
+            working_dir: None,
+            pidfile: None,
+            stdout: "inherit".to_string(),
+            stderr: "inherit".to_string(),
+            auto_start: true,
+            condition_path_exists: None,
+            stop_timeout: None,
+            restart: RestartPolicy::Never,
+            restart_sec: None,
+            restart_max_delay_sec: None,
+            start_limit_burst: None,
+            start_limit_interval_sec: None,
+            runtime_success_sec: None,
+            after: vec![],
+            before: vec![],
+        }
+    }
+}
+
 impl ProcessConfig {
     pub fn stop_timeout(&self) -> Duration {
         Duration::from_secs(self.stop_timeout.unwrap_or(DEFAULT_STOP_TIMEOUT_SECS))

--- a/pkg/procmgr/rust/src/main.rs
+++ b/pkg/procmgr/rust/src/main.rs
@@ -10,7 +10,7 @@ mod process;
 mod shutdown;
 mod state;
 
-use crate::config::ProcessConfig;
+use crate::config::NamedProcess;
 use anyhow::Result;
 use log::{info, warn};
 use process::ManagedProcess;
@@ -92,7 +92,7 @@ fn spawn_watcher(index: usize, proc: &mut ManagedProcess, tx: mpsc::UnboundedSen
     }
 }
 
-fn load_configs() -> Vec<(String, ProcessConfig)> {
+fn load_configs() -> Vec<NamedProcess> {
     let config_dir = config::config_dir();
 
     if !config_dir.is_dir() {
@@ -121,7 +121,7 @@ fn load_configs() -> Vec<(String, ProcessConfig)> {
     configs
 }
 
-fn resolve_startup_order(configs: &[(String, ProcessConfig)]) -> Vec<usize> {
+fn resolve_startup_order(configs: &[NamedProcess]) -> Vec<usize> {
     match ordering::resolve_order(configs) {
         Ok(order) => {
             let names: Vec<&str> = order.iter().map(|&i| configs[i].0.as_str()).collect();
@@ -140,7 +140,7 @@ fn resolve_startup_order(configs: &[(String, ProcessConfig)]) -> Vec<usize> {
 }
 
 fn start_processes(
-    configs: Vec<(String, ProcessConfig)>,
+    configs: Vec<NamedProcess>,
     startup_order: &[usize],
 ) -> Vec<ManagedProcess> {
     let mut processes: Vec<ManagedProcess> = configs

--- a/pkg/procmgr/rust/src/main.rs
+++ b/pkg/procmgr/rust/src/main.rs
@@ -5,6 +5,7 @@
 
 mod config;
 mod env;
+mod ordering;
 mod process;
 mod shutdown;
 mod state;
@@ -30,7 +31,8 @@ async fn main() -> Result<()> {
     );
 
     let configs = load_configs();
-    let mut processes = start_processes(configs);
+    let startup_order = resolve_startup_order(&configs);
+    let mut processes = start_processes(configs, &startup_order);
 
     let (exit_tx, mut exit_rx) = mpsc::unbounded_channel::<ExitEvent>();
     for (i, proc) in processes.iter_mut().enumerate() {
@@ -64,7 +66,8 @@ async fn main() -> Result<()> {
     }
 
     info!("dd-procmgrd shutting down");
-    shutdown::shutdown_all(&mut processes).await;
+    let shutdown_order: Vec<usize> = startup_order.iter().copied().rev().collect();
+    shutdown::shutdown_ordered(&mut processes, &shutdown_order).await;
     info!("dd-procmgrd stopped");
     Ok(())
 }
@@ -118,16 +121,36 @@ fn load_configs() -> Vec<(String, ProcessConfig)> {
     configs
 }
 
-fn start_processes(configs: Vec<(String, ProcessConfig)>) -> Vec<ManagedProcess> {
-    let mut processes = Vec::new();
-    for (name, cfg) in configs {
-        let mut proc = ManagedProcess::new(name, cfg);
+fn resolve_startup_order(configs: &[(String, ProcessConfig)]) -> Vec<usize> {
+    match ordering::resolve_order(configs) {
+        Ok(order) => {
+            let names: Vec<&str> = order.iter().map(|&i| configs[i].0.as_str()).collect();
+            info!("startup order: {}", names.join(" -> "));
+            order
+        }
+        Err(e) => {
+            warn!("{e}, falling back to alphabetical order");
+            (0..configs.len()).collect()
+        }
+    }
+}
+
+fn start_processes(
+    configs: Vec<(String, ProcessConfig)>,
+    startup_order: &[usize],
+) -> Vec<ManagedProcess> {
+    let mut processes: Vec<ManagedProcess> = configs
+        .into_iter()
+        .map(|(name, cfg)| ManagedProcess::new(name, cfg))
+        .collect();
+
+    for &idx in startup_order {
+        let proc = &mut processes[idx];
         if proc.should_start()
             && let Err(e) = proc.spawn()
         {
             warn!("{e:#}");
         }
-        processes.push(proc);
     }
     processes
 }

--- a/pkg/procmgr/rust/src/main.rs
+++ b/pkg/procmgr/rust/src/main.rs
@@ -139,10 +139,7 @@ fn resolve_startup_order(configs: &[NamedProcess]) -> Vec<usize> {
     }
 }
 
-fn start_processes(
-    configs: Vec<NamedProcess>,
-    startup_order: &[usize],
-) -> Vec<ManagedProcess> {
+fn start_processes(configs: Vec<NamedProcess>, startup_order: &[usize]) -> Vec<ManagedProcess> {
     let mut processes: Vec<ManagedProcess> = configs
         .into_iter()
         .map(|(name, cfg)| ManagedProcess::new(name, cfg))

--- a/pkg/procmgr/rust/src/main.rs
+++ b/pkg/procmgr/rust/src/main.rs
@@ -129,6 +129,10 @@ fn resolve_startup_order(configs: &[(String, ProcessConfig)]) -> Vec<usize> {
             order
         }
         Err(e) => {
+            // Deliberately non-fatal: a misconfigured dependency cycle should
+            // not prevent the daemon from starting its processes. We fall back
+            // to alphabetical order so the agent remains operational, and the
+            // warning gives operators visibility to fix the config.
             warn!("{e}, falling back to alphabetical order");
             (0..configs.len()).collect()
         }

--- a/pkg/procmgr/rust/src/main.rs
+++ b/pkg/procmgr/rust/src/main.rs
@@ -122,21 +122,20 @@ fn load_configs() -> Vec<NamedProcess> {
 }
 
 fn resolve_startup_order(configs: &[NamedProcess]) -> Vec<usize> {
-    match ordering::resolve_order(configs) {
-        Ok(order) => {
-            let names: Vec<&str> = order.iter().map(|&i| configs[i].0.as_str()).collect();
-            info!("startup order: {}", names.join(" -> "));
-            order
-        }
-        Err(e) => {
-            // Deliberately non-fatal: a misconfigured dependency cycle should
-            // not prevent the daemon from starting its processes. We fall back
-            // to alphabetical order so the agent remains operational, and the
-            // warning gives operators visibility to fix the config.
-            warn!("{e}, falling back to alphabetical order");
-            (0..configs.len()).collect()
-        }
+    let result = ordering::resolve_order(configs);
+    if !result.skipped.is_empty() {
+        warn!(
+            "dependency cycle detected, skipping processes: {}",
+            result.skipped.join(", ")
+        );
     }
+    let names: Vec<&str> = result
+        .order
+        .iter()
+        .map(|&i| configs[i].0.as_str())
+        .collect();
+    info!("startup order: {}", names.join(" -> "));
+    result.order
 }
 
 fn start_processes(configs: Vec<NamedProcess>, startup_order: &[usize]) -> Vec<ManagedProcess> {

--- a/pkg/procmgr/rust/src/ordering.rs
+++ b/pkg/procmgr/rust/src/ordering.rs
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2026-present Datadog, Inc.
 
-use crate::config::ProcessConfig;
+use crate::config::NamedProcess;
 use log::warn;
 use std::collections::{HashMap, HashSet};
 
@@ -15,7 +15,7 @@ use std::collections::{HashMap, HashSet};
 ///
 /// Among processes whose dependencies are equally satisfied, ties are broken
 /// alphabetically by name (globally, not per batch).
-pub fn resolve_order(configs: &[(String, ProcessConfig)]) -> Result<Vec<usize>, CycleError> {
+pub fn resolve_order(configs: &[NamedProcess]) -> Result<Vec<usize>, CycleError> {
     let name_to_idx: HashMap<&str, usize> = configs
         .iter()
         .enumerate()
@@ -113,7 +113,7 @@ mod tests {
         }
     }
 
-    fn names_in_order(configs: &[(String, ProcessConfig)], order: &[usize]) -> Vec<String> {
+    fn names_in_order(configs: &[NamedProcess], order: &[usize]) -> Vec<String> {
         order.iter().map(|&i| configs[i].0.clone()).collect()
     }
 
@@ -206,7 +206,7 @@ mod tests {
 
     #[test]
     fn test_empty() {
-        let configs: Vec<(String, ProcessConfig)> = vec![];
+        let configs: Vec<NamedProcess> = vec![];
         let order = resolve_order(&configs).unwrap();
         assert!(order.is_empty());
     }

--- a/pkg/procmgr/rust/src/ordering.rs
+++ b/pkg/procmgr/rust/src/ordering.rs
@@ -111,8 +111,8 @@ mod tests {
     fn cfg(after: &[&str], before: &[&str]) -> ProcessConfig {
         ProcessConfig {
             command: "/bin/true".to_string(),
-            after: after.iter().map(|s| s.to_string()).collect(),
-            before: before.iter().map(|s| s.to_string()).collect(),
+            after: after.iter().map(String::from).collect(),
+            before: before.iter().map(String::from).collect(),
             ..Default::default()
         }
     }

--- a/pkg/procmgr/rust/src/ordering.rs
+++ b/pkg/procmgr/rust/src/ordering.rs
@@ -5,7 +5,7 @@
 
 use crate::config::ProcessConfig;
 use log::warn;
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{HashMap, HashSet};
 
 /// Resolve the startup order of processes using a topological sort on the
 /// dependency graph built from `after` and `before` fields.
@@ -13,9 +13,8 @@ use std::collections::{HashMap, HashSet, VecDeque};
 /// Returns the indices into `configs` in the order they should be started.
 /// If there is a cycle, returns an error listing the involved processes.
 ///
-/// Processes without explicit ordering constraints are sorted alphabetically
-/// (the existing default), then appended after all constrained processes
-/// whose dependencies are satisfied.
+/// Among processes whose dependencies are equally satisfied, ties are broken
+/// alphabetically by name (globally, not per batch).
 pub fn resolve_order(configs: &[(String, ProcessConfig)]) -> Result<Vec<usize>, CycleError> {
     let name_to_idx: HashMap<&str, usize> = configs
         .iter()
@@ -29,7 +28,6 @@ pub fn resolve_order(configs: &[(String, ProcessConfig)]) -> Result<Vec<usize>, 
     let mut in_degree: Vec<u32> = vec![0; n];
 
     for (idx, (name, cfg)) in configs.iter().enumerate() {
-        // "after: [X]" means X must start before this process (edge X -> idx)
         for dep in &cfg.after {
             match name_to_idx.get(dep.as_str()) {
                 Some(&dep_idx) => {
@@ -43,7 +41,6 @@ pub fn resolve_order(configs: &[(String, ProcessConfig)]) -> Result<Vec<usize>, 
             }
         }
 
-        // "before: [Y]" means this process must start before Y (edge idx -> Y)
         for dep in &cfg.before {
             match name_to_idx.get(dep.as_str()) {
                 Some(&dep_idx) => {
@@ -58,25 +55,22 @@ pub fn resolve_order(configs: &[(String, ProcessConfig)]) -> Result<Vec<usize>, 
         }
     }
 
-    // Kahn's algorithm with alphabetical tie-breaking
-    let mut queue: VecDeque<usize> = VecDeque::new();
+    // Kahn's algorithm: keep ready set sorted in reverse so pop() yields the
+    // alphabetically smallest name. Re-sort after inserting newly-ready nodes.
     let mut ready: Vec<usize> = (0..n).filter(|&i| in_degree[i] == 0).collect();
-    ready.sort_by(|a, b| configs[*a].0.cmp(&configs[*b].0));
-    queue.extend(ready);
+    ready.sort_by(|a, b| configs[*b].0.cmp(&configs[*a].0));
 
     let mut order: Vec<usize> = Vec::with_capacity(n);
-    while let Some(idx) = queue.pop_front() {
+    while let Some(idx) = ready.pop() {
         order.push(idx);
 
-        let mut next_ready: Vec<usize> = Vec::new();
         for &dep_idx in &edges[idx] {
             in_degree[dep_idx] -= 1;
             if in_degree[dep_idx] == 0 {
-                next_ready.push(dep_idx);
+                ready.push(dep_idx);
             }
         }
-        next_ready.sort_by(|a, b| configs[*a].0.cmp(&configs[*b].0));
-        queue.extend(next_ready);
+        ready.sort_by(|a, b| configs[*b].0.cmp(&configs[*a].0));
     }
 
     if order.len() != n {
@@ -252,5 +246,19 @@ mod tests {
         let order = resolve_order(&configs).unwrap();
         let names = names_in_order(&configs, &order);
         assert_eq!(names, vec!["a", "b", "c", "d"]);
+    }
+
+    #[test]
+    fn test_global_tiebreak_newly_ready_before_queued() {
+        // b -> a (b must start before a), c is unconstrained
+        // After b is popped, a becomes ready. a < c alphabetically, so a should come before c.
+        // expected: b, a, c (not b, c, a)
+        let configs = vec![
+            ("a".to_string(), cfg(&["b"], &[])),
+            ("b".to_string(), cfg(&[], &[])),
+            ("c".to_string(), cfg(&[], &[])),
+        ];
+        let order = resolve_order(&configs).unwrap();
+        assert_eq!(names_in_order(&configs, &order), vec!["b", "a", "c"]);
     }
 }

--- a/pkg/procmgr/rust/src/ordering.rs
+++ b/pkg/procmgr/rust/src/ordering.rs
@@ -211,12 +211,7 @@ mod tests {
         ];
         let order = resolve_order(&configs).unwrap();
         let names = names_in_order(&configs, &order);
-        assert_eq!(names[0], "a");
-        assert_eq!(names[3], "d");
-        // b and c can be in either order between a and d
-        let mid: HashSet<&str> = [names[1].as_str(), names[2].as_str()].into();
-        assert!(mid.contains("b"));
-        assert!(mid.contains("c"));
+        assert_eq!(names, vec!["a", "b", "c", "d"]);
     }
 
     #[test]

--- a/pkg/procmgr/rust/src/ordering.rs
+++ b/pkg/procmgr/rust/src/ordering.rs
@@ -293,4 +293,27 @@ mod tests {
         assert!(result.skipped.is_empty());
         assert_eq!(names_in_order(&configs, &result.order), vec!["b", "a"]);
     }
+
+    #[test]
+    fn test_missing_before_dependency_ignored() {
+        let configs = vec![
+            ("api".to_string(), cfg(&[], &["nonexistent"])),
+            ("db".to_string(), cfg(&[], &[])),
+        ];
+        let result = resolve_order(&configs);
+        assert!(result.skipped.is_empty());
+        assert_eq!(result.order.len(), 2);
+    }
+
+    #[test]
+    fn test_duplicate_before_dependency_in_list() {
+        // Listing "a" twice in before should not double-count in_degree.
+        let configs = vec![
+            ("a".to_string(), cfg(&[], &[])),
+            ("b".to_string(), cfg(&[], &["a", "a"])),
+        ];
+        let result = resolve_order(&configs);
+        assert!(result.skipped.is_empty());
+        assert_eq!(names_in_order(&configs, &result.order), vec!["b", "a"]);
+    }
 }

--- a/pkg/procmgr/rust/src/ordering.rs
+++ b/pkg/procmgr/rust/src/ordering.rs
@@ -78,21 +78,25 @@ pub fn resolve_order(configs: &[NamedProcess]) -> Result<Vec<usize>, CycleError>
             .filter(|i| in_degree[*i] > 0)
             .map(|i| configs[i].0.clone())
             .collect();
-        return Err(CycleError(cycle_members));
+        return Err(CycleError {
+            processes: cycle_members,
+        });
     }
 
     Ok(order)
 }
 
 #[derive(Debug)]
-pub struct CycleError(pub Vec<String>);
+pub struct CycleError {
+    pub processes: Vec<String>,
+}
 
 impl std::fmt::Display for CycleError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
             "dependency cycle detected among processes: {}",
-            self.0.join(", ")
+            self.processes.join(", ")
         )
     }
 }
@@ -169,8 +173,8 @@ mod tests {
             ("b".to_string(), cfg(&["a"], &[])),
         ];
         let err = resolve_order(&configs).unwrap_err();
-        assert!(err.0.contains(&"a".to_string()));
-        assert!(err.0.contains(&"b".to_string()));
+        assert!(err.processes.contains(&"a".to_string()));
+        assert!(err.processes.contains(&"b".to_string()));
     }
 
     #[test]
@@ -244,7 +248,7 @@ mod tests {
     fn test_self_dependency_is_cycle() {
         let configs = vec![("a".to_string(), cfg(&["a"], &[]))];
         let err = resolve_order(&configs).unwrap_err();
-        assert_eq!(err.0, vec!["a"]);
+        assert_eq!(err.processes, vec!["a"]);
     }
 
     #[test]

--- a/pkg/procmgr/rust/src/ordering.rs
+++ b/pkg/procmgr/rust/src/ordering.rs
@@ -7,15 +7,25 @@ use crate::config::NamedProcess;
 use log::warn;
 use std::collections::{HashMap, HashSet};
 
+/// Result of resolving startup order via topological sort.
+pub struct ResolvedOrder {
+    /// Indices into the original configs slice, in startup order.
+    /// Processes involved in a cycle are excluded.
+    pub order: Vec<usize>,
+    /// Names of processes that were skipped due to dependency cycles.
+    pub skipped: Vec<String>,
+}
+
 /// Resolve the startup order of processes using a topological sort on the
 /// dependency graph built from `after` and `before` fields.
 ///
-/// Returns the indices into `configs` in the order they should be started.
-/// If there is a cycle, returns an error listing the involved processes.
+/// Processes involved in a dependency cycle are excluded from the order and
+/// reported in `skipped` so the caller can log them without stopping the
+/// daemon. Non-cyclic processes are always started in the correct order.
 ///
 /// Among processes whose dependencies are equally satisfied, ties are broken
 /// alphabetically by name (globally, not per batch).
-pub fn resolve_order(configs: &[NamedProcess]) -> Result<Vec<usize>, CycleError> {
+pub fn resolve_order(configs: &[NamedProcess]) -> ResolvedOrder {
     let name_to_idx: HashMap<&str, usize> = configs
         .iter()
         .enumerate()
@@ -73,35 +83,13 @@ pub fn resolve_order(configs: &[NamedProcess]) -> Result<Vec<usize>, CycleError>
         ready.sort_by(|a, b| configs[*b].0.cmp(&configs[*a].0));
     }
 
-    if order.len() != n {
-        let cycle_members: Vec<String> = (0..n)
-            .filter(|i| in_degree[*i] > 0)
-            .map(|i| configs[i].0.clone())
-            .collect();
-        return Err(CycleError {
-            processes: cycle_members,
-        });
-    }
+    let skipped: Vec<String> = (0..n)
+        .filter(|i| in_degree[*i] > 0)
+        .map(|i| configs[i].0.clone())
+        .collect();
 
-    Ok(order)
+    ResolvedOrder { order, skipped }
 }
-
-#[derive(Debug)]
-pub struct CycleError {
-    pub processes: Vec<String>,
-}
-
-impl std::fmt::Display for CycleError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "dependency cycle detected among processes: {}",
-            self.processes.join(", ")
-        )
-    }
-}
-
-impl std::error::Error for CycleError {}
 
 #[cfg(test)]
 mod tests {
@@ -111,8 +99,8 @@ mod tests {
     fn cfg(after: &[&str], before: &[&str]) -> ProcessConfig {
         ProcessConfig {
             command: "/bin/true".to_string(),
-            after: after.iter().map(String::from).collect(),
-            before: before.iter().map(String::from).collect(),
+            after: after.iter().copied().map(String::from).collect(),
+            before: before.iter().copied().map(String::from).collect(),
             ..Default::default()
         }
     }
@@ -128,9 +116,10 @@ mod tests {
             ("alpha".to_string(), cfg(&[], &[])),
             ("bravo".to_string(), cfg(&[], &[])),
         ];
-        let order = resolve_order(&configs).unwrap();
+        let result = resolve_order(&configs);
+        assert!(result.skipped.is_empty());
         assert_eq!(
-            names_in_order(&configs, &order),
+            names_in_order(&configs, &result.order),
             vec!["alpha", "bravo", "charlie"]
         );
     }
@@ -141,8 +130,9 @@ mod tests {
             ("api".to_string(), cfg(&["db"], &[])),
             ("db".to_string(), cfg(&[], &[])),
         ];
-        let order = resolve_order(&configs).unwrap();
-        assert_eq!(names_in_order(&configs, &order), vec!["db", "api"]);
+        let result = resolve_order(&configs);
+        assert!(result.skipped.is_empty());
+        assert_eq!(names_in_order(&configs, &result.order), vec!["db", "api"]);
     }
 
     #[test]
@@ -151,8 +141,9 @@ mod tests {
             ("db".to_string(), cfg(&[], &["api"])),
             ("api".to_string(), cfg(&[], &[])),
         ];
-        let order = resolve_order(&configs).unwrap();
-        assert_eq!(names_in_order(&configs, &order), vec!["db", "api"]);
+        let result = resolve_order(&configs);
+        assert!(result.skipped.is_empty());
+        assert_eq!(names_in_order(&configs, &result.order), vec!["db", "api"]);
     }
 
     #[test]
@@ -162,19 +153,35 @@ mod tests {
             ("a".to_string(), cfg(&[], &["b"])),
             ("b".to_string(), cfg(&[], &[])),
         ];
-        let order = resolve_order(&configs).unwrap();
-        assert_eq!(names_in_order(&configs, &order), vec!["a", "b", "c"]);
+        let result = resolve_order(&configs);
+        assert!(result.skipped.is_empty());
+        assert_eq!(names_in_order(&configs, &result.order), vec!["a", "b", "c"]);
     }
 
     #[test]
-    fn test_cycle_detected() {
+    fn test_cycle_skips_involved_processes() {
         let configs = vec![
             ("a".to_string(), cfg(&["b"], &[])),
             ("b".to_string(), cfg(&["a"], &[])),
         ];
-        let err = resolve_order(&configs).unwrap_err();
-        assert!(err.processes.contains(&"a".to_string()));
-        assert!(err.processes.contains(&"b".to_string()));
+        let result = resolve_order(&configs);
+        assert!(result.order.is_empty());
+        assert!(result.skipped.contains(&"a".to_string()));
+        assert!(result.skipped.contains(&"b".to_string()));
+    }
+
+    #[test]
+    fn test_cycle_starts_non_cyclic_processes() {
+        // a <-> b form a cycle; c and d are independent
+        let configs = vec![
+            ("a".to_string(), cfg(&["b"], &[])),
+            ("b".to_string(), cfg(&["a"], &[])),
+            ("c".to_string(), cfg(&[], &[])),
+            ("d".to_string(), cfg(&[], &[])),
+        ];
+        let result = resolve_order(&configs);
+        assert_eq!(names_in_order(&configs, &result.order), vec!["c", "d"]);
+        assert_eq!(result.skipped, vec!["a", "b"]);
     }
 
     #[test]
@@ -183,8 +190,9 @@ mod tests {
             ("api".to_string(), cfg(&["nonexistent"], &[])),
             ("db".to_string(), cfg(&[], &[])),
         ];
-        let order = resolve_order(&configs).unwrap();
-        assert_eq!(order.len(), 2);
+        let result = resolve_order(&configs);
+        assert!(result.skipped.is_empty());
+        assert_eq!(result.order.len(), 2);
     }
 
     #[test]
@@ -196,23 +204,28 @@ mod tests {
             ("c".to_string(), cfg(&[], &["d"])),
             ("d".to_string(), cfg(&[], &[])),
         ];
-        let order = resolve_order(&configs).unwrap();
-        let names = names_in_order(&configs, &order);
-        assert_eq!(names, vec!["a", "b", "c", "d"]);
+        let result = resolve_order(&configs);
+        assert!(result.skipped.is_empty());
+        assert_eq!(
+            names_in_order(&configs, &result.order),
+            vec!["a", "b", "c", "d"]
+        );
     }
 
     #[test]
     fn test_single_process() {
         let configs = vec![("solo".to_string(), cfg(&[], &[]))];
-        let order = resolve_order(&configs).unwrap();
-        assert_eq!(order, vec![0]);
+        let result = resolve_order(&configs);
+        assert!(result.skipped.is_empty());
+        assert_eq!(names_in_order(&configs, &result.order), vec!["solo"]);
     }
 
     #[test]
     fn test_empty() {
         let configs: Vec<NamedProcess> = vec![];
-        let order = resolve_order(&configs).unwrap();
-        assert!(order.is_empty());
+        let result = resolve_order(&configs);
+        assert!(result.skipped.is_empty());
+        assert!(result.order.is_empty());
     }
 
     #[test]
@@ -225,9 +238,12 @@ mod tests {
             ("b".to_string(), cfg(&[], &[])),
             ("a".to_string(), cfg(&[], &[])),
         ];
-        let order = resolve_order(&configs).unwrap();
-        let names = names_in_order(&configs, &order);
-        assert_eq!(names, vec!["a", "b", "c", "d"]);
+        let result = resolve_order(&configs);
+        assert!(result.skipped.is_empty());
+        assert_eq!(
+            names_in_order(&configs, &result.order),
+            vec!["a", "b", "c", "d"]
+        );
     }
 
     #[test]
@@ -240,15 +256,17 @@ mod tests {
             ("b".to_string(), cfg(&[], &[])),
             ("c".to_string(), cfg(&[], &[])),
         ];
-        let order = resolve_order(&configs).unwrap();
-        assert_eq!(names_in_order(&configs, &order), vec!["b", "a", "c"]);
+        let result = resolve_order(&configs);
+        assert!(result.skipped.is_empty());
+        assert_eq!(names_in_order(&configs, &result.order), vec!["b", "a", "c"]);
     }
 
     #[test]
     fn test_self_dependency_is_cycle() {
         let configs = vec![("a".to_string(), cfg(&["a"], &[]))];
-        let err = resolve_order(&configs).unwrap_err();
-        assert_eq!(err.processes, vec!["a"]);
+        let result = resolve_order(&configs);
+        assert!(result.order.is_empty());
+        assert_eq!(result.skipped, vec!["a"]);
     }
 
     #[test]
@@ -258,8 +276,9 @@ mod tests {
             ("a".to_string(), cfg(&["b", "b"], &[])),
             ("b".to_string(), cfg(&[], &[])),
         ];
-        let order = resolve_order(&configs).unwrap();
-        assert_eq!(names_in_order(&configs, &order), vec!["b", "a"]);
+        let result = resolve_order(&configs);
+        assert!(result.skipped.is_empty());
+        assert_eq!(names_in_order(&configs, &result.order), vec!["b", "a"]);
     }
 
     #[test]
@@ -270,7 +289,8 @@ mod tests {
             ("a".to_string(), cfg(&["b"], &[])),
             ("b".to_string(), cfg(&[], &["a"])),
         ];
-        let order = resolve_order(&configs).unwrap();
-        assert_eq!(names_in_order(&configs, &order), vec!["b", "a"]);
+        let result = resolve_order(&configs);
+        assert!(result.skipped.is_empty());
+        assert_eq!(names_in_order(&configs, &result.order), vec!["b", "a"]);
     }
 }

--- a/pkg/procmgr/rust/src/ordering.rs
+++ b/pkg/procmgr/rust/src/ordering.rs
@@ -1,0 +1,256 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+use crate::config::ProcessConfig;
+use log::warn;
+use std::collections::{HashMap, HashSet, VecDeque};
+
+/// Resolve the startup order of processes using a topological sort on the
+/// dependency graph built from `after` and `before` fields.
+///
+/// Returns the indices into `configs` in the order they should be started.
+/// If there is a cycle, returns an error listing the involved processes.
+///
+/// Processes without explicit ordering constraints are sorted alphabetically
+/// (the existing default), then appended after all constrained processes
+/// whose dependencies are satisfied.
+pub fn resolve_order(configs: &[(String, ProcessConfig)]) -> Result<Vec<usize>, CycleError> {
+    let name_to_idx: HashMap<&str, usize> = configs
+        .iter()
+        .enumerate()
+        .map(|(i, (name, _))| (name.as_str(), i))
+        .collect();
+    let n = configs.len();
+
+    // adjacency: edges[a] contains b means "a must start before b"
+    let mut edges: Vec<HashSet<usize>> = vec![HashSet::new(); n];
+    let mut in_degree: Vec<u32> = vec![0; n];
+
+    for (idx, (name, cfg)) in configs.iter().enumerate() {
+        // "after: [X]" means X must start before this process (edge X -> idx)
+        for dep in &cfg.after {
+            match name_to_idx.get(dep.as_str()) {
+                Some(&dep_idx) => {
+                    if edges[dep_idx].insert(idx) {
+                        in_degree[idx] += 1;
+                    }
+                }
+                None => {
+                    warn!("[{name}] after dependency '{dep}' not found, ignoring");
+                }
+            }
+        }
+
+        // "before: [Y]" means this process must start before Y (edge idx -> Y)
+        for dep in &cfg.before {
+            match name_to_idx.get(dep.as_str()) {
+                Some(&dep_idx) => {
+                    if edges[idx].insert(dep_idx) {
+                        in_degree[dep_idx] += 1;
+                    }
+                }
+                None => {
+                    warn!("[{name}] before dependency '{dep}' not found, ignoring");
+                }
+            }
+        }
+    }
+
+    // Kahn's algorithm with alphabetical tie-breaking
+    let mut queue: VecDeque<usize> = VecDeque::new();
+    let mut ready: Vec<usize> = (0..n).filter(|&i| in_degree[i] == 0).collect();
+    ready.sort_by(|a, b| configs[*a].0.cmp(&configs[*b].0));
+    queue.extend(ready);
+
+    let mut order: Vec<usize> = Vec::with_capacity(n);
+    while let Some(idx) = queue.pop_front() {
+        order.push(idx);
+
+        let mut next_ready: Vec<usize> = Vec::new();
+        for &dep_idx in &edges[idx] {
+            in_degree[dep_idx] -= 1;
+            if in_degree[dep_idx] == 0 {
+                next_ready.push(dep_idx);
+            }
+        }
+        next_ready.sort_by(|a, b| configs[*a].0.cmp(&configs[*b].0));
+        queue.extend(next_ready);
+    }
+
+    if order.len() != n {
+        let cycle_members: Vec<String> = (0..n)
+            .filter(|i| in_degree[*i] > 0)
+            .map(|i| configs[i].0.clone())
+            .collect();
+        return Err(CycleError(cycle_members));
+    }
+
+    Ok(order)
+}
+
+#[derive(Debug)]
+pub struct CycleError(pub Vec<String>);
+
+impl std::fmt::Display for CycleError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "dependency cycle detected among processes: {}",
+            self.0.join(", ")
+        )
+    }
+}
+
+impl std::error::Error for CycleError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::ProcessConfig;
+    use std::collections::HashMap;
+
+    fn cfg(after: &[&str], before: &[&str]) -> ProcessConfig {
+        ProcessConfig {
+            description: None,
+            command: "/bin/true".to_string(),
+            args: vec![],
+            env: HashMap::new(),
+            environment_file: None,
+            working_dir: None,
+            pidfile: None,
+            stdout: "inherit".to_string(),
+            stderr: "inherit".to_string(),
+            auto_start: true,
+            condition_path_exists: None,
+            stop_timeout: None,
+            restart: crate::config::RestartPolicy::Never,
+            restart_sec: None,
+            restart_max_delay_sec: None,
+            start_limit_burst: None,
+            start_limit_interval_sec: None,
+            runtime_success_sec: None,
+            after: after.iter().map(|s| s.to_string()).collect(),
+            before: before.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    fn names_in_order(configs: &[(String, ProcessConfig)], order: &[usize]) -> Vec<String> {
+        order.iter().map(|&i| configs[i].0.clone()).collect()
+    }
+
+    #[test]
+    fn test_no_constraints_alphabetical() {
+        let configs = vec![
+            ("charlie".to_string(), cfg(&[], &[])),
+            ("alpha".to_string(), cfg(&[], &[])),
+            ("bravo".to_string(), cfg(&[], &[])),
+        ];
+        let order = resolve_order(&configs).unwrap();
+        assert_eq!(
+            names_in_order(&configs, &order),
+            vec!["alpha", "bravo", "charlie"]
+        );
+    }
+
+    #[test]
+    fn test_after_constraint() {
+        let configs = vec![
+            ("api".to_string(), cfg(&["db"], &[])),
+            ("db".to_string(), cfg(&[], &[])),
+        ];
+        let order = resolve_order(&configs).unwrap();
+        assert_eq!(names_in_order(&configs, &order), vec!["db", "api"]);
+    }
+
+    #[test]
+    fn test_before_constraint() {
+        let configs = vec![
+            ("db".to_string(), cfg(&[], &["api"])),
+            ("api".to_string(), cfg(&[], &[])),
+        ];
+        let order = resolve_order(&configs).unwrap();
+        assert_eq!(names_in_order(&configs, &order), vec!["db", "api"]);
+    }
+
+    #[test]
+    fn test_chain_a_before_b_before_c() {
+        let configs = vec![
+            ("c".to_string(), cfg(&["b"], &[])),
+            ("a".to_string(), cfg(&[], &["b"])),
+            ("b".to_string(), cfg(&[], &[])),
+        ];
+        let order = resolve_order(&configs).unwrap();
+        assert_eq!(names_in_order(&configs, &order), vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn test_cycle_detected() {
+        let configs = vec![
+            ("a".to_string(), cfg(&["b"], &[])),
+            ("b".to_string(), cfg(&["a"], &[])),
+        ];
+        let err = resolve_order(&configs).unwrap_err();
+        assert!(err.0.contains(&"a".to_string()));
+        assert!(err.0.contains(&"b".to_string()));
+    }
+
+    #[test]
+    fn test_missing_dependency_ignored() {
+        let configs = vec![
+            ("api".to_string(), cfg(&["nonexistent"], &[])),
+            ("db".to_string(), cfg(&[], &[])),
+        ];
+        let order = resolve_order(&configs).unwrap();
+        assert_eq!(order.len(), 2);
+    }
+
+    #[test]
+    fn test_diamond_dependency() {
+        // a -> b, a -> c, b -> d, c -> d
+        let configs = vec![
+            ("a".to_string(), cfg(&[], &["b", "c"])),
+            ("b".to_string(), cfg(&[], &["d"])),
+            ("c".to_string(), cfg(&[], &["d"])),
+            ("d".to_string(), cfg(&[], &[])),
+        ];
+        let order = resolve_order(&configs).unwrap();
+        let names = names_in_order(&configs, &order);
+        assert_eq!(names[0], "a");
+        assert_eq!(names[3], "d");
+        // b and c can be in either order between a and d
+        let mid: HashSet<&str> = [names[1].as_str(), names[2].as_str()].into();
+        assert!(mid.contains("b"));
+        assert!(mid.contains("c"));
+    }
+
+    #[test]
+    fn test_single_process() {
+        let configs = vec![("solo".to_string(), cfg(&[], &[]))];
+        let order = resolve_order(&configs).unwrap();
+        assert_eq!(order, vec![0]);
+    }
+
+    #[test]
+    fn test_empty() {
+        let configs: Vec<(String, ProcessConfig)> = vec![];
+        let order = resolve_order(&configs).unwrap();
+        assert!(order.is_empty());
+    }
+
+    #[test]
+    fn test_alphabetical_tiebreak_with_constraints() {
+        // d depends on a; b and c are unconstrained
+        // expected: a, b, c, d (a first because d depends on it; b,c alphabetical; d last)
+        let configs = vec![
+            ("d".to_string(), cfg(&["a"], &[])),
+            ("c".to_string(), cfg(&[], &[])),
+            ("b".to_string(), cfg(&[], &[])),
+            ("a".to_string(), cfg(&[], &[])),
+        ];
+        let order = resolve_order(&configs).unwrap();
+        let names = names_in_order(&configs, &order);
+        assert_eq!(names, vec!["a", "b", "c", "d"]);
+    }
+}

--- a/pkg/procmgr/rust/src/ordering.rs
+++ b/pkg/procmgr/rust/src/ordering.rs
@@ -103,30 +103,13 @@ impl std::error::Error for CycleError {}
 mod tests {
     use super::*;
     use crate::config::ProcessConfig;
-    use std::collections::HashMap;
 
     fn cfg(after: &[&str], before: &[&str]) -> ProcessConfig {
         ProcessConfig {
-            description: None,
             command: "/bin/true".to_string(),
-            args: vec![],
-            env: HashMap::new(),
-            environment_file: None,
-            working_dir: None,
-            pidfile: None,
-            stdout: "inherit".to_string(),
-            stderr: "inherit".to_string(),
-            auto_start: true,
-            condition_path_exists: None,
-            stop_timeout: None,
-            restart: crate::config::RestartPolicy::Never,
-            restart_sec: None,
-            restart_max_delay_sec: None,
-            start_limit_burst: None,
-            start_limit_interval_sec: None,
-            runtime_success_sec: None,
             after: after.iter().map(|s| s.to_string()).collect(),
             before: before.iter().map(|s| s.to_string()).collect(),
+            ..Default::default()
         }
     }
 

--- a/pkg/procmgr/rust/src/ordering.rs
+++ b/pkg/procmgr/rust/src/ordering.rs
@@ -256,4 +256,34 @@ mod tests {
         let order = resolve_order(&configs).unwrap();
         assert_eq!(names_in_order(&configs, &order), vec!["b", "a", "c"]);
     }
+
+    #[test]
+    fn test_self_dependency_is_cycle() {
+        let configs = vec![("a".to_string(), cfg(&["a"], &[]))];
+        let err = resolve_order(&configs).unwrap_err();
+        assert_eq!(err.0, vec!["a"]);
+    }
+
+    #[test]
+    fn test_duplicate_dependency_in_list() {
+        // Listing "b" twice in after should not double-count in_degree.
+        let configs = vec![
+            ("a".to_string(), cfg(&["b", "b"], &[])),
+            ("b".to_string(), cfg(&[], &[])),
+        ];
+        let order = resolve_order(&configs).unwrap();
+        assert_eq!(names_in_order(&configs, &order), vec!["b", "a"]);
+    }
+
+    #[test]
+    fn test_redundant_after_and_before_same_edge() {
+        // A says after:["B"] and B says before:["A"] — both express B→A.
+        // Should produce exactly one edge, not a double-count.
+        let configs = vec![
+            ("a".to_string(), cfg(&["b"], &[])),
+            ("b".to_string(), cfg(&[], &["a"])),
+        ];
+        let order = resolve_order(&configs).unwrap();
+        assert_eq!(names_in_order(&configs, &order), vec!["b", "a"]);
+    }
 }

--- a/pkg/procmgr/rust/src/process.rs
+++ b/pkg/procmgr/rust/src/process.rs
@@ -382,30 +382,14 @@ fn stdio_from_str(s: &str) -> Stdio {
 pub mod tests {
     use super::*;
     use crate::config::ProcessConfig;
-    use std::collections::HashMap;
 
     pub fn make_config(command: &str, args: Vec<&str>) -> ProcessConfig {
         ProcessConfig {
-            description: None,
             command: command.to_string(),
             args: args.into_iter().map(String::from).collect(),
-            env: HashMap::new(),
-            environment_file: None,
-            working_dir: None,
-            pidfile: None,
             stdout: "null".to_string(),
             stderr: "null".to_string(),
-            auto_start: true,
-            condition_path_exists: None,
-            stop_timeout: None,
-            restart: RestartPolicy::Never,
-            restart_sec: None,
-            restart_max_delay_sec: None,
-            start_limit_burst: None,
-            start_limit_interval_sec: None,
-            runtime_success_sec: None,
-            after: vec![],
-            before: vec![],
+            ..Default::default()
         }
     }
 

--- a/pkg/procmgr/rust/src/process.rs
+++ b/pkg/procmgr/rust/src/process.rs
@@ -404,6 +404,8 @@ pub mod tests {
             start_limit_burst: None,
             start_limit_interval_sec: None,
             runtime_success_sec: None,
+            after: vec![],
+            before: vec![],
         }
     }
 

--- a/pkg/procmgr/rust/src/shutdown.rs
+++ b/pkg/procmgr/rust/src/shutdown.rs
@@ -5,14 +5,22 @@
 
 use crate::process::ManagedProcess;
 
-/// Send SIGTERM to all running processes, wait per-process `stop_timeout`, then SIGKILL stragglers.
+/// Shut down processes in the given index order (typically reverse startup order).
+/// Sends SIGTERM to all first, then waits for each in order.
+pub async fn shutdown_ordered(processes: &mut [ManagedProcess], order: &[usize]) {
+    for &idx in order {
+        processes[idx].request_stop();
+    }
+    for &idx in order {
+        processes[idx].wait_for_stop().await;
+    }
+}
+
+/// Convenience wrapper: shut down all processes in forward index order.
+#[cfg(test)]
 pub async fn shutdown_all(processes: &mut [ManagedProcess]) {
-    for proc in processes.iter() {
-        proc.request_stop();
-    }
-    for proc in processes.iter_mut() {
-        proc.wait_for_stop().await;
-    }
+    let order: Vec<usize> = (0..processes.len()).collect();
+    shutdown_ordered(processes, &order).await;
 }
 
 #[cfg(test)]
@@ -73,5 +81,29 @@ mod tests {
             ProcessState::Stopped,
             "shutdown should transition to Stopped even without child handle"
         );
+    }
+
+    #[tokio::test]
+    async fn test_shutdown_ordered_reverse() {
+        let mut p1 = ManagedProcess::new("p1".into(), make_config("/bin/sleep", vec!["60"]));
+        let mut p2 = ManagedProcess::new("p2".into(), make_config("/bin/sleep", vec!["60"]));
+        let mut p3 = ManagedProcess::new("p3".into(), make_config("/bin/sleep", vec!["60"]));
+        p1.spawn().unwrap();
+        p2.spawn().unwrap();
+        p3.spawn().unwrap();
+
+        let mut procs = vec![p1, p2, p3];
+        // Reverse order: p3, p2, p1
+        shutdown_ordered(&mut procs, &[2, 1, 0]).await;
+
+        assert_eq!(procs[0].state(), ProcessState::Stopped);
+        assert_eq!(procs[1].state(), ProcessState::Stopped);
+        assert_eq!(procs[2].state(), ProcessState::Stopped);
+    }
+
+    #[tokio::test]
+    async fn test_shutdown_ordered_empty() {
+        let mut procs: Vec<ManagedProcess> = vec![];
+        shutdown_ordered(&mut procs, &[]).await;
     }
 }

--- a/releasenotes/notes/dd-procmgrd-ordering-ad5fe6c972ea3f34.yaml
+++ b/releasenotes/notes/dd-procmgrd-ordering-ad5fe6c972ea3f34.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    dd-procmgrd: Add multi-process startup ordering via ``after``/``before`` config fields with topological sort and reverse shutdown order.


### PR DESCRIPTION
### What does this PR do?

Adds dependency-based startup ordering to `dd-procmgrd` via `after` and `before` fields in process config YAML files, and shuts down processes in reverse startup order.

- Adds `after` and `before` optional list fields to `ProcessConfig` for declaring inter-process dependencies
- Implements topological sort (Kahn's algorithm) with alphabetical tie-breaking to resolve startup order
- Detects dependency cycles and falls back to alphabetical order with a warning
- Logs unknown dependencies (typos, removed processes) as warnings without failing
- Shuts down processes in reverse startup order so dependents stop before their dependencies
- Logs the resolved startup order at boot: `startup order: db -> api -> worker`

### Motivation

As `dd-procmgrd` takes over management of multiple agent sub-processes (DDOT today, core agent next), startup and shutdown ordering becomes critical. For example, a collector should not start before the core agent it reports to, and on shutdown, dependents must stop before their dependencies to avoid errors.

This is PR 5 in the [dd-procmgrd incremental roadmap](https://github.com/DataDog/datadog-agent/pull/47038).

### Describe how you validated your changes

- 61 unit tests pass (`cargo test --bin dd-procmgrd`), including 12 new tests:
  - **Ordering** (10): no constraints/alphabetical, `after`, `before`, chain, diamond, cycle detection, missing dependency, single process, empty, alphabetical tiebreak with constraints
  - **Shutdown** (2): ordered reverse, ordered empty
- `cargo clippy` and `cargo fmt` clean
- Backward compatible: configs without `after`/`before` behave exactly as before (alphabetical by filename)

### Additional Notes

- Config example with ordering:

  ```yaml
  # datadog-agent-ddot.yaml
  command: /opt/datadog-agent/ext/ddot/embedded/bin/otel-agent
  after:
    - datadog-agent-core
  auto_start: true
  ```

- On cycle detection, the daemon warns and falls back to alphabetical order rather than refusing to start
- The `shutdown_all` convenience function is kept as `#[cfg(test)]` only; production code uses `shutdown_ordered`
