### PR TITLE
feat(slack): Use Packs API for team Slack channel resolution

### DIFF
--- a/tasks/libs/pipeline/notifications.py
+++ b/tasks/libs/pipeline/notifications.py
@@ -27,16 +27,87 @@ def load_and_validate(
     return result
 
 
+class ProxyMap(dict):
+    def __init__(self, file_name, channel_type):
+        self.file_name = file_name
+        self.channel_type = channel_type
+        self._local_map = None
+        self._final_map = None
+
+    def _ensure_initialized(self):
+        if self._final_map is not None:
+            return
+
+        if self._local_map is None:
+            self._local_map = load_and_validate(self.file_name, "DEFAULT_SLACK_CHANNEL", DEFAULT_SLACK_CHANNEL)
+
+        self._final_map = self._local_map.copy()
+        try:
+            from tasks.libs.pipeline.packs import get_team_channels
+
+            for team in self._local_map:
+                notif, review = get_team_channels(team)
+                pack_val = notif if self.channel_type == 'notification' else review
+                if pack_val:
+                    self._final_map[team] = pack_val
+        except Exception:
+            # Fallback to local map on error (e.g. no network, no ddtool)
+            pass
+
+    def __getitem__(self, key):
+        self._ensure_initialized()
+        return self._final_map[key]
+
+    def __iter__(self):
+        self._ensure_initialized()
+        return iter(self._final_map)
+
+    def __len__(self):
+        self._ensure_initialized()
+        return len(self._final_map)
+
+    def __contains__(self, key):
+        self._ensure_initialized()
+        return key in self._final_map
+
+    def keys(self):
+        self._ensure_initialized()
+        return self._final_map.keys()
+
+    def values(self):
+        self._ensure_initialized()
+        return self._final_map.values()
+
+    def items(self):
+        self._ensure_initialized()
+        return self._final_map.items()
+
+    def get(self, key, default=None):
+        self._ensure_initialized()
+        return self._final_map.get(key, default)
+
+    def clear(self):
+        # Needed for some tests that clear the map
+        self._final_map = {}
+        self._local_map = {}
+
+    def __setitem__(self, key, value):
+        self._ensure_initialized()
+        self._final_map[key] = value
+
+    def __repr__(self):
+        self._ensure_initialized()
+        return repr(self._final_map)
+
+
 GITHUB_BASE_URL = "https://github.com"
 DEFAULT_SLACK_CHANNEL = "#agent-devx-ops"
 HELP_SLACK_CHANNEL = "#agent-devx-help"
 DEFAULT_JIRA_PROJECT = "AGNTR"
 # Map keys in lowercase
-GITHUB_SLACK_MAP = load_and_validate("github_slack_map.yaml", "DEFAULT_SLACK_CHANNEL", DEFAULT_SLACK_CHANNEL)
+GITHUB_SLACK_MAP = ProxyMap("github_slack_map.yaml", "notification")
 GITHUB_JIRA_MAP = load_and_validate("github_jira_map.yaml", "DEFAULT_JIRA_PROJECT", DEFAULT_JIRA_PROJECT)
-GITHUB_SLACK_REVIEW_MAP = load_and_validate(
-    "github_slack_review_map.yaml", "DEFAULT_SLACK_CHANNEL", DEFAULT_SLACK_CHANNEL
-)
+GITHUB_SLACK_REVIEW_MAP = ProxyMap("github_slack_review_map.yaml", "review")
 
 
 def check_for_missing_owners_slack_and_jira(print_missing_teams=True, owners_file=".github/CODEOWNERS"):

--- a/tasks/libs/pipeline/packs.py
+++ b/tasks/libs/pipeline/packs.py
@@ -1,0 +1,88 @@
+import functools
+import os
+import subprocess
+
+import requests
+
+# Default datacenter
+DATACENTER = "us1.ddbuild.io"
+HOLOCENE_URL = f"https://holocene.{DATACENTER}/v1/packs"
+
+
+def get_token():
+    try:
+        # Check if we have a token in the environment
+        if "HOLOCENE_TOKEN" in os.environ:
+            return os.environ["HOLOCENE_TOKEN"]
+
+        # Fallback to ddtool
+        return (
+            subprocess.check_output(
+                ["ddtool", "auth", "token", "holocene", "--datacenter", DATACENTER],
+                stderr=subprocess.DEVNULL,
+                timeout=2,
+            )
+            .decode()
+            .strip()
+        )
+    except Exception:
+        return None
+
+
+@functools.lru_cache(maxsize=1)
+def fetch_all_packs():
+    token = get_token()
+    if not token:
+        return []
+
+    packs = []
+    next_page_token = ""
+    while True:
+        try:
+            url = f"{HOLOCENE_URL}?pageSize=1000"
+            if next_page_token:
+                url += f"&next_page_token={next_page_token}"
+
+            response = requests.get(url, headers={"Authorization": f"Bearer {token}"}, timeout=10)
+            if response.status_code != 200:
+                break
+
+            data = response.json()
+            packs.extend(data.get("packs", []))
+            next_page_token = data.get("next_page_token")
+            if not next_page_token:
+                break
+        except Exception:
+            break
+    return packs
+
+
+@functools.lru_cache(maxsize=1)
+def get_packs_map():
+    packs = fetch_all_packs()
+    # Map pack ID (which corresponds to team slug) to communication channels
+    return {p['id'].lower(): p.get('communication_channels', {}) for p in packs}
+
+
+def get_team_channels(team_name):
+    """
+    Returns (notification_channel, review_channel) for a team name (e.g. '@datadog/agent-devx').
+    """
+    packs_map = get_packs_map()
+
+    # Remove @datadog/ prefix and lowercase
+    pack_id = team_name.replace("@datadog/", "").lower()
+    channels = packs_map.get(pack_id, {})
+
+    notif = channels.get("notification_channel")
+    contact = channels.get("contact_channel")
+    review = channels.get("review_channel")
+
+    # Fallbacks as per requirements
+    # Notification: notification_channel or contact_channel
+    final_notif = notif or contact
+
+    # Review: review_channel or contact_channel
+    final_review = review or contact
+
+    return final_notif, final_review

--- a/tasks/unit_tests/libs/pipeline/notifications_proxy_tests.py
+++ b/tasks/unit_tests/libs/pipeline/notifications_proxy_tests.py
@@ -1,0 +1,59 @@
+import unittest
+from unittest.mock import patch
+
+from tasks.libs.pipeline.notifications import ProxyMap
+
+
+class TestProxyMap(unittest.TestCase):
+    def test_proxy_map_lazy_loading(self):
+        # We want to verify that the packs are only called once we access the map
+        with (
+            patch('tasks.libs.pipeline.notifications.load_and_validate') as mock_load,
+            patch('tasks.libs.pipeline.packs.get_team_channels') as mock_get_channels,
+        ):
+            mock_load.return_value = {"@datadog/team1": "#local-chan1", "@datadog/team2": "#local-chan2"}
+
+            # Should NOT have called get_team_channels yet
+            proxy = ProxyMap("dummy.yaml", "notification")
+            self.assertEqual(mock_get_channels.call_count, 0)
+
+            # Accessing an item should trigger initialization
+            mock_get_channels.return_value = ("#pack-chan1", "#pack-review1")
+            val = proxy["@datadog/team1"]
+
+            self.assertEqual(val, "#pack-chan1")
+            self.assertGreater(mock_get_channels.call_count, 0)
+
+    def test_proxy_map_fallback(self):
+        with (
+            patch('tasks.libs.pipeline.notifications.load_and_validate') as mock_load,
+            patch('tasks.libs.pipeline.packs.get_team_channels') as mock_get_channels,
+        ):
+            mock_load.return_value = {"@datadog/team1": "#local-chan1", "@datadog/team2": "#local-chan2"}
+
+            # Pack returns None for team2, should fallback to local
+            def side_effect(team):
+                if team == "@datadog/team1":
+                    return ("#pack-chan1", None)
+                return (None, None)
+
+            mock_get_channels.side_effect = side_effect
+
+            proxy = ProxyMap("dummy.yaml", "notification")
+
+            self.assertEqual(proxy["@datadog/team1"], "#pack-chan1")
+            self.assertEqual(proxy["@datadog/team2"], "#local-chan2")
+
+    def test_proxy_map_error_fallback(self):
+        with (
+            patch('tasks.libs.pipeline.notifications.load_and_validate') as mock_load,
+            patch('tasks.libs.pipeline.packs.get_team_channels') as mock_get_channels,
+        ):
+            mock_load.return_value = {"@datadog/team1": "#local-chan1"}
+
+            mock_get_channels.side_effect = Exception("Packs service down")
+
+            proxy = ProxyMap("dummy.yaml", "notification")
+
+            # Should still work and return local value
+            self.assertEqual(proxy["@datadog/team1"], "#local-chan1")

--- a/tasks/unit_tests/libs/pipeline/packs_tests.py
+++ b/tasks/unit_tests/libs/pipeline/packs_tests.py
@@ -1,0 +1,76 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from tasks.libs.pipeline.packs import fetch_all_packs, get_team_channels
+
+
+class TestPacks(unittest.TestCase):
+    @patch('tasks.libs.pipeline.packs.subprocess.check_output')
+    @patch('tasks.libs.pipeline.packs.os.environ', {})
+    def test_get_token_ddtool(self, mock_subprocess):
+        from tasks.libs.pipeline.packs import get_token
+
+        mock_subprocess.return_value = b"fake-token\n"
+        token = get_token()
+        self.assertEqual(token, "fake-token")
+        mock_subprocess.assert_called_once()
+
+    @patch('tasks.libs.pipeline.packs.os.environ', {'HOLOCENE_TOKEN': 'env-token'})
+    def test_get_token_env(self):
+        from tasks.libs.pipeline.packs import get_token
+
+        token = get_token()
+        self.assertEqual(token, "env-token")
+
+    @patch('tasks.libs.pipeline.packs.requests.get')
+    @patch('tasks.libs.pipeline.packs.get_token')
+    def test_fetch_all_packs(self, mock_get_token, mock_get):
+        mock_get_token.return_value = "token"
+
+        # Mocking two pages of results
+        mock_response1 = MagicMock()
+        mock_response1.status_code = 200
+        mock_response1.json.return_value = {"packs": [{"id": "pack1"}], "next_page_token": "page2"}
+
+        mock_response2 = MagicMock()
+        mock_response2.status_code = 200
+        mock_response2.json.return_value = {"packs": [{"id": "pack2"}], "next_page_token": None}
+
+        mock_get.side_effect = [mock_response1, mock_response2]
+
+        # Clear cache before test
+        fetch_all_packs.cache_clear()
+        packs = fetch_all_packs()
+
+        self.assertEqual(len(packs), 2)
+        self.assertEqual(packs[0]["id"], "pack1")
+        self.assertEqual(packs[1]["id"], "pack2")
+        self.assertEqual(mock_get.call_count, 2)
+
+    @patch('tasks.libs.pipeline.packs.get_packs_map')
+    def test_get_team_channels(self, mock_get_packs_map):
+        mock_get_packs_map.return_value = {
+            "agent-devx": {"notification_channel": "C1", "review_channel": "C2", "contact_channel": "C3"},
+            "no-notif": {"review_channel": "C2", "contact_channel": "C3"},
+            "only-contact": {"contact_channel": "C3"},
+        }
+
+        # Test full definition
+        notif, review = get_team_channels("@datadog/agent-devx")
+        self.assertEqual(notif, "C1")
+        self.assertEqual(review, "C2")
+
+        # Test fallback to contact_channel for notification
+        notif, review = get_team_channels("@datadog/no-notif")
+        self.assertEqual(notif, "C3")
+        self.assertEqual(review, "C2")
+
+        # Test fallback to contact_channel for both
+        notif, review = get_team_channels("@datadog/only-contact")
+        self.assertEqual(notif, "C3")
+        self.assertEqual(review, "C3")
+
+        # Test unknown team
+        notif, review = get_team_channels("@datadog/unknown")
+        self.assertIsNone(notif)
+        self.assertIsNone(review)


### PR DESCRIPTION
### What does this PR do?

Introduces a `ProxyMap` class that lazily fetches team communication channels from the Holocene Packs API and overlays them on top of the existing local YAML-based Slack channel mappings (`github_slack_map.yaml` / `github_slack_review_map.yaml`).

- **`tasks/libs/pipeline/packs.py`** — New module that authenticates via `HOLOCENE_TOKEN` env var or `ddtool`, fetches all packs from the Holocene API with pagination, and extracts `notification_channel` / `review_channel` / `contact_channel` per team.
- **`tasks/libs/pipeline/notifications.py`** — Replaces the eagerly-loaded `GITHUB_SLACK_MAP` and `GITHUB_SLACK_REVIEW_MAP` dicts with `ProxyMap` instances. `ProxyMap` is a lazy `dict` subclass that only calls the Packs API on first access, merges pack-sourced channels over local values, and falls back to local YAML if the Packs API is unreachable.

### Motivation

Team Slack channels are currently hardcoded in YAML files that must be manually updated. By sourcing channels from the Packs API (the source of truth for team metadata), we keep notifications accurate without manual maintenance.
https://datadoghq.atlassian.net/browse/ACIX-1332

### Describe how you validated your changes

Added unit tests for both new modules:
- `tasks/unit_tests/libs/pipeline/packs_tests.py` — Tests token retrieval (env / ddtool), paginated pack fetching, channel resolution with fallbacks.
- `tasks/unit_tests/libs/pipeline/notifications_proxy_tests.py` — Tests lazy initialization, pack-override behavior, fallback to local values when packs return `None`, and graceful error handling when the Packs API is down.

### Additional Notes

The `ProxyMap` is fully transparent to existing consumers — it implements the same `dict` interface, so no call-site changes are needed.

This won't work for now when called in Github context as we don't have free access to `ddtool` to generate the token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)