### PR TITLE
refactor(collector): group collectorImpl fields into focused sub-structs

### DIFF
--- a/comp/collector/collector/collectorimpl/collector.go
+++ b/comp/collector/collector/collectorimpl/collector.go
@@ -62,6 +62,19 @@ type dependencies struct {
 	AgentTelemetry   option.Option[agenttelemetry.Component]
 }
 
+// checkState groups fields related to tracking running checks.
+type checkState struct {
+	checks         map[checkid.ID]*middleware.CheckWrapper
+	eventReceivers []collector.EventReceiver
+	checkInstances int64
+}
+
+// schedulingState groups fields related to the scheduler and runner.
+type schedulingState struct {
+	scheduler *scheduler.Scheduler
+	runner    *runner.Runner
+}
+
 type collectorImpl struct {
 	log            log.Component
 	config         config.Component
@@ -72,15 +85,12 @@ type collectorImpl struct {
 	senderManager    sender.SenderManager
 	metricSerializer option.Option[serializer.MetricSerializer]
 	agentTelemetry   option.Option[agenttelemetry.Component]
-	checkInstances   int64
 
 	// state is 'started' or 'stopped'
 	state *atomic.Uint32
 
-	scheduler      *scheduler.Scheduler
-	runner         *runner.Runner
-	checks         map[checkid.ID]*middleware.CheckWrapper
-	eventReceivers []collector.EventReceiver
+	scheduling schedulingState
+	checks     checkState
 
 	cancelCheckTimeout     time.Duration
 	watchdogWarningTimeout time.Duration
@@ -126,17 +136,19 @@ func newProvides(deps dependencies) provides {
 
 func newCollector(deps dependencies) *collectorImpl {
 	c := &collectorImpl{
-		log:                    deps.Log,
-		config:                 deps.Config,
-		haAgent:                deps.HaAgent,
-		healthPlatform:         deps.HealthPlatform,
-		hostname:               deps.Hostname,
-		senderManager:          deps.SenderManager,
-		metricSerializer:       deps.MetricSerializer,
-		agentTelemetry:         deps.AgentTelemetry,
-		checks:                 make(map[checkid.ID]*middleware.CheckWrapper),
-		state:                  atomic.NewUint32(stopped),
-		checkInstances:         int64(0),
+		log:              deps.Log,
+		config:           deps.Config,
+		haAgent:          deps.HaAgent,
+		healthPlatform:   deps.HealthPlatform,
+		hostname:         deps.Hostname,
+		senderManager:    deps.SenderManager,
+		metricSerializer: deps.MetricSerializer,
+		agentTelemetry:   deps.AgentTelemetry,
+		state:            atomic.NewUint32(stopped),
+		checks: checkState{
+			checks:         make(map[checkid.ID]*middleware.CheckWrapper),
+			checkInstances: int64(0),
+		},
 		cancelCheckTimeout:     deps.Config.GetDuration("check_cancel_timeout"),
 		watchdogWarningTimeout: deps.Config.GetDuration("check_watchdog_warning_timeout"),
 		createdAt:              time.Now(),
@@ -163,11 +175,11 @@ func (c *collectorImpl) AddEventReceiver(cb collector.EventReceiver) {
 	c.m.Lock()
 	defer c.m.Unlock()
 
-	c.eventReceivers = append(c.eventReceivers, cb)
+	c.checks.eventReceivers = append(c.checks.eventReceivers, cb)
 }
 
 func (c *collectorImpl) notify(cid checkid.ID, e collector.EventType) {
-	for _, cb := range c.eventReceivers {
+	for _, cb := range c.checks.eventReceivers {
 		cb(cid, e)
 	}
 }
@@ -190,8 +202,8 @@ func (c *collectorImpl) start(_ context.Context) error {
 	run.SetScheduler(sched)
 	sched.Run()
 
-	c.scheduler = sched
-	c.runner = run
+	c.scheduling.scheduler = sched
+	c.scheduling.runner = run
 	c.state.Store(started)
 
 	c.log.Debug("Collector up and running!")
@@ -204,13 +216,13 @@ func (c *collectorImpl) stop(_ context.Context) error {
 	c.m.Lock()
 	defer c.m.Unlock()
 
-	if c.scheduler != nil {
-		_ = c.scheduler.Stop()
-		c.scheduler = nil
+	if c.scheduling.scheduler != nil {
+		_ = c.scheduling.scheduler.Stop()
+		c.scheduling.scheduler = nil
 	}
-	if c.runner != nil {
-		c.runner.Stop()
-		c.runner = nil
+	if c.scheduling.runner != nil {
+		c.scheduling.runner.Stop()
+		c.scheduling.runner = nil
 	}
 	c.state.Store(stopped)
 	return nil
@@ -229,27 +241,27 @@ func (c *collectorImpl) RunCheck(inner check.Check) (checkid.ID, error) {
 		return emptyID, errors.New("the collector is not running")
 	}
 
-	if _, found := c.checks[ch.ID()]; found {
+	if _, found := c.checks.checks[ch.ID()]; found {
 		return emptyID, fmt.Errorf("a check with ID %s is already running", ch.ID())
 	}
 
-	if err := c.scheduler.Enter(ch); err != nil {
+	if err := c.scheduling.scheduler.Enter(ch); err != nil {
 		return emptyID, fmt.Errorf("unable to schedule the check: %s", err)
 	}
 
 	// Track the total number of checks running in order to have an appropriate number of workers
-	c.checkInstances++
+	c.checks.checkInstances++
 	if ch.Interval() == 0 {
 		// Adding a temporary runner for long running check in case the
 		// number of runners is lower than the number of long running
 		// checks.
 		c.log.Infof("Adding an extra runner for the '%s' long running check", ch)
-		c.runner.AddWorker()
+		c.scheduling.runner.AddWorker()
 	} else {
-		c.runner.UpdateNumWorkers(c.checkInstances)
+		c.scheduling.runner.UpdateNumWorkers(c.checks.checkInstances)
 	}
 
-	c.checks[ch.ID()] = ch
+	c.checks.checks[ch.ID()] = ch
 	c.notify(ch.ID(), collector.CheckRun)
 	return ch.ID(), nil
 }
@@ -261,22 +273,22 @@ func (c *collectorImpl) StopCheck(id checkid.ID) error {
 	var collectorRunner *runner.Runner
 
 	// This lock is needed because stop() can be called concurrently and sets
-	// c.runner and c.scheduler to nil
+	// c.scheduling.runner and c.scheduling.scheduler to nil
 	c.m.RLock()
 	if !c.started() {
 		c.m.RUnlock()
 		return errors.New("the collector is not running")
 	}
 
-	ch, found := c.checks[id]
+	ch, found := c.checks.checks[id]
 	if !found {
 		c.m.RUnlock()
 		return fmt.Errorf("cannot find a check with ID %s", id)
 	}
 
 	// These two are not nil because we checked that the collector is started
-	collectorScheduler = c.scheduler
-	collectorRunner = c.runner
+	collectorScheduler = c.scheduling.scheduler
+	collectorRunner = c.scheduling.runner
 	c.m.RUnlock()
 
 	// unschedule the instance
@@ -329,7 +341,7 @@ func (c *collectorImpl) get(id checkid.ID) (check.Check, bool) {
 	c.m.RLock()
 	defer c.m.RUnlock()
 
-	ch, found := c.checks[id]
+	ch, found := c.checks.checks[id]
 	return ch, found
 }
 
@@ -338,7 +350,7 @@ func (c *collectorImpl) delete(id checkid.ID) {
 	c.m.Lock()
 	defer c.m.Unlock()
 
-	delete(c.checks, id)
+	delete(c.checks.checks, id)
 	c.notify(id, collector.CheckStop)
 }
 
@@ -352,8 +364,8 @@ func (c *collectorImpl) MapOverChecks(cb func([]check.Info)) {
 	c.m.RLock()
 	defer c.m.RUnlock()
 
-	cInfo := make([]check.Info, 0, len(c.checks))
-	for _, c := range c.checks {
+	cInfo := make([]check.Info, 0, len(c.checks.checks))
+	for _, c := range c.checks.checks {
 		cInfo = append(cInfo, c)
 	}
 	cb(cInfo)
@@ -364,8 +376,8 @@ func (c *collectorImpl) GetChecks() []check.Check {
 	c.m.RLock()
 	defer c.m.RUnlock()
 
-	chks := make([]check.Check, 0, len(c.checks))
-	for _, chck := range c.checks {
+	chks := make([]check.Check, 0, len(c.checks.checks))
+	for _, chck := range c.checks.checks {
 		chks = append(chks, chck)
 	}
 
@@ -403,7 +415,7 @@ func (c *collectorImpl) getAllInstanceIDs(checkName string) []checkid.ID {
 	defer c.m.RUnlock()
 
 	instances := []checkid.ID{}
-	for id, check := range c.checks {
+	for id, check := range c.checks.checks {
 		if check.String() == checkName {
 			instances = append(instances, id)
 		}

--- a/comp/collector/collector/collectorimpl/collector_demux_test.go
+++ b/comp/collector/collector/collectorimpl/collector_demux_test.go
@@ -185,7 +185,7 @@ func (suite *CollectorDemuxTestSuite) TestCancelledCheckDestroysSender() {
 	suite.c.RunCheck(ch)
 	<-flip
 	flop <- struct{}{}
-	suite.c.checks[ch.ID()].Wait()
+	suite.c.checks.checks[ch.ID()].Wait()
 	err := suite.c.StopCheck(ch.ID())
 	assert.NoError(suite.T(), err)
 

--- a/comp/collector/collector/collectorimpl/collector_test.go
+++ b/comp/collector/collector/collectorimpl/collector_test.go
@@ -126,15 +126,15 @@ func (suite *CollectorTestSuite) TearDownTest() {
 }
 
 func (suite *CollectorTestSuite) TestNewCollector() {
-	assert.NotNil(suite.T(), suite.c.runner)
-	assert.NotNil(suite.T(), suite.c.scheduler)
+	assert.NotNil(suite.T(), suite.c.scheduling.runner)
+	assert.NotNil(suite.T(), suite.c.scheduling.scheduler)
 	assert.Equal(suite.T(), started, suite.c.state.Load())
 }
 
 func (suite *CollectorTestSuite) TestStop() {
 	suite.c.stop(context.TODO())
-	assert.Nil(suite.T(), suite.c.runner)
-	assert.Nil(suite.T(), suite.c.scheduler)
+	assert.Nil(suite.T(), suite.c.scheduling.runner)
+	assert.Nil(suite.T(), suite.c.scheduling.scheduler)
 	assert.Equal(suite.T(), stopped, suite.c.state.Load())
 }
 
@@ -145,8 +145,8 @@ func (suite *CollectorTestSuite) TestRunCheck() {
 	id, err := suite.c.RunCheck(ch)
 	assert.NotNil(suite.T(), id)
 	assert.Nil(suite.T(), err)
-	assert.Equal(suite.T(), 1, len(suite.c.checks))
-	assert.Equal(suite.T(), ch, suite.c.checks["TestCheck"].Inner())
+	assert.Equal(suite.T(), 1, len(suite.c.checks.checks))
+	assert.Equal(suite.T(), ch, suite.c.checks.checks["TestCheck"].Inner())
 
 	// schedule the same check twice
 	_, err = suite.c.RunCheck(ch)
@@ -164,7 +164,7 @@ func (suite *CollectorTestSuite) TestStopCheck() {
 	// all good
 	err = suite.c.StopCheck("TestCheck")
 	assert.Nil(suite.T(), err)
-	assert.Zero(suite.T(), len(suite.c.checks))
+	assert.Zero(suite.T(), len(suite.c.checks.checks))
 	ch.AssertNumberOfCalls(suite.T(), "Cancel", 1)
 }
 
@@ -186,24 +186,24 @@ func (suite *CollectorTestSuite) TestCancelCheck_CheckIsCleanedUp() {
 	start := time.Now()
 	id, err := suite.c.RunCheck(ch)
 	assert.Nil(suite.T(), err)
-	assert.NotEmpty(suite.T(), suite.c.checks)
+	assert.NotEmpty(suite.T(), suite.c.checks.checks)
 
 	err = suite.c.StopCheck(id)
 	assert.NotNil(suite.T(), err)
 	assert.WithinDuration(suite.T(), start, time.Now(), 5*time.Second)
-	assert.Empty(suite.T(), suite.c.checks)
+	assert.Empty(suite.T(), suite.c.checks.checks)
 }
 
 func (suite *CollectorTestSuite) TestGet() {
 	_, found := suite.c.get("bar")
 	assert.False(suite.T(), found)
 
-	suite.c.checks["bar"] = middleware.NewCheckWrapper(NewCheck(), aggregator.NewNoOpSenderManager(), option.None[agenttelemetry.Component]())
+	suite.c.checks.checks["bar"] = middleware.NewCheckWrapper(NewCheck(), aggregator.NewNoOpSenderManager(), option.None[agenttelemetry.Component]())
 	_, found = suite.c.get("foo")
 	assert.False(suite.T(), found)
 	c, found := suite.c.get("bar")
 	assert.True(suite.T(), found)
-	assert.Equal(suite.T(), suite.c.checks["bar"], c)
+	assert.Equal(suite.T(), suite.c.checks.checks["bar"], c)
 }
 
 func (suite *CollectorTestSuite) TestDelete() {
@@ -212,7 +212,7 @@ func (suite *CollectorTestSuite) TestDelete() {
 	suite.c.delete("foo")
 
 	// for good
-	suite.c.checks["bar"] = nil
+	suite.c.checks.checks["bar"] = nil
 	_, found := suite.c.get("bar")
 	assert.True(suite.T(), found)
 	suite.c.delete("bar")
@@ -240,7 +240,7 @@ func (suite *CollectorTestSuite) TestgetAllInstanceIDs() {
 	id3, err := suite.c.RunCheck(ch3)
 	assert.NotNil(suite.T(), id3)
 	assert.Nil(suite.T(), err)
-	assert.Equal(suite.T(), 3, len(suite.c.checks))
+	assert.Equal(suite.T(), 3, len(suite.c.checks.checks))
 
 	ids := suite.c.getAllInstanceIDs("TestCheck1")
 	assert.Equal(suite.T(), 2, len(ids))
@@ -285,7 +285,7 @@ func (suite *CollectorTestSuite) TestReloadAllCheckInstances() {
 	sort.Sort(ChecksList(killed))
 	assert.Equal(suite.T(), killed, []checkid.ID{"baz", "qux"})
 
-	assert.Zero(suite.T(), len(suite.c.checks))
+	assert.Zero(suite.T(), len(suite.c.checks.checks))
 }
 
 func TestCollectorSuite(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?
Groups the 20+ fields of `collectorImpl` into focused sub-structs (`checkState`, `schedulingState`) to make ownership and dependencies explicit at a glance.

### Motivation
`collectorImpl` had a flat list of 20+ fields spanning check tracking, scheduler/runner management, telemetry, and health reporting. This made it hard to understand which fields are related, which are protected by which lock, and which could be extracted into independent components. Grouping into sub-structs is a first step toward cleaner separation of concerns and improves readability without changing any behaviour.

### Describe how you validated your changes
- `go build ./comp/collector/...` passes
- `go test ./comp/collector/...` passes
- Pure structural refactoring: zero behaviour change, no interface changes

### Additional Notes
This is a structural first step. A follow-up PR can extract the sub-structs into separate types with their own methods and locks, enabling finer-grained concurrency control.