### PR TITLE
otlp/metrics: reduce heap allocations in dimensions, key hash cache, and tag enrichment

### DIFF
--- a/comp/otelcol/otlp/components/exporter/serializerexporter/consumer.go
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/consumer.go
@@ -128,11 +128,8 @@ func (c *serializerConsumer) ConsumeAPMStats(ss *pb.ClientStatsPayload) {
 	c.apmstats = append(c.apmstats, body)
 }
 
-func enrichTags(extraTags []string, dimensions *otlpmetrics.Dimensions) []string {
-	enrichedTags := make([]string, 0, len(extraTags)+len(dimensions.Tags()))
-	enrichedTags = append(enrichedTags, extraTags...)
-	enrichedTags = append(enrichedTags, dimensions.Tags()...)
-	return enrichedTags
+func enrichTags(extraTags []string, dimensions *otlpmetrics.Dimensions) tagset.CompositeTags {
+	return tagset.NewCompositeTags(extraTags, dimensions.Tags())
 }
 
 func (c *serializerConsumer) ConsumeSketch(_ context.Context, dimensions *otlpmetrics.Dimensions, ts uint64, interval int64, qsketch *quantile.Sketch) {
@@ -142,7 +139,7 @@ func (c *serializerConsumer) ConsumeSketch(_ context.Context, dimensions *otlpme
 	}
 	c.sketches = append(c.sketches, &metrics.SketchSeries{
 		Name:     dimensions.Name(),
-		Tags:     tagset.CompositeTagsFromSlice(enrichTags(c.extraTags, dimensions)),
+		Tags:     enrichTags(c.extraTags, dimensions),
 		Host:     dimensions.Host(),
 		Interval: interval,
 		Points: []metrics.SketchPoint{{
@@ -172,7 +169,7 @@ func (c *serializerConsumer) ConsumeTimeSeries(_ context.Context, dimensions *ot
 		&metrics.Serie{
 			Name:     dimensions.Name(),
 			Points:   []metrics.Point{{Ts: float64(ts / 1e9), Value: value}},
-			Tags:     tagset.CompositeTagsFromSlice(enrichTags(c.extraTags, dimensions)),
+			Tags:     enrichTags(c.extraTags, dimensions),
 			Host:     dimensions.Host(),
 			MType:    apiTypeFromTranslatorType(typ),
 			Interval: interval,

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/consumer_test.go
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/consumer_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/DataDog/datadog-agent/pkg/metrics/event"
 	"github.com/DataDog/datadog-agent/pkg/metrics/servicecheck"
+	otlpmetrics "github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/metrics"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 	"github.com/DataDog/datadog-agent/pkg/serializer/marshaler"
 	"github.com/DataDog/datadog-agent/pkg/serializer/types"
@@ -26,6 +27,31 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tinylib/msgp/msgp"
 )
+
+func TestEnrichTags(t *testing.T) {
+	extraTags := []string{"extra1:v1", "extra2:v2"}
+	dims := (&otlpmetrics.Dimensions{}).AddTags("dim1:a", "dim2:b")
+
+	ct := enrichTags(extraTags, dims)
+
+	// Flatten the CompositeTags to verify all tags are present.
+	var got []string
+	ct.ForEach(func(tag string) {
+		got = append(got, tag)
+	})
+	assert.ElementsMatch(t, []string{"extra1:v1", "extra2:v2", "dim1:a", "dim2:b"}, got)
+}
+
+func TestEnrichTagsNoExtra(t *testing.T) {
+	dims := (&otlpmetrics.Dimensions{}).AddTags("k:v")
+	ct := enrichTags(nil, dims)
+
+	var got []string
+	ct.ForEach(func(tag string) {
+		got = append(got, tag)
+	})
+	assert.Equal(t, []string{"k:v"}, got)
+}
 
 var statsPayloads = []*pb.ClientStatsPayload{
 	{

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/exporter_test.go
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/exporter_test.go
@@ -94,8 +94,8 @@ func Test_ConsumeMetrics_Tags(t *testing.T) {
 				return newMetrics(histogramMetricName, h, numberMetricName, n)
 			},
 			extraTags:      []string{},
-			wantSketchTags: tagset.NewCompositeTags([]string{}, nil),
-			wantSerieTags:  tagset.NewCompositeTags([]string{}, nil),
+			wantSketchTags: tagset.NewCompositeTags(nil, []string{}),
+			wantSerieTags:  tagset.NewCompositeTags(nil, []string{}),
 		},
 		{
 			name: "metric tags and extra tags",
@@ -119,18 +119,12 @@ func Test_ConsumeMetrics_Tags(t *testing.T) {
 			},
 			extraTags: []string{"serverless_tag1:test1", "serverless_tag2:test2", "serverless_tag3:test3"},
 			wantSketchTags: tagset.NewCompositeTags(
-				[]string{
-					"serverless_tag1:test1", "serverless_tag2:test2", "serverless_tag3:test3",
-					"histogram_1_id:value1", "histogram_2_id:value2", "histogram_3_id:value3",
-				},
-				nil,
+				[]string{"serverless_tag1:test1", "serverless_tag2:test2", "serverless_tag3:test3"},
+				[]string{"histogram_1_id:value1", "histogram_2_id:value2", "histogram_3_id:value3"},
 			),
 			wantSerieTags: tagset.NewCompositeTags(
-				[]string{
-					"serverless_tag1:test1", "serverless_tag2:test2", "serverless_tag3:test3",
-					"gauge_1_id:value1", "gauge_2_id:value2", "gauge_3_id:value3",
-				},
-				nil,
+				[]string{"serverless_tag1:test1", "serverless_tag2:test2", "serverless_tag3:test3"},
+				[]string{"gauge_1_id:value1", "gauge_2_id:value2", "gauge_3_id:value3"},
 			),
 		},
 		{
@@ -145,8 +139,8 @@ func Test_ConsumeMetrics_Tags(t *testing.T) {
 				n.SetIntValue(777)
 				return newMetrics(histogramMetricName, h, numberMetricName, n)
 			},
-			wantSketchTags: tagset.NewCompositeTags([]string{}, nil),
-			wantSerieTags:  tagset.NewCompositeTags([]string{}, nil),
+			wantSketchTags: tagset.NewCompositeTags(nil, []string{}),
+			wantSerieTags:  tagset.NewCompositeTags(nil, []string{}),
 		},
 		{
 			name: "runtime metrics, metric tags and extra tags",
@@ -170,18 +164,12 @@ func Test_ConsumeMetrics_Tags(t *testing.T) {
 			},
 			extraTags: []string{"serverless_tag1:test1", "serverless_tag2:test2", "serverless_tag3:test3"},
 			wantSketchTags: tagset.NewCompositeTags(
-				[]string{
-					"serverless_tag1:test1", "serverless_tag2:test2", "serverless_tag3:test3",
-					"histogram_1_id:value1", "histogram_2_id:value2", "histogram_3_id:value3",
-				},
-				nil,
+				[]string{"serverless_tag1:test1", "serverless_tag2:test2", "serverless_tag3:test3"},
+				[]string{"histogram_1_id:value1", "histogram_2_id:value2", "histogram_3_id:value3"},
 			),
 			wantSerieTags: tagset.NewCompositeTags(
-				[]string{
-					"serverless_tag1:test1", "serverless_tag2:test2", "serverless_tag3:test3",
-					"gauge_1_id:value1", "gauge_2_id:value2", "gauge_3_id:value3",
-				},
-				nil,
+				[]string{"serverless_tag1:test1", "serverless_tag2:test2", "serverless_tag3:test3"},
+				[]string{"gauge_1_id:value1", "gauge_2_id:value2", "gauge_3_id:value3"},
 			),
 		},
 		{
@@ -201,12 +189,12 @@ func Test_ConsumeMetrics_Tags(t *testing.T) {
 				return md
 			},
 			extraTags: []string{},
-			wantSketchTags: tagset.NewCompositeTags([]string{
+			wantSketchTags: tagset.NewCompositeTags(nil, []string{
 				"instrumentation_scope:my_library", "instrumentation_scope_version:v1.0.0",
-			}, nil),
-			wantSerieTags: tagset.NewCompositeTags([]string{
+			}),
+			wantSerieTags: tagset.NewCompositeTags(nil, []string{
 				"instrumentation_scope:my_library", "instrumentation_scope_version:v1.0.0",
-			}, nil),
+			}),
 			instrumentationScopeMetadataAsTags: true,
 		},
 	}
@@ -233,7 +221,7 @@ func Test_ConsumeMetrics_Tags(t *testing.T) {
 			if tt.wantSketchTags.Len() > 0 {
 				assert.Equal(t, tt.wantSketchTags, rec.sketchSeriesList[0].Tags)
 			} else {
-				assert.Equal(t, tagset.NewCompositeTags([]string{}, nil), rec.sketchSeriesList[0].Tags)
+				assert.Equal(t, tagset.NewCompositeTags(nil, []string{}), rec.sketchSeriesList[0].Tags)
 			}
 			assert.True(t, len(rec.series) > 0)
 			for _, s := range rec.series {
@@ -249,7 +237,7 @@ func Test_ConsumeMetrics_Tags(t *testing.T) {
 					if tt.wantSerieTags.Len() > 0 {
 						assert.Equal(t, tt.wantSerieTags, s.Tags)
 					} else {
-						assert.Equal(t, tagset.NewCompositeTags([]string{}, nil), s.Tags)
+						assert.Equal(t, tagset.NewCompositeTags(nil, []string{}), s.Tags)
 					}
 				}
 			}

--- a/pkg/opentelemetry-mapping-go/otlp/metrics/dimensions.go
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/dimensions.go
@@ -76,17 +76,6 @@ func (d *Dimensions) OriginProductDetail() OriginProductDetail {
 	return d.originProductDetail
 }
 
-// getTags maps an attributeMap into a slice of Datadog tags
-func getTags(labels pcommon.Map) []string {
-	tags := make([]string, 0, labels.Len())
-	labels.Range(func(key string, value pcommon.Value) bool {
-		v := value.AsString()
-		tags = append(tags, utils.FormatKeyValueTag(key, v))
-		return true
-	})
-	return tags
-}
-
 // AddTags to metrics dimensions.
 func (d *Dimensions) AddTags(tags ...string) *Dimensions {
 	// defensively copy the tags
@@ -104,9 +93,30 @@ func (d *Dimensions) AddTags(tags ...string) *Dimensions {
 	}
 }
 
-// WithAttributeMap creates a new metricDimensions struct with additional tags from attributes.
+// WithAttributeMap creates a new Dimensions struct with additional tags from attributes.
+// It avoids the intermediate []string allocation that AddTags(getTags(labels)...) would produce.
 func (d *Dimensions) WithAttributeMap(labels pcommon.Map) *Dimensions {
-	return d.AddTags(getTags(labels)...)
+	n := labels.Len()
+	if n == 0 {
+		return d
+	}
+	// Allocate a single slice for both the new attribute tags and the existing tags,
+	// avoiding the separate getTags allocation.
+	newTags := make([]string, 0, n+len(d.tags))
+	labels.Range(func(key string, value pcommon.Value) bool {
+		newTags = append(newTags, utils.FormatKeyValueTag(key, value.AsString()))
+		return true
+	})
+	newTags = append(newTags, d.tags...)
+	return &Dimensions{
+		name:                d.name,
+		tags:                newTags,
+		host:                d.host,
+		originID:            d.originID,
+		originProduct:       d.originProduct,
+		originSubProduct:    d.originSubProduct,
+		originProductDetail: d.originProductDetail,
+	}
 }
 
 // WithSuffix creates a new dimensions struct with an extra name suffix.

--- a/pkg/opentelemetry-mapping-go/otlp/metrics/dimensions_test.go
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/dimensions_test.go
@@ -36,6 +36,17 @@ func TestWithAttributeMap(t *testing.T) {
 	)
 }
 
+func TestWithAttributeMapEmptyReturnsOriginal(t *testing.T) {
+	dims := &Dimensions{
+		name: "metric.name",
+		tags: []string{"key:val"},
+		host: "host",
+	}
+	result := dims.WithAttributeMap(pcommon.NewMap())
+	// Empty map must return the same pointer (no unnecessary allocation).
+	assert.Same(t, dims, result)
+}
+
 func TestMetricDimensionsString(t *testing.T) {
 	getKey := func(name string, tags []string, host string) string {
 		dims := Dimensions{name: name, tags: tags, host: host}

--- a/pkg/opentelemetry-mapping-go/otlp/metrics/key_hash_cache.go
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/key_hash_cache.go
@@ -17,7 +17,10 @@ package metrics
 import (
 	"encoding/ascii85"
 	"encoding/binary"
+	"sort"
+	"sync"
 	"time"
+	"unsafe"
 
 	gocache "github.com/patrickmn/go-cache"
 	"github.com/twmb/murmur3"
@@ -49,13 +52,71 @@ func (m *keyHashCache) set(s keyHashCacheKey, v interface{}, expiration time.Dur
 	m.cache.Set(string(s), v, expiration)
 }
 
+// ascii85EncodedLen128 is the exact output length of ascii85.Encode for a
+// 128-bit (16-byte) input. ascii85.MaxEncodedLen(16) == ceil(16/4)*5 == 20.
+const ascii85EncodedLen128 = 20
+
+// dimensionSep is the single-byte separator written between each dimension field.
+const dimensionSep = byte(0)
+
+// hasherState holds a reusable murmur3 Hash128 and the sort buffer.
+// Pooling avoids the heap allocations that murmur3.New128() and slice growth make per call.
+type hasherState struct {
+	h    murmur3.Hash128
+	dims []string
+}
+
+var hasherPool = sync.Pool{
+	New: func() interface{} {
+		return &hasherState{
+			h:    murmur3.New128(),
+			dims: make([]string, 0, 16),
+		}
+	},
+}
+
 func (m *keyHashCache) computeKey(s string) keyHashCacheKey {
 	h1, h2 := murmur3.StringSum128(s)
-	var bytes [16]byte
-	binary.LittleEndian.PutUint64(bytes[0:], h1)
-	binary.LittleEndian.PutUint64(bytes[8:], h2)
+	var raw [16]byte
+	binary.LittleEndian.PutUint64(raw[0:], h1)
+	binary.LittleEndian.PutUint64(raw[8:], h2)
 
-	buf := make([]byte, ascii85.MaxEncodedLen(len(bytes)))
-	n := ascii85.Encode(buf, bytes[:])
+	// Use a stack-allocated array to avoid a heap allocation for every cache lookup.
+	var buf [ascii85EncodedLen128]byte
+	n := ascii85.Encode(buf[:], raw[:])
+	return keyHashCacheKey(buf[:n])
+}
+
+// computeKeyFromDimensions computes the cache key directly from a Dimensions
+// value, bypassing the intermediate string allocation that Dimensions.String()
+// would produce.  It replicates the same sort-then-join semantics so that the
+// resulting key is identical to computeKey(dimensions.String()).
+func (m *keyHashCache) computeKeyFromDimensions(d *Dimensions) keyHashCacheKey {
+	hs := hasherPool.Get().(*hasherState)
+	hs.dims = hs.dims[:0]
+	hs.dims = append(hs.dims, d.tags...)
+	hs.dims = append(hs.dims, "name:"+d.name, "host:"+d.host, "originID:"+d.originID)
+	sort.Strings(hs.dims)
+
+	// Feed each sorted dimension directly into the pooled streaming hasher,
+	// using unsafe to avoid the []byte allocation from string→[]byte conversion.
+	hs.h.Reset()
+	sep := [1]byte{dimensionSep}
+	for _, dim := range hs.dims {
+		if len(dim) > 0 {
+			_, _ = hs.h.Write(unsafe.Slice(unsafe.StringData(dim), len(dim)))
+		}
+		_, _ = hs.h.Write(sep[:])
+	}
+	h1, h2 := hs.h.Sum128()
+
+	hasherPool.Put(hs)
+
+	var raw [16]byte
+	binary.LittleEndian.PutUint64(raw[0:], h1)
+	binary.LittleEndian.PutUint64(raw[8:], h2)
+
+	var buf [ascii85EncodedLen128]byte
+	n := ascii85.Encode(buf[:], raw[:])
 	return keyHashCacheKey(buf[:n])
 }

--- a/pkg/opentelemetry-mapping-go/otlp/metrics/key_hash_cache_test.go
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/key_hash_cache_test.go
@@ -51,3 +51,45 @@ func TestKeyHashCache_ComputeKey(t *testing.T) {
 	// Make sure we have 100 unique keys
 	require.Equal(t, 100, len(keys))
 }
+
+// TestComputeKeyFromDimensions verifies that computeKeyFromDimensions produces
+// the same cache key as computeKey(dimensions.String()).
+func TestComputeKeyFromDimensions(t *testing.T) {
+	khc := newKeyHashCache(cache.New(5*time.Minute, 10*time.Minute))
+
+	cases := []Dimensions{
+		{name: "metric.name", host: "host-one"},
+		{name: "metric.name", host: "host-one", tags: []string{"key1:val1", "key2:val2"}},
+		{name: "metric.name", host: "host-two", tags: []string{"key2:val2", "key1:val1"}, originID: "orig"},
+		{name: "a.metric.name", tags: []string{"zzz:last", "aaa:first"}},
+		// Empty fields
+		{},
+	}
+
+	for _, d := range cases {
+		d := d
+		fromString := khc.computeKey(d.String())
+		fromDims := khc.computeKeyFromDimensions(&d)
+		require.Equal(t, fromString, fromDims,
+			"key mismatch for dims %+v", d)
+	}
+}
+
+// TestComputeKeyFromDimensions_Uniqueness verifies that different Dimensions produce different keys.
+func TestComputeKeyFromDimensions_Uniqueness(t *testing.T) {
+	khc := newKeyHashCache(cache.New(5*time.Minute, 10*time.Minute))
+
+	dims := []Dimensions{
+		{name: "m1", host: "h1"},
+		{name: "m2", host: "h1"},
+		{name: "m1", host: "h2"},
+		{name: "m1", host: "h1", tags: []string{"k:v"}},
+		{name: "m1", host: "h1", originID: "o1"},
+	}
+	keys := make(map[keyHashCacheKey]struct{})
+	for _, d := range dims {
+		d := d
+		keys[khc.computeKeyFromDimensions(&d)] = struct{}{}
+	}
+	require.Equal(t, len(dims), len(keys), "expected all keys to be unique")
+}

--- a/pkg/opentelemetry-mapping-go/otlp/metrics/ttlcache.go
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/ttlcache.go
@@ -86,7 +86,7 @@ func (t *ttlCache) putAndGetMonotonic(
 	// assume it's first point before cache check.
 	firstPoint = true
 
-	key := t.cache.computeKey(dimensions.String())
+	key := t.cache.computeKeyFromDimensions(dimensions)
 	if c, found := t.cache.get(key); found {
 		cnt := c.(numberCounter)
 		if cnt.ts >= ts {
@@ -121,7 +121,7 @@ func (t *ttlCache) putAndGetDiff(
 	startTs, ts uint64,
 	val float64,
 ) (dx float64, ok bool) {
-	key := t.cache.computeKey(dimensions.String())
+	key := t.cache.computeKeyFromDimensions(dimensions)
 	if c, found := t.cache.get(key); found {
 		cnt := c.(numberCounter)
 		if cnt.ts > ts {
@@ -159,7 +159,7 @@ func (t *ttlCache) putAndCheckExtrema(
 	curExtrema float64,
 	min bool,
 ) (assumeFromLastWindow bool) {
-	key := t.cache.computeKey(dimensions.String())
+	key := t.cache.computeKeyFromDimensions(dimensions)
 	if c, found := t.cache.get(key); found {
 		cnt := c.(extrema)
 		if cnt.ts > ts {


### PR DESCRIPTION
### What does this PR do?

Reduces heap allocations in the OTLP metrics pipeline by:

1. **`WithAttributeMap` optimization** (`dimensions.go`): Inlines the former `getTags` helper directly into `WithAttributeMap`, building a single combined slice instead of two separate allocations. Returns the original `*Dimensions` pointer unchanged when the attribute map is empty.

2. **`computeKeyFromDimensions`** (`key_hash_cache.go`): Adds a new method that hashes a `*Dimensions` value directly using a pooled `murmur3.Hash128` and a stack-allocated ascii85 buffer, bypassing the `dimensions.String()` intermediate string allocation. `ttlcache` callers are updated to use this method.

3. **`enrichTags` refactor** (`consumer.go`): Changes the return type from `[]string` to `tagset.CompositeTags` by delegating to `tagset.NewCompositeTags`, eliminating an intermediate slice copy before constructing `CompositeTags`.

### Motivation

Hot paths in the OTLP metrics pipeline (cumulative sum/monotonic counter handling and sketch/time-series emission) were creating avoidable short-lived allocations on every data point. These changes reduce GC pressure and improve throughput for high-cardinality metric workloads.

### Describe how you validated your changes

Run unit test

### Additional Notes

The new `computeKeyFromDimensions` replicates the sort-then-hash semantics of `Dimensions.String()` so existing cache key compatibility is preserved. A dedicated test (`TestComputeKeyFromDimensions`) verifies byte-for-byte equality between the two paths across multiple dimension configurations.