### PR TITLE
Enable SMP image publishing on release branches

### DIFF
--- a/.gitlab/deploy/container_build/docker_linux.yml
+++ b/.gitlab/deploy/container_build/docker_linux.yml
@@ -186,7 +186,7 @@ single_machine_performance-full-amd64-a7:
   rules:
     - !reference [.except_mergequeue]
     # Always publish SMP images on main (needed for baseline comparisons)
-    - !reference [.on_main]
+    - !reference [.on_main_or_release_branch]
     # On dev branches, only publish when artifact-impacting files change.
     # This skips SMP for doc-only, CI-only, or e2e test-only PRs.
     - !reference [.on_dev_branches_with_artifact_changes]


### PR DESCRIPTION
### What does this PR do?

Changes the `single_machine_performance-full-amd64-a7` CI job to trigger on release branches in addition to `main`, by switching from `.on_main` to `.on_main_or_release_branch`.

### Motivation

The SMP (Single Machine Performance) job publishes baseline images used for performance comparisons. Without this change, these images are not published during release branch pipelines, which means performance baselines are unavailable when testing release candidates on the `7.77.x` branch.

### Describe how you validated your changes

This is a CI configuration change. The rule reference `.on_main_or_release_branch` already exists in the pipeline and is used by other jobs for the same purpose.

### Additional Notes

This is a targeted backport fix for the `7.77.x` release branch to ensure SMP baseline images are built and published during RC pipelines.