### PR TITLE
Account for GitHub Actions not resolving `*.ddbuild.io`

### DIFF
--- a/tools/bazel
+++ b/tools/bazel
@@ -26,8 +26,9 @@ if [ -n "${XDG_CACHE_HOME:-}" ]; then
     >&2 echo "🔴 XDG_CACHE_HOME ($XDG_CACHE_HOME) must denote an absolute path!"
     exit 2
   fi
-
-  [ -n "${CI:-}" ] && exec "$BAZEL_REAL" ${1:+"$1" --config=ci} "${@:2}"
+  if [[ -n "${CI:-}" && -z "${GITHUB_ACTIONS:-}" ]]; then
+    exec "$BAZEL_REAL" ${1:+"$1" --config=ci} "${@:2}"
+  fi
 fi
 
 exec "$BAZEL_REAL" "$@"

--- a/tools/bazel.bat
+++ b/tools/bazel.bat
@@ -47,11 +47,11 @@ if not exist "!more_than_260_chars!" (
   )
 )
 
-:: Not in CI: simply execute `bazel` - done
-if not defined CI (
-  "%BAZEL_REAL%" !bazel_home_startup_option! %*
-  exit /b !errorlevel!
-)
+:: Not in CI nor GitHub Actions: simply execute `bazel` - done
+if defined CI if not defined GITHUB_ACTIONS goto :ci_config
+"%BAZEL_REAL%" !bazel_home_startup_option! %*
+exit /b !errorlevel!
+:ci_config
 
 :: Pass CI-specific options through `.user.bazelrc` so any nested `bazel run` and next `bazel shutdown` also honor them
 (


### PR DESCRIPTION
### What does this PR do?
Skip `--config=ci` in `tools/bazel*` when `GITHUB_ACTIONS` is set, falling back to bare `bazel` invocation.

### Motivation
[Issue](https://github.com/DataDog/datadog-agent/actions/runs/22627661907/job/65571502283#step:7:36):
> ERROR: Error computing the main repository mapping: Error accessing registry https://bcr.bazel.build/: Failed to fetch registry file https://bcr.bazel.build/modules/package_metadata/0.0.7/MODULE.bazel: Connect timed out

`--config=ci` pulls in:
- `--config=adms`: ADMS mirror at `depot-read-api-bzl.us1.ddbuild.io` **with `block *`**,
- `--config=cache`: remote executor at `buildbarn-frontend.us1.ddbuild.io`,

... both of which are unreachable from GitHub-hosted runners, causing BCR timeouts.