### PR TITLE
dyninst/compiler: treat partial availability as unavailable

### DIFF
--- a/pkg/dyninst/compiler/generate.go
+++ b/pkg/dyninst/compiler/generate.go
@@ -649,6 +649,8 @@ func offsetOfUint8(fields []ir.Field, name string) (uint8, error) {
 	return uint8(offset), nil
 }
 
+func nilPieceOp(piece ir.Piece) bool { return piece.Op == nil }
+
 // `ops` is used as an output buffer for the encoded instructions.
 func (g *generator) EncodeLocationOp(pc uint64, op *ir.LocationOp, ops []Op) ([]Op, error) {
 	for _, loclist := range op.Variable.Locations {
@@ -669,15 +671,20 @@ func (g *generator) EncodeLocationOp(pc uint64, op *ir.LocationOp, ops []Op) ([]
 			// Nothing needs to be read.
 			return ops, nil
 		}
+
+		// Check if the matching location list is unavailable (partially or
+		// completely). If so, we'll want by breaking here we'll make sure we
+		// don't mark the variable as available.
+		if len(loclist.Pieces) == 0 ||
+			slices.ContainsFunc(loclist.Pieces, nilPieceOp) {
+			break
+		}
+
 		layoutPieces, err := g.typeMemoryLayout(op.Variable.Type)
 		if err != nil {
 			return nil, err
 		}
 		layoutIdx := 0
-		if len(loclist.Pieces) == 0 {
-			// Variable has loclist entry for relevant PC range, but it is still unavailable.
-			break
-		}
 		for _, piece := range loclist.Pieces {
 			if layoutIdx >= len(layoutPieces) {
 				return nil, fmt.Errorf("mismatch between loclist pieces and type memory layout for %s : %s", op.Variable.Name, op.Variable.Type.GetName())
@@ -708,6 +715,10 @@ func (g *generator) EncodeLocationOp(pc uint64, op *ir.LocationOp, ops []Op) ([]
 					})
 				case ir.Addr:
 					return nil, errUnsupportedAddrLocationOp
+				default:
+					return nil, fmt.Errorf(
+						"internal error: unexpected piece op: %#v (%T)", p, p,
+					)
 				}
 			}
 		}

--- a/pkg/dyninst/compiler/generate.go
+++ b/pkg/dyninst/compiler/generate.go
@@ -651,6 +651,21 @@ func offsetOfUint8(fields []ir.Field, name string) (uint8, error) {
 
 func nilPieceOp(piece ir.Piece) bool { return piece.Op == nil }
 
+// hasDuplicateInterfacePieces returns true if an interface type has both
+// pieces claiming the same register. Interface types have two distinct
+// pointers (type/itab and data) that can never have the same value, so
+// duplicate registers indicate invalid DWARF. Seen on ARM64 with go1.26rc1.
+func hasDuplicateInterfacePieces(typ ir.Type, pieces []ir.Piece) bool {
+	switch typ.(type) {
+	case *ir.GoInterfaceType, *ir.GoEmptyInterfaceType:
+		// Interfaces always have exactly 2 pieces
+		if len(pieces) == 2 && pieces[0].Op == pieces[1].Op {
+			return true
+		}
+	}
+	return false
+}
+
 // `ops` is used as an output buffer for the encoded instructions.
 func (g *generator) EncodeLocationOp(pc uint64, op *ir.LocationOp, ops []Op) ([]Op, error) {
 	for _, loclist := range op.Variable.Locations {
@@ -673,10 +688,15 @@ func (g *generator) EncodeLocationOp(pc uint64, op *ir.LocationOp, ops []Op) ([]
 		}
 
 		// Check if the matching location list is unavailable (partially or
-		// completely). If so, we'll want by breaking here we'll make sure we
-		// don't mark the variable as available.
+		// completely). If so, by breaking here we'll make sure we don't mark
+		// the variable as available.
+		//
+		// Also check for duplicate interface pieces where both claim the same
+		// register (seen on ARM64 with go1.26rc1). Interface types have two
+		// distinct pointers that can never share a register.
 		if len(loclist.Pieces) == 0 ||
-			slices.ContainsFunc(loclist.Pieces, nilPieceOp) {
+			slices.ContainsFunc(loclist.Pieces, nilPieceOp) ||
+			hasDuplicateInterfacePieces(op.Variable.Type, loclist.Pieces) {
 			break
 		}
 

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -8,15 +8,15 @@ Probes:
       template: stackC
       segments: [stackC]
       captureSnapshot: true
-      subprogram: {subprogram: 142}
+      subprogram: {subprogram: 143}
       events:
         - Kind: Entry
-          Type: 1332 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0xd0a52a", Frameless: false}]
+          Type: 1333 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0xd0a64a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1333 EventRootType Probe[main.stackC]Return
-          InjectionPoints: [{PC: "0xd0a565", Frameless: false}]
+          Type: 1334 EventRootType Probe[main.stackC]Return
+          InjectionPoints: [{PC: "0xd0a685", Frameless: false}]
           Condition: null
       probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -27,15 +27,15 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 56}
+      subprogram: {subprogram: 57}
       events:
         - Kind: Entry
-          Type: 1196 EventRootType Probe[main.testAny]
-          InjectionPoints: [{PC: "0xd04dea", Frameless: false}]
+          Type: 1197 EventRootType Probe[main.testAny]
+          InjectionPoints: [{PC: "0xd04f0a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1197 EventRootType Probe[main.testAny]Return
-          InjectionPoints: [{PC: "0xd04e25", Frameless: false}]
+          Type: 1198 EventRootType Probe[main.testAny]Return
+          InjectionPoints: [{PC: "0xd04f45", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -52,15 +52,15 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 58}
+      subprogram: {subprogram: 59}
       events:
         - Kind: Entry
-          Type: 1199 EventRootType Probe[main.testAnyPtr]
-          InjectionPoints: [{PC: "0xd04e8a", Frameless: false}]
+          Type: 1200 EventRootType Probe[main.testAnyPtr]
+          InjectionPoints: [{PC: "0xd04faa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1200 EventRootType Probe[main.testAnyPtr]Return
-          InjectionPoints: [{PC: "0xd04ebd", Frameless: false}]
+          Type: 1201 EventRootType Probe[main.testAnyPtr]Return
+          InjectionPoints: [{PC: "0xd04fdd", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -76,15 +76,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 122}
+      subprogram: {subprogram: 123}
       events:
         - Kind: Entry
-          Type: 1303 EventRootType Probe[main.testArrayArgAndReturn]
-          InjectionPoints: [{PC: "0xd08f6e", Frameless: false}]
+          Type: 1304 EventRootType Probe[main.testArrayArgAndReturn]
+          InjectionPoints: [{PC: "0xd0908e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1304 EventRootType Probe[main.testArrayArgAndReturn]Return
-          InjectionPoints: [{PC: "0xd09022", Frameless: false}]
+          Type: 1305 EventRootType Probe[main.testArrayArgAndReturn]Return
+          InjectionPoints: [{PC: "0xd09142", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -164,11 +164,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 66}
+      subprogram: {subprogram: 67}
       events:
         - Kind: Entry
-          Type: 1208 EventRootType Probe[main.testArrayOfMaps]
-          InjectionPoints: [{PC: "0xd05600", Frameless: true}]
+          Type: 1209 EventRootType Probe[main.testArrayOfMaps]
+          InjectionPoints: [{PC: "0xd05720", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -226,15 +226,15 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 87}
       events:
         - Kind: Entry
-          Type: 1230 EventRootType Probe[main.testAtomicAdd]
-          InjectionPoints: [{PC: "0xd07320", Frameless: true}]
+          Type: 1231 EventRootType Probe[main.testAtomicAdd]
+          InjectionPoints: [{PC: "0xd07440", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1231 EventRootType Probe[main.testAtomicAdd]Return
-          InjectionPoints: [{PC: "0xd07332", Frameless: true}]
+          Type: 1232 EventRootType Probe[main.testAtomicAdd]Return
+          InjectionPoints: [{PC: "0xd07452", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -323,15 +323,15 @@ Probes:
           expr:
             dsl: x.aString
             json: {getmember: [{ref: x}, aString]}
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1351 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0xd0a960", Frameless: true}]
+          Type: 1352 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0xd0aa80", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1352 EventRootType Probe[main.testStruct]Return
-          InjectionPoints: [{PC: "0xd0a982", Frameless: true}]
+          Type: 1353 EventRootType Probe[main.testStruct]Return
+          InjectionPoints: [{PC: "0xd0aaa2", Frameless: true}]
           Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -345,20 +345,20 @@ Probes:
       segments: []
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1361 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1362 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
-            - PC: "0xd0460e"
+            - PC: "0xd0472e"
               Frameless: false
-            - PC: "0xd04691"
+            - PC: "0xd047b1"
               Frameless: false
-            - PC: "0xd047d2"
+            - PC: "0xd048f2"
               Frameless: false
-            - PC: "0xd0485c"
+            - PC: "0xd0497c"
               Frameless: false
-            - PC: "0xd0492f"
+            - PC: "0xd04a4f"
               Frameless: false
           Condition: null
     - id: testCaptureExprLineWithTemplate
@@ -373,20 +373,20 @@ Probes:
       segments: [x=, {json: {ref: x}, dsl: x}]
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1362 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1363 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
-            - PC: "0xd0460e"
+            - PC: "0xd0472e"
               Frameless: false
-            - PC: "0xd04691"
+            - PC: "0xd047b1"
               Frameless: false
-            - PC: "0xd047d2"
+            - PC: "0xd048f2"
               Frameless: false
-            - PC: "0xd0485c"
+            - PC: "0xd0497c"
               Frameless: false
-            - PC: "0xd0492f"
+            - PC: "0xd04a4f"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -409,11 +409,11 @@ Probes:
           expr: {dsl: x, json: {ref: x}}
         - name: w_val
           expr: {dsl: w, json: {ref: w}}
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 85}
       events:
         - Kind: Entry
-          Type: 1227 EventRootType Probe[main.testCombinedString]
-          InjectionPoints: [{PC: "0xd06f80", Frameless: true}]
+          Type: 1228 EventRootType Probe[main.testCombinedString]
+          InjectionPoints: [{PC: "0xd070a0", Frameless: true}]
           Condition: null
     - id: testCaptureExprWithTemplate
       version: 0
@@ -427,11 +427,11 @@ Probes:
           expr: {dsl: x, json: {ref: x}}
         - name: w_val
           expr: {dsl: w, json: {ref: w}}
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 85}
       events:
         - Kind: Entry
-          Type: 1228 EventRootType Probe[main.testCombinedString]
-          InjectionPoints: [{PC: "0xd06f80", Frameless: true}]
+          Type: 1229 EventRootType Probe[main.testCombinedString]
+          InjectionPoints: [{PC: "0xd070a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: x={x}
@@ -449,11 +449,11 @@ Probes:
       template: '{c}'
       segments: [{json: {ref: c}, dsl: c}]
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 88}
       events:
         - Kind: Entry
-          Type: 1232 EventRootType Probe[main.testChannel]
-          InjectionPoints: [{PC: "0xd07340", Frameless: true}]
+          Type: 1233 EventRootType Probe[main.testChannel]
+          InjectionPoints: [{PC: "0xd07460", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{c}'
@@ -478,11 +478,11 @@ Probes:
         - json: {ref: y}
           dsl: y
       captureSnapshot: true
-      subprogram: {subprogram: 83}
+      subprogram: {subprogram: 84}
       events:
         - Kind: Entry
-          Type: 1226 EventRootType Probe[main.testCombinedByte]
-          InjectionPoints: [{PC: "0xd06f40", Frameless: true}]
+          Type: 1227 EventRootType Probe[main.testCombinedByte]
+          InjectionPoints: [{PC: "0xd07060", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{w}, {x}, {y}'
@@ -509,11 +509,11 @@ Probes:
       template: '{t}'
       segments: [{json: {ref: t}, dsl: t}]
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 96}
       events:
         - Kind: Entry
-          Type: 1240 EventRootType Probe[main.testCycle]
-          InjectionPoints: [{PC: "0xd07720", Frameless: true}]
+          Type: 1241 EventRootType Probe[main.testCycle]
+          InjectionPoints: [{PC: "0xd07840", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{t}'
@@ -530,11 +530,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 42}
+      subprogram: {subprogram: 43}
       events:
         - Kind: Entry
-          Type: 1171 EventRootType Probe[main.testDeepMap1]
-          InjectionPoints: [{PC: "0xd03b20", Frameless: true}]
+          Type: 1172 EventRootType Probe[main.testDeepMap1]
+          InjectionPoints: [{PC: "0xd03c40", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -551,11 +551,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 43}
+      subprogram: {subprogram: 44}
       events:
         - Kind: Entry
-          Type: 1172 EventRootType Probe[main.testDeepMap7]
-          InjectionPoints: [{PC: "0xd03b40", Frameless: true}]
+          Type: 1173 EventRootType Probe[main.testDeepMap7]
+          InjectionPoints: [{PC: "0xd03c60", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -572,11 +572,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 38}
+      subprogram: {subprogram: 39}
       events:
         - Kind: Entry
-          Type: 1167 EventRootType Probe[main.testDeepPtr1]
-          InjectionPoints: [{PC: "0xd03800", Frameless: true}]
+          Type: 1168 EventRootType Probe[main.testDeepPtr1]
+          InjectionPoints: [{PC: "0xd03920", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -593,11 +593,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 39}
+      subprogram: {subprogram: 40}
       events:
         - Kind: Entry
-          Type: 1168 EventRootType Probe[main.testDeepPtr7]
-          InjectionPoints: [{PC: "0xd03820", Frameless: true}]
+          Type: 1169 EventRootType Probe[main.testDeepPtr7]
+          InjectionPoints: [{PC: "0xd03940", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -614,11 +614,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 40}
+      subprogram: {subprogram: 41}
       events:
         - Kind: Entry
-          Type: 1169 EventRootType Probe[main.testDeepSlice1]
-          InjectionPoints: [{PC: "0xd039a0", Frameless: true}]
+          Type: 1170 EventRootType Probe[main.testDeepSlice1]
+          InjectionPoints: [{PC: "0xd03ac0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -635,11 +635,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 41}
+      subprogram: {subprogram: 42}
       events:
         - Kind: Entry
-          Type: 1170 EventRootType Probe[main.testDeepSlice7]
-          InjectionPoints: [{PC: "0xd039c0", Frameless: true}]
+          Type: 1171 EventRootType Probe[main.testDeepSlice7]
+          InjectionPoints: [{PC: "0xd03ae0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -656,11 +656,11 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 131}
+      subprogram: {subprogram: 132}
       events:
         - Kind: Entry
-          Type: 1320 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0xd0a040", Frameless: true}]
+          Type: 1321 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0xd0a160", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{u}'
@@ -682,11 +682,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 134}
+      subprogram: {subprogram: 135}
       events:
         - Kind: Entry
-          Type: 1323 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0xd0a0a0", Frameless: true}]
+          Type: 1324 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0xd0a1c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}, {a}'
@@ -709,11 +709,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 150}
+      subprogram: {subprogram: 151}
       events:
         - Kind: Entry
-          Type: 1346 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0xd0a660", Frameless: true}]
+          Type: 1347 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0xd0a780", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -730,11 +730,11 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 156}
+      subprogram: {subprogram: 157}
       events:
         - Kind: Entry
-          Type: 1359 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0xd0aae0", Frameless: true}]
+          Type: 1360 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0xd0ac00", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -750,11 +750,11 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 157}
+      subprogram: {subprogram: 158}
       events:
         - Kind: Entry
-          Type: 1360 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0xd0ab00", Frameless: true}]
+          Type: 1361 EventRootType Probe[main.testEmptyStructPointer]
+          InjectionPoints: [{PC: "0xd0ac20", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -771,11 +771,11 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 57}
+      subprogram: {subprogram: 58}
       events:
         - Kind: Entry
-          Type: 1198 EventRootType Probe[main.testError]
-          InjectionPoints: [{PC: "0xd04e60", Frameless: true}]
+          Type: 1199 EventRootType Probe[main.testError]
+          InjectionPoints: [{PC: "0xd04f80", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -784,6 +784,45 @@ Probes:
               DSL: e
               EventKind: Entry
               EventExpressionIndex: 1
+    - id: testErrorAtLine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testErrorAtLine
+        sourceFile: complex.go
+        lines: ["108"]
+      tags:
+        - config_diff:arch=amd64,toolchain=go1.26rc1
+        - skip_integration:arch=arm64,toolchain=go1.25.0
+      sampling: {snapshotsPerSecond: 100}
+      template: x={x}, err={err}
+      segments:
+        - x=
+        - json: {ref: x}
+          dsl: x
+        - ', err='
+        - json: {ref: err}
+          dsl: err
+      captureSnapshot: true
+      subprogram: {subprogram: 38}
+      events:
+        - Kind: Line
+          Type: 1167 EventRootType Probe[main.testErrorAtLine]Line
+          InjectionPoints: [{PC: "0xd037db", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: x={x}, err={err}
+        Segments:
+            - x=
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Line
+              EventExpressionIndex: 2
+            - ', err='
+            - JSON: {Ref: err}
+              DSL: err
+              EventKind: Line
+              EventExpressionIndex: 4
     - id: testEsotericHeap
       version: 0
       type: LOG_PROBE
@@ -792,15 +831,15 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 48}
+      subprogram: {subprogram: 49}
       events:
         - Kind: Entry
-          Type: 1180 EventRootType Probe[main.testEsotericHeap]
-          InjectionPoints: [{PC: "0xd0436a", Frameless: false}]
+          Type: 1181 EventRootType Probe[main.testEsotericHeap]
+          InjectionPoints: [{PC: "0xd0448a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1181 EventRootType Probe[main.testEsotericHeap]Return
-          InjectionPoints: [{PC: "0xd043ac", Frameless: false}]
+          Type: 1182 EventRootType Probe[main.testEsotericHeap]Return
+          InjectionPoints: [{PC: "0xd044cc", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -817,15 +856,15 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 47}
+      subprogram: {subprogram: 48}
       events:
         - Kind: Entry
-          Type: 1178 EventRootType Probe[main.testEsotericStack]
-          InjectionPoints: [{PC: "0xd0424e", Frameless: false}]
+          Type: 1179 EventRootType Probe[main.testEsotericStack]
+          InjectionPoints: [{PC: "0xd0436e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1179 EventRootType Probe[main.testEsotericStack]Return
-          InjectionPoints: [{PC: "0xd042db", Frameless: false}]
+          Type: 1180 EventRootType Probe[main.testEsotericStack]Return
+          InjectionPoints: [{PC: "0xd043fb", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -842,15 +881,15 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 53}
+      subprogram: {subprogram: 54}
       events:
         - Kind: Entry
-          Type: 1190 EventRootType Probe[main.testFrameless]
-          InjectionPoints: [{PC: "0xd04ac0", Frameless: true}]
+          Type: 1191 EventRootType Probe[main.testFrameless]
+          InjectionPoints: [{PC: "0xd04be0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1191 EventRootType Probe[main.testFrameless]Return
-          InjectionPoints: [{PC: "0xd04ac5", Frameless: true}]
+          Type: 1192 EventRootType Probe[main.testFrameless]Return
+          InjectionPoints: [{PC: "0xd04be5", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -867,15 +906,15 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 54}
+      subprogram: {subprogram: 55}
       events:
         - Kind: Entry
-          Type: 1192 EventRootType Probe[main.testFramelessArray]
-          InjectionPoints: [{PC: "0xd04ae4", Frameless: false}]
+          Type: 1193 EventRootType Probe[main.testFramelessArray]
+          InjectionPoints: [{PC: "0xd04c04", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1193 EventRootType Probe[main.testFramelessArray]Return
-          InjectionPoints: [{PC: "0xd04b1d", Frameless: false}]
+          Type: 1194 EventRootType Probe[main.testFramelessArray]Return
+          InjectionPoints: [{PC: "0xd04c3d", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -895,11 +934,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 54}
+      subprogram: {subprogram: 55}
       events:
         - Kind: Line
-          Type: 1194 EventRootType Probe[main.testFramelessArray]Line
-          InjectionPoints: [{PC: "0xd04ae8", Frameless: false}]
+          Type: 1195 EventRootType Probe[main.testFramelessArray]Line
+          InjectionPoints: [{PC: "0xd04c08", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -916,15 +955,15 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 49}
+      subprogram: {subprogram: 50}
       events:
         - Kind: Entry
-          Type: 1182 EventRootType Probe[main.testInlinedBA]
-          InjectionPoints: [{PC: "0xd047aa", Frameless: false}]
+          Type: 1183 EventRootType Probe[main.testInlinedBA]
+          InjectionPoints: [{PC: "0xd048ca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1183 EventRootType Probe[main.testInlinedBA]Return
-          InjectionPoints: [{PC: "0xd0480e", Frameless: false}]
+          Type: 1184 EventRootType Probe[main.testInlinedBA]Return
+          InjectionPoints: [{PC: "0xd0492e", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -946,15 +985,15 @@ Probes:
         - json: {ref: y}
           dsl: y
       captureSnapshot: true
-      subprogram: {subprogram: 50}
+      subprogram: {subprogram: 51}
       events:
         - Kind: Entry
-          Type: 1184 EventRootType Probe[main.testInlinedBB]
-          InjectionPoints: [{PC: "0xd0484e", Frameless: false}]
+          Type: 1185 EventRootType Probe[main.testInlinedBB]
+          InjectionPoints: [{PC: "0xd0496e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1185 EventRootType Probe[main.testInlinedBB]Return
-          InjectionPoints: [{PC: "0xd048de", Frameless: false}]
+          Type: 1186 EventRootType Probe[main.testInlinedBB]Return
+          InjectionPoints: [{PC: "0xd049fe", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}, {y}'
@@ -976,15 +1015,15 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 51}
+      subprogram: {subprogram: 52}
       events:
         - Kind: Entry
-          Type: 1186 EventRootType Probe[main.testInlinedBBA]
-          InjectionPoints: [{PC: "0xd0492a", Frameless: false}]
+          Type: 1187 EventRootType Probe[main.testInlinedBBA]
+          InjectionPoints: [{PC: "0xd04a4a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1187 EventRootType Probe[main.testInlinedBBA]Return
-          InjectionPoints: [{PC: "0xd0496b", Frameless: false}]
+          Type: 1188 EventRootType Probe[main.testInlinedBBA]Return
+          InjectionPoints: [{PC: "0xd04a8b", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1001,11 +1040,11 @@ Probes:
       template: testInlinedBBB
       segments: [testInlinedBBB]
       captureSnapshot: true
-      subprogram: {subprogram: 159}
+      subprogram: {subprogram: 160}
       events:
         - Kind: Entry
-          Type: 1366 EventRootType Probe[main.testInlinedBBB]
-          InjectionPoints: [{PC: "0xd048a6", Frameless: false}]
+          Type: 1367 EventRootType Probe[main.testInlinedBBB]
+          InjectionPoints: [{PC: "0xd049c6", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBBB
@@ -1018,15 +1057,15 @@ Probes:
       template: testInlinedBC
       segments: [testInlinedBC]
       captureSnapshot: true
-      subprogram: {subprogram: 52}
+      subprogram: {subprogram: 53}
       events:
         - Kind: Entry
-          Type: 1188 EventRootType Probe[main.testInlinedBC]
-          InjectionPoints: [{PC: "0xd049ae", Frameless: false}]
+          Type: 1189 EventRootType Probe[main.testInlinedBC]
+          InjectionPoints: [{PC: "0xd04ace", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1189 EventRootType Probe[main.testInlinedBC]Return
-          InjectionPoints: [{PC: "0xd04a9e", Frameless: false}]
+          Type: 1190 EventRootType Probe[main.testInlinedBC]Return
+          InjectionPoints: [{PC: "0xd04bbe", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBC
@@ -1039,11 +1078,11 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Entry
-          Type: 1367 EventRootType Probe[main.testInlinedBCA]
-          InjectionPoints: [{PC: "0xd049b3", Frameless: false}]
+          Type: 1368 EventRootType Probe[main.testInlinedBCA]
+          InjectionPoints: [{PC: "0xd04ad3", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBCA
@@ -1059,11 +1098,11 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Line
-          Type: 1368 EventRootType Probe[main.testInlinedBCA]Line
-          InjectionPoints: [{PC: "0xd049b3", Frameless: false}]
+          Type: 1369 EventRootType Probe[main.testInlinedBCA]Line
+          InjectionPoints: [{PC: "0xd04ad3", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBCA
@@ -1076,11 +1115,11 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Entry
-          Type: 1369 EventRootType Probe[main.testInlinedBCB]
-          InjectionPoints: [{PC: "0xd04a66", Frameless: false}]
+          Type: 1370 EventRootType Probe[main.testInlinedBCB]
+          InjectionPoints: [{PC: "0xd04b86", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBCB
@@ -1096,11 +1135,11 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Line
-          Type: 1370 EventRootType Probe[main.testInlinedBCB]Line
-          InjectionPoints: [{PC: "0xd04a66", Frameless: false}]
+          Type: 1371 EventRootType Probe[main.testInlinedBCB]Line
+          InjectionPoints: [{PC: "0xd04b86", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBCB
@@ -1113,14 +1152,14 @@ Probes:
       template: testInlinedFuncFromOtherPackage
       segments: [testInlinedFuncFromOtherPackage]
       captureSnapshot: true
-      subprogram: {subprogram: 165}
+      subprogram: {subprogram: 166}
       events:
         - Kind: Entry
-          Type: 1376 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
+          Type: 1377 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
           InjectionPoints:
             - PC: "0xd02932"
               Frameless: true
-            - PC: "0xd0548b"
+            - PC: "0xd055ab"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -1135,25 +1174,25 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Entry
-          Type: 1363 EventRootType Probe[main.testInlinedPrint]
+          Type: 1364 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
-            - PC: "0xd0460a"
+            - PC: "0xd0472a"
               Frameless: false
-            - PC: "0xd04691"
+            - PC: "0xd047b1"
               Frameless: false
-            - PC: "0xd047d2"
+            - PC: "0xd048f2"
               Frameless: false
-            - PC: "0xd0485c"
+            - PC: "0xd0497c"
               Frameless: false
-            - PC: "0xd0492f"
+            - PC: "0xd04a4f"
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1364 EventRootType Probe[main.testInlinedPrint]Return
-          InjectionPoints: [{PC: "0xd0464a", Frameless: false}]
+          Type: 1365 EventRootType Probe[main.testInlinedPrint]Return
+          InjectionPoints: [{PC: "0xd0476a", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1173,20 +1212,20 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1365 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1366 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
-            - PC: "0xd0460e"
+            - PC: "0xd0472e"
               Frameless: false
-            - PC: "0xd04691"
+            - PC: "0xd047b1"
               Frameless: false
-            - PC: "0xd047d2"
+            - PC: "0xd048f2"
               Frameless: false
-            - PC: "0xd0485c"
+            - PC: "0xd0497c"
               Frameless: false
-            - PC: "0xd0492f"
+            - PC: "0xd04a4f"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -1204,11 +1243,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 162}
+      subprogram: {subprogram: 163}
       events:
         - Kind: Entry
-          Type: 1371 EventRootType Probe[main.testInlinedSq]
-          InjectionPoints: [{PC: "0xd04ac1", Frameless: true}]
+          Type: 1372 EventRootType Probe[main.testInlinedSq]
+          InjectionPoints: [{PC: "0xd04be1", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1228,11 +1267,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 162}
+      subprogram: {subprogram: 163}
       events:
         - Kind: Line
-          Type: 1372 EventRootType Probe[main.testInlinedSq]Line
-          InjectionPoints: [{PC: "0xd04ac1", Frameless: true}]
+          Type: 1373 EventRootType Probe[main.testInlinedSq]Line
+          InjectionPoints: [{PC: "0xd04be1", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1250,14 +1289,14 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 163}
+      subprogram: {subprogram: 164}
       events:
         - Kind: Entry
-          Type: 1373 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1374 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
-            - PC: "0xd04b05"
+            - PC: "0xd04c25"
               Frameless: false
-            - PC: "0xd04ba5"
+            - PC: "0xd04cc5"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -1380,11 +1419,11 @@ Probes:
       template: '{b}'
       segments: [{json: {ref: b}, dsl: b}]
       captureSnapshot: true
-      subprogram: {subprogram: 55}
+      subprogram: {subprogram: 56}
       events:
         - Kind: Entry
-          Type: 1195 EventRootType Probe[main.testInterface]
-          InjectionPoints: [{PC: "0xd04dc0", Frameless: true}]
+          Type: 1196 EventRootType Probe[main.testInterface]
+          InjectionPoints: [{PC: "0xd04ee0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{b}'
@@ -1400,15 +1439,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 121}
+      subprogram: {subprogram: 122}
       events:
         - Kind: Entry
-          Type: 1301 EventRootType Probe[main.testLargeArgAndReturn]
-          InjectionPoints: [{PC: "0xd08dee", Frameless: false}]
+          Type: 1302 EventRootType Probe[main.testLargeArgAndReturn]
+          InjectionPoints: [{PC: "0xd08f0e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1302 EventRootType Probe[main.testLargeArgAndReturn]Return
-          InjectionPoints: [{PC: "0xd08f33", Frameless: false}]
+          Type: 1303 EventRootType Probe[main.testLargeArgAndReturn]Return
+          InjectionPoints: [{PC: "0xd09053", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -1425,11 +1464,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 90}
       events:
         - Kind: Entry
-          Type: 1234 EventRootType Probe[main.testLinkedList]
-          InjectionPoints: [{PC: "0xd07540", Frameless: true}]
+          Type: 1235 EventRootType Probe[main.testLinkedList]
+          InjectionPoints: [{PC: "0xd07660", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -1444,16 +1483,16 @@ Probes:
       where:
         methodName: main.testLongFunctionWithChangingState
         sourceFile: complex.go
-        lines: ["211"]
+        lines: ["230"]
       sampling: {snapshotsPerSecond: 100}
       template: testLongFunctionWithChangingState
       segments: [testLongFunctionWithChangingState]
       captureSnapshot: true
-      subprogram: {subprogram: 46}
+      subprogram: {subprogram: 47}
       events:
         - Kind: Line
-          Type: 1175 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-          InjectionPoints: [{PC: "0xd03bba", Frameless: false}]
+          Type: 1176 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          InjectionPoints: [{PC: "0xd03cda", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testLongFunctionWithChangingState
@@ -1464,17 +1503,17 @@ Probes:
       where:
         methodName: main.testLongFunctionWithChangingState
         sourceFile: complex.go
-        lines: ["218"]
+        lines: ["237"]
       tags: ['version_diff:go1.26rc1']
       sampling: {snapshotsPerSecond: 100}
       template: testLongFunctionWithChangingState
       segments: [testLongFunctionWithChangingState]
       captureSnapshot: true
-      subprogram: {subprogram: 46}
+      subprogram: {subprogram: 47}
       events:
         - Kind: Line
-          Type: 1176 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-          InjectionPoints: [{PC: "0xd03c6d", Frameless: false}]
+          Type: 1177 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          InjectionPoints: [{PC: "0xd03d8d", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testLongFunctionWithChangingState
@@ -1485,17 +1524,17 @@ Probes:
       where:
         methodName: main.testLongFunctionWithChangingState
         sourceFile: complex.go
-        lines: ["223"]
+        lines: ["242"]
       tags: ['version_diff:go1.26rc1']
       sampling: {snapshotsPerSecond: 100}
       template: testLongFunctionWithChangingState
       segments: [testLongFunctionWithChangingState]
       captureSnapshot: true
-      subprogram: {subprogram: 46}
+      subprogram: {subprogram: 47}
       events:
         - Kind: Line
-          Type: 1177 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-          InjectionPoints: [{PC: "0xd03d34", Frameless: false}]
+          Type: 1178 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          InjectionPoints: [{PC: "0xd03e54", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testLongFunctionWithChangingState
@@ -1533,15 +1572,15 @@ Probes:
         - json: {ref: i}
           dsl: i
       captureSnapshot: true
-      subprogram: {subprogram: 124}
+      subprogram: {subprogram: 125}
       events:
         - Kind: Entry
-          Type: 1307 EventRootType Probe[main.testManyArgsArrayReturn]
-          InjectionPoints: [{PC: "0xd09293", Frameless: false}]
+          Type: 1308 EventRootType Probe[main.testManyArgsArrayReturn]
+          InjectionPoints: [{PC: "0xd093b3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1308 EventRootType Probe[main.testManyArgsArrayReturn]Return
-          InjectionPoints: [{PC: "0xd094a2", Frameless: false}]
+          Type: 1309 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          InjectionPoints: [{PC: "0xd095c2", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -1598,11 +1637,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 64}
+      subprogram: {subprogram: 65}
       events:
         - Kind: Entry
-          Type: 1206 EventRootType Probe[main.testMapArrayToArray]
-          InjectionPoints: [{PC: "0xd055c0", Frameless: true}]
+          Type: 1207 EventRootType Probe[main.testMapArrayToArray]
+          InjectionPoints: [{PC: "0xd056e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1619,11 +1658,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 70}
+      subprogram: {subprogram: 71}
       events:
         - Kind: Entry
-          Type: 1213 EventRootType Probe[main.testMapEmbeddedMaps]
-          InjectionPoints: [{PC: "0xd05680", Frameless: true}]
+          Type: 1214 EventRootType Probe[main.testMapEmbeddedMaps]
+          InjectionPoints: [{PC: "0xd057a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1640,11 +1679,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 80}
+      subprogram: {subprogram: 81}
       events:
         - Kind: Entry
-          Type: 1223 EventRootType Probe[main.testMapEmptyKey]
-          InjectionPoints: [{PC: "0xd057c0", Frameless: true}]
+          Type: 1224 EventRootType Probe[main.testMapEmptyKey]
+          InjectionPoints: [{PC: "0xd058e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1661,11 +1700,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 82}
+      subprogram: {subprogram: 83}
       events:
         - Kind: Entry
-          Type: 1225 EventRootType Probe[main.testMapEmptyKeyAndValue]
-          InjectionPoints: [{PC: "0xd05800", Frameless: true}]
+          Type: 1226 EventRootType Probe[main.testMapEmptyKeyAndValue]
+          InjectionPoints: [{PC: "0xd05920", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1682,11 +1721,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 81}
+      subprogram: {subprogram: 82}
       events:
         - Kind: Entry
-          Type: 1224 EventRootType Probe[main.testMapEmptyValue]
-          InjectionPoints: [{PC: "0xd057e0", Frameless: true}]
+          Type: 1225 EventRootType Probe[main.testMapEmptyValue]
+          InjectionPoints: [{PC: "0xd05900", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1703,11 +1742,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 68}
+      subprogram: {subprogram: 69}
       events:
         - Kind: Entry
-          Type: 1210 EventRootType Probe[main.testMapIntToInt]
-          InjectionPoints: [{PC: "0xd05640", Frameless: true}]
+          Type: 1211 EventRootType Probe[main.testMapIntToInt]
+          InjectionPoints: [{PC: "0xd05760", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1724,11 +1763,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 79}
+      subprogram: {subprogram: 80}
       events:
         - Kind: Entry
-          Type: 1222 EventRootType Probe[main.testMapLargeKeyLargeValue]
-          InjectionPoints: [{PC: "0xd057a0", Frameless: true}]
+          Type: 1223 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          InjectionPoints: [{PC: "0xd058c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1745,11 +1784,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 78}
+      subprogram: {subprogram: 79}
       events:
         - Kind: Entry
-          Type: 1221 EventRootType Probe[main.testMapLargeKeySmallValue]
-          InjectionPoints: [{PC: "0xd05780", Frameless: true}]
+          Type: 1222 EventRootType Probe[main.testMapLargeKeySmallValue]
+          InjectionPoints: [{PC: "0xd058a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1768,11 +1807,11 @@ Probes:
         - json: {ref: redactMyEntries}
           dsl: redactMyEntries
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 70}
       events:
         - Kind: Entry
-          Type: 1211 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0xd05660", Frameless: true}]
+          Type: 1212 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0xd05780", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{redactMyEntries}'
@@ -1791,11 +1830,11 @@ Probes:
         - json: {ref: redactMyEntries}
           dsl: redactMyEntries
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 70}
       events:
         - Kind: Entry
-          Type: 1212 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0xd05660", Frameless: true}]
+          Type: 1213 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0xd05780", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{redactMyEntries}'
@@ -1812,11 +1851,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 77}
+      subprogram: {subprogram: 78}
       events:
         - Kind: Entry
-          Type: 1220 EventRootType Probe[main.testMapSmallKeyLargeValue]
-          InjectionPoints: [{PC: "0xd05760", Frameless: true}]
+          Type: 1221 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          InjectionPoints: [{PC: "0xd05880", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1833,11 +1872,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 76}
+      subprogram: {subprogram: 77}
       events:
         - Kind: Entry
-          Type: 1219 EventRootType Probe[main.testMapSmallKeySmallValue]
-          InjectionPoints: [{PC: "0xd05740", Frameless: true}]
+          Type: 1220 EventRootType Probe[main.testMapSmallKeySmallValue]
+          InjectionPoints: [{PC: "0xd05860", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1854,11 +1893,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 62}
+      subprogram: {subprogram: 63}
       events:
         - Kind: Entry
-          Type: 1204 EventRootType Probe[main.testMapStringToInt]
-          InjectionPoints: [{PC: "0xd05580", Frameless: true}]
+          Type: 1205 EventRootType Probe[main.testMapStringToInt]
+          InjectionPoints: [{PC: "0xd056a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1875,11 +1914,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 63}
+      subprogram: {subprogram: 64}
       events:
         - Kind: Entry
-          Type: 1205 EventRootType Probe[main.testMapStringToSlice]
-          InjectionPoints: [{PC: "0xd055a0", Frameless: true}]
+          Type: 1206 EventRootType Probe[main.testMapStringToSlice]
+          InjectionPoints: [{PC: "0xd056c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1896,11 +1935,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 61}
+      subprogram: {subprogram: 62}
       events:
         - Kind: Entry
-          Type: 1203 EventRootType Probe[main.testMapStringToStruct]
-          InjectionPoints: [{PC: "0xd05560", Frameless: true}]
+          Type: 1204 EventRootType Probe[main.testMapStringToStruct]
+          InjectionPoints: [{PC: "0xd05680", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1917,11 +1956,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 71}
+      subprogram: {subprogram: 72}
       events:
         - Kind: Entry
-          Type: 1214 EventRootType Probe[main.testMapWithLinkedList]
-          InjectionPoints: [{PC: "0xd056a0", Frameless: true}]
+          Type: 1215 EventRootType Probe[main.testMapWithLinkedList]
+          InjectionPoints: [{PC: "0xd057c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1938,11 +1977,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 74}
+      subprogram: {subprogram: 75}
       events:
         - Kind: Entry
-          Type: 1217 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-          InjectionPoints: [{PC: "0xd05700", Frameless: true}]
+          Type: 1218 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          InjectionPoints: [{PC: "0xd05820", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1959,11 +1998,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 75}
+      subprogram: {subprogram: 76}
       events:
         - Kind: Entry
-          Type: 1218 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-          InjectionPoints: [{PC: "0xd05720", Frameless: true}]
+          Type: 1219 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          InjectionPoints: [{PC: "0xd05840", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1980,11 +2019,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 72}
+      subprogram: {subprogram: 73}
       events:
         - Kind: Entry
-          Type: 1215 EventRootType Probe[main.testMapWithSmallValue]
-          InjectionPoints: [{PC: "0xd056c0", Frameless: true}]
+          Type: 1216 EventRootType Probe[main.testMapWithSmallValue]
+          InjectionPoints: [{PC: "0xd057e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -2003,11 +2042,11 @@ Probes:
         - json: {ref: redactMyEntries}
           dsl: redactMyEntries
       captureSnapshot: true
-      subprogram: {subprogram: 73}
+      subprogram: {subprogram: 74}
       events:
         - Kind: Entry
-          Type: 1216 EventRootType Probe[main.testMapWithSmallValueMassive]
-          InjectionPoints: [{PC: "0xd056e0", Frameless: true}]
+          Type: 1217 EventRootType Probe[main.testMapWithSmallValueMassive]
+          InjectionPoints: [{PC: "0xd05800", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{redactMyEntries}'
@@ -2024,11 +2063,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 148}
+      subprogram: {subprogram: 149}
       events:
         - Kind: Entry
-          Type: 1343 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0xd0a620", Frameless: true}]
+          Type: 1344 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0xd0a740", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -2046,11 +2085,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 148}
+      subprogram: {subprogram: 149}
       events:
         - Kind: Entry
-          Type: 1344 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0xd0a620", Frameless: true}]
+          Type: 1345 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0xd0a740", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -2092,15 +2131,15 @@ Probes:
         - json: {ref: s}
           dsl: s
       captureSnapshot: true
-      subprogram: {subprogram: 125}
+      subprogram: {subprogram: 126}
       events:
         - Kind: Entry
-          Type: 1309 EventRootType Probe[main.testMixedArgsStackReturn]
-          InjectionPoints: [{PC: "0xd09533", Frameless: false}]
+          Type: 1310 EventRootType Probe[main.testMixedArgsStackReturn]
+          InjectionPoints: [{PC: "0xd09653", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1310 EventRootType Probe[main.testMixedArgsStackReturn]Return
-          InjectionPoints: [{PC: "0xd0976b", Frameless: false}]
+          Type: 1311 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          InjectionPoints: [{PC: "0xd0988b", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -2161,15 +2200,15 @@ Probes:
         - json: {ref: b}
           dsl: b
       captureSnapshot: true
-      subprogram: {subprogram: 127}
+      subprogram: {subprogram: 128}
       events:
         - Kind: Entry
-          Type: 1313 EventRootType Probe[main.testMultipleArrayArgs]
-          InjectionPoints: [{PC: "0xd098ae", Frameless: false}]
+          Type: 1314 EventRootType Probe[main.testMultipleArrayArgs]
+          InjectionPoints: [{PC: "0xd099ce", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1314 EventRootType Probe[main.testMultipleArrayArgs]Return
-          InjectionPoints: [{PC: "0xd09976", Frameless: false}]
+          Type: 1315 EventRootType Probe[main.testMultipleArrayArgs]Return
+          InjectionPoints: [{PC: "0xd09a96", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}'
@@ -2195,15 +2234,15 @@ Probes:
         - json: {ref: s2}
           dsl: s2
       captureSnapshot: true
-      subprogram: {subprogram: 123}
+      subprogram: {subprogram: 124}
       events:
         - Kind: Entry
-          Type: 1305 EventRootType Probe[main.testMultipleLargeArgs]
-          InjectionPoints: [{PC: "0xd0904e", Frameless: false}]
+          Type: 1306 EventRootType Probe[main.testMultipleLargeArgs]
+          InjectionPoints: [{PC: "0xd0916e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1306 EventRootType Probe[main.testMultipleLargeArgs]Return
-          InjectionPoints: [{PC: "0xd0926a", Frameless: false}]
+          Type: 1307 EventRootType Probe[main.testMultipleLargeArgs]Return
+          InjectionPoints: [{PC: "0xd0938a", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{s1}, {s2}'
@@ -2224,15 +2263,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1259 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0xd0840e", Frameless: false}]
+          Type: 1260 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xd0852e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1260 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0xd084af", Frameless: false}]
+          Type: 1261 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xd085cf", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2263,11 +2302,11 @@ Probes:
         - json: {ref: e}
           dsl: e
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 86}
       events:
         - Kind: Entry
-          Type: 1229 EventRootType Probe[main.testMultipleSimpleParams]
-          InjectionPoints: [{PC: "0xd07100", Frameless: true}]
+          Type: 1230 EventRootType Probe[main.testMultipleSimpleParams]
+          InjectionPoints: [{PC: "0xd07220", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}, {d}, {e}'
@@ -2303,15 +2342,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1255 EventRootType Probe[main.testNamedReturn]
-          InjectionPoints: [{PC: "0xd0836a", Frameless: false}]
+          Type: 1256 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0xd0848a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1256 EventRootType Probe[main.testNamedReturn]Return
-          InjectionPoints: [{PC: "0xd083d5", Frameless: false}]
+          Type: 1257 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0xd084f5", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2333,15 +2372,15 @@ Probes:
         - json: {ref: result}
           dsl: result
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1257 EventRootType Probe[main.testNamedReturn]
-          InjectionPoints: [{PC: "0xd0836a", Frameless: false}]
+          Type: 1258 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0xd0848a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1258 EventRootType Probe[main.testNamedReturn]Return
-          InjectionPoints: [{PC: "0xd083d5", Frameless: false}]
+          Type: 1259 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0xd084f5", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: Parameter {i} * 2 = result {result}
@@ -2364,11 +2403,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 155}
+      subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1355 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0xd0aa60", Frameless: true}]
+          Type: 1356 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0xd0ab80", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -2388,11 +2427,11 @@ Probes:
             getmember: [{getmember: [{ref: x}, nested]}, anotherString]
           dsl: x.nested.anotherString
       captureSnapshot: false
-      subprogram: {subprogram: 155}
+      subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1356 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0xd0aa60", Frameless: true}]
+          Type: 1357 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0xd0ab80", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x.nested.anotherString}'
@@ -2418,11 +2457,11 @@ Probes:
         - json: {getmember: [{ref: x}, notAMember]}
           dsl: x.notAMember
       captureSnapshot: false
-      subprogram: {subprogram: 155}
+      subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1357 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0xd0aa60", Frameless: true}]
+          Type: 1358 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0xd0ab80", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -2442,11 +2481,11 @@ Probes:
         - json: {getmember: [{ref: x}, nested]}
           dsl: x.nested
       captureSnapshot: false
-      subprogram: {subprogram: 155}
+      subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1358 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0xd0aa60", Frameless: true}]
+          Type: 1359 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0xd0ab80", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x.nested}'
@@ -2468,11 +2507,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 95}
       events:
         - Kind: Entry
-          Type: 1239 EventRootType Probe[main.testNilPointer]
-          InjectionPoints: [{PC: "0xd076e0", Frameless: true}]
+          Type: 1240 EventRootType Probe[main.testNilPointer]
+          InjectionPoints: [{PC: "0xd07800", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{z}, {a}'
@@ -2494,11 +2533,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 138}
+      subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1327 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0xd0a120", Frameless: true}]
+          Type: 1328 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0xd0a240", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -2520,11 +2559,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 135}
+      subprogram: {subprogram: 136}
       events:
         - Kind: Entry
-          Type: 1324 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0xd0a0c0", Frameless: true}]
+          Type: 1325 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0xd0a1e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}, {a}'
@@ -2554,11 +2593,11 @@ Probes:
         - json: {ref: x}
           dsl: x
       captureSnapshot: true
-      subprogram: {subprogram: 137}
+      subprogram: {subprogram: 138}
       events:
         - Kind: Entry
-          Type: 1326 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0xd0a100", Frameless: true}]
+          Type: 1327 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0xd0a220", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {s}, {x}'
@@ -2585,11 +2624,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 147}
+      subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1342 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0xd0a600", Frameless: true}]
+          Type: 1343 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0xd0a720", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -2606,11 +2645,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 91}
       events:
         - Kind: Entry
-          Type: 1235 EventRootType Probe[main.testPointerLoop]
-          InjectionPoints: [{PC: "0xd07560", Frameless: true}]
+          Type: 1236 EventRootType Probe[main.testPointerLoop]
+          InjectionPoints: [{PC: "0xd07680", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -2627,11 +2666,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 67}
+      subprogram: {subprogram: 68}
       events:
         - Kind: Entry
-          Type: 1209 EventRootType Probe[main.testPointerToMap]
-          InjectionPoints: [{PC: "0xd05620", Frameless: true}]
+          Type: 1210 EventRootType Probe[main.testPointerToMap]
+          InjectionPoints: [{PC: "0xd05740", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -2648,11 +2687,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 89}
       events:
         - Kind: Entry
-          Type: 1233 EventRootType Probe[main.testPointerToSimpleStruct]
-          InjectionPoints: [{PC: "0xd07520", Frameless: true}]
+          Type: 1234 EventRootType Probe[main.testPointerToSimpleStruct]
+          InjectionPoints: [{PC: "0xd07640", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -2669,22 +2708,22 @@ Probes:
       template: '{v}'
       segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
         - Kind: Entry
-          Type: 1251 EventRootType Probe[main.testReturnsAny]
-          InjectionPoints: [{PC: "0xd07fee", Frameless: false}]
+          Type: 1252 EventRootType Probe[main.testReturnsAny]
+          InjectionPoints: [{PC: "0xd0810e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1252 EventRootType Probe[main.testReturnsAny]Return
+          Type: 1253 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints:
-            - PC: "0xd080a4"
+            - PC: "0xd081c4"
               Frameless: false
-            - PC: "0xd080df"
+            - PC: "0xd081ff"
               Frameless: false
-            - PC: "0xd081a2"
+            - PC: "0xd082c2"
               Frameless: false
-            - PC: "0xd081ac"
+            - PC: "0xd082cc"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2707,22 +2746,22 @@ Probes:
         - json: {ref: failed}
           dsl: failed
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 101}
       events:
         - Kind: Entry
-          Type: 1249 EventRootType Probe[main.testReturnsAnyAndError]
-          InjectionPoints: [{PC: "0xd07e8e", Frameless: false}]
+          Type: 1250 EventRootType Probe[main.testReturnsAnyAndError]
+          InjectionPoints: [{PC: "0xd07fae", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1250 EventRootType Probe[main.testReturnsAnyAndError]Return
+          Type: 1251 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
-            - PC: "0xd07ef8"
+            - PC: "0xd08018"
               Frameless: false
-            - PC: "0xd07f33"
+            - PC: "0xd08053"
               Frameless: false
-            - PC: "0xd07f67"
+            - PC: "0xd08087"
               Frameless: false
-            - PC: "0xd07f99"
+            - PC: "0xd080b9"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2744,15 +2783,15 @@ Probes:
       template: testReturnsArray
       segments: [testReturnsArray]
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 111}
       events:
         - Kind: Entry
-          Type: 1279 EventRootType Probe[main.testReturnsArray]
-          InjectionPoints: [{PC: "0xd0888a", Frameless: false}]
+          Type: 1280 EventRootType Probe[main.testReturnsArray]
+          InjectionPoints: [{PC: "0xd089aa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1280 EventRootType Probe[main.testReturnsArray]Return
-          InjectionPoints: [{PC: "0xd088ed", Frameless: false}]
+          Type: 1281 EventRootType Probe[main.testReturnsArray]Return
+          InjectionPoints: [{PC: "0xd08a0d", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsArray
@@ -2764,15 +2803,15 @@ Probes:
       template: testReturnsArrayOne
       segments: [testReturnsArrayOne]
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 112}
       events:
         - Kind: Entry
-          Type: 1281 EventRootType Probe[main.testReturnsArrayOne]
-          InjectionPoints: [{PC: "0xd0890a", Frameless: false}]
+          Type: 1282 EventRootType Probe[main.testReturnsArrayOne]
+          InjectionPoints: [{PC: "0xd08a2a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1282 EventRootType Probe[main.testReturnsArrayOne]Return
-          InjectionPoints: [{PC: "0xd0894b", Frameless: false}]
+          Type: 1283 EventRootType Probe[main.testReturnsArrayOne]Return
+          InjectionPoints: [{PC: "0xd08a6b", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsArrayOne
@@ -2784,15 +2823,15 @@ Probes:
       template: testReturnsArrayZero
       segments: [testReturnsArrayZero]
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 113}
       events:
         - Kind: Entry
-          Type: 1283 EventRootType Probe[main.testReturnsArrayZero]
-          InjectionPoints: [{PC: "0xd0896a", Frameless: false}]
+          Type: 1284 EventRootType Probe[main.testReturnsArrayZero]
+          InjectionPoints: [{PC: "0xd08a8a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1284 EventRootType Probe[main.testReturnsArrayZero]Return
-          InjectionPoints: [{PC: "0xd089a6", Frameless: false}]
+          Type: 1285 EventRootType Probe[main.testReturnsArrayZero]Return
+          InjectionPoints: [{PC: "0xd08ac6", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsArrayZero
@@ -2804,15 +2843,15 @@ Probes:
       template: testReturnsBacktrackInt
       segments: [testReturnsBacktrackInt]
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 115}
       events:
         - Kind: Entry
-          Type: 1287 EventRootType Probe[main.testReturnsBacktrackInt]
-          InjectionPoints: [{PC: "0xd08a4e", Frameless: false}]
+          Type: 1288 EventRootType Probe[main.testReturnsBacktrackInt]
+          InjectionPoints: [{PC: "0xd08b6e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1288 EventRootType Probe[main.testReturnsBacktrackInt]Return
-          InjectionPoints: [{PC: "0xd08aca", Frameless: false}]
+          Type: 1289 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          InjectionPoints: [{PC: "0xd08bea", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsBacktrackInt
@@ -2824,15 +2863,15 @@ Probes:
       template: testReturnsBoolAndUintptr
       segments: [testReturnsBoolAndUintptr]
       captureSnapshot: true
-      subprogram: {subprogram: 120}
+      subprogram: {subprogram: 121}
       events:
         - Kind: Entry
-          Type: 1299 EventRootType Probe[main.testReturnsBoolAndUintptr]
-          InjectionPoints: [{PC: "0xd08d8a", Frameless: false}]
+          Type: 1300 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          InjectionPoints: [{PC: "0xd08eaa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1300 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-          InjectionPoints: [{PC: "0xd08dd0", Frameless: false}]
+          Type: 1301 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          InjectionPoints: [{PC: "0xd08ef0", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsBoolAndUintptr
@@ -2844,15 +2883,15 @@ Probes:
       template: testReturnsComplex
       segments: [testReturnsComplex]
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 109}
       events:
         - Kind: Entry
-          Type: 1275 EventRootType Probe[main.testReturnsComplex]
-          InjectionPoints: [{PC: "0xd0874a", Frameless: false}]
+          Type: 1276 EventRootType Probe[main.testReturnsComplex]
+          InjectionPoints: [{PC: "0xd0886a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1276 EventRootType Probe[main.testReturnsComplex]Return
-          InjectionPoints: [{PC: "0xd087a6", Frameless: false}]
+          Type: 1277 EventRootType Probe[main.testReturnsComplex]Return
+          InjectionPoints: [{PC: "0xd088c6", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsComplex
@@ -2865,18 +2904,18 @@ Probes:
       template: '{failed}'
       segments: [{json: {ref: failed}, dsl: failed}]
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 100}
       events:
         - Kind: Entry
-          Type: 1247 EventRootType Probe[main.testReturnsError]
-          InjectionPoints: [{PC: "0xd07e2a", Frameless: false}]
+          Type: 1248 EventRootType Probe[main.testReturnsError]
+          InjectionPoints: [{PC: "0xd07f4a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1248 EventRootType Probe[main.testReturnsError]Return
+          Type: 1249 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
-            - PC: "0xd07e5a"
+            - PC: "0xd07f7a"
               Frameless: false
-            - PC: "0xd07e65"
+            - PC: "0xd07f85"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2893,15 +2932,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 97}
       events:
         - Kind: Entry
-          Type: 1241 EventRootType Probe[main.testReturnsInt]
-          InjectionPoints: [{PC: "0xd07c2a", Frameless: false}]
+          Type: 1242 EventRootType Probe[main.testReturnsInt]
+          InjectionPoints: [{PC: "0xd07d4a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1242 EventRootType Probe[main.testReturnsInt]Return
-          InjectionPoints: [{PC: "0xd07c7b", Frameless: false}]
+          Type: 1243 EventRootType Probe[main.testReturnsInt]Return
+          InjectionPoints: [{PC: "0xd07d9b", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2917,15 +2956,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 99}
       events:
         - Kind: Entry
-          Type: 1245 EventRootType Probe[main.testReturnsIntAndFloat]
-          InjectionPoints: [{PC: "0xd07d4e", Frameless: false}]
+          Type: 1246 EventRootType Probe[main.testReturnsIntAndFloat]
+          InjectionPoints: [{PC: "0xd07e6e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1246 EventRootType Probe[main.testReturnsIntAndFloat]Return
-          InjectionPoints: [{PC: "0xd07e04", Frameless: false}]
+          Type: 1247 EventRootType Probe[main.testReturnsIntAndFloat]Return
+          InjectionPoints: [{PC: "0xd07f24", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2941,15 +2980,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 98}
       events:
         - Kind: Entry
-          Type: 1243 EventRootType Probe[main.testReturnsIntPointer]
-          InjectionPoints: [{PC: "0xd07caa", Frameless: false}]
+          Type: 1244 EventRootType Probe[main.testReturnsIntPointer]
+          InjectionPoints: [{PC: "0xd07dca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1244 EventRootType Probe[main.testReturnsIntPointer]Return
-          InjectionPoints: [{PC: "0xd07d1b", Frameless: false}]
+          Type: 1245 EventRootType Probe[main.testReturnsIntPointer]Return
+          InjectionPoints: [{PC: "0xd07e3b", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2966,18 +3005,18 @@ Probes:
       template: '{v}'
       segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1253 EventRootType Probe[main.testReturnsInterface]
-          InjectionPoints: [{PC: "0xd081ee", Frameless: false}]
+          Type: 1254 EventRootType Probe[main.testReturnsInterface]
+          InjectionPoints: [{PC: "0xd0830e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1254 EventRootType Probe[main.testReturnsInterface]Return
+          Type: 1255 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
-            - PC: "0xd082d1"
+            - PC: "0xd083f1"
               Frameless: false
-            - PC: "0xd082db"
+            - PC: "0xd083fb"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2994,15 +3033,15 @@ Probes:
       template: testReturnsLargeStruct
       segments: [testReturnsLargeStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 110}
       events:
         - Kind: Entry
-          Type: 1277 EventRootType Probe[main.testReturnsLargeStruct]
-          InjectionPoints: [{PC: "0xd087ce", Frameless: false}]
+          Type: 1278 EventRootType Probe[main.testReturnsLargeStruct]
+          InjectionPoints: [{PC: "0xd088ee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1278 EventRootType Probe[main.testReturnsLargeStruct]Return
-          InjectionPoints: [{PC: "0xd08853", Frameless: false}]
+          Type: 1279 EventRootType Probe[main.testReturnsLargeStruct]Return
+          InjectionPoints: [{PC: "0xd08973", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsLargeStruct
@@ -3014,15 +3053,15 @@ Probes:
       template: testReturnsManyFloats
       segments: [testReturnsManyFloats]
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 108}
       events:
         - Kind: Entry
-          Type: 1273 EventRootType Probe[main.testReturnsManyFloats]
-          InjectionPoints: [{PC: "0xd0864e", Frameless: false}]
+          Type: 1274 EventRootType Probe[main.testReturnsManyFloats]
+          InjectionPoints: [{PC: "0xd0876e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1274 EventRootType Probe[main.testReturnsManyFloats]Return
-          InjectionPoints: [{PC: "0xd08725", Frameless: false}]
+          Type: 1275 EventRootType Probe[main.testReturnsManyFloats]Return
+          InjectionPoints: [{PC: "0xd08845", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsManyFloats
@@ -3034,15 +3073,15 @@ Probes:
       template: testReturnsMixed
       segments: [testReturnsMixed]
       captureSnapshot: true
-      subprogram: {subprogram: 116}
+      subprogram: {subprogram: 117}
       events:
         - Kind: Entry
-          Type: 1291 EventRootType Probe[main.testReturnsMixed]
-          InjectionPoints: [{PC: "0xd08baa", Frameless: false}]
+          Type: 1292 EventRootType Probe[main.testReturnsMixed]
+          InjectionPoints: [{PC: "0xd08cca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1292 EventRootType Probe[main.testReturnsMixed]Return
-          InjectionPoints: [{PC: "0xd08c0c", Frameless: false}]
+          Type: 1293 EventRootType Probe[main.testReturnsMixed]Return
+          InjectionPoints: [{PC: "0xd08d2c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsMixed
@@ -3054,15 +3093,15 @@ Probes:
       template: testReturnsMixedStruct
       segments: [testReturnsMixedStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 114}
       events:
         - Kind: Entry
-          Type: 1285 EventRootType Probe[main.testReturnsMixedStruct]
-          InjectionPoints: [{PC: "0xd089ca", Frameless: false}]
+          Type: 1286 EventRootType Probe[main.testReturnsMixedStruct]
+          InjectionPoints: [{PC: "0xd08aea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1286 EventRootType Probe[main.testReturnsMixedStruct]Return
-          InjectionPoints: [{PC: "0xd08a18", Frameless: false}]
+          Type: 1287 EventRootType Probe[main.testReturnsMixedStruct]Return
+          InjectionPoints: [{PC: "0xd08b38", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsMixedStruct
@@ -3074,15 +3113,15 @@ Probes:
       template: testReturnsMultipleFloats
       segments: [testReturnsMultipleFloats]
       captureSnapshot: true
-      subprogram: {subprogram: 119}
+      subprogram: {subprogram: 120}
       events:
         - Kind: Entry
-          Type: 1297 EventRootType Probe[main.testReturnsMultipleFloats]
-          InjectionPoints: [{PC: "0xd08d0a", Frameless: false}]
+          Type: 1298 EventRootType Probe[main.testReturnsMultipleFloats]
+          InjectionPoints: [{PC: "0xd08e2a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1298 EventRootType Probe[main.testReturnsMultipleFloats]Return
-          InjectionPoints: [{PC: "0xd08d56", Frameless: false}]
+          Type: 1299 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          InjectionPoints: [{PC: "0xd08e76", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsMultipleFloats
@@ -3094,15 +3133,15 @@ Probes:
       template: testReturnsOnlyFloat
       segments: [testReturnsOnlyFloat]
       captureSnapshot: true
-      subprogram: {subprogram: 118}
+      subprogram: {subprogram: 119}
       events:
         - Kind: Entry
-          Type: 1295 EventRootType Probe[main.testReturnsOnlyFloat]
-          InjectionPoints: [{PC: "0xd08caa", Frameless: false}]
+          Type: 1296 EventRootType Probe[main.testReturnsOnlyFloat]
+          InjectionPoints: [{PC: "0xd08dca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1296 EventRootType Probe[main.testReturnsOnlyFloat]Return
-          InjectionPoints: [{PC: "0xd08cee", Frameless: false}]
+          Type: 1297 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          InjectionPoints: [{PC: "0xd08e0e", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsOnlyFloat
@@ -3114,15 +3153,15 @@ Probes:
       template: testReturnsPrimitives
       segments: [testReturnsPrimitives]
       captureSnapshot: true
-      subprogram: {subprogram: 106}
+      subprogram: {subprogram: 107}
       events:
         - Kind: Entry
-          Type: 1271 EventRootType Probe[main.testReturnsPrimitives]
-          InjectionPoints: [{PC: "0xd085ca", Frameless: false}]
+          Type: 1272 EventRootType Probe[main.testReturnsPrimitives]
+          InjectionPoints: [{PC: "0xd086ea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1272 EventRootType Probe[main.testReturnsPrimitives]Return
-          InjectionPoints: [{PC: "0xd08631", Frameless: false}]
+          Type: 1273 EventRootType Probe[main.testReturnsPrimitives]Return
+          InjectionPoints: [{PC: "0xd08751", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsPrimitives
@@ -3134,15 +3173,15 @@ Probes:
       template: testReturnsStructWithArray
       segments: [testReturnsStructWithArray]
       captureSnapshot: true
-      subprogram: {subprogram: 117}
+      subprogram: {subprogram: 118}
       events:
         - Kind: Entry
-          Type: 1293 EventRootType Probe[main.testReturnsStructWithArray]
-          InjectionPoints: [{PC: "0xd08c2a", Frameless: false}]
+          Type: 1294 EventRootType Probe[main.testReturnsStructWithArray]
+          InjectionPoints: [{PC: "0xd08d4a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1294 EventRootType Probe[main.testReturnsStructWithArray]Return
-          InjectionPoints: [{PC: "0xd08c8d", Frameless: false}]
+          Type: 1295 EventRootType Probe[main.testReturnsStructWithArray]Return
+          InjectionPoints: [{PC: "0xd08dad", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsStructWithArray
@@ -3154,15 +3193,15 @@ Probes:
       template: testReturnsWideStruct
       segments: [testReturnsWideStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 115}
+      subprogram: {subprogram: 116}
       events:
         - Kind: Entry
-          Type: 1289 EventRootType Probe[main.testReturnsWideStruct]
-          InjectionPoints: [{PC: "0xd08aee", Frameless: false}]
+          Type: 1290 EventRootType Probe[main.testReturnsWideStruct]
+          InjectionPoints: [{PC: "0xd08c0e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1290 EventRootType Probe[main.testReturnsWideStruct]Return
-          InjectionPoints: [{PC: "0xd08b74", Frameless: false}]
+          Type: 1291 EventRootType Probe[main.testReturnsWideStruct]Return
+          InjectionPoints: [{PC: "0xd08c94", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsWideStruct
@@ -3209,15 +3248,15 @@ Probes:
         - json: {ref: result}
           dsl: result
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1261 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0xd0840e", Frameless: false}]
+          Type: 1262 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xd0852e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1262 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0xd084af", Frameless: false}]
+          Type: 1263 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xd085cf", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -3485,11 +3524,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 143}
+      subprogram: {subprogram: 144}
       events:
         - Kind: Entry
-          Type: 1334 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0xd0a580", Frameless: true}]
+          Type: 1335 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0xd0a6a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -3611,11 +3650,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 140}
+      subprogram: {subprogram: 141}
       events:
         - Kind: Entry
-          Type: 1330 EventRootType Probe[main.testSliceEmptyStructs]
-          InjectionPoints: [{PC: "0xd0a160", Frameless: true}]
+          Type: 1331 EventRootType Probe[main.testSliceEmptyStructs]
+          InjectionPoints: [{PC: "0xd0a280", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -3632,11 +3671,11 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 132}
+      subprogram: {subprogram: 133}
       events:
         - Kind: Entry
-          Type: 1321 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0xd0a060", Frameless: true}]
+          Type: 1322 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0xd0a180", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{u}'
@@ -3653,11 +3692,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 65}
+      subprogram: {subprogram: 66}
       events:
         - Kind: Entry
-          Type: 1207 EventRootType Probe[main.testSmallMap]
-          InjectionPoints: [{PC: "0xd055e0", Frameless: true}]
+          Type: 1208 EventRootType Probe[main.testSmallMap]
+          InjectionPoints: [{PC: "0xd05700", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -3673,15 +3712,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 105}
+      subprogram: {subprogram: 106}
       events:
         - Kind: Entry
-          Type: 1269 EventRootType Probe[main.testSomeNamedReturn]
-          InjectionPoints: [{PC: "0xd084ee", Frameless: false}]
+          Type: 1270 EventRootType Probe[main.testSomeNamedReturn]
+          InjectionPoints: [{PC: "0xd0860e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1270 EventRootType Probe[main.testSomeNamedReturn]Return
-          InjectionPoints: [{PC: "0xd0858e", Frameless: false}]
+          Type: 1271 EventRootType Probe[main.testSomeNamedReturn]Return
+          InjectionPoints: [{PC: "0xd086ae", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -3697,15 +3736,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 126}
+      subprogram: {subprogram: 127}
       events:
         - Kind: Entry
-          Type: 1311 EventRootType Probe[main.testStackArgRegReturns]
-          InjectionPoints: [{PC: "0xd0980a", Frameless: false}]
+          Type: 1312 EventRootType Probe[main.testStackArgRegReturns]
+          InjectionPoints: [{PC: "0xd0992a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1312 EventRootType Probe[main.testStackArgRegReturns]Return
-          InjectionPoints: [{PC: "0xd0987c", Frameless: false}]
+          Type: 1313 EventRootType Probe[main.testStackArgRegReturns]Return
+          InjectionPoints: [{PC: "0xd0999c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -3743,11 +3782,11 @@ Probes:
       template: '{z}'
       segments: [{json: {ref: z}, dsl: z}]
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 94}
       events:
         - Kind: Entry
-          Type: 1238 EventRootType Probe[main.testStringPointer]
-          InjectionPoints: [{PC: "0xd076a0", Frameless: true}]
+          Type: 1239 EventRootType Probe[main.testStringPointer]
+          InjectionPoints: [{PC: "0xd077c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{z}'
@@ -3764,11 +3803,11 @@ Probes:
       template: '{s}'
       segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
-      subprogram: {subprogram: 136}
+      subprogram: {subprogram: 137}
       events:
         - Kind: Entry
-          Type: 1325 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0xd0a0e0", Frameless: true}]
+          Type: 1326 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0xd0a200", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{s}'
@@ -3785,11 +3824,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 44}
+      subprogram: {subprogram: 45}
       events:
         - Kind: Entry
-          Type: 1173 EventRootType Probe[main.testStringType1]
-          InjectionPoints: [{PC: "0xd03b60", Frameless: true}]
+          Type: 1174 EventRootType Probe[main.testStringType1]
+          InjectionPoints: [{PC: "0xd03c80", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3806,11 +3845,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 45}
+      subprogram: {subprogram: 46}
       events:
         - Kind: Entry
-          Type: 1174 EventRootType Probe[main.testStringType2]
-          InjectionPoints: [{PC: "0xd03b80", Frameless: true}]
+          Type: 1175 EventRootType Probe[main.testStringType2]
+          InjectionPoints: [{PC: "0xd03ca0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3827,15 +3866,15 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1353 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0xd0a960", Frameless: true}]
+          Type: 1354 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0xd0aa80", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1354 EventRootType Probe[main.testStruct]Return
-          InjectionPoints: [{PC: "0xd0a982", Frameless: true}]
+          Type: 1355 EventRootType Probe[main.testStruct]Return
+          InjectionPoints: [{PC: "0xd0aaa2", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -3857,11 +3896,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 133}
+      subprogram: {subprogram: 134}
       events:
         - Kind: Entry
-          Type: 1322 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0xd0a080", Frameless: true}]
+          Type: 1323 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0xd0a1a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}, {a}'
@@ -3883,11 +3922,11 @@ Probes:
       template: '{s}'
       segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
-      subprogram: {subprogram: 59}
+      subprogram: {subprogram: 60}
       events:
         - Kind: Entry
-          Type: 1201 EventRootType Probe[main.testStructWithAny]
-          InjectionPoints: [{PC: "0xd04ee0", Frameless: true}]
+          Type: 1202 EventRootType Probe[main.testStructWithAny]
+          InjectionPoints: [{PC: "0xd05000", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{s}'
@@ -3903,15 +3942,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 128}
+      subprogram: {subprogram: 129}
       events:
         - Kind: Entry
-          Type: 1315 EventRootType Probe[main.testStructWithArrayArg]
-          InjectionPoints: [{PC: "0xd099ae", Frameless: false}]
+          Type: 1316 EventRootType Probe[main.testStructWithArrayArg]
+          InjectionPoints: [{PC: "0xd09ace", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1316 EventRootType Probe[main.testStructWithArrayArg]Return
-          InjectionPoints: [{PC: "0xd09a5a", Frameless: false}]
+          Type: 1317 EventRootType Probe[main.testStructWithArrayArg]Return
+          InjectionPoints: [{PC: "0xd09b7a", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -3928,15 +3967,15 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 153}
+      subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1349 EventRootType Probe[main.testStructWithCyclicMaps]
-          InjectionPoints: [{PC: "0xd0a820", Frameless: true}]
+          Type: 1350 EventRootType Probe[main.testStructWithCyclicMaps]
+          InjectionPoints: [{PC: "0xd0a940", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1350 EventRootType Probe[main.testStructWithCyclicMaps]Return
-          InjectionPoints: [{PC: "0xd0a83e", Frameless: true}]
+          Type: 1351 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          InjectionPoints: [{PC: "0xd0a95e", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3952,11 +3991,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 152}
+      subprogram: {subprogram: 153}
       events:
         - Kind: Entry
-          Type: 1348 EventRootType Probe[main.testStructWithCyclicSlices]
-          InjectionPoints: [{PC: "0xd0a800", Frameless: true}]
+          Type: 1349 EventRootType Probe[main.testStructWithCyclicSlices]
+          InjectionPoints: [{PC: "0xd0a920", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3978,11 +4017,11 @@ Probes:
         - json: {ref: '@duration'}
           dsl: '@duration'
       captureSnapshot: true
-      subprogram: {subprogram: 60}
+      subprogram: {subprogram: 61}
       events:
         - Kind: Entry
-          Type: 1202 EventRootType Probe[main.testStructWithMap]
-          InjectionPoints: [{PC: "0xd05540", Frameless: true}]
+          Type: 1203 EventRootType Probe[main.testStructWithMap]
+          InjectionPoints: [{PC: "0xd05660", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{s} {@duration}'
@@ -4009,11 +4048,11 @@ Probes:
         - json: {ref: cs}
           dsl: cs
       captureSnapshot: true
-      subprogram: {subprogram: 141}
+      subprogram: {subprogram: 142}
       events:
         - Kind: Entry
-          Type: 1331 EventRootType Probe[main.testSubslices]
-          InjectionPoints: [{PC: "0xd0a180", Frameless: true}]
+          Type: 1332 EventRootType Probe[main.testSubslices]
+          InjectionPoints: [{PC: "0xd0a2a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{as}, {bs}, {cs}'
@@ -4048,11 +4087,11 @@ Probes:
         - json: {ref: c}
           dsl: c
       captureSnapshot: true
-      subprogram: {subprogram: 151}
+      subprogram: {subprogram: 152}
       events:
         - Kind: Entry
-          Type: 1347 EventRootType Probe[main.testSubstrings]
-          InjectionPoints: [{PC: "0xd0a680", Frameless: true}]
+          Type: 1348 EventRootType Probe[main.testSubstrings]
+          InjectionPoints: [{PC: "0xd0a7a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}'
@@ -4080,15 +4119,15 @@ Probes:
         - json: {ref: nonexistentVariable}
           dsl: nonexistentVariable
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1263 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0xd0840e", Frameless: false}]
+          Type: 1264 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xd0852e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1264 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0xd084af", Frameless: false}]
+          Type: 1265 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xd085cf", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{nonexistentVariable}'
@@ -4104,15 +4143,15 @@ Probes:
         - json: {foobar: unsupportedExpression}
           dsl: unsupportedExpression
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1265 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0xd0840e", Frameless: false}]
+          Type: 1266 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xd0852e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1266 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0xd084af", Frameless: false}]
+          Type: 1267 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xd085cf", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{unsupportedExpression}'
@@ -4130,15 +4169,15 @@ Probes:
           dsl: '@duration'
         - ms
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1267 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0xd0840e", Frameless: false}]
+          Type: 1268 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xd0852e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1268 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0xd084af", Frameless: false}]
+          Type: 1269 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xd085cf", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -4162,11 +4201,11 @@ Probes:
         - json: {ref: z}
           dsl: z
       captureSnapshot: true
-      subprogram: {subprogram: 144}
+      subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1335 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0xd0a5a0", Frameless: true}]
+          Type: 1336 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0xd0a6c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}, {y}, {z}'
@@ -4193,15 +4232,15 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 145}
+      subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1336 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0xd0a5c0", Frameless: true}]
+          Type: 1337 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0xd0a6e0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1337 EventRootType Probe[main.testThreeStringsInStruct]Return
-          InjectionPoints: [{PC: "0xd0a5de", Frameless: true}]
+          Type: 1338 EventRootType Probe[main.testThreeStringsInStruct]Return
+          InjectionPoints: [{PC: "0xd0a6fe", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -4226,15 +4265,15 @@ Probes:
         - json: {getmember: [{ref: a}, c]}
           dsl: t.c
       captureSnapshot: false
-      subprogram: {subprogram: 145}
+      subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1338 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0xd0a5c0", Frameless: true}]
+          Type: 1339 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0xd0a6e0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1339 EventRootType Probe[main.testThreeStringsInStruct]Return
-          InjectionPoints: [{PC: "0xd0a5de", Frameless: true}]
+          Type: 1340 EventRootType Probe[main.testThreeStringsInStruct]Return
+          InjectionPoints: [{PC: "0xd0a6fe", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a.a} {a.b} {a.c}'
@@ -4261,11 +4300,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 146}
+      subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1340 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0xd0a5e0", Frameless: true}]
+          Type: 1341 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0xd0a700", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -4290,11 +4329,11 @@ Probes:
         - json: {getmember: [{ref: a}, c]}
           dsl: a.c
       captureSnapshot: false
-      subprogram: {subprogram: 146}
+      subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1341 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0xd0a5e0", Frameless: true}]
+          Type: 1342 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0xd0a700", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a.a} {a.b} {a.c}'
@@ -4447,11 +4486,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 93}
       events:
         - Kind: Entry
-          Type: 1237 EventRootType Probe[main.testUintPointer]
-          InjectionPoints: [{PC: "0xd075c0", Frameless: true}]
+          Type: 1238 EventRootType Probe[main.testUintPointer]
+          InjectionPoints: [{PC: "0xd076e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4468,11 +4507,11 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 130}
+      subprogram: {subprogram: 131}
       events:
         - Kind: Entry
-          Type: 1319 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0xd0a020", Frameless: true}]
+          Type: 1320 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0xd0a140", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{u}'
@@ -4489,11 +4528,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 149}
+      subprogram: {subprogram: 150}
       events:
         - Kind: Entry
-          Type: 1345 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0xd0a640", Frameless: true}]
+          Type: 1346 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0xd0a760", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4510,11 +4549,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 92}
       events:
         - Kind: Entry
-          Type: 1236 EventRootType Probe[main.testUnsafePointer]
-          InjectionPoints: [{PC: "0xd07580", Frameless: true}]
+          Type: 1237 EventRootType Probe[main.testUnsafePointer]
+          InjectionPoints: [{PC: "0xd076a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4552,11 +4591,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 139}
+      subprogram: {subprogram: 140}
       events:
         - Kind: Entry
-          Type: 1328 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0xd0a140", Frameless: true}]
+          Type: 1329 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0xd0a260", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -4573,11 +4612,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 139}
+      subprogram: {subprogram: 140}
       events:
         - Kind: Entry
-          Type: 1329 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0xd0a140", Frameless: true}]
+          Type: 1330 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0xd0a260", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -4593,19 +4632,19 @@ Probes:
       template: testWhollyInlinedSubroutine
       segments: [testWhollyInlinedSubroutine]
       captureSnapshot: true
-      subprogram: {subprogram: 164}
+      subprogram: {subprogram: 165}
       events:
         - Kind: Entry
-          Type: 1374 EventRootType Probe[main.firstBehavior.DoSomething]
+          Type: 1375 EventRootType Probe[main.firstBehavior.DoSomething]
           InjectionPoints:
-            - PC: "0xd04cea"
+            - PC: "0xd04e0a"
               Frameless: false
-            - PC: "0xd0c043"
+            - PC: "0xd0c163"
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1375 EventRootType Probe[main.firstBehavior.DoSomething]Return
-          InjectionPoints: [{PC: "0xd04d30", Frameless: false}]
+          Type: 1376 EventRootType Probe[main.firstBehavior.DoSomething]Return
+          InjectionPoints: [{PC: "0xd04e50", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testWhollyInlinedSubroutine
@@ -4622,15 +4661,15 @@ Probes:
         - json: {ref: b}
           dsl: b
       captureSnapshot: true
-      subprogram: {subprogram: 129}
+      subprogram: {subprogram: 130}
       events:
         - Kind: Entry
-          Type: 1317 EventRootType Probe[main.testZeroSizeArgAndReturn]
-          InjectionPoints: [{PC: "0xd09a8e", Frameless: false}]
+          Type: 1318 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          InjectionPoints: [{PC: "0xd09bae", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1318 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-          InjectionPoints: [{PC: "0xd09b0c", Frameless: false}]
+          Type: 1319 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          InjectionPoints: [{PC: "0xd09c2c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}'
@@ -5065,36 +5104,83 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
     - ID: 38
+      Name: main.testErrorAtLine
+      OutOfLinePCRanges: [0xd037a0..0xd038b2]
+      InlinePCRanges: []
+      Variables:
+        - Name: shouldErr
+          Type: 4 BaseType bool
+          Locations:
+            - Range: 0xd037a0..0xd037b8
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+        - Name: ~r0
+          Type: 9 BaseType int
+          Locations: [{Range: 0xd037a0..0xd038b2, Pieces: []}]
+          Role: Return
+        - Name: x
+          Type: 9 BaseType int
+          Locations: [{Range: 0xd037a0..0xd038b2, Pieces: []}]
+          Role: Local
+        - Name: err
+          Type: 18 GoInterfaceType error
+          Locations:
+            - Range: 0xd037c9..0xd037e5
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+            - Range: 0xd037e5..0xd0381e
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xd0381e..0xd03825
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: -80}
+                - Size: 8
+                  Op: {CfaOffset: -72}
+            - Range: 0xd03825..0xd038b2
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: -80}
+                - Size: 8
+                  Op: {CfaOffset: -72}
+          Role: Local
+    - ID: 39
       Name: main.testDeepPtr1
-      OutOfLinePCRanges: [0xd03800..0xd03801]
+      OutOfLinePCRanges: [0xd03920..0xd03921]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 125 StructureType main.deepPtr1
           Locations:
-            - Range: 0xd03800..0xd03801
+            - Range: 0xd03920..0xd03921
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 39
+    - ID: 40
       Name: main.testDeepPtr7
-      OutOfLinePCRanges: [0xd03820..0xd03821]
+      OutOfLinePCRanges: [0xd03940..0xd03941]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 128 PointerType *main.deepPtr7
           Locations:
-            - Range: 0xd03820..0xd03821
+            - Range: 0xd03940..0xd03941
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 40
+    - ID: 41
       Name: main.testDeepSlice1
-      OutOfLinePCRanges: [0xd039a0..0xd039a1]
+      OutOfLinePCRanges: [0xd03ac0..0xd03ac1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 130 StructureType main.deepSlice1
           Locations:
-            - Range: 0xd039a0..0xd039a1
+            - Range: 0xd03ac0..0xd03ac1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -5103,117 +5189,117 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 41
+    - ID: 42
       Name: main.testDeepSlice7
-      OutOfLinePCRanges: [0xd039c0..0xd039c1]
+      OutOfLinePCRanges: [0xd03ae0..0xd03ae1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 134 PointerType *main.deepSlice7
           Locations:
-            - Range: 0xd039c0..0xd039c1
+            - Range: 0xd03ae0..0xd03ae1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 42
+    - ID: 43
       Name: main.testDeepMap1
-      OutOfLinePCRanges: [0xd03b20..0xd03b21]
+      OutOfLinePCRanges: [0xd03c40..0xd03c41]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 136 StructureType main.deepMap1
           Locations:
-            - Range: 0xd03b20..0xd03b21
+            - Range: 0xd03c40..0xd03c41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 43
+    - ID: 44
       Name: main.testDeepMap7
-      OutOfLinePCRanges: [0xd03b40..0xd03b41]
+      OutOfLinePCRanges: [0xd03c60..0xd03c61]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 144 PointerType *main.deepMap7
           Locations:
-            - Range: 0xd03b40..0xd03b41
+            - Range: 0xd03c60..0xd03c61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 44
+    - ID: 45
       Name: main.testStringType1
-      OutOfLinePCRanges: [0xd03b60..0xd03b61]
+      OutOfLinePCRanges: [0xd03c80..0xd03c81]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 146 PointerType *main.stringType1
           Locations:
-            - Range: 0xd03b60..0xd03b61
+            - Range: 0xd03c80..0xd03c81
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 45
+    - ID: 46
       Name: main.testStringType2
-      OutOfLinePCRanges: [0xd03b80..0xd03b81]
+      OutOfLinePCRanges: [0xd03ca0..0xd03ca1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 148 PointerType **main.stringType2
           Locations:
-            - Range: 0xd03b80..0xd03b81
+            - Range: 0xd03ca0..0xd03ca1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 46
+    - ID: 47
       Name: main.testLongFunctionWithChangingState
-      OutOfLinePCRanges: [0xd03ba0..0xd03dea]
+      OutOfLinePCRanges: [0xd03cc0..0xd03f0a]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd03c84..0xd03ca5
+            - Range: 0xd03da4..0xd03dc5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd03d58..0xd03d6f
+            - Range: 0xd03e78..0xd03e8f
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
         - Name: aPerArch
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd03c6d..0xd03c70
+            - Range: 0xd03d8d..0xd03d90
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd03c70..0xd03ca5
+            - Range: 0xd03d90..0xd03dc5
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd03ca5..0xd03d4b
+            - Range: 0xd03dc5..0xd03e6b
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0xd03d4b..0xd03d58
+            - Range: 0xd03e6b..0xd03e78
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0xd03d58..0xd03dea
+            - Range: 0xd03e78..0xd03f0a
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
           Role: Local
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd03c6a..0xd03c70
+            - Range: 0xd03d8a..0xd03d90
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd03c70..0xd03c70
+            - Range: 0xd03d90..0xd03d90
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd03c70..0xd03ca5
+            - Range: 0xd03d90..0xd03dc5
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd03ca5..0xd03d4b
+            - Range: 0xd03dc5..0xd03e6b
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0xd03d4b..0xd03d50
+            - Range: 0xd03e6b..0xd03e70
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0xd03d50..0xd03d58
+            - Range: 0xd03e70..0xd03e78
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
-            - Range: 0xd03d58..0xd03d6f
+            - Range: 0xd03e78..0xd03e8f
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
-            - Range: 0xd03d6f..0xd03dea
+            - Range: 0xd03e8f..0xd03f0a
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
           Role: Local
-    - ID: 47
+    - ID: 48
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0xd04240..0xd04345]
+      OutOfLinePCRanges: [0xd04360..0xd04465]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 150 StructureType main.esotericStack
           Locations:
-            - Range: 0xd04240..0xd04293
+            - Range: 0xd04360..0xd043b3
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -5233,7 +5319,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
-            - Range: 0xd04293..0xd04298
+            - Range: 0xd043b3..0xd043b8
               Pieces:
                 - Size: 4
                   Op: null
@@ -5253,7 +5339,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
-            - Range: 0xd04298..0xd0429d
+            - Range: 0xd043b8..0xd043bd
               Pieces:
                 - Size: 4
                   Op: null
@@ -5274,226 +5360,136 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
           Role: Parameter
-    - ID: 48
+    - ID: 49
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0xd04360..0xd043c3]
+      OutOfLinePCRanges: [0xd04480..0xd044e3]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 154 PointerType *main.esotericHeap
           Locations:
-            - Range: 0xd04360..0xd0438d
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-    - ID: 49
-      Name: main.testInlinedBA
-      OutOfLinePCRanges: [0xd047a0..0xd04828]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0xd047a0..0xd047b5
+            - Range: 0xd04480..0xd044ad
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 50
-      Name: main.testInlinedBB
-      OutOfLinePCRanges: [0xd04840..0xd04905]
+      Name: main.testInlinedBA
+      OutOfLinePCRanges: [0xd048c0..0xd04948]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd04840..0xd04856
+            - Range: 0xd048c0..0xd048d5
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+    - ID: 51
+      Name: main.testInlinedBB
+      OutOfLinePCRanges: [0xd04960..0xd04a25]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd04960..0xd04976
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: y
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd04840..0xd04867
+            - Range: 0xd04960..0xd04987
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
         - Name: z
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd04856..0xd04867
+            - Range: 0xd04976..0xd04987
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd04867..0xd04905
+            - Range: 0xd04987..0xd04a25
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Local
-    - ID: 51
+    - ID: 52
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0xd04920..0xd04982]
+      OutOfLinePCRanges: [0xd04a40..0xd04aa2]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd04920..0xd0493a
+            - Range: 0xd04a40..0xd04a5a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 52
+    - ID: 53
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0xd049a0..0xd04aae]
+      OutOfLinePCRanges: [0xd04ac0..0xd04bce]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd049fb..0xd04a05
+            - Range: 0xd04b1b..0xd04b25
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xd04a05..0xd04a20
+            - Range: 0xd04b25..0xd04b40
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xd04a20..0xd04a34
+            - Range: 0xd04b40..0xd04b54
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd049f6..0xd04a00
+            - Range: 0xd04b16..0xd04b20
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xd04a00..0xd04a20
+            - Range: 0xd04b20..0xd04b40
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xd04a20..0xd04a2f
+            - Range: 0xd04b40..0xd04b4f
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 53
+    - ID: 54
       Name: main.testFrameless
-      OutOfLinePCRanges: [0xd04ac0..0xd04ac6]
+      OutOfLinePCRanges: [0xd04be0..0xd04be6]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd04ac0..0xd04ac5
+            - Range: 0xd04be0..0xd04be5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd04ac0..0xd04ac5
+            - Range: 0xd04be0..0xd04be5
               Pieces: []
-            - Range: 0xd04ac5..0xd04ac6
+            - Range: 0xd04be5..0xd04be6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
-    - ID: 54
+    - ID: 55
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0xd04ae0..0xd04b23]
+      OutOfLinePCRanges: [0xd04c00..0xd04c43]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 156 ArrayType [5]int
           Locations:
-            - Range: 0xd04ae0..0xd04b23
+            - Range: 0xd04c00..0xd04c43
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd04ae0..0xd04b1d
+            - Range: 0xd04c00..0xd04c3d
               Pieces: []
-            - Range: 0xd04b1d..0xd04b1e
+            - Range: 0xd04c3d..0xd04c3e
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd04b1e..0xd04b23
+            - Range: 0xd04c3e..0xd04c43
               Pieces: []
           Role: Return
-    - ID: 55
+    - ID: 56
       Name: main.testInterface
-      OutOfLinePCRanges: [0xd04dc0..0xd04dc1]
+      OutOfLinePCRanges: [0xd04ee0..0xd04ee1]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 157 GoInterfaceType main.behavior
-          Locations:
-            - Range: 0xd04dc0..0xd04dc1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          Role: Parameter
-    - ID: 56
-      Name: main.testAny
-      OutOfLinePCRanges: [0xd04de0..0xd04e46]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 152 GoEmptyInterfaceType interface {}
-          Locations:
-            - Range: 0xd04de0..0xd04e09
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd04e09..0xd04e0e
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          Role: Parameter
-        - Name: ~r0
-          Type: 11 GoStringHeaderType string
-          Locations:
-            - Range: 0xd04de0..0xd04e25
-              Pieces: []
-            - Range: 0xd04e25..0xd04e26
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd04e26..0xd04e46
-              Pieces: []
-          Role: Return
-    - ID: 57
-      Name: main.testError
-      OutOfLinePCRanges: [0xd04e60..0xd04e61]
-      InlinePCRanges: []
-      Variables:
-        - Name: e
-          Type: 18 GoInterfaceType error
-          Locations:
-            - Range: 0xd04e60..0xd04e61
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          Role: Parameter
-    - ID: 58
-      Name: main.testAnyPtr
-      OutOfLinePCRanges: [0xd04e80..0xd04ed4]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 158 PointerType *interface {}
-          Locations:
-            - Range: 0xd04e80..0xd04ea6
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-        - Name: ~r0
-          Type: 11 GoStringHeaderType string
-          Locations:
-            - Range: 0xd04e80..0xd04ebd
-              Pieces: []
-            - Range: 0xd04ebd..0xd04ebe
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd04ebe..0xd04ed4
-              Pieces: []
-          Role: Return
-    - ID: 59
-      Name: main.testStructWithAny
-      OutOfLinePCRanges: [0xd04ee0..0xd04ee1]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 159 StructureType main.structWithAny
           Locations:
             - Range: 0xd04ee0..0xd04ee1
               Pieces:
@@ -5502,297 +5498,387 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
+    - ID: 57
+      Name: main.testAny
+      OutOfLinePCRanges: [0xd04f00..0xd04f66]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 152 GoEmptyInterfaceType interface {}
+          Locations:
+            - Range: 0xd04f00..0xd04f29
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xd04f29..0xd04f2e
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Parameter
+        - Name: ~r0
+          Type: 11 GoStringHeaderType string
+          Locations:
+            - Range: 0xd04f00..0xd04f45
+              Pieces: []
+            - Range: 0xd04f45..0xd04f46
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xd04f46..0xd04f66
+              Pieces: []
+          Role: Return
+    - ID: 58
+      Name: main.testError
+      OutOfLinePCRanges: [0xd04f80..0xd04f81]
+      InlinePCRanges: []
+      Variables:
+        - Name: e
+          Type: 18 GoInterfaceType error
+          Locations:
+            - Range: 0xd04f80..0xd04f81
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Parameter
+    - ID: 59
+      Name: main.testAnyPtr
+      OutOfLinePCRanges: [0xd04fa0..0xd04ff4]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 158 PointerType *interface {}
+          Locations:
+            - Range: 0xd04fa0..0xd04fc6
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+        - Name: ~r0
+          Type: 11 GoStringHeaderType string
+          Locations:
+            - Range: 0xd04fa0..0xd04fdd
+              Pieces: []
+            - Range: 0xd04fdd..0xd04fde
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xd04fde..0xd04ff4
+              Pieces: []
+          Role: Return
     - ID: 60
+      Name: main.testStructWithAny
+      OutOfLinePCRanges: [0xd05000..0xd05001]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 159 StructureType main.structWithAny
+          Locations:
+            - Range: 0xd05000..0xd05001
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Parameter
+    - ID: 61
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0xd05540..0xd05541]
+      OutOfLinePCRanges: [0xd05660..0xd05661]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 160 StructureType main.structWithMap
           Locations:
-            - Range: 0xd05540..0xd05541
+            - Range: 0xd05660..0xd05661
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 61
+    - ID: 62
       Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0xd05560..0xd05561]
+      OutOfLinePCRanges: [0xd05680..0xd05681]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 166 GoMapType map[string]main.nestedStruct
           Locations:
-            - Range: 0xd05560..0xd05561
+            - Range: 0xd05680..0xd05681
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 62
+    - ID: 63
       Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0xd05580..0xd05581]
+      OutOfLinePCRanges: [0xd056a0..0xd056a1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 171 GoMapType map[string]int
           Locations:
-            - Range: 0xd05580..0xd05581
+            - Range: 0xd056a0..0xd056a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 63
+    - ID: 64
       Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0xd055a0..0xd055a1]
+      OutOfLinePCRanges: [0xd056c0..0xd056c1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 176 GoMapType map[string][]string
           Locations:
-            - Range: 0xd055a0..0xd055a1
+            - Range: 0xd056c0..0xd056c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 64
+    - ID: 65
       Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0xd055c0..0xd055c1]
+      OutOfLinePCRanges: [0xd056e0..0xd056e1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 181 GoMapType map[[4]string][2]int
           Locations:
-            - Range: 0xd055c0..0xd055c1
+            - Range: 0xd056e0..0xd056e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 65
+    - ID: 66
       Name: main.testSmallMap
-      OutOfLinePCRanges: [0xd055e0..0xd055e1]
+      OutOfLinePCRanges: [0xd05700..0xd05701]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 171 GoMapType map[string]int
           Locations:
-            - Range: 0xd055e0..0xd055e1
+            - Range: 0xd05700..0xd05701
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 66
+    - ID: 67
       Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0xd05600..0xd05601]
+      OutOfLinePCRanges: [0xd05720..0xd05721]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 186 ArrayType [2]map[string]int
           Locations:
-            - Range: 0xd05600..0xd05601
+            - Range: 0xd05720..0xd05721
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
-    - ID: 67
+    - ID: 68
       Name: main.testPointerToMap
-      OutOfLinePCRanges: [0xd05620..0xd05621]
+      OutOfLinePCRanges: [0xd05740..0xd05741]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 187 PointerType *map[string]int
           Locations:
-            - Range: 0xd05620..0xd05621
+            - Range: 0xd05740..0xd05741
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 68
+    - ID: 69
       Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0xd05640..0xd05641]
+      OutOfLinePCRanges: [0xd05760..0xd05761]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 161 GoMapType map[int]int
           Locations:
-            - Range: 0xd05640..0xd05641
+            - Range: 0xd05760..0xd05761
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 69
+    - ID: 70
       Name: main.testMapMassive
-      OutOfLinePCRanges: [0xd05660..0xd05661]
+      OutOfLinePCRanges: [0xd05780..0xd05781]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 188 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0xd05660..0xd05661
+            - Range: 0xd05780..0xd05781
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 70
+    - ID: 71
       Name: main.testMapEmbeddedMaps
-      OutOfLinePCRanges: [0xd05680..0xd05681]
+      OutOfLinePCRanges: [0xd057a0..0xd057a1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 188 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0xd05680..0xd05681
+            - Range: 0xd057a0..0xd057a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 71
+    - ID: 72
       Name: main.testMapWithLinkedList
-      OutOfLinePCRanges: [0xd056a0..0xd056a1]
+      OutOfLinePCRanges: [0xd057c0..0xd057c1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 193 GoMapType map[bool]main.node
           Locations:
-            - Range: 0xd056a0..0xd056a1
+            - Range: 0xd057c0..0xd057c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 72
+    - ID: 73
       Name: main.testMapWithSmallValue
-      OutOfLinePCRanges: [0xd056c0..0xd056c1]
+      OutOfLinePCRanges: [0xd057e0..0xd057e1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 198 GoMapType map[int]uint8
           Locations:
-            - Range: 0xd056c0..0xd056c1
+            - Range: 0xd057e0..0xd057e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 73
+    - ID: 74
       Name: main.testMapWithSmallValueMassive
-      OutOfLinePCRanges: [0xd056e0..0xd056e1]
+      OutOfLinePCRanges: [0xd05800..0xd05801]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 198 GoMapType map[int]uint8
           Locations:
-            - Range: 0xd056e0..0xd056e1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-    - ID: 74
-      Name: main.testMapWithSmallKeyAndValue
-      OutOfLinePCRanges: [0xd05700..0xd05701]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 203 GoMapType map[uint8]uint8
-          Locations:
-            - Range: 0xd05700..0xd05701
+            - Range: 0xd05800..0xd05801
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 75
-      Name: main.testMapWithSmallKeyAndValueMassive
-      OutOfLinePCRanges: [0xd05720..0xd05721]
+      Name: main.testMapWithSmallKeyAndValue
+      OutOfLinePCRanges: [0xd05820..0xd05821]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 203 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0xd05720..0xd05721
+            - Range: 0xd05820..0xd05821
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 76
-      Name: main.testMapSmallKeySmallValue
-      OutOfLinePCRanges: [0xd05740..0xd05741]
+      Name: main.testMapWithSmallKeyAndValueMassive
+      OutOfLinePCRanges: [0xd05840..0xd05841]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 203 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0xd05740..0xd05741
+            - Range: 0xd05840..0xd05841
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 77
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0xd05860..0xd05861]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 203 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xd05860..0xd05861
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+    - ID: 78
       Name: main.testMapSmallKeyLargeValue
-      OutOfLinePCRanges: [0xd05760..0xd05761]
+      OutOfLinePCRanges: [0xd05880..0xd05881]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 208 GoMapType map[uint8][4]int
           Locations:
-            - Range: 0xd05760..0xd05761
+            - Range: 0xd05880..0xd05881
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 78
+    - ID: 79
       Name: main.testMapLargeKeySmallValue
-      OutOfLinePCRanges: [0xd05780..0xd05781]
+      OutOfLinePCRanges: [0xd058a0..0xd058a1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 213 GoMapType map[[4]int]uint8
           Locations:
-            - Range: 0xd05780..0xd05781
+            - Range: 0xd058a0..0xd058a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 79
+    - ID: 80
       Name: main.testMapLargeKeyLargeValue
-      OutOfLinePCRanges: [0xd057a0..0xd057a1]
+      OutOfLinePCRanges: [0xd058c0..0xd058c1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 218 GoMapType map[[4]int][4]int
           Locations:
-            - Range: 0xd057a0..0xd057a1
+            - Range: 0xd058c0..0xd058c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 80
+    - ID: 81
       Name: main.testMapEmptyKey
-      OutOfLinePCRanges: [0xd057c0..0xd057c1]
+      OutOfLinePCRanges: [0xd058e0..0xd058e1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 223 GoMapType map[struct {}]int
           Locations:
-            - Range: 0xd057c0..0xd057c1
+            - Range: 0xd058e0..0xd058e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 81
+    - ID: 82
       Name: main.testMapEmptyValue
-      OutOfLinePCRanges: [0xd057e0..0xd057e1]
+      OutOfLinePCRanges: [0xd05900..0xd05901]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 228 GoMapType map[int]struct {}
           Locations:
-            - Range: 0xd057e0..0xd057e1
+            - Range: 0xd05900..0xd05901
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 82
+    - ID: 83
       Name: main.testMapEmptyKeyAndValue
-      OutOfLinePCRanges: [0xd05800..0xd05801]
+      OutOfLinePCRanges: [0xd05920..0xd05921]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 233 GoMapType map[struct {}]struct {}
           Locations:
-            - Range: 0xd05800..0xd05801
+            - Range: 0xd05920..0xd05921
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 83
+    - ID: 84
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0xd06f40..0xd06f41]
+      OutOfLinePCRanges: [0xd07060..0xd07061]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xd06f40..0xd06f41
+            - Range: 0xd07060..0xd07061
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xd06f40..0xd06f41
+            - Range: 0xd07060..0xd07061
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
         - Name: y
           Type: 16 BaseType float32
           Locations:
-            - Range: 0xd06f40..0xd06f41
+            - Range: 0xd07060..0xd07061
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
-    - ID: 84
+    - ID: 85
       Name: main.testCombinedString
-      OutOfLinePCRanges: [0xd06f80..0xd06f81]
+      OutOfLinePCRanges: [0xd070a0..0xd070a1]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xd06f80..0xd06f81
+            - Range: 0xd070a0..0xd070a1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd06f80..0xd06f81
+            - Range: 0xd070a0..0xd070a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -5802,343 +5888,343 @@ Subprograms:
         - Name: y
           Type: 16 BaseType float32
           Locations:
-            - Range: 0xd06f80..0xd06f81
+            - Range: 0xd070a0..0xd070a1
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
-    - ID: 85
+    - ID: 86
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0xd07100..0xd07101]
+      OutOfLinePCRanges: [0xd07220..0xd07221]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xd07100..0xd07101
+            - Range: 0xd07220..0xd07221
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: b
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xd07100..0xd07101
+            - Range: 0xd07220..0xd07221
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
         - Name: c
           Type: 12 BaseType int32
           Locations:
-            - Range: 0xd07100..0xd07101
+            - Range: 0xd07220..0xd07221
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
         - Name: d
           Type: 15 BaseType uint
           Locations:
-            - Range: 0xd07100..0xd07101
+            - Range: 0xd07220..0xd07221
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
         - Name: e
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd07100..0xd07101
+            - Range: 0xd07220..0xd07221
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 86
+    - ID: 87
       Name: main.testAtomicAdd
-      OutOfLinePCRanges: [0xd07320..0xd07333]
+      OutOfLinePCRanges: [0xd07440..0xd07453]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0xd07320..0xd07332
+            - Range: 0xd07440..0xd07452
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0xd07320..0xd07332
+            - Range: 0xd07440..0xd07452
               Pieces: []
-            - Range: 0xd07332..0xd07333
+            - Range: 0xd07452..0xd07453
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
-    - ID: 87
+    - ID: 88
       Name: main.testChannel
-      OutOfLinePCRanges: [0xd07340..0xd07341]
+      OutOfLinePCRanges: [0xd07460..0xd07461]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 238 GoChannelType chan bool
           Locations:
-            - Range: 0xd07340..0xd07341
+            - Range: 0xd07460..0xd07461
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 88
+    - ID: 89
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0xd07520..0xd07521]
+      OutOfLinePCRanges: [0xd07640..0xd07641]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 239 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0xd07520..0xd07521
+            - Range: 0xd07640..0xd07641
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 89
+    - ID: 90
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0xd07540..0xd07541]
+      OutOfLinePCRanges: [0xd07660..0xd07661]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 241 StructureType main.node
           Locations:
-            - Range: 0xd07540..0xd07541
+            - Range: 0xd07660..0xd07661
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
-    - ID: 90
+    - ID: 91
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0xd07560..0xd07561]
+      OutOfLinePCRanges: [0xd07680..0xd07681]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 242 PointerType *main.node
           Locations:
-            - Range: 0xd07560..0xd07561
+            - Range: 0xd07680..0xd07681
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 91
+    - ID: 92
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0xd07580..0xd07581]
+      OutOfLinePCRanges: [0xd076a0..0xd076a1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 19 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0xd07580..0xd07581
+            - Range: 0xd076a0..0xd076a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 92
+    - ID: 93
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0xd075c0..0xd075c1]
+      OutOfLinePCRanges: [0xd076e0..0xd076e1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 100 PointerType *uint
           Locations:
-            - Range: 0xd075c0..0xd075c1
+            - Range: 0xd076e0..0xd076e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 93
+    - ID: 94
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0xd076a0..0xd076a1]
+      OutOfLinePCRanges: [0xd077c0..0xd077c1]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 88 PointerType *string
           Locations:
-            - Range: 0xd076a0..0xd076a1
+            - Range: 0xd077c0..0xd077c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 94
+    - ID: 95
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0xd076e0..0xd076e1]
+      OutOfLinePCRanges: [0xd07800..0xd07801]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 5 PointerType *bool
           Locations:
-            - Range: 0xd076e0..0xd076e1
+            - Range: 0xd07800..0xd07801
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: a
           Type: 15 BaseType uint
           Locations:
-            - Range: 0xd076e0..0xd076e1
+            - Range: 0xd07800..0xd07801
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
-    - ID: 95
+    - ID: 96
       Name: main.testCycle
-      OutOfLinePCRanges: [0xd07720..0xd07721]
+      OutOfLinePCRanges: [0xd07840..0xd07841]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 243 PointerType *main.t
           Locations:
-            - Range: 0xd07720..0xd07721
+            - Range: 0xd07840..0xd07841
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 96
+    - ID: 97
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0xd07c20..0xd07c92]
+      OutOfLinePCRanges: [0xd07d40..0xd07db2]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd07c20..0xd07c32
+            - Range: 0xd07d40..0xd07d52
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd07c20..0xd07c7b
+            - Range: 0xd07d40..0xd07d9b
               Pieces: []
-            - Range: 0xd07c7b..0xd07c7c
+            - Range: 0xd07d9b..0xd07d9c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd07c7c..0xd07c92
+            - Range: 0xd07d9c..0xd07db2
               Pieces: []
           Role: Return
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd07c32..0xd07c45
+            - Range: 0xd07d52..0xd07d65
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd07c45..0xd07c92
+            - Range: 0xd07d65..0xd07db2
               Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
           Role: Local
-    - ID: 97
+    - ID: 98
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0xd07ca0..0xd07d35]
+      OutOfLinePCRanges: [0xd07dc0..0xd07e55]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd07ca0..0xd07cba
+            - Range: 0xd07dc0..0xd07dda
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd07cba..0xd07d35
+            - Range: 0xd07dda..0xd07e55
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 93 PointerType *int
           Locations:
-            - Range: 0xd07ca0..0xd07d1b
+            - Range: 0xd07dc0..0xd07e3b
               Pieces: []
-            - Range: 0xd07d1b..0xd07d1c
+            - Range: 0xd07e3b..0xd07e3c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd07d1c..0xd07d35
+            - Range: 0xd07e3c..0xd07e55
               Pieces: []
           Role: Return
         - Name: '&result'
           Type: 93 PointerType *int
           Locations:
-            - Range: 0xd07cbf..0xd07cdc
+            - Range: 0xd07ddf..0xd07dfc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd07cdc..0xd07d35
+            - Range: 0xd07dfc..0xd07e55
               Pieces: [{Size: 8, Op: {CfaOffset: -24}}]
           Role: Local
-    - ID: 98
+    - ID: 99
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0xd07d40..0xd07e1e]
+      OutOfLinePCRanges: [0xd07e60..0xd07f3e]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd07d40..0xd07da2
+            - Range: 0xd07e60..0xd07ec2
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd07d40..0xd07e04
+            - Range: 0xd07e60..0xd07f24
               Pieces: []
-            - Range: 0xd07e04..0xd07e05
+            - Range: 0xd07f24..0xd07f25
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd07e05..0xd07e1e
+            - Range: 0xd07f25..0xd07f3e
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd07d40..0xd07e1e, Pieces: []}]
+          Locations: [{Range: 0xd07e60..0xd07f3e, Pieces: []}]
           Role: Return
         - Name: resultInt
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd07d56..0xd07da7
+            - Range: 0xd07e76..0xd07ec7
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd07da7..0xd07e1e
+            - Range: 0xd07ec7..0xd07f3e
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
           Role: Local
         - Name: resultFloat
           Type: 17 BaseType float64
           Locations:
-            - Range: 0xd07d6f..0xd07da7
+            - Range: 0xd07e8f..0xd07ec7
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
-            - Range: 0xd07da7..0xd07e1e
+            - Range: 0xd07ec7..0xd07f3e
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
-    - ID: 99
+    - ID: 100
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0xd07e20..0xd07e7b]
+      OutOfLinePCRanges: [0xd07f40..0xd07f9b]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xd07e20..0xd07e39
+            - Range: 0xd07f40..0xd07f59
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 18 GoInterfaceType error
           Locations:
-            - Range: 0xd07e20..0xd07e5a
+            - Range: 0xd07f40..0xd07f7a
               Pieces: []
-            - Range: 0xd07e5a..0xd07e5b
+            - Range: 0xd07f7a..0xd07f7b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd07e5b..0xd07e65
+            - Range: 0xd07f7b..0xd07f85
               Pieces: []
-            - Range: 0xd07e65..0xd07e66
+            - Range: 0xd07f85..0xd07f86
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd07e66..0xd07e7b
+            - Range: 0xd07f86..0xd07f9b
               Pieces: []
           Role: Return
-    - ID: 100
+    - ID: 101
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0xd07e80..0xd07fc6]
+      OutOfLinePCRanges: [0xd07fa0..0xd080e6]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xd07e80..0xd07ed1
+            - Range: 0xd07fa0..0xd07ff1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd07ed1..0xd07ed4
+            - Range: 0xd07ff1..0xd07ff4
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd07f17..0xd07f25
+            - Range: 0xd08037..0xd08045
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd07f40..0xd07f45
+            - Range: 0xd08060..0xd08065
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd07f74..0xd07f79
+            - Range: 0xd08094..0xd08099
               Pieces:
                 - Size: 8
                   Op: null
@@ -6148,112 +6234,112 @@ Subprograms:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xd07e80..0xd07ecf
+            - Range: 0xd07fa0..0xd07fef
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xd07e80..0xd07ef8
+            - Range: 0xd07fa0..0xd08018
               Pieces: []
-            - Range: 0xd07ef8..0xd07ef9
+            - Range: 0xd08018..0xd08019
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd07ef9..0xd07f33
+            - Range: 0xd08019..0xd08053
               Pieces: []
-            - Range: 0xd07f33..0xd07f34
+            - Range: 0xd08053..0xd08054
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd07f34..0xd07f67
+            - Range: 0xd08054..0xd08087
               Pieces: []
-            - Range: 0xd07f67..0xd07f68
+            - Range: 0xd08087..0xd08088
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd07f68..0xd07f99
+            - Range: 0xd08088..0xd080b9
               Pieces: []
-            - Range: 0xd07f99..0xd07f9a
+            - Range: 0xd080b9..0xd080ba
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd07f9a..0xd07fc6
+            - Range: 0xd080ba..0xd080e6
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 18 GoInterfaceType error
           Locations:
-            - Range: 0xd07e80..0xd07ef8
+            - Range: 0xd07fa0..0xd08018
               Pieces: []
-            - Range: 0xd07ef8..0xd07ef9
+            - Range: 0xd08018..0xd08019
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd07ef9..0xd07f33
+            - Range: 0xd08019..0xd08053
               Pieces: []
-            - Range: 0xd07f33..0xd07f34
+            - Range: 0xd08053..0xd08054
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd07f34..0xd07f67
+            - Range: 0xd08054..0xd08087
               Pieces: []
-            - Range: 0xd07f67..0xd07f68
+            - Range: 0xd08087..0xd08088
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd07f68..0xd07f99
+            - Range: 0xd08088..0xd080b9
               Pieces: []
-            - Range: 0xd07f99..0xd07f9a
+            - Range: 0xd080b9..0xd080ba
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd07f9a..0xd07fc6
+            - Range: 0xd080ba..0xd080e6
               Pieces: []
           Role: Return
         - Name: val
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd07f17..0xd07f20
+            - Range: 0xd08037..0xd08040
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 101
+    - ID: 102
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0xd07fe0..0xd081d4]
+      OutOfLinePCRanges: [0xd08100..0xd082f4]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xd07fe0..0xd0803f
+            - Range: 0xd08100..0xd0815f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0803f..0xd08042
+            - Range: 0xd0815f..0xd08162
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd08042..0xd081d4
+            - Range: 0xd08162..0xd082f4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -6263,941 +6349,941 @@ Subprograms:
         - Name: ~r0
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xd07fe0..0xd080a4
+            - Range: 0xd08100..0xd081c4
               Pieces: []
-            - Range: 0xd080a4..0xd080a5
+            - Range: 0xd081c4..0xd081c5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd080a5..0xd080df
+            - Range: 0xd081c5..0xd081ff
               Pieces: []
-            - Range: 0xd080df..0xd080e0
+            - Range: 0xd081ff..0xd08200
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd080e0..0xd081a2
+            - Range: 0xd08200..0xd082c2
               Pieces: []
-            - Range: 0xd081a2..0xd081a3
+            - Range: 0xd082c2..0xd082c3
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd081a3..0xd081ac
+            - Range: 0xd082c3..0xd082cc
               Pieces: []
-            - Range: 0xd081ac..0xd081ad
+            - Range: 0xd082cc..0xd082cd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd081ad..0xd081d4
+            - Range: 0xd082cd..0xd082f4
               Pieces: []
           Role: Return
         - Name: val
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd080ca..0xd080d0
+            - Range: 0xd081ea..0xd081f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
         - Name: '&result'
           Type: 93 PointerType *int
           Locations:
-            - Range: 0xd08085..0xd080a4
+            - Range: 0xd081a5..0xd081c4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 102
+    - ID: 103
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0xd081e0..0xd08345]
+      OutOfLinePCRanges: [0xd08300..0xd08465]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xd081e0..0xd08220
+            - Range: 0xd08300..0xd08340
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd08220..0xd08285
+            - Range: 0xd08340..0xd083a5
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xd08285..0xd082e1
+            - Range: 0xd083a5..0xd08401
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xd082e1..0xd08301
+            - Range: 0xd08401..0xd08421
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd08301..0xd08308
+            - Range: 0xd08421..0xd08428
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd08308..0xd08345
+            - Range: 0xd08428..0xd08465
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 157 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xd081e0..0xd082d1
+            - Range: 0xd08300..0xd083f1
               Pieces: []
-            - Range: 0xd082d1..0xd082d2
+            - Range: 0xd083f1..0xd083f2
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd082d2..0xd082db
+            - Range: 0xd083f2..0xd083fb
               Pieces: []
-            - Range: 0xd082db..0xd082dc
+            - Range: 0xd083fb..0xd083fc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd082dc..0xd08345
+            - Range: 0xd083fc..0xd08465
               Pieces: []
           Role: Return
         - Name: b
           Type: 157 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xd081e0..0xd08220
+            - Range: 0xd08300..0xd08340
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd08220..0xd08275
+            - Range: 0xd08340..0xd08395
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd08275..0xd08285
+            - Range: 0xd08395..0xd083a5
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -72}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd08285..0xd082d7
+            - Range: 0xd083a5..0xd083f7
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -72}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd082d7..0xd082d9
+            - Range: 0xd083f7..0xd083f9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd082d9..0xd082db
+            - Range: 0xd083f9..0xd083fb
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xd082db..0xd08345
+            - Range: 0xd083fb..0xd08465
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           Role: Local
-    - ID: 103
+    - ID: 104
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0xd08360..0xd083ef]
+      OutOfLinePCRanges: [0xd08480..0xd0850f]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd08360..0xd08371
+            - Range: 0xd08480..0xd08491
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd08360..0xd083d5
+            - Range: 0xd08480..0xd084f5
               Pieces: []
-            - Range: 0xd083d5..0xd083d6
+            - Range: 0xd084f5..0xd084f6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd083d6..0xd083ef
+            - Range: 0xd084f6..0xd0850f
               Pieces: []
           Role: Return
-    - ID: 104
+    - ID: 105
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0xd08400..0xd084c9]
+      OutOfLinePCRanges: [0xd08520..0xd085e9]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd08400..0xd08453
+            - Range: 0xd08520..0xd08573
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd08400..0xd084af
+            - Range: 0xd08520..0xd085cf
               Pieces: []
-            - Range: 0xd084af..0xd084b0
+            - Range: 0xd085cf..0xd085d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd084b0..0xd084c9
+            - Range: 0xd085d0..0xd085e9
               Pieces: []
           Role: Return
         - Name: result2
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd08400..0xd084af
+            - Range: 0xd08520..0xd085cf
               Pieces: []
-            - Range: 0xd084af..0xd084b0
+            - Range: 0xd085cf..0xd085d0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd084b0..0xd084c9
+            - Range: 0xd085d0..0xd085e9
               Pieces: []
           Role: Return
-    - ID: 105
+    - ID: 106
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0xd084e0..0xd085a8]
+      OutOfLinePCRanges: [0xd08600..0xd086c8]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd084e0..0xd08525
+            - Range: 0xd08600..0xd08645
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd08525..0xd085a8
+            - Range: 0xd08645..0xd086c8
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd084e0..0xd0858e
+            - Range: 0xd08600..0xd086ae
               Pieces: []
-            - Range: 0xd0858e..0xd0858f
+            - Range: 0xd086ae..0xd086af
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0858f..0xd085a8
+            - Range: 0xd086af..0xd086c8
               Pieces: []
           Role: Return
         - Name: result2
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd084e0..0xd0858e
+            - Range: 0xd08600..0xd086ae
               Pieces: []
-            - Range: 0xd0858e..0xd0858f
+            - Range: 0xd086ae..0xd086af
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd0858f..0xd085a8
+            - Range: 0xd086af..0xd086c8
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd084e0..0xd0858e
+            - Range: 0xd08600..0xd086ae
               Pieces: []
-            - Range: 0xd0858e..0xd0858f
+            - Range: 0xd086ae..0xd086af
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd0858f..0xd085a8
+            - Range: 0xd086af..0xd086c8
               Pieces: []
           Role: Return
-    - ID: 106
+    - ID: 107
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0xd085c0..0xd0863e]
+      OutOfLinePCRanges: [0xd086e0..0xd0875e]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 14 BaseType int8
           Locations:
-            - Range: 0xd085c0..0xd08631
+            - Range: 0xd086e0..0xd08751
               Pieces: []
-            - Range: 0xd08631..0xd08632
+            - Range: 0xd08751..0xd08752
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd08632..0xd0863e
+            - Range: 0xd08752..0xd0875e
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 97 BaseType int16
           Locations:
-            - Range: 0xd085c0..0xd08631
+            - Range: 0xd086e0..0xd08751
               Pieces: []
-            - Range: 0xd08631..0xd08632
+            - Range: 0xd08751..0xd08752
               Pieces: [{Size: 2, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd08632..0xd0863e
+            - Range: 0xd08752..0xd0875e
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 12 BaseType int32
           Locations:
-            - Range: 0xd085c0..0xd08631
+            - Range: 0xd086e0..0xd08751
               Pieces: []
-            - Range: 0xd08631..0xd08632
+            - Range: 0xd08751..0xd08752
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd08632..0xd0863e
+            - Range: 0xd08752..0xd0875e
               Pieces: []
           Role: Return
         - Name: ~r3
           Type: 13 BaseType int64
           Locations:
-            - Range: 0xd085c0..0xd08631
+            - Range: 0xd086e0..0xd08751
               Pieces: []
-            - Range: 0xd08631..0xd08632
+            - Range: 0xd08751..0xd08752
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xd08632..0xd0863e
+            - Range: 0xd08752..0xd0875e
               Pieces: []
           Role: Return
         - Name: ~r4
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xd085c0..0xd08631
+            - Range: 0xd086e0..0xd08751
               Pieces: []
-            - Range: 0xd08631..0xd08632
+            - Range: 0xd08751..0xd08752
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xd08632..0xd0863e
+            - Range: 0xd08752..0xd0875e
               Pieces: []
           Role: Return
         - Name: ~r5
           Type: 7 BaseType uint16
           Locations:
-            - Range: 0xd085c0..0xd08631
+            - Range: 0xd086e0..0xd08751
               Pieces: []
-            - Range: 0xd08631..0xd08632
+            - Range: 0xd08751..0xd08752
               Pieces: [{Size: 2, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xd08632..0xd0863e
+            - Range: 0xd08752..0xd0875e
               Pieces: []
           Role: Return
         - Name: ~r6
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0xd085c0..0xd08631
+            - Range: 0xd086e0..0xd08751
               Pieces: []
-            - Range: 0xd08631..0xd08632
+            - Range: 0xd08751..0xd08752
               Pieces: [{Size: 4, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xd08632..0xd0863e
+            - Range: 0xd08752..0xd0875e
               Pieces: []
           Role: Return
         - Name: ~r7
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0xd085c0..0xd08631
+            - Range: 0xd086e0..0xd08751
               Pieces: []
-            - Range: 0xd08631..0xd08632
+            - Range: 0xd08751..0xd08752
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xd08632..0xd0863e
+            - Range: 0xd08752..0xd0875e
               Pieces: []
           Role: Return
-    - ID: 107
+    - ID: 108
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0xd08640..0xd08735]
+      OutOfLinePCRanges: [0xd08760..0xd08855]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd08640..0xd08735, Pieces: []}]
+          Locations: [{Range: 0xd08760..0xd08855, Pieces: []}]
           Role: Return
         - Name: ~r1
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd08640..0xd08735, Pieces: []}]
+          Locations: [{Range: 0xd08760..0xd08855, Pieces: []}]
           Role: Return
         - Name: ~r2
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd08640..0xd08735, Pieces: []}]
+          Locations: [{Range: 0xd08760..0xd08855, Pieces: []}]
           Role: Return
         - Name: ~r3
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd08640..0xd08735, Pieces: []}]
+          Locations: [{Range: 0xd08760..0xd08855, Pieces: []}]
           Role: Return
         - Name: ~r4
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd08640..0xd08735, Pieces: []}]
+          Locations: [{Range: 0xd08760..0xd08855, Pieces: []}]
           Role: Return
         - Name: ~r5
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd08640..0xd08735, Pieces: []}]
+          Locations: [{Range: 0xd08760..0xd08855, Pieces: []}]
           Role: Return
         - Name: ~r6
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd08640..0xd08735, Pieces: []}]
+          Locations: [{Range: 0xd08760..0xd08855, Pieces: []}]
           Role: Return
         - Name: ~r7
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd08640..0xd08735, Pieces: []}]
+          Locations: [{Range: 0xd08760..0xd08855, Pieces: []}]
           Role: Return
         - Name: ~r8
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd08640..0xd08735, Pieces: []}]
+          Locations: [{Range: 0xd08760..0xd08855, Pieces: []}]
           Role: Return
         - Name: ~r9
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd08640..0xd08735, Pieces: []}]
+          Locations: [{Range: 0xd08760..0xd08855, Pieces: []}]
           Role: Return
         - Name: ~r10
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd08640..0xd08735, Pieces: []}]
+          Locations: [{Range: 0xd08760..0xd08855, Pieces: []}]
           Role: Return
         - Name: ~r11
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd08640..0xd08735, Pieces: []}]
+          Locations: [{Range: 0xd08760..0xd08855, Pieces: []}]
           Role: Return
         - Name: ~r12
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd08640..0xd08735, Pieces: []}]
+          Locations: [{Range: 0xd08760..0xd08855, Pieces: []}]
           Role: Return
         - Name: ~r13
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd08640..0xd08735, Pieces: []}]
+          Locations: [{Range: 0xd08760..0xd08855, Pieces: []}]
           Role: Return
         - Name: ~r14
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd08640..0xd08735, Pieces: []}]
+          Locations: [{Range: 0xd08760..0xd08855, Pieces: []}]
           Role: Return
         - Name: onlyOnAmd64_16
           Type: 17 BaseType float64
           Locations:
-            - Range: 0xd08640..0xd08725
+            - Range: 0xd08760..0xd08845
               Pieces: []
-            - Range: 0xd08725..0xd08726
+            - Range: 0xd08845..0xd08846
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xd08726..0xd08735
+            - Range: 0xd08846..0xd08855
               Pieces: []
           Role: Return
         - Name: bothArmAndAmd64
           Type: 17 BaseType float64
           Locations:
-            - Range: 0xd08640..0xd08725
+            - Range: 0xd08760..0xd08845
               Pieces: []
-            - Range: 0xd08725..0xd08726
+            - Range: 0xd08845..0xd08846
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xd08726..0xd08735
+            - Range: 0xd08846..0xd08855
               Pieces: []
           Role: Return
-    - ID: 108
+    - ID: 109
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0xd08740..0xd087b3]
+      OutOfLinePCRanges: [0xd08860..0xd088d3]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 89 BaseType complex64
-          Locations: [{Range: 0xd08740..0xd087b3, Pieces: []}]
+          Locations: [{Range: 0xd08860..0xd088d3, Pieces: []}]
           Role: Return
         - Name: ~r1
           Type: 90 BaseType complex128
-          Locations: [{Range: 0xd08740..0xd087b3, Pieces: []}]
+          Locations: [{Range: 0xd08860..0xd088d3, Pieces: []}]
           Role: Return
-    - ID: 109
+    - ID: 110
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0xd087c0..0xd08865]
+      OutOfLinePCRanges: [0xd088e0..0xd08985]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0xd087c0..0xd08853
+            - Range: 0xd088e0..0xd08973
               Pieces: []
-            - Range: 0xd08853..0xd08854
+            - Range: 0xd08973..0xd08974
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
-            - Range: 0xd08854..0xd08865
+            - Range: 0xd08974..0xd08985
               Pieces: []
           Role: Return
-    - ID: 110
+    - ID: 111
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0xd08880..0xd088fa]
+      OutOfLinePCRanges: [0xd089a0..0xd08a1a]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 246 ArrayType [3]int
           Locations:
-            - Range: 0xd08880..0xd088ed
+            - Range: 0xd089a0..0xd08a0d
               Pieces: []
-            - Range: 0xd088ed..0xd088ee
+            - Range: 0xd08a0d..0xd08a0e
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xd088ee..0xd088fa
+            - Range: 0xd08a0e..0xd08a1a
               Pieces: []
           Role: Return
-    - ID: 111
+    - ID: 112
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0xd08900..0xd08958]
+      OutOfLinePCRanges: [0xd08a20..0xd08a78]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 247 ArrayType [1]int
           Locations:
-            - Range: 0xd08900..0xd0894b
+            - Range: 0xd08a20..0xd08a6b
               Pieces: []
-            - Range: 0xd0894b..0xd0894c
+            - Range: 0xd08a6b..0xd08a6c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0894c..0xd08958
+            - Range: 0xd08a6c..0xd08a78
               Pieces: []
           Role: Return
-    - ID: 112
+    - ID: 113
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0xd08960..0xd089b3]
+      OutOfLinePCRanges: [0xd08a80..0xd08ad3]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 248 ArrayType [0]int
           Locations:
-            - Range: 0xd08960..0xd089a6
+            - Range: 0xd08a80..0xd08ac6
               Pieces: []
-            - Range: 0xd089a6..0xd089a7
+            - Range: 0xd08ac6..0xd08ac7
               Pieces: []
-            - Range: 0xd089a7..0xd089b3
+            - Range: 0xd08ac7..0xd08ad3
               Pieces: []
           Role: Return
-    - ID: 113
+    - ID: 114
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0xd089c0..0xd08a27]
+      OutOfLinePCRanges: [0xd08ae0..0xd08b47]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 249 StructureType main.mixedStruct
-          Locations: [{Range: 0xd089c0..0xd08a27, Pieces: []}]
+          Locations: [{Range: 0xd08ae0..0xd08b47, Pieces: []}]
           Role: Return
-    - ID: 114
+    - ID: 115
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0xd08a40..0xd08ada]
+      OutOfLinePCRanges: [0xd08b60..0xd08bfa]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd08a40..0xd08aca
+            - Range: 0xd08b60..0xd08bea
               Pieces: []
-            - Range: 0xd08aca..0xd08acb
+            - Range: 0xd08bea..0xd08beb
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd08acb..0xd08ada
+            - Range: 0xd08beb..0xd08bfa
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd08a40..0xd08aca
+            - Range: 0xd08b60..0xd08bea
               Pieces: []
-            - Range: 0xd08aca..0xd08acb
+            - Range: 0xd08bea..0xd08beb
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd08acb..0xd08ada
+            - Range: 0xd08beb..0xd08bfa
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd08a40..0xd08aca
+            - Range: 0xd08b60..0xd08bea
               Pieces: []
-            - Range: 0xd08aca..0xd08acb
+            - Range: 0xd08bea..0xd08beb
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd08acb..0xd08ada
+            - Range: 0xd08beb..0xd08bfa
               Pieces: []
           Role: Return
         - Name: ~r3
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd08a40..0xd08aca
+            - Range: 0xd08b60..0xd08bea
               Pieces: []
-            - Range: 0xd08aca..0xd08acb
+            - Range: 0xd08bea..0xd08beb
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xd08acb..0xd08ada
+            - Range: 0xd08beb..0xd08bfa
               Pieces: []
           Role: Return
         - Name: ~r4
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd08a40..0xd08aca
+            - Range: 0xd08b60..0xd08bea
               Pieces: []
-            - Range: 0xd08aca..0xd08acb
+            - Range: 0xd08bea..0xd08beb
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xd08acb..0xd08ada
+            - Range: 0xd08beb..0xd08bfa
               Pieces: []
           Role: Return
         - Name: ~r5
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd08a40..0xd08aca
+            - Range: 0xd08b60..0xd08bea
               Pieces: []
-            - Range: 0xd08aca..0xd08acb
+            - Range: 0xd08bea..0xd08beb
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xd08acb..0xd08ada
+            - Range: 0xd08beb..0xd08bfa
               Pieces: []
           Role: Return
         - Name: ~r6
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd08a40..0xd08aca
+            - Range: 0xd08b60..0xd08bea
               Pieces: []
-            - Range: 0xd08aca..0xd08acb
+            - Range: 0xd08bea..0xd08beb
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xd08acb..0xd08ada
+            - Range: 0xd08beb..0xd08bfa
               Pieces: []
           Role: Return
         - Name: ~r7
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd08a40..0xd08aca
+            - Range: 0xd08b60..0xd08bea
               Pieces: []
-            - Range: 0xd08aca..0xd08acb
+            - Range: 0xd08bea..0xd08beb
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xd08acb..0xd08ada
+            - Range: 0xd08beb..0xd08bfa
               Pieces: []
           Role: Return
         - Name: ~r8
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd08a40..0xd08aca
+            - Range: 0xd08b60..0xd08bea
               Pieces: []
-            - Range: 0xd08aca..0xd08acb
+            - Range: 0xd08bea..0xd08beb
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xd08acb..0xd08ada
+            - Range: 0xd08beb..0xd08bfa
               Pieces: []
           Role: Return
-    - ID: 115
+    - ID: 116
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0xd08ae0..0xd08b85]
+      OutOfLinePCRanges: [0xd08c00..0xd08ca5]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 250 StructureType main.wideStruct
           Locations:
-            - Range: 0xd08ae0..0xd08b74
+            - Range: 0xd08c00..0xd08c94
               Pieces: []
-            - Range: 0xd08b74..0xd08b75
+            - Range: 0xd08c94..0xd08c95
               Pieces: [{Size: 88, Op: {CfaOffset: 0}}]
-            - Range: 0xd08b75..0xd08b85
+            - Range: 0xd08c95..0xd08ca5
               Pieces: []
           Role: Return
-    - ID: 116
+    - ID: 117
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0xd08ba0..0xd08c19]
+      OutOfLinePCRanges: [0xd08cc0..0xd08d39]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd08ba0..0xd08c0c
+            - Range: 0xd08cc0..0xd08d2c
               Pieces: []
-            - Range: 0xd08c0c..0xd08c0d
+            - Range: 0xd08d2c..0xd08d2d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd08c0d..0xd08c19
+            - Range: 0xd08d2d..0xd08d39
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd08ba0..0xd08c19, Pieces: []}]
+          Locations: [{Range: 0xd08cc0..0xd08d39, Pieces: []}]
           Role: Return
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd08ba0..0xd08c0c
+            - Range: 0xd08cc0..0xd08d2c
               Pieces: []
-            - Range: 0xd08c0c..0xd08c0d
+            - Range: 0xd08d2c..0xd08d2d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd08c0d..0xd08c19
+            - Range: 0xd08d2d..0xd08d39
               Pieces: []
           Role: Return
         - Name: ~r3
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd08ba0..0xd08c19, Pieces: []}]
+          Locations: [{Range: 0xd08cc0..0xd08d39, Pieces: []}]
           Role: Return
         - Name: ~r4
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd08ba0..0xd08c0c
+            - Range: 0xd08cc0..0xd08d2c
               Pieces: []
-            - Range: 0xd08c0c..0xd08c0d
+            - Range: 0xd08d2c..0xd08d2d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd08c0d..0xd08c19
+            - Range: 0xd08d2d..0xd08d39
               Pieces: []
           Role: Return
-    - ID: 117
+    - ID: 118
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0xd08c20..0xd08c9a]
+      OutOfLinePCRanges: [0xd08d40..0xd08dba]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 251 StructureType main.structWithArray
           Locations:
-            - Range: 0xd08c20..0xd08c8d
+            - Range: 0xd08d40..0xd08dad
               Pieces: []
-            - Range: 0xd08c8d..0xd08c8e
+            - Range: 0xd08dad..0xd08dae
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xd08c8e..0xd08c9a
+            - Range: 0xd08dae..0xd08dba
               Pieces: []
           Role: Return
-    - ID: 118
+    - ID: 119
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0xd08ca0..0xd08cfb]
+      OutOfLinePCRanges: [0xd08dc0..0xd08e1b]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd08ca0..0xd08cfb, Pieces: []}]
+          Locations: [{Range: 0xd08dc0..0xd08e1b, Pieces: []}]
           Role: Return
-    - ID: 119
+    - ID: 120
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0xd08d00..0xd08d67]
+      OutOfLinePCRanges: [0xd08e20..0xd08e87]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 16 BaseType float32
-          Locations: [{Range: 0xd08d00..0xd08d67, Pieces: []}]
+          Locations: [{Range: 0xd08e20..0xd08e87, Pieces: []}]
           Role: Return
         - Name: ~r1
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd08d00..0xd08d67, Pieces: []}]
+          Locations: [{Range: 0xd08e20..0xd08e87, Pieces: []}]
           Role: Return
-    - ID: 120
+    - ID: 121
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0xd08d80..0xd08ddd]
+      OutOfLinePCRanges: [0xd08ea0..0xd08efd]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xd08d80..0xd08dd0
+            - Range: 0xd08ea0..0xd08ef0
               Pieces: []
-            - Range: 0xd08dd0..0xd08dd1
+            - Range: 0xd08ef0..0xd08ef1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd08dd1..0xd08ddd
+            - Range: 0xd08ef1..0xd08efd
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 1 BaseType uintptr
           Locations:
-            - Range: 0xd08d80..0xd08dd0
+            - Range: 0xd08ea0..0xd08ef0
               Pieces: []
-            - Range: 0xd08dd0..0xd08dd1
+            - Range: 0xd08ef0..0xd08ef1
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd08dd1..0xd08ddd
+            - Range: 0xd08ef1..0xd08efd
               Pieces: []
           Role: Return
-    - ID: 121
+    - ID: 122
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0xd08de0..0xd08f45]
+      OutOfLinePCRanges: [0xd08f00..0xd09065]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0xd08de0..0xd08f45
+            - Range: 0xd08f00..0xd09065
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0xd08de0..0xd08f33
+            - Range: 0xd08f00..0xd09053
               Pieces: []
-            - Range: 0xd08f33..0xd08f34
+            - Range: 0xd09053..0xd09054
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
-            - Range: 0xd08f34..0xd08f45
+            - Range: 0xd09054..0xd09065
               Pieces: []
           Role: Return
-    - ID: 122
+    - ID: 123
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0xd08f60..0xd09032]
+      OutOfLinePCRanges: [0xd09080..0xd09152]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 246 ArrayType [3]int
           Locations:
-            - Range: 0xd08f60..0xd09032
+            - Range: 0xd09080..0xd09152
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 246 ArrayType [3]int
           Locations:
-            - Range: 0xd08f60..0xd09022
+            - Range: 0xd09080..0xd09142
               Pieces: []
-            - Range: 0xd09022..0xd09023
+            - Range: 0xd09142..0xd09143
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xd09023..0xd09032
+            - Range: 0xd09143..0xd09152
               Pieces: []
           Role: Return
-    - ID: 123
+    - ID: 124
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0xd09040..0xd0927a]
+      OutOfLinePCRanges: [0xd09160..0xd0939a]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0xd09040..0xd0927a
+            - Range: 0xd09160..0xd0939a
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: s2
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0xd09040..0xd0927a
+            - Range: 0xd09160..0xd0939a
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
           Role: Parameter
         - Name: ~r0
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0xd09040..0xd0926a
+            - Range: 0xd09160..0xd0938a
               Pieces: []
-            - Range: 0xd0926a..0xd0926b
+            - Range: 0xd0938a..0xd0938b
               Pieces: [{Size: 80, Op: {CfaOffset: 160}}]
-            - Range: 0xd0926b..0xd0927a
+            - Range: 0xd0938b..0xd0939a
               Pieces: []
           Role: Return
-    - ID: 124
+    - ID: 125
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0xd09280..0xd0950f]
+      OutOfLinePCRanges: [0xd093a0..0xd0962f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd09280..0xd09330
+            - Range: 0xd093a0..0xd09450
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd09330..0xd0950f
+            - Range: 0xd09450..0xd0962f
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd09280..0xd09330
+            - Range: 0xd093a0..0xd09450
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd09330..0xd0950f
+            - Range: 0xd09450..0xd0962f
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
         - Name: c
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd09280..0xd09330
+            - Range: 0xd093a0..0xd09450
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd09330..0xd0950f
+            - Range: 0xd09450..0xd0962f
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
         - Name: d
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd09280..0xd092f0
+            - Range: 0xd093a0..0xd09410
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xd092f0..0xd0950f
+            - Range: 0xd09410..0xd0962f
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
         - Name: e
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd09280..0xd09330
+            - Range: 0xd093a0..0xd09450
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xd09330..0xd0950f
+            - Range: 0xd09450..0xd0962f
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
         - Name: f
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd09280..0xd09330
+            - Range: 0xd093a0..0xd09450
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xd09330..0xd0950f
+            - Range: 0xd09450..0xd0962f
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
         - Name: g
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd09280..0xd09330
+            - Range: 0xd093a0..0xd09450
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xd09330..0xd0950f
+            - Range: 0xd09450..0xd0962f
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
         - Name: h
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd09280..0xd09330
+            - Range: 0xd093a0..0xd09450
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xd09330..0xd0950f
+            - Range: 0xd09450..0xd0962f
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd09280..0xd09330
+            - Range: 0xd093a0..0xd09450
               Pieces: [{Size: 8, Op: {RegNo: 11, Shift: 0}}]
-            - Range: 0xd09330..0xd0950f
+            - Range: 0xd09450..0xd0962f
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
         - Name: ~r0
           Type: 106 ArrayType [2]int
           Locations:
-            - Range: 0xd09280..0xd094a2
+            - Range: 0xd093a0..0xd095c2
               Pieces: []
-            - Range: 0xd094a2..0xd094a3
+            - Range: 0xd095c2..0xd095c3
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xd094a3..0xd0950f
+            - Range: 0xd095c3..0xd0962f
               Pieces: []
           Role: Return
-    - ID: 125
+    - ID: 126
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0xd09520..0xd097ec]
+      OutOfLinePCRanges: [0xd09640..0xd0990c]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd09520..0xd095cb
+            - Range: 0xd09640..0xd096eb
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd095cb..0xd097ec
+            - Range: 0xd096eb..0xd0990c
               Pieces: [{Size: 8, Op: {CfaOffset: 96}}]
           Role: Parameter
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd09520..0xd095cb
+            - Range: 0xd09640..0xd096eb
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd095cb..0xd097ec
+            - Range: 0xd096eb..0xd0990c
               Pieces: [{Size: 8, Op: {CfaOffset: 104}}]
           Role: Parameter
         - Name: c
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd09520..0xd095cb
+            - Range: 0xd09640..0xd096eb
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd095cb..0xd097ec
+            - Range: 0xd096eb..0xd0990c
               Pieces: [{Size: 8, Op: {CfaOffset: 112}}]
           Role: Parameter
         - Name: d
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd09520..0xd09582
+            - Range: 0xd09640..0xd096a2
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xd09582..0xd097ec
+            - Range: 0xd096a2..0xd0990c
               Pieces: [{Size: 8, Op: {CfaOffset: 120}}]
           Role: Parameter
         - Name: e
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd09520..0xd095cb
+            - Range: 0xd09640..0xd096eb
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xd095cb..0xd097ec
+            - Range: 0xd096eb..0xd0990c
               Pieces: [{Size: 8, Op: {CfaOffset: 128}}]
           Role: Parameter
         - Name: f
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd09520..0xd095cb
+            - Range: 0xd09640..0xd096eb
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xd095cb..0xd097ec
+            - Range: 0xd096eb..0xd0990c
               Pieces: [{Size: 8, Op: {CfaOffset: 136}}]
           Role: Parameter
         - Name: g
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd09520..0xd095cb
+            - Range: 0xd09640..0xd096eb
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xd095cb..0xd097ec
+            - Range: 0xd096eb..0xd0990c
               Pieces: [{Size: 8, Op: {CfaOffset: 144}}]
           Role: Parameter
         - Name: h
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd09520..0xd095cb
+            - Range: 0xd09640..0xd096eb
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xd095cb..0xd097ec
+            - Range: 0xd096eb..0xd0990c
               Pieces: [{Size: 8, Op: {CfaOffset: 152}}]
           Role: Parameter
         - Name: s
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd09520..0xd097ec
+            - Range: 0xd09640..0xd0990c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -7207,358 +7293,175 @@ Subprograms:
         - Name: ~r0
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0xd09520..0xd0976b
+            - Range: 0xd09640..0xd0988b
               Pieces: []
-            - Range: 0xd0976b..0xd0976c
+            - Range: 0xd0988b..0xd0988c
               Pieces: [{Size: 80, Op: {CfaOffset: 16}}]
-            - Range: 0xd0976c..0xd097ec
+            - Range: 0xd0988c..0xd0990c
               Pieces: []
           Role: Return
-    - ID: 126
+    - ID: 127
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0xd09800..0xd0988c]
+      OutOfLinePCRanges: [0xd09920..0xd099ac]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 156 ArrayType [5]int
           Locations:
-            - Range: 0xd09800..0xd0988c
+            - Range: 0xd09920..0xd099ac
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd09800..0xd0987c
+            - Range: 0xd09920..0xd0999c
               Pieces: []
-            - Range: 0xd0987c..0xd0987d
+            - Range: 0xd0999c..0xd0999d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0987d..0xd0988c
+            - Range: 0xd0999d..0xd099ac
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd09800..0xd0987c
+            - Range: 0xd09920..0xd0999c
               Pieces: []
-            - Range: 0xd0987c..0xd0987d
+            - Range: 0xd0999c..0xd0999d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd0987d..0xd0988c
+            - Range: 0xd0999d..0xd099ac
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd09800..0xd0987c
+            - Range: 0xd09920..0xd0999c
               Pieces: []
-            - Range: 0xd0987c..0xd0987d
+            - Range: 0xd0999c..0xd0999d
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd0987d..0xd0988c
+            - Range: 0xd0999d..0xd099ac
               Pieces: []
           Role: Return
-    - ID: 127
+    - ID: 128
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0xd098a0..0xd0998a]
+      OutOfLinePCRanges: [0xd099c0..0xd09aaa]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 106 ArrayType [2]int
           Locations:
-            - Range: 0xd098a0..0xd0998a
+            - Range: 0xd099c0..0xd09aaa
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: b
           Type: 246 ArrayType [3]int
           Locations:
-            - Range: 0xd098a0..0xd0998a
+            - Range: 0xd099c0..0xd09aaa
               Pieces: [{Size: 24, Op: {CfaOffset: 16}}]
           Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd098a0..0xd09976
+            - Range: 0xd099c0..0xd09a96
               Pieces: []
-            - Range: 0xd09976..0xd09977
+            - Range: 0xd09a96..0xd09a97
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd09977..0xd0998a
+            - Range: 0xd09a97..0xd09aaa
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 106 ArrayType [2]int
           Locations:
-            - Range: 0xd098a0..0xd09976
+            - Range: 0xd099c0..0xd09a96
               Pieces: []
-            - Range: 0xd09976..0xd09977
+            - Range: 0xd09a96..0xd09a97
               Pieces: [{Size: 16, Op: {CfaOffset: 40}}]
-            - Range: 0xd09977..0xd0998a
+            - Range: 0xd09a97..0xd09aaa
               Pieces: []
           Role: Return
-    - ID: 128
+    - ID: 129
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0xd099a0..0xd09a6b]
+      OutOfLinePCRanges: [0xd09ac0..0xd09b8b]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 251 StructureType main.structWithArray
           Locations:
-            - Range: 0xd099a0..0xd09a6b
+            - Range: 0xd09ac0..0xd09b8b
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd099a0..0xd09a5a
+            - Range: 0xd09ac0..0xd09b7a
               Pieces: []
-            - Range: 0xd09a5a..0xd09a5b
+            - Range: 0xd09b7a..0xd09b7b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd09a5b..0xd09a6b
+            - Range: 0xd09b7b..0xd09b8b
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 251 StructureType main.structWithArray
           Locations:
-            - Range: 0xd099a0..0xd09a5a
+            - Range: 0xd09ac0..0xd09b7a
               Pieces: []
-            - Range: 0xd09a5a..0xd09a5b
+            - Range: 0xd09b7a..0xd09b7b
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xd09a5b..0xd09a6b
+            - Range: 0xd09b7b..0xd09b8b
               Pieces: []
           Role: Return
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd09a26..0xd09a6b
+            - Range: 0xd09b46..0xd09b8b
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
-    - ID: 129
+    - ID: 130
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0xd09a80..0xd09b26]
+      OutOfLinePCRanges: [0xd09ba0..0xd09c46]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 248 ArrayType [0]int
-          Locations: [{Range: 0xd09a80..0xd09b26, Pieces: []}]
+          Locations: [{Range: 0xd09ba0..0xd09c46, Pieces: []}]
           Role: Parameter
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd09a80..0xd09ac5
+            - Range: 0xd09ba0..0xd09be5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd09ac5..0xd09ae7
+            - Range: 0xd09be5..0xd09c07
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xd09ae7..0xd09b02
+            - Range: 0xd09c07..0xd09c22
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xd09b02..0xd09b26
+            - Range: 0xd09c22..0xd09c46
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd09a80..0xd09b0c
+            - Range: 0xd09ba0..0xd09c2c
               Pieces: []
-            - Range: 0xd09b0c..0xd09b0d
+            - Range: 0xd09c2c..0xd09c2d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd09b0d..0xd09b26
+            - Range: 0xd09c2d..0xd09c46
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 248 ArrayType [0]int
           Locations:
-            - Range: 0xd09a80..0xd09b0c
+            - Range: 0xd09ba0..0xd09c2c
               Pieces: []
-            - Range: 0xd09b0c..0xd09b0d
+            - Range: 0xd09c2c..0xd09c2d
               Pieces: []
-            - Range: 0xd09b0d..0xd09b26
+            - Range: 0xd09c2d..0xd09c46
               Pieces: []
           Role: Return
-    - ID: 130
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0xd0a020..0xd0a021]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 252 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xd0a020..0xd0a021
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
     - ID: 131
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0xd0a040..0xd0a041]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 252 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xd0a040..0xd0a041
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-    - ID: 132
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0xd0a060..0xd0a061]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 253 GoSliceHeaderType [][]uint
-          Locations:
-            - Range: 0xd0a060..0xd0a061
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-    - ID: 133
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0xd0a080..0xd0a081]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 255 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xd0a080..0xd0a081
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-        - Name: a
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0xd0a080..0xd0a081
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          Role: Parameter
-    - ID: 134
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0xd0a0a0..0xd0a0a1]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 255 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xd0a0a0..0xd0a0a1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-        - Name: a
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0xd0a0a0..0xd0a0a1
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          Role: Parameter
-    - ID: 135
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0xd0a0c0..0xd0a0c1]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 255 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xd0a0c0..0xd0a0c1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-        - Name: a
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0xd0a0c0..0xd0a0c1
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          Role: Parameter
-    - ID: 136
-      Name: main.testStringSlice
-      OutOfLinePCRanges: [0xd0a0e0..0xd0a0e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 258 GoSliceHeaderType []string
-          Locations:
-            - Range: 0xd0a0e0..0xd0a0e1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-    - ID: 137
-      Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0xd0a100..0xd0a101]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 14 BaseType int8
-          Locations:
-            - Range: 0xd0a100..0xd0a101
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-        - Name: s
-          Type: 259 GoSliceHeaderType []bool
-          Locations:
-            - Range: 0xd0a100..0xd0a101
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-          Role: Parameter
-        - Name: x
-          Type: 15 BaseType uint
-          Locations:
-            - Range: 0xd0a100..0xd0a101
-              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-          Role: Parameter
-    - ID: 138
-      Name: main.testNilSlice
-      OutOfLinePCRanges: [0xd0a120..0xd0a121]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 260 GoSliceHeaderType []uint16
-          Locations:
-            - Range: 0xd0a120..0xd0a121
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-    - ID: 139
-      Name: main.testVeryLargeSlice
+      Name: main.testUintSlice
       OutOfLinePCRanges: [0xd0a140..0xd0a141]
       InlinePCRanges: []
       Variables:
-        - Name: xs
+        - Name: u
           Type: 252 GoSliceHeaderType []uint
           Locations:
             - Range: 0xd0a140..0xd0a141
@@ -7570,13 +7473,13 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 140
-      Name: main.testSliceEmptyStructs
+    - ID: 132
+      Name: main.testEmptySlice
       OutOfLinePCRanges: [0xd0a160..0xd0a161]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 261 GoSliceHeaderType []struct {}
+        - Name: u
+          Type: 252 GoSliceHeaderType []uint
           Locations:
             - Range: 0xd0a160..0xd0a161
               Pieces:
@@ -7587,15 +7490,198 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 141
-      Name: main.testSubslices
+    - ID: 133
+      Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0xd0a180..0xd0a181]
+      InlinePCRanges: []
+      Variables:
+        - Name: u
+          Type: 253 GoSliceHeaderType [][]uint
+          Locations:
+            - Range: 0xd0a180..0xd0a181
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+    - ID: 134
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0xd0a1a0..0xd0a1a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 255 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xd0a1a0..0xd0a1a1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+        - Name: a
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd0a1a0..0xd0a1a1
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          Role: Parameter
+    - ID: 135
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0xd0a1c0..0xd0a1c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 255 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xd0a1c0..0xd0a1c1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+        - Name: a
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd0a1c0..0xd0a1c1
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          Role: Parameter
+    - ID: 136
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0xd0a1e0..0xd0a1e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 255 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xd0a1e0..0xd0a1e1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+        - Name: a
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd0a1e0..0xd0a1e1
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          Role: Parameter
+    - ID: 137
+      Name: main.testStringSlice
+      OutOfLinePCRanges: [0xd0a200..0xd0a201]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 258 GoSliceHeaderType []string
+          Locations:
+            - Range: 0xd0a200..0xd0a201
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+    - ID: 138
+      Name: main.testNilSliceWithOtherParams
+      OutOfLinePCRanges: [0xd0a220..0xd0a221]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 14 BaseType int8
+          Locations:
+            - Range: 0xd0a220..0xd0a221
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+        - Name: s
+          Type: 259 GoSliceHeaderType []bool
+          Locations:
+            - Range: 0xd0a220..0xd0a221
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+          Role: Parameter
+        - Name: x
+          Type: 15 BaseType uint
+          Locations:
+            - Range: 0xd0a220..0xd0a221
+              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
+          Role: Parameter
+    - ID: 139
+      Name: main.testNilSlice
+      OutOfLinePCRanges: [0xd0a240..0xd0a241]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 260 GoSliceHeaderType []uint16
+          Locations:
+            - Range: 0xd0a240..0xd0a241
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+    - ID: 140
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0xd0a260..0xd0a261]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 252 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0xd0a260..0xd0a261
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+    - ID: 141
+      Name: main.testSliceEmptyStructs
+      OutOfLinePCRanges: [0xd0a280..0xd0a281]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 261 GoSliceHeaderType []struct {}
+          Locations:
+            - Range: 0xd0a280..0xd0a281
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+    - ID: 142
+      Name: main.testSubslices
+      OutOfLinePCRanges: [0xd0a2a0..0xd0a2a1]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 252 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xd0a180..0xd0a181
+            - Range: 0xd0a2a0..0xd0a2a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7607,7 +7693,7 @@ Subprograms:
         - Name: bs
           Type: 252 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xd0a180..0xd0a181
+            - Range: 0xd0a2a0..0xd0a2a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -7619,7 +7705,7 @@ Subprograms:
         - Name: cs
           Type: 252 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xd0a180..0xd0a181
+            - Range: 0xd0a2a0..0xd0a2a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
@@ -7628,49 +7714,49 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
           Role: Parameter
-    - ID: 142
+    - ID: 143
       Name: main.stackC
-      OutOfLinePCRanges: [0xd0a520..0xd0a572]
+      OutOfLinePCRanges: [0xd0a640..0xd0a692]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd0a520..0xd0a565
+            - Range: 0xd0a640..0xd0a685
               Pieces: []
-            - Range: 0xd0a565..0xd0a566
+            - Range: 0xd0a685..0xd0a686
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0a566..0xd0a572
+            - Range: 0xd0a686..0xd0a692
               Pieces: []
           Role: Return
-    - ID: 143
+    - ID: 144
       Name: main.testSingleString
-      OutOfLinePCRanges: [0xd0a580..0xd0a581]
+      OutOfLinePCRanges: [0xd0a6a0..0xd0a6a1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd0a580..0xd0a581
+            - Range: 0xd0a6a0..0xd0a6a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
-    - ID: 144
+    - ID: 145
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0xd0a5a0..0xd0a5a1]
+      OutOfLinePCRanges: [0xd0a6c0..0xd0a6c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd0a5a0..0xd0a5a1
+            - Range: 0xd0a6c0..0xd0a6c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7680,7 +7766,7 @@ Subprograms:
         - Name: y
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd0a5a0..0xd0a5a1
+            - Range: 0xd0a6c0..0xd0a6c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -7690,22 +7776,22 @@ Subprograms:
         - Name: z
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd0a5a0..0xd0a5a1
+            - Range: 0xd0a6c0..0xd0a6c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 145
+    - ID: 146
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0xd0a5c0..0xd0a5df]
+      OutOfLinePCRanges: [0xd0a6e0..0xd0a6ff]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 263 StructureType main.threeStringStruct
           Locations:
-            - Range: 0xd0a5c0..0xd0a5df
+            - Range: 0xd0a6e0..0xd0a6ff
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7720,52 +7806,37 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 146
+    - ID: 147
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0xd0a5e0..0xd0a5e1]
+      OutOfLinePCRanges: [0xd0a700..0xd0a701]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 264 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0xd0a5e0..0xd0a5e1
+            - Range: 0xd0a700..0xd0a701
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 147
+    - ID: 148
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0xd0a600..0xd0a601]
+      OutOfLinePCRanges: [0xd0a720..0xd0a721]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 265 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0xd0a600..0xd0a601
+            - Range: 0xd0a720..0xd0a721
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 148
-      Name: main.testMassiveString
-      OutOfLinePCRanges: [0xd0a620..0xd0a621]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 11 GoStringHeaderType string
-          Locations:
-            - Range: 0xd0a620..0xd0a621
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          Role: Parameter
     - ID: 149
-      Name: main.testUnitializedString
-      OutOfLinePCRanges: [0xd0a640..0xd0a641]
+      Name: main.testMassiveString
+      OutOfLinePCRanges: [0xd0a740..0xd0a741]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd0a640..0xd0a641
+            - Range: 0xd0a740..0xd0a741
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7773,14 +7844,14 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
     - ID: 150
-      Name: main.testEmptyString
-      OutOfLinePCRanges: [0xd0a660..0xd0a661]
+      Name: main.testUnitializedString
+      OutOfLinePCRanges: [0xd0a760..0xd0a761]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd0a660..0xd0a661
+            - Range: 0xd0a760..0xd0a761
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7788,14 +7859,29 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
     - ID: 151
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0xd0a780..0xd0a781]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 11 GoStringHeaderType string
+          Locations:
+            - Range: 0xd0a780..0xd0a781
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Parameter
+    - ID: 152
       Name: main.testSubstrings
-      OutOfLinePCRanges: [0xd0a680..0xd0a681]
+      OutOfLinePCRanges: [0xd0a7a0..0xd0a7a1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd0a680..0xd0a681
+            - Range: 0xd0a7a0..0xd0a7a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7805,7 +7891,7 @@ Subprograms:
         - Name: b
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd0a680..0xd0a681
+            - Range: 0xd0a7a0..0xd0a7a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -7815,33 +7901,33 @@ Subprograms:
         - Name: c
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd0a680..0xd0a681
+            - Range: 0xd0a7a0..0xd0a7a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 152
+    - ID: 153
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0xd0a800..0xd0a801]
+      OutOfLinePCRanges: [0xd0a920..0xd0a921]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 267 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0xd0a800..0xd0a801
+            - Range: 0xd0a920..0xd0a921
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
-    - ID: 153
+    - ID: 154
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0xd0a820..0xd0a83f]
+      OutOfLinePCRanges: [0xd0a940..0xd0a95f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 280 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0xd0a820..0xd0a83f
+            - Range: 0xd0a940..0xd0a95f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7856,15 +7942,15 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 154
+    - ID: 155
       Name: main.testStruct
-      OutOfLinePCRanges: [0xd0a960..0xd0a983]
+      OutOfLinePCRanges: [0xd0aa80..0xd0aaa3]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 311 StructureType main.aStruct
           Locations:
-            - Range: 0xd0a960..0xd0a983
+            - Range: 0xd0aa80..0xd0aaa3
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -7881,134 +7967,134 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
           Role: Parameter
-    - ID: 155
+    - ID: 156
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0xd0aa60..0xd0aa61]
+      OutOfLinePCRanges: [0xd0ab80..0xd0ab81]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 312 PointerType *main.anotherStruct
           Locations:
-            - Range: 0xd0aa60..0xd0aa61
+            - Range: 0xd0ab80..0xd0ab81
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 156
+    - ID: 157
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xd0aae0..0xd0aae1]
+      OutOfLinePCRanges: [0xd0ac00..0xd0ac01]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 314 StructureType main.emptyStruct
-          Locations: [{Range: 0xd0aae0..0xd0aae1, Pieces: []}]
+          Locations: [{Range: 0xd0ac00..0xd0ac01, Pieces: []}]
           Role: Parameter
-    - ID: 157
+    - ID: 158
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0xd0ab00..0xd0ab01]
+      OutOfLinePCRanges: [0xd0ac20..0xd0ac21]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 315 PointerType *main.emptyStruct
           Locations:
-            - Range: 0xd0ab00..0xd0ab01
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-    - ID: 158
-      Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0xd04600..0xd04662]
-      InlinePCRanges:
-        - Ranges: [0xd04691..0xd046cd]
-          RootRanges: [0xd04680..0xd046f1]
-        - Ranges: [0xd047d2..0xd0480e]
-          RootRanges: [0xd047a0..0xd04828]
-        - Ranges: [0xd0485c..0xd04898]
-          RootRanges: [0xd04840..0xd04905]
-        - Ranges: [0xd0492f..0xd0496b]
-          RootRanges: [0xd04920..0xd04982]
-      Variables:
-        - Name: x
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0xd04600..0xd04619
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd04691..0xd0469c
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd047d2..0xd047dd
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd04856..0xd04867
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd04867..0xd04905
-              Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xd04920..0xd0493a
+            - Range: 0xd0ac20..0xd0ac21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 159
-      Name: main.testInlinedBBB
-      OutOfLinePCRanges: []
+      Name: main.testInlinedPrint
+      OutOfLinePCRanges: [0xd04720..0xd04782]
       InlinePCRanges:
-        - Ranges: [0xd048a6..0xd048de]
-          RootRanges: [0xd04840..0xd04905]
-      Variables: []
-    - ID: 160
-      Name: main.testInlinedBCA
-      OutOfLinePCRanges: []
-      InlinePCRanges:
-        - Ranges: [0xd049b3..0xd049f1]
-          RootRanges: [0xd049a0..0xd04aae]
-      Variables: []
-    - ID: 161
-      Name: main.testInlinedBCB
-      OutOfLinePCRanges: []
-      InlinePCRanges:
-        - Ranges: [0xd04a66..0xd04a9e]
-          RootRanges: [0xd049a0..0xd04aae]
-      Variables: []
-    - ID: 162
-      Name: main.testInlinedSq
-      OutOfLinePCRanges: []
-      InlinePCRanges:
-        - Ranges: [0xd04ac1..0xd04ac5]
-          RootRanges: [0xd04ac0..0xd04ac6]
+        - Ranges: [0xd047b1..0xd047ed]
+          RootRanges: [0xd047a0..0xd04811]
+        - Ranges: [0xd048f2..0xd0492e]
+          RootRanges: [0xd048c0..0xd04948]
+        - Ranges: [0xd0497c..0xd049b8]
+          RootRanges: [0xd04960..0xd04a25]
+        - Ranges: [0xd04a4f..0xd04a8b]
+          RootRanges: [0xd04a40..0xd04aa2]
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd04ac0..0xd04ac5
+            - Range: 0xd04720..0xd04739
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xd047b1..0xd047bc
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xd048f2..0xd048fd
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xd04976..0xd04987
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xd04987..0xd04a25
+              Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
+            - Range: 0xd04a40..0xd04a5a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
+    - ID: 160
+      Name: main.testInlinedBBB
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0xd049c6..0xd049fe]
+          RootRanges: [0xd04960..0xd04a25]
+      Variables: []
+    - ID: 161
+      Name: main.testInlinedBCA
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0xd04ad3..0xd04b11]
+          RootRanges: [0xd04ac0..0xd04bce]
+      Variables: []
+    - ID: 162
+      Name: main.testInlinedBCB
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0xd04b86..0xd04bbe]
+          RootRanges: [0xd04ac0..0xd04bce]
+      Variables: []
     - ID: 163
+      Name: main.testInlinedSq
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0xd04be1..0xd04be5]
+          RootRanges: [0xd04be0..0xd04be6]
+      Variables:
+        - Name: x
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd04be0..0xd04be5
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+    - ID: 164
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xd04b05..0xd04b1d]
-          RootRanges: [0xd04ae0..0xd04b23]
-        - Ranges: [0xd04ba5..0xd04bc3]
-          RootRanges: [0xd04b40..0xd04cc5]
+        - Ranges: [0xd04c25..0xd04c3d]
+          RootRanges: [0xd04c00..0xd04c43]
+        - Ranges: [0xd04cc5..0xd04ce3]
+          RootRanges: [0xd04c60..0xd04de5]
       Variables:
         - Name: a
           Type: 156 ArrayType [5]int
           Locations:
-            - Range: 0xd04aed..0xd04b23
+            - Range: 0xd04c0d..0xd04c43
               Pieces: [{Size: 40, Op: {CfaOffset: -56}}]
-            - Range: 0xd04b8c..0xd04cc5
+            - Range: 0xd04cac..0xd04de5
               Pieces: [{Size: 40, Op: {CfaOffset: -128}}]
           Role: Parameter
-    - ID: 164
+    - ID: 165
       Name: main.firstBehavior.DoSomething
-      OutOfLinePCRanges: [0xd04ce0..0xd04d51]
+      OutOfLinePCRanges: [0xd04e00..0xd04e71]
       InlinePCRanges:
-        - Ranges: [0xd0c043..0xd0c085]
-          RootRanges: [0xd0c020..0xd0c0b6]
+        - Ranges: [0xd0c163..0xd0c1a5]
+          RootRanges: [0xd0c140..0xd0c1d6]
       Variables:
         - Name: b
           Type: 316 StructureType main.firstBehavior
           Locations:
-            - Range: 0xd04ce0..0xd04d08
+            - Range: 0xd04e00..0xd04e28
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd04d08..0xd04d0d
+            - Range: 0xd04e28..0xd04e2d
               Pieces:
                 - Size: 8
                   Op: null
@@ -8018,23 +8104,23 @@ Subprograms:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd04ce0..0xd04d30
+            - Range: 0xd04e00..0xd04e50
               Pieces: []
-            - Range: 0xd04d30..0xd04d31
+            - Range: 0xd04e50..0xd04e51
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd04d31..0xd04d51
+            - Range: 0xd04e51..0xd04e71
               Pieces: []
           Role: Return
-    - ID: 165
+    - ID: 166
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xd0548b..0xd05492]
-          RootRanges: [0xd05340..0xd054ce]
+        - Ranges: [0xd055ab..0xd055b2]
+          RootRanges: [0xd05460..0xd055ee]
         - Ranges: [0xd02932..0xd02936, 0xd02937..0xd0293e]
           RootRanges: [0xd02920..0xd0293f]
       Variables: []
@@ -10991,10 +11077,10 @@ Types:
       GoKind: 22
       Pointee: 674 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1376
+      ID: 1377
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
     - __kind: EventRootType
-      ID: 1374
+      ID: 1375
       Name: Probe[main.firstBehavior.DoSomething]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11006,11 +11092,11 @@ Types:
             Type: 316 StructureType main.firstBehavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 0, name: b}
+                  Variable: {subprogram: 165, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1375
+      ID: 1376
       Name: Probe[main.firstBehavior.DoSomething]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11022,14 +11108,14 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 1, name: ~r0}
+                  Variable: {subprogram: 165, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1332
+      ID: 1333
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1333
+      ID: 1334
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11041,11 +11127,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: ~r0}
+                  Variable: {subprogram: 143, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1199
+      ID: 1200
       Name: Probe[main.testAnyPtr]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11057,7 +11143,7 @@ Types:
             Type: 158 PointerType *interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: a}
+                  Variable: {subprogram: 59, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -11067,11 +11153,11 @@ Types:
             Type: 158 PointerType *interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: a}
+                  Variable: {subprogram: 59, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1200
+      ID: 1201
       Name: Probe[main.testAnyPtr]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11083,11 +11169,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 1, name: ~r0}
+                  Variable: {subprogram: 59, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1196
+      ID: 1197
       Name: Probe[main.testAny]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11099,7 +11185,7 @@ Types:
             Type: 152 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: a}
+                  Variable: {subprogram: 57, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -11109,11 +11195,11 @@ Types:
             Type: 152 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: a}
+                  Variable: {subprogram: 57, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1197
+      ID: 1198
       Name: Probe[main.testAny]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11125,11 +11211,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 1, name: ~r0}
+                  Variable: {subprogram: 57, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1303
+      ID: 1304
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11141,7 +11227,7 @@ Types:
             Type: 246 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: arg}
+                  Variable: {subprogram: 123, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
         - Name: arg
@@ -11151,11 +11237,11 @@ Types:
             Type: 246 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: arg}
+                  Variable: {subprogram: 123, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1304
+      ID: 1305
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11167,7 +11253,7 @@ Types:
             Type: 246 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 1, name: ~r0}
+                  Variable: {subprogram: 123, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -11249,7 +11335,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1208
+      ID: 1209
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11261,7 +11347,7 @@ Types:
             Type: 186 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: m}
+                  Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
         - Name: m
@@ -11271,7 +11357,7 @@ Types:
             Type: 186 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: m}
+                  Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -11327,7 +11413,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1230
+      ID: 1231
       Name: Probe[main.testAtomicAdd]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11339,7 +11425,7 @@ Types:
             Type: 10 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: x}
+                  Variable: {subprogram: 87, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -11349,11 +11435,11 @@ Types:
             Type: 10 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: x}
+                  Variable: {subprogram: 87, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1231
+      ID: 1232
       Name: Probe[main.testAtomicAdd]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11365,7 +11451,7 @@ Types:
             Type: 10 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 1, name: ~r0}
+                  Variable: {subprogram: 87, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -11450,7 +11536,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1232
+      ID: 1233
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11462,7 +11548,7 @@ Types:
             Type: 238 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: c}
+                  Variable: {subprogram: 88, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
         - Name: c
@@ -11472,11 +11558,11 @@ Types:
             Type: 238 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: c}
+                  Variable: {subprogram: 88, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1226
+      ID: 1227
       Name: Probe[main.testCombinedByte]
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -11488,7 +11574,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: w}
+                  Variable: {subprogram: 84, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: w
@@ -11498,7 +11584,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: w}
+                  Variable: {subprogram: 84, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: x
@@ -11508,7 +11594,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 1, name: x}
+                  Variable: {subprogram: 84, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: x
@@ -11518,7 +11604,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 1, name: x}
+                  Variable: {subprogram: 84, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: y
@@ -11528,7 +11614,7 @@ Types:
             Type: 16 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 2, name: y}
+                  Variable: {subprogram: 84, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
         - Name: y
@@ -11538,11 +11624,11 @@ Types:
             Type: 16 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 2, name: y}
+                  Variable: {subprogram: 84, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1227
+      ID: 1228
       Name: Probe[main.testCombinedString]
       ByteSize: 18
       PresenceBitsetSize: 1
@@ -11554,7 +11640,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 1, name: x}
+                  Variable: {subprogram: 85, index: 1, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: w_val
@@ -11564,11 +11650,11 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: w}
+                  Variable: {subprogram: 85, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1228
+      ID: 1229
       Name: Probe[main.testCombinedString]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -11580,7 +11666,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 1, name: x}
+                  Variable: {subprogram: 85, index: 1, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x_val
@@ -11590,7 +11676,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 1, name: x}
+                  Variable: {subprogram: 85, index: 1, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: w_val
@@ -11600,11 +11686,11 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: w}
+                  Variable: {subprogram: 85, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1240
+      ID: 1241
       Name: Probe[main.testCycle]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11616,7 +11702,7 @@ Types:
             Type: 243 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: t}
+                  Variable: {subprogram: 96, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
         - Name: t
@@ -11626,11 +11712,11 @@ Types:
             Type: 243 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: t}
+                  Variable: {subprogram: 96, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1171
+      ID: 1172
       Name: Probe[main.testDeepMap1]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11642,7 +11728,7 @@ Types:
             Type: 136 StructureType main.deepMap1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: a}
+                  Variable: {subprogram: 43, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -11652,11 +11738,11 @@ Types:
             Type: 136 StructureType main.deepMap1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: a}
+                  Variable: {subprogram: 43, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1172
+      ID: 1173
       Name: Probe[main.testDeepMap7]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11668,7 +11754,7 @@ Types:
             Type: 144 PointerType *main.deepMap7
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 0, name: a}
+                  Variable: {subprogram: 44, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -11678,11 +11764,11 @@ Types:
             Type: 144 PointerType *main.deepMap7
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 0, name: a}
+                  Variable: {subprogram: 44, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1167
+      ID: 1168
       Name: Probe[main.testDeepPtr1]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11694,7 +11780,7 @@ Types:
             Type: 125 StructureType main.deepPtr1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: a}
+                  Variable: {subprogram: 39, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -11704,11 +11790,11 @@ Types:
             Type: 125 StructureType main.deepPtr1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: a}
+                  Variable: {subprogram: 39, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1168
+      ID: 1169
       Name: Probe[main.testDeepPtr7]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11720,7 +11806,7 @@ Types:
             Type: 128 PointerType *main.deepPtr7
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: a}
+                  Variable: {subprogram: 40, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -11730,11 +11816,11 @@ Types:
             Type: 128 PointerType *main.deepPtr7
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: a}
+                  Variable: {subprogram: 40, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1169
+      ID: 1170
       Name: Probe[main.testDeepSlice1]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11746,7 +11832,7 @@ Types:
             Type: 130 StructureType main.deepSlice1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: a}
+                  Variable: {subprogram: 41, index: 0, name: a}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -11756,11 +11842,11 @@ Types:
             Type: 130 StructureType main.deepSlice1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: a}
+                  Variable: {subprogram: 41, index: 0, name: a}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1170
+      ID: 1171
       Name: Probe[main.testDeepSlice7]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11772,7 +11858,7 @@ Types:
             Type: 134 PointerType *main.deepSlice7
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: a}
+                  Variable: {subprogram: 42, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -11782,11 +11868,11 @@ Types:
             Type: 134 PointerType *main.deepSlice7
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: a}
+                  Variable: {subprogram: 42, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1323
+      ID: 1324
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -11798,7 +11884,7 @@ Types:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: xs}
+                  Variable: {subprogram: 135, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -11808,7 +11894,7 @@ Types:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: xs}
+                  Variable: {subprogram: 135, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -11818,7 +11904,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 1, name: a}
+                  Variable: {subprogram: 135, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -11828,11 +11914,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 1, name: a}
+                  Variable: {subprogram: 135, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1320
+      ID: 1321
       Name: Probe[main.testEmptySlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11844,7 +11930,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: u}
+                  Variable: {subprogram: 132, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -11854,11 +11940,11 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: u}
+                  Variable: {subprogram: 132, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1346
+      ID: 1347
       Name: Probe[main.testEmptyString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11870,7 +11956,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: x}
+                  Variable: {subprogram: 151, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -11880,11 +11966,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: x}
+                  Variable: {subprogram: 151, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1360
+      ID: 1361
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11896,7 +11982,7 @@ Types:
             Type: 315 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: e}
+                  Variable: {subprogram: 158, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -11906,11 +11992,11 @@ Types:
             Type: 315 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: e}
+                  Variable: {subprogram: 158, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1359
+      ID: 1360
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11922,7 +12008,7 @@ Types:
             Type: 314 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: e}
+                  Variable: {subprogram: 157, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
         - Name: e
@@ -11932,11 +12018,67 @@ Types:
             Type: 314 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: e}
+                  Variable: {subprogram: 157, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1198
+      ID: 1167
+      Name: Probe[main.testErrorAtLine]Line
+      ByteSize: 57
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 2, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 2, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: err
+          Offset: 25
+          Kind: local
+          Expression:
+            Type: 18 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 3, name: err}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: err
+          Offset: 41
+          Kind: template_segment
+          Expression:
+            Type: 18 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 3, name: err}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1199
       Name: Probe[main.testError]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11948,7 +12090,7 @@ Types:
             Type: 18 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: e}
+                  Variable: {subprogram: 58, index: 0, name: e}
                   Offset: 0
                   ByteSize: 16
         - Name: e
@@ -11958,11 +12100,11 @@ Types:
             Type: 18 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: e}
+                  Variable: {subprogram: 58, index: 0, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1180
+      ID: 1181
       Name: Probe[main.testEsotericHeap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11974,7 +12116,7 @@ Types:
             Type: 154 PointerType *main.esotericHeap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 48, index: 0, name: e}
+                  Variable: {subprogram: 49, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -11984,14 +12126,14 @@ Types:
             Type: 154 PointerType *main.esotericHeap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 48, index: 0, name: e}
+                  Variable: {subprogram: 49, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1181
+      ID: 1182
       Name: Probe[main.testEsotericHeap]Return
     - __kind: EventRootType
-      ID: 1178
+      ID: 1179
       Name: Probe[main.testEsotericStack]
       ByteSize: 129
       PresenceBitsetSize: 1
@@ -12003,7 +12145,7 @@ Types:
             Type: 150 StructureType main.esotericStack
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 0, name: e}
+                  Variable: {subprogram: 48, index: 0, name: e}
                   Offset: 0
                   ByteSize: 64
         - Name: e
@@ -12013,14 +12155,14 @@ Types:
             Type: 150 StructureType main.esotericStack
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 0, name: e}
+                  Variable: {subprogram: 48, index: 0, name: e}
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1179
+      ID: 1180
       Name: Probe[main.testEsotericStack]Return
     - __kind: EventRootType
-      ID: 1192
+      ID: 1193
       Name: Probe[main.testFramelessArray]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12032,7 +12174,7 @@ Types:
             Type: 156 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: a}
+                  Variable: {subprogram: 55, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: a
@@ -12042,11 +12184,11 @@ Types:
             Type: 156 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: a}
+                  Variable: {subprogram: 55, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1194
+      ID: 1195
       Name: Probe[main.testFramelessArray]Line
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -12058,7 +12200,7 @@ Types:
             Type: 156 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: a}
+                  Variable: {subprogram: 55, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: a
@@ -12068,7 +12210,7 @@ Types:
             Type: 156 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: a}
+                  Variable: {subprogram: 55, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: ~r0
@@ -12078,11 +12220,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 1, name: ~r0}
+                  Variable: {subprogram: 55, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1193
+      ID: 1194
       Name: Probe[main.testFramelessArray]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12094,11 +12236,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 1, name: ~r0}
+                  Variable: {subprogram: 55, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1190
+      ID: 1191
       Name: Probe[main.testFrameless]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12110,7 +12252,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: x}
+                  Variable: {subprogram: 54, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12120,11 +12262,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: x}
+                  Variable: {subprogram: 54, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1191
+      ID: 1192
       Name: Probe[main.testFrameless]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12136,11 +12278,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 1, name: ~r0}
+                  Variable: {subprogram: 54, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1182
+      ID: 1183
       Name: Probe[main.testInlinedBA]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12152,7 +12294,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: x}
+                  Variable: {subprogram: 50, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12162,14 +12304,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: x}
+                  Variable: {subprogram: 50, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1183
+      ID: 1184
       Name: Probe[main.testInlinedBA]Return
     - __kind: EventRootType
-      ID: 1186
+      ID: 1187
       Name: Probe[main.testInlinedBBA]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12181,7 +12323,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: x}
+                  Variable: {subprogram: 52, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12191,17 +12333,17 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: x}
+                  Variable: {subprogram: 52, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1187
+      ID: 1188
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1366
+      ID: 1367
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 1184
+      ID: 1185
       Name: Probe[main.testInlinedBB]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12213,7 +12355,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: x}
+                  Variable: {subprogram: 51, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12223,7 +12365,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: x}
+                  Variable: {subprogram: 51, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: y
@@ -12233,7 +12375,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 1, name: y}
+                  Variable: {subprogram: 51, index: 1, name: y}
                   Offset: 0
                   ByteSize: 8
         - Name: y
@@ -12243,32 +12385,32 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 1, name: y}
+                  Variable: {subprogram: 51, index: 1, name: y}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1185
+      ID: 1186
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1367
+      ID: 1368
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1368
+      ID: 1369
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1369
+      ID: 1370
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1370
+      ID: 1371
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
-      ID: 1188
+      ID: 1189
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 1189
+      ID: 1190
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1363
+      ID: 1364
       Name: Probe[main.testInlinedPrint]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12280,7 +12422,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12290,11 +12432,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1361
+      ID: 1362
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12306,11 +12448,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1362
+      ID: 1363
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12322,7 +12464,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x_val
@@ -12332,11 +12474,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1365
+      ID: 1366
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12348,7 +12490,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12358,14 +12500,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1364
+      ID: 1365
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1371
+      ID: 1372
       Name: Probe[main.testInlinedSq]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12377,7 +12519,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12387,11 +12529,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1372
+      ID: 1373
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12403,7 +12545,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12413,11 +12555,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1373
+      ID: 1374
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12429,7 +12571,7 @@ Types:
             Type: 156 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: a}
+                  Variable: {subprogram: 164, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: a
@@ -12439,7 +12581,7 @@ Types:
             Type: 156 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: a}
+                  Variable: {subprogram: 164, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
@@ -12573,7 +12715,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1195
+      ID: 1196
       Name: Probe[main.testInterface]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12585,7 +12727,7 @@ Types:
             Type: 157 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: b}
+                  Variable: {subprogram: 56, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -12595,11 +12737,11 @@ Types:
             Type: 157 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: b}
+                  Variable: {subprogram: 56, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1301
+      ID: 1302
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 161
       PresenceBitsetSize: 1
@@ -12611,7 +12753,7 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: arg}
+                  Variable: {subprogram: 122, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
         - Name: arg
@@ -12621,11 +12763,11 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: arg}
+                  Variable: {subprogram: 122, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1302
+      ID: 1303
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12637,11 +12779,11 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 1, name: ~r0}
+                  Variable: {subprogram: 122, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1234
+      ID: 1235
       Name: Probe[main.testLinkedList]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12653,7 +12795,7 @@ Types:
             Type: 241 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: a}
+                  Variable: {subprogram: 90, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -12663,38 +12805,12 @@ Types:
             Type: 241 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: a}
+                  Variable: {subprogram: 90, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1175
-      Name: Probe[main.testLongFunctionWithChangingState]Line
-    - __kind: EventRootType
       ID: 1176
       Name: Probe[main.testLongFunctionWithChangingState]Line
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: aPerArch
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 1, name: aPerArch}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: b
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 2, name: b}
-                  Offset: 0
-                  ByteSize: 8
     - __kind: EventRootType
       ID: 1177
       Name: Probe[main.testLongFunctionWithChangingState]Line
@@ -12708,7 +12824,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 1, name: aPerArch}
+                  Variable: {subprogram: 47, index: 1, name: aPerArch}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -12718,11 +12834,37 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 2, name: b}
+                  Variable: {subprogram: 47, index: 2, name: b}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1307
+      ID: 1178
+      Name: Probe[main.testLongFunctionWithChangingState]Line
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: aPerArch
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 47, index: 1, name: aPerArch}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 47, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1308
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 147
       PresenceBitsetSize: 3
@@ -12734,7 +12876,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: a}
+                  Variable: {subprogram: 125, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12744,7 +12886,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: a}
+                  Variable: {subprogram: 125, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -12754,7 +12896,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 1, name: b}
+                  Variable: {subprogram: 125, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -12764,7 +12906,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 1, name: b}
+                  Variable: {subprogram: 125, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -12774,7 +12916,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 2, name: c}
+                  Variable: {subprogram: 125, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -12784,7 +12926,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 2, name: c}
+                  Variable: {subprogram: 125, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -12794,7 +12936,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 3, name: d}
+                  Variable: {subprogram: 125, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -12804,7 +12946,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 3, name: d}
+                  Variable: {subprogram: 125, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -12814,7 +12956,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 4, name: e}
+                  Variable: {subprogram: 125, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -12824,7 +12966,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 4, name: e}
+                  Variable: {subprogram: 125, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -12834,7 +12976,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 5, name: f}
+                  Variable: {subprogram: 125, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -12844,7 +12986,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 5, name: f}
+                  Variable: {subprogram: 125, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -12854,7 +12996,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 6, name: g}
+                  Variable: {subprogram: 125, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -12864,7 +13006,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 6, name: g}
+                  Variable: {subprogram: 125, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -12874,7 +13016,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 7, name: h}
+                  Variable: {subprogram: 125, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -12884,7 +13026,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 7, name: h}
+                  Variable: {subprogram: 125, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -12894,7 +13036,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 8, name: i}
+                  Variable: {subprogram: 125, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -12904,11 +13046,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 8, name: i}
+                  Variable: {subprogram: 125, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1308
+      ID: 1309
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12920,11 +13062,11 @@ Types:
             Type: 106 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 9, name: ~r0}
+                  Variable: {subprogram: 125, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1206
+      ID: 1207
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12936,7 +13078,7 @@ Types:
             Type: 181 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -12946,11 +13088,11 @@ Types:
             Type: 181 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1213
+      ID: 1214
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12962,7 +13104,7 @@ Types:
             Type: 188 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: m}
+                  Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -12972,11 +13114,11 @@ Types:
             Type: 188 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: m}
+                  Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1225
+      ID: 1226
       Name: Probe[main.testMapEmptyKeyAndValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12988,7 +13130,7 @@ Types:
             Type: 233 GoMapType map[struct {}]struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: m}
+                  Variable: {subprogram: 83, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -12998,11 +13140,11 @@ Types:
             Type: 233 GoMapType map[struct {}]struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: m}
+                  Variable: {subprogram: 83, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1223
+      ID: 1224
       Name: Probe[main.testMapEmptyKey]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13014,7 +13156,7 @@ Types:
             Type: 223 GoMapType map[struct {}]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: m}
+                  Variable: {subprogram: 81, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13024,11 +13166,11 @@ Types:
             Type: 223 GoMapType map[struct {}]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: m}
+                  Variable: {subprogram: 81, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1224
+      ID: 1225
       Name: Probe[main.testMapEmptyValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13040,7 +13182,7 @@ Types:
             Type: 228 GoMapType map[int]struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: m}
+                  Variable: {subprogram: 82, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13050,11 +13192,11 @@ Types:
             Type: 228 GoMapType map[int]struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: m}
+                  Variable: {subprogram: 82, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1210
+      ID: 1211
       Name: Probe[main.testMapIntToInt]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13066,7 +13208,7 @@ Types:
             Type: 161 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
+                  Variable: {subprogram: 69, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13076,11 +13218,11 @@ Types:
             Type: 161 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
+                  Variable: {subprogram: 69, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1222
+      ID: 1223
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13092,7 +13234,7 @@ Types:
             Type: 218 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: m}
+                  Variable: {subprogram: 80, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13102,11 +13244,11 @@ Types:
             Type: 218 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: m}
+                  Variable: {subprogram: 80, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1221
+      ID: 1222
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13118,7 +13260,7 @@ Types:
             Type: 213 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: m}
+                  Variable: {subprogram: 79, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13128,33 +13270,7 @@ Types:
             Type: 213 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1211
-      Name: Probe[main.testMapMassive]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: redactMyEntries
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 188 GoMapType map[string][]main.structWithMap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: redactMyEntries
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 188 GoMapType map[string][]main.structWithMap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 79, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -13170,7 +13286,7 @@ Types:
             Type: 188 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 70, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
         - Name: redactMyEntries
@@ -13180,11 +13296,37 @@ Types:
             Type: 188 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 70, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1220
+      ID: 1213
+      Name: Probe[main.testMapMassive]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: redactMyEntries
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 188 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 70, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: redactMyEntries
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 188 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 70, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1221
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13196,7 +13338,7 @@ Types:
             Type: 208 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: m}
+                  Variable: {subprogram: 78, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13206,11 +13348,11 @@ Types:
             Type: 208 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: m}
+                  Variable: {subprogram: 78, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1219
+      ID: 1220
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13222,6 +13364,136 @@ Types:
             Type: 203 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
+                  Variable: {subprogram: 77, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 203 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 77, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1205
+      Name: Probe[main.testMapStringToInt]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 171 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 63, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 171 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 63, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1206
+      Name: Probe[main.testMapStringToSlice]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 176 GoMapType map[string][]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 64, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 176 GoMapType map[string][]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 64, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1204
+      Name: Probe[main.testMapStringToStruct]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 166 GoMapType map[string]main.nestedStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 62, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 166 GoMapType map[string]main.nestedStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 62, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1215
+      Name: Probe[main.testMapWithLinkedList]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 193 GoMapType map[bool]main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 72, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 193 GoMapType map[bool]main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 72, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1219
+      Name: Probe[main.testMapWithSmallKeyAndValueMassive]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 203 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
                   Variable: {subprogram: 76, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
@@ -13236,112 +13508,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1204
-      Name: Probe[main.testMapStringToInt]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 171 GoMapType map[string]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: m
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 171 GoMapType map[string]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1205
-      Name: Probe[main.testMapStringToSlice]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 176 GoMapType map[string][]string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: m
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 176 GoMapType map[string][]string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1203
-      Name: Probe[main.testMapStringToStruct]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 166 GoMapType map[string]main.nestedStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: m
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 166 GoMapType map[string]main.nestedStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1214
-      Name: Probe[main.testMapWithLinkedList]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 193 GoMapType map[bool]main.node
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: m
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 193 GoMapType map[bool]main.node
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
       ID: 1218
-      Name: Probe[main.testMapWithSmallKeyAndValueMassive]
+      Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
@@ -13367,32 +13535,6 @@ Types:
                   ByteSize: 8
     - __kind: EventRootType
       ID: 1217
-      Name: Probe[main.testMapWithSmallKeyAndValue]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 203 GoMapType map[uint8]uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: m
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 203 GoMapType map[uint8]uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1216
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13404,7 +13546,7 @@ Types:
             Type: 198 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 74, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
         - Name: redactMyEntries
@@ -13414,11 +13556,11 @@ Types:
             Type: 198 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 74, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1215
+      ID: 1216
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13430,7 +13572,7 @@ Types:
             Type: 198 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: m}
+                  Variable: {subprogram: 73, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13440,35 +13582,9 @@ Types:
             Type: 198 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: m}
+                  Variable: {subprogram: 73, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
-    - __kind: EventRootType
-      ID: 1343
-      Name: Probe[main.testMassiveString]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 11 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: x
-          Offset: 17
-          Kind: template_segment
-          Expression:
-            Type: 11 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
     - __kind: EventRootType
       ID: 1344
       Name: Probe[main.testMassiveString]
@@ -13482,7 +13598,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
+                  Variable: {subprogram: 149, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -13492,11 +13608,37 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
+                  Variable: {subprogram: 149, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1309
+      ID: 1345
+      Name: Probe[main.testMassiveString]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 149, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 149, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1310
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 163
       PresenceBitsetSize: 3
@@ -13508,7 +13650,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: a}
+                  Variable: {subprogram: 126, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -13518,7 +13660,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: a}
+                  Variable: {subprogram: 126, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13528,7 +13670,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: b}
+                  Variable: {subprogram: 126, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13538,7 +13680,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: b}
+                  Variable: {subprogram: 126, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13548,7 +13690,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: c}
+                  Variable: {subprogram: 126, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13558,7 +13700,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: c}
+                  Variable: {subprogram: 126, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13568,7 +13710,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 3, name: d}
+                  Variable: {subprogram: 126, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13578,7 +13720,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 3, name: d}
+                  Variable: {subprogram: 126, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13588,7 +13730,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 4, name: e}
+                  Variable: {subprogram: 126, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13598,7 +13740,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 4, name: e}
+                  Variable: {subprogram: 126, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13608,7 +13750,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 5, name: f}
+                  Variable: {subprogram: 126, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13618,7 +13760,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 5, name: f}
+                  Variable: {subprogram: 126, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13628,7 +13770,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 6, name: g}
+                  Variable: {subprogram: 126, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13638,7 +13780,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 6, name: g}
+                  Variable: {subprogram: 126, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13648,7 +13790,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 7, name: h}
+                  Variable: {subprogram: 126, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13658,7 +13800,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 7, name: h}
+                  Variable: {subprogram: 126, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: s
@@ -13668,7 +13810,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 8, name: s}
+                  Variable: {subprogram: 126, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
         - Name: s
@@ -13678,11 +13820,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 8, name: s}
+                  Variable: {subprogram: 126, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1310
+      ID: 1311
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13694,11 +13836,11 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 9, name: ~r0}
+                  Variable: {subprogram: 126, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1313
+      ID: 1314
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13710,7 +13852,7 @@ Types:
             Type: 106 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -13720,7 +13862,7 @@ Types:
             Type: 106 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -13730,7 +13872,7 @@ Types:
             Type: 246 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: b}
+                  Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
         - Name: b
@@ -13740,11 +13882,11 @@ Types:
             Type: 246 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: b}
+                  Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1314
+      ID: 1315
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13756,7 +13898,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 2, name: ~r0}
+                  Variable: {subprogram: 128, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -13766,11 +13908,11 @@ Types:
             Type: 106 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 3, name: ~r1}
+                  Variable: {subprogram: 128, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1305
+      ID: 1306
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 321
       PresenceBitsetSize: 1
@@ -13782,7 +13924,7 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: s1}
+                  Variable: {subprogram: 124, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
         - Name: s1
@@ -13792,7 +13934,7 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: s1}
+                  Variable: {subprogram: 124, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
         - Name: s2
@@ -13802,7 +13944,7 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: s2}
+                  Variable: {subprogram: 124, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
         - Name: s2
@@ -13812,11 +13954,11 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: s2}
+                  Variable: {subprogram: 124, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1306
+      ID: 1307
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13828,11 +13970,11 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 2, name: ~r0}
+                  Variable: {subprogram: 124, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1259
+      ID: 1260
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13844,7 +13986,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13854,11 +13996,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1261
+      ID: 1262
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13870,7 +14012,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13880,7 +14022,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13890,7 +14032,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13900,11 +14042,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1263
+      ID: 1264
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -13916,11 +14058,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1265
+      ID: 1266
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -13932,11 +14074,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1267
+      ID: 1268
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -13948,11 +14090,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1260
+      ID: 1261
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13964,7 +14106,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -13974,11 +14116,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1262
+      ID: 1263
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -13990,7 +14132,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14000,7 +14142,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14010,7 +14152,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14020,7 +14162,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14030,7 +14172,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14040,11 +14182,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1264
+      ID: 1265
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14056,7 +14198,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14066,11 +14208,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1266
+      ID: 1267
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14082,7 +14224,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14092,11 +14234,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1268
+      ID: 1269
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14108,7 +14250,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14118,11 +14260,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1229
+      ID: 1230
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 62
       PresenceBitsetSize: 2
@@ -14134,7 +14276,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: a}
+                  Variable: {subprogram: 86, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: a
@@ -14144,7 +14286,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: a}
+                  Variable: {subprogram: 86, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -14154,7 +14296,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 1, name: b}
+                  Variable: {subprogram: 86, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -14164,7 +14306,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 1, name: b}
+                  Variable: {subprogram: 86, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: c
@@ -14174,7 +14316,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 2, name: c}
+                  Variable: {subprogram: 86, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: c
@@ -14184,7 +14326,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 2, name: c}
+                  Variable: {subprogram: 86, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: d
@@ -14194,7 +14336,7 @@ Types:
             Type: 15 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 3, name: d}
+                  Variable: {subprogram: 86, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -14204,7 +14346,7 @@ Types:
             Type: 15 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 3, name: d}
+                  Variable: {subprogram: 86, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -14214,7 +14356,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 4, name: e}
+                  Variable: {subprogram: 86, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
         - Name: e
@@ -14224,11 +14366,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 4, name: e}
+                  Variable: {subprogram: 86, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1255
+      ID: 1256
       Name: Probe[main.testNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14240,7 +14382,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14250,37 +14392,37 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1258
+      Name: Probe[main.testNamedReturn]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
       ID: 1257
-      Name: Probe[main.testNamedReturn]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1256
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14292,11 +14434,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1258
+      ID: 1259
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14308,7 +14450,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14318,11 +14460,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1355
+      ID: 1356
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14334,7 +14476,7 @@ Types:
             Type: 312 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: x}
+                  Variable: {subprogram: 156, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -14344,11 +14486,11 @@ Types:
             Type: 312 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: x}
+                  Variable: {subprogram: 156, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1356
+      ID: 1357
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14360,7 +14502,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: x}
+                  Variable: {subprogram: 156, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -14370,10 +14512,10 @@ Types:
                   Bias: 8
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1357
+      ID: 1358
       Name: Probe[main.testNestedPointer]
     - __kind: EventRootType
-      ID: 1358
+      ID: 1359
       Name: Probe[main.testNestedPointer]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -14385,7 +14527,7 @@ Types:
             Type: 116 StructureType main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: x}
+                  Variable: {subprogram: 156, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -14395,7 +14537,7 @@ Types:
                   Bias: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1239
+      ID: 1240
       Name: Probe[main.testNilPointer]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14407,7 +14549,7 @@ Types:
             Type: 5 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: z}
+                  Variable: {subprogram: 95, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: z
@@ -14417,7 +14559,7 @@ Types:
             Type: 5 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: z}
+                  Variable: {subprogram: 95, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14427,7 +14569,7 @@ Types:
             Type: 15 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 1, name: a}
+                  Variable: {subprogram: 95, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14437,11 +14579,11 @@ Types:
             Type: 15 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 1, name: a}
+                  Variable: {subprogram: 95, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1324
+      ID: 1325
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -14453,7 +14595,7 @@ Types:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: xs}
+                  Variable: {subprogram: 136, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -14463,7 +14605,7 @@ Types:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: xs}
+                  Variable: {subprogram: 136, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -14473,7 +14615,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 1, name: a}
+                  Variable: {subprogram: 136, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14483,11 +14625,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 1, name: a}
+                  Variable: {subprogram: 136, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1326
+      ID: 1327
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 67
       PresenceBitsetSize: 1
@@ -14499,7 +14641,7 @@ Types:
             Type: 14 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: a}
+                  Variable: {subprogram: 138, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: a
@@ -14509,7 +14651,7 @@ Types:
             Type: 14 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: a}
+                  Variable: {subprogram: 138, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
@@ -14519,7 +14661,7 @@ Types:
             Type: 259 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 1, name: s}
+                  Variable: {subprogram: 138, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: s
@@ -14529,7 +14671,7 @@ Types:
             Type: 259 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 1, name: s}
+                  Variable: {subprogram: 138, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -14539,7 +14681,7 @@ Types:
             Type: 15 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 2, name: x}
+                  Variable: {subprogram: 138, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -14549,11 +14691,11 @@ Types:
             Type: 15 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 2, name: x}
+                  Variable: {subprogram: 138, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1327
+      ID: 1328
       Name: Probe[main.testNilSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -14565,7 +14707,7 @@ Types:
             Type: 260 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -14575,11 +14717,11 @@ Types:
             Type: 260 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1342
+      ID: 1343
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14591,7 +14733,7 @@ Types:
             Type: 265 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14601,11 +14743,11 @@ Types:
             Type: 265 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1235
+      ID: 1236
       Name: Probe[main.testPointerLoop]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14617,7 +14759,7 @@ Types:
             Type: 242 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: a}
+                  Variable: {subprogram: 91, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14627,11 +14769,11 @@ Types:
             Type: 242 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: a}
+                  Variable: {subprogram: 91, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1209
+      ID: 1210
       Name: Probe[main.testPointerToMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14643,7 +14785,7 @@ Types:
             Type: 187 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: m}
+                  Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -14653,11 +14795,11 @@ Types:
             Type: 187 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: m}
+                  Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1233
+      ID: 1234
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14669,7 +14811,7 @@ Types:
             Type: 239 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: a}
+                  Variable: {subprogram: 89, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14679,11 +14821,11 @@ Types:
             Type: 239 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: a}
+                  Variable: {subprogram: 89, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1249
+      ID: 1250
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 35
       PresenceBitsetSize: 1
@@ -14695,7 +14837,7 @@ Types:
             Type: 152 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: v}
+                  Variable: {subprogram: 101, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: v
@@ -14705,7 +14847,7 @@ Types:
             Type: 152 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: v}
+                  Variable: {subprogram: 101, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: failed
@@ -14715,7 +14857,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 1, name: failed}
+                  Variable: {subprogram: 101, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
         - Name: failed
@@ -14725,11 +14867,11 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 1, name: failed}
+                  Variable: {subprogram: 101, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1250
+      ID: 1251
       Name: Probe[main.testReturnsAnyAndError]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14741,7 +14883,7 @@ Types:
             Type: 152 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 2, name: ~r0}
+                  Variable: {subprogram: 101, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
         - Name: ~r1
@@ -14751,11 +14893,11 @@ Types:
             Type: 18 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 3, name: ~r1}
+                  Variable: {subprogram: 101, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1251
+      ID: 1252
       Name: Probe[main.testReturnsAny]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14767,7 +14909,7 @@ Types:
             Type: 152 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: v}
+                  Variable: {subprogram: 102, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: v
@@ -14777,11 +14919,11 @@ Types:
             Type: 152 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: v}
+                  Variable: {subprogram: 102, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1252
+      ID: 1253
       Name: Probe[main.testReturnsAny]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14793,14 +14935,14 @@ Types:
             Type: 152 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 1, name: ~r0}
+                  Variable: {subprogram: 102, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1281
+      ID: 1282
       Name: Probe[main.testReturnsArrayOne]
     - __kind: EventRootType
-      ID: 1282
+      ID: 1283
       Name: Probe[main.testReturnsArrayOne]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14812,14 +14954,14 @@ Types:
             Type: 247 ArrayType [1]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 0, name: ~r0}
+                  Variable: {subprogram: 112, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1283
+      ID: 1284
       Name: Probe[main.testReturnsArrayZero]
     - __kind: EventRootType
-      ID: 1284
+      ID: 1285
       Name: Probe[main.testReturnsArrayZero]Return
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -14831,14 +14973,14 @@ Types:
             Type: 248 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 0, name: ~r0}
+                  Variable: {subprogram: 113, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1279
+      ID: 1280
       Name: Probe[main.testReturnsArray]
     - __kind: EventRootType
-      ID: 1280
+      ID: 1281
       Name: Probe[main.testReturnsArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -14850,14 +14992,14 @@ Types:
             Type: 246 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 0, name: ~r0}
+                  Variable: {subprogram: 111, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1287
+      ID: 1288
       Name: Probe[main.testReturnsBacktrackInt]
     - __kind: EventRootType
-      ID: 1288
+      ID: 1289
       Name: Probe[main.testReturnsBacktrackInt]Return
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -14869,7 +15011,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: ~r0}
+                  Variable: {subprogram: 115, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -14879,7 +15021,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 1, name: ~r1}
+                  Variable: {subprogram: 115, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -14889,7 +15031,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 2, name: ~r2}
+                  Variable: {subprogram: 115, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -14899,7 +15041,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 3, name: ~r3}
+                  Variable: {subprogram: 115, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -14909,7 +15051,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 4, name: ~r4}
+                  Variable: {subprogram: 115, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r5
@@ -14919,7 +15061,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 5, name: ~r5}
+                  Variable: {subprogram: 115, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r6
@@ -14929,7 +15071,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 6, name: ~r6}
+                  Variable: {subprogram: 115, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r7
@@ -14939,7 +15081,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 7, name: ~r7}
+                  Variable: {subprogram: 115, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r8
@@ -14949,14 +15091,14 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 8, name: ~r8}
+                  Variable: {subprogram: 115, index: 8, name: ~r8}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1299
+      ID: 1300
       Name: Probe[main.testReturnsBoolAndUintptr]
     - __kind: EventRootType
-      ID: 1300
+      ID: 1301
       Name: Probe[main.testReturnsBoolAndUintptr]Return
       ByteSize: 10
       PresenceBitsetSize: 1
@@ -14968,7 +15110,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: ~r0}
+                  Variable: {subprogram: 121, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r1
@@ -14978,14 +15120,14 @@ Types:
             Type: 1 BaseType uintptr
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 1, name: ~r1}
+                  Variable: {subprogram: 121, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1275
+      ID: 1276
       Name: Probe[main.testReturnsComplex]
     - __kind: EventRootType
-      ID: 1276
+      ID: 1277
       Name: Probe[main.testReturnsComplex]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -14997,7 +15139,7 @@ Types:
             Type: 89 BaseType complex64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: ~r0}
+                  Variable: {subprogram: 109, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15007,11 +15149,11 @@ Types:
             Type: 90 BaseType complex128
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: ~r1}
+                  Variable: {subprogram: 109, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1247
+      ID: 1248
       Name: Probe[main.testReturnsError]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -15023,7 +15165,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: failed}
+                  Variable: {subprogram: 100, index: 0, name: failed}
                   Offset: 0
                   ByteSize: 1
         - Name: failed
@@ -15033,11 +15175,11 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: failed}
+                  Variable: {subprogram: 100, index: 0, name: failed}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1248
+      ID: 1249
       Name: Probe[main.testReturnsError]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15049,11 +15191,11 @@ Types:
             Type: 18 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 1, name: ~r0}
+                  Variable: {subprogram: 100, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1245
+      ID: 1246
       Name: Probe[main.testReturnsIntAndFloat]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15065,7 +15207,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: i}
+                  Variable: {subprogram: 99, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -15075,11 +15217,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: i}
+                  Variable: {subprogram: 99, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1246
+      ID: 1247
       Name: Probe[main.testReturnsIntAndFloat]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15091,7 +15233,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 1, name: ~r0}
+                  Variable: {subprogram: 99, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15101,11 +15243,11 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 2, name: ~r1}
+                  Variable: {subprogram: 99, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1243
+      ID: 1244
       Name: Probe[main.testReturnsIntPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15117,7 +15259,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: i}
+                  Variable: {subprogram: 98, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -15127,11 +15269,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: i}
+                  Variable: {subprogram: 98, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1244
+      ID: 1245
       Name: Probe[main.testReturnsIntPointer]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15143,11 +15285,11 @@ Types:
             Type: 93 PointerType *int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 1, name: ~r0}
+                  Variable: {subprogram: 98, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1241
+      ID: 1242
       Name: Probe[main.testReturnsInt]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15159,7 +15301,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: i}
+                  Variable: {subprogram: 97, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -15169,11 +15311,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: i}
+                  Variable: {subprogram: 97, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1242
+      ID: 1243
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15185,11 +15327,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 1, name: ~r0}
+                  Variable: {subprogram: 97, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1253
+      ID: 1254
       Name: Probe[main.testReturnsInterface]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15201,7 +15343,7 @@ Types:
             Type: 152 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: v}
+                  Variable: {subprogram: 103, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: v
@@ -15211,11 +15353,11 @@ Types:
             Type: 152 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: v}
+                  Variable: {subprogram: 103, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1254
+      ID: 1255
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15227,14 +15369,14 @@ Types:
             Type: 157 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: ~r0}
+                  Variable: {subprogram: 103, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1277
+      ID: 1278
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1278
+      ID: 1279
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -15246,14 +15388,14 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: ~r0}
+                  Variable: {subprogram: 110, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1273
+      ID: 1274
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1274
+      ID: 1275
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 139
       PresenceBitsetSize: 3
@@ -15265,7 +15407,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: ~r0}
+                  Variable: {subprogram: 108, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15275,7 +15417,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 1, name: ~r1}
+                  Variable: {subprogram: 108, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15285,7 +15427,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 2, name: ~r2}
+                  Variable: {subprogram: 108, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -15295,7 +15437,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 3, name: ~r3}
+                  Variable: {subprogram: 108, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15305,7 +15447,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 4, name: ~r4}
+                  Variable: {subprogram: 108, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r5
@@ -15315,7 +15457,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 5, name: ~r5}
+                  Variable: {subprogram: 108, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r6
@@ -15325,7 +15467,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 6, name: ~r6}
+                  Variable: {subprogram: 108, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r7
@@ -15335,7 +15477,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 7, name: ~r7}
+                  Variable: {subprogram: 108, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r8
@@ -15345,7 +15487,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 8, name: ~r8}
+                  Variable: {subprogram: 108, index: 8, name: ~r8}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r9
@@ -15355,7 +15497,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 9, name: ~r9}
+                  Variable: {subprogram: 108, index: 9, name: ~r9}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r10
@@ -15365,7 +15507,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 10, name: ~r10}
+                  Variable: {subprogram: 108, index: 10, name: ~r10}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r11
@@ -15375,7 +15517,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 11, name: ~r11}
+                  Variable: {subprogram: 108, index: 11, name: ~r11}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r12
@@ -15385,7 +15527,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 12, name: ~r12}
+                  Variable: {subprogram: 108, index: 12, name: ~r12}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r13
@@ -15395,7 +15537,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 13, name: ~r13}
+                  Variable: {subprogram: 108, index: 13, name: ~r13}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r14
@@ -15405,7 +15547,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 14, name: ~r14}
+                  Variable: {subprogram: 108, index: 14, name: ~r14}
                   Offset: 0
                   ByteSize: 8
         - Name: onlyOnAmd64_16
@@ -15415,7 +15557,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 15, name: onlyOnAmd64_16}
+                  Variable: {subprogram: 108, index: 15, name: onlyOnAmd64_16}
                   Offset: 0
                   ByteSize: 8
         - Name: bothArmAndAmd64
@@ -15425,14 +15567,14 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 16, name: bothArmAndAmd64}
+                  Variable: {subprogram: 108, index: 16, name: bothArmAndAmd64}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1285
+      ID: 1286
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1286
+      ID: 1287
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15444,14 +15586,14 @@ Types:
             Type: 249 StructureType main.mixedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: ~r0}
+                  Variable: {subprogram: 114, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1291
+      ID: 1292
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1292
+      ID: 1293
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -15463,7 +15605,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 0, name: ~r0}
+                  Variable: {subprogram: 117, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15473,7 +15615,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 1, name: ~r1}
+                  Variable: {subprogram: 117, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15483,7 +15625,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 2, name: ~r2}
+                  Variable: {subprogram: 117, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -15493,7 +15635,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 3, name: ~r3}
+                  Variable: {subprogram: 117, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15503,14 +15645,14 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 4, name: ~r4}
+                  Variable: {subprogram: 117, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1297
+      ID: 1298
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1298
+      ID: 1299
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -15522,7 +15664,7 @@ Types:
             Type: 16 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: ~r0}
+                  Variable: {subprogram: 120, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r1
@@ -15532,14 +15674,14 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 1, name: ~r1}
+                  Variable: {subprogram: 120, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1295
+      ID: 1296
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1296
+      ID: 1297
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15551,14 +15693,14 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 0, name: ~r0}
+                  Variable: {subprogram: 119, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1271
+      ID: 1272
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1272
+      ID: 1273
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -15570,7 +15712,7 @@ Types:
             Type: 14 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 0, name: ~r0}
+                  Variable: {subprogram: 107, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r1
@@ -15580,7 +15722,7 @@ Types:
             Type: 97 BaseType int16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 1, name: ~r1}
+                  Variable: {subprogram: 107, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 2
         - Name: ~r2
@@ -15590,7 +15732,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 2, name: ~r2}
+                  Variable: {subprogram: 107, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r3
@@ -15600,7 +15742,7 @@ Types:
             Type: 13 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 3, name: ~r3}
+                  Variable: {subprogram: 107, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15610,7 +15752,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 4, name: ~r4}
+                  Variable: {subprogram: 107, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r5
@@ -15620,7 +15762,7 @@ Types:
             Type: 7 BaseType uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 5, name: ~r5}
+                  Variable: {subprogram: 107, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 2
         - Name: ~r6
@@ -15630,7 +15772,7 @@ Types:
             Type: 2 BaseType uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 6, name: ~r6}
+                  Variable: {subprogram: 107, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r7
@@ -15640,14 +15782,14 @@ Types:
             Type: 10 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 7, name: ~r7}
+                  Variable: {subprogram: 107, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1293
+      ID: 1294
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1294
+      ID: 1295
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15659,14 +15801,14 @@ Types:
             Type: 251 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 0, name: ~r0}
+                  Variable: {subprogram: 118, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1289
+      ID: 1290
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1290
+      ID: 1291
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -15678,7 +15820,7 @@ Types:
             Type: 250 StructureType main.wideStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 0, name: ~r0}
+                  Variable: {subprogram: 116, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 88
     - __kind: EventRootType
@@ -15988,7 +16130,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1334
+      ID: 1335
       Name: Probe[main.testSingleString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16000,7 +16142,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: x}
+                  Variable: {subprogram: 144, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -16010,7 +16152,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: x}
+                  Variable: {subprogram: 144, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -16144,7 +16286,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1330
+      ID: 1331
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16156,7 +16298,7 @@ Types:
             Type: 261 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: xs}
+                  Variable: {subprogram: 141, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -16166,11 +16308,11 @@ Types:
             Type: 261 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: xs}
+                  Variable: {subprogram: 141, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1321
+      ID: 1322
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16182,7 +16324,7 @@ Types:
             Type: 253 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: u}
+                  Variable: {subprogram: 133, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -16192,11 +16334,11 @@ Types:
             Type: 253 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: u}
+                  Variable: {subprogram: 133, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1207
+      ID: 1208
       Name: Probe[main.testSmallMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16208,7 +16350,7 @@ Types:
             Type: 171 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -16218,11 +16360,11 @@ Types:
             Type: 171 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1269
+      ID: 1270
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16234,7 +16376,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: i}
+                  Variable: {subprogram: 106, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -16244,11 +16386,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: i}
+                  Variable: {subprogram: 106, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1270
+      ID: 1271
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16260,7 +16402,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 1, name: ~r0}
+                  Variable: {subprogram: 106, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -16270,7 +16412,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 2, name: result2}
+                  Variable: {subprogram: 106, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -16280,11 +16422,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 3, name: ~r2}
+                  Variable: {subprogram: 106, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1311
+      ID: 1312
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -16296,7 +16438,7 @@ Types:
             Type: 156 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: arg}
+                  Variable: {subprogram: 127, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
         - Name: arg
@@ -16306,11 +16448,11 @@ Types:
             Type: 156 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: arg}
+                  Variable: {subprogram: 127, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1312
+      ID: 1313
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16322,7 +16464,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: ~r0}
+                  Variable: {subprogram: 127, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -16332,7 +16474,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: ~r1}
+                  Variable: {subprogram: 127, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -16342,7 +16484,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 3, name: ~r2}
+                  Variable: {subprogram: 127, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -16372,7 +16514,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1238
+      ID: 1239
       Name: Probe[main.testStringPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16384,7 +16526,7 @@ Types:
             Type: 88 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: z}
+                  Variable: {subprogram: 94, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: z
@@ -16394,11 +16536,11 @@ Types:
             Type: 88 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: z}
+                  Variable: {subprogram: 94, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1325
+      ID: 1326
       Name: Probe[main.testStringSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16410,7 +16552,7 @@ Types:
             Type: 258 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: s}
+                  Variable: {subprogram: 137, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: s
@@ -16420,11 +16562,11 @@ Types:
             Type: 258 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: s}
+                  Variable: {subprogram: 137, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1173
+      ID: 1174
       Name: Probe[main.testStringType1]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16436,7 +16578,7 @@ Types:
             Type: 146 PointerType *main.stringType1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 0, name: a}
+                  Variable: {subprogram: 45, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -16446,11 +16588,11 @@ Types:
             Type: 146 PointerType *main.stringType1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 0, name: a}
+                  Variable: {subprogram: 45, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1174
+      ID: 1175
       Name: Probe[main.testStringType2]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16462,7 +16604,7 @@ Types:
             Type: 148 PointerType **main.stringType2
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: a}
+                  Variable: {subprogram: 46, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -16472,11 +16614,11 @@ Types:
             Type: 148 PointerType **main.stringType2
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: a}
+                  Variable: {subprogram: 46, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1322
+      ID: 1323
       Name: Probe[main.testStructSlice]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -16488,7 +16630,7 @@ Types:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Variable: {subprogram: 134, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -16498,7 +16640,7 @@ Types:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Variable: {subprogram: 134, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -16508,7 +16650,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 1, name: a}
+                  Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -16518,11 +16660,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 1, name: a}
+                  Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1201
+      ID: 1202
       Name: Probe[main.testStructWithAny]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16534,7 +16676,7 @@ Types:
             Type: 159 StructureType main.structWithAny
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: s}
+                  Variable: {subprogram: 60, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
         - Name: s
@@ -16544,11 +16686,11 @@ Types:
             Type: 159 StructureType main.structWithAny
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: s}
+                  Variable: {subprogram: 60, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1315
+      ID: 1316
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16560,7 +16702,7 @@ Types:
             Type: 251 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: arg}
+                  Variable: {subprogram: 129, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
         - Name: arg
@@ -16570,11 +16712,11 @@ Types:
             Type: 251 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: arg}
+                  Variable: {subprogram: 129, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1316
+      ID: 1317
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16586,7 +16728,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 1, name: ~r0}
+                  Variable: {subprogram: 129, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -16596,11 +16738,11 @@ Types:
             Type: 251 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 2, name: ~r1}
+                  Variable: {subprogram: 129, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1349
+      ID: 1350
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16612,7 +16754,7 @@ Types:
             Type: 280 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: a}
+                  Variable: {subprogram: 154, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
         - Name: a
@@ -16622,14 +16764,14 @@ Types:
             Type: 280 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: a}
+                  Variable: {subprogram: 154, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1350
+      ID: 1351
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1348
+      ID: 1349
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 289
       PresenceBitsetSize: 1
@@ -16641,7 +16783,7 @@ Types:
             Type: 267 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: a}
+                  Variable: {subprogram: 153, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
         - Name: a
@@ -16651,11 +16793,11 @@ Types:
             Type: 267 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: a}
+                  Variable: {subprogram: 153, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
     - __kind: EventRootType
-      ID: 1202
+      ID: 1203
       Name: Probe[main.testStructWithMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16667,7 +16809,7 @@ Types:
             Type: 160 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: s}
+                  Variable: {subprogram: 61, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
         - Name: s
@@ -16677,11 +16819,11 @@ Types:
             Type: 160 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: s}
+                  Variable: {subprogram: 61, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1351
+      ID: 1352
       Name: Probe[main.testStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16693,11 +16835,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 8
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1353
+      ID: 1354
       Name: Probe[main.testStruct]
       ByteSize: 113
       PresenceBitsetSize: 1
@@ -16709,7 +16851,7 @@ Types:
             Type: 311 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
         - Name: x
@@ -16719,17 +16861,17 @@ Types:
             Type: 311 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1352
+      ID: 1353
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1354
+      ID: 1355
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1331
+      ID: 1332
       Name: Probe[main.testSubslices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -16741,7 +16883,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: as}
+                  Variable: {subprogram: 142, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
         - Name: as
@@ -16751,7 +16893,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: as}
+                  Variable: {subprogram: 142, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
         - Name: bs
@@ -16761,7 +16903,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 1, name: bs}
+                  Variable: {subprogram: 142, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
         - Name: bs
@@ -16771,7 +16913,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 1, name: bs}
+                  Variable: {subprogram: 142, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
         - Name: cs
@@ -16781,7 +16923,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 2, name: cs}
+                  Variable: {subprogram: 142, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
         - Name: cs
@@ -16791,11 +16933,11 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 2, name: cs}
+                  Variable: {subprogram: 142, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1347
+      ID: 1348
       Name: Probe[main.testSubstrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16807,7 +16949,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: a}
+                  Variable: {subprogram: 152, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -16817,7 +16959,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: a}
+                  Variable: {subprogram: 152, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -16827,7 +16969,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 1, name: b}
+                  Variable: {subprogram: 152, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -16837,7 +16979,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 1, name: b}
+                  Variable: {subprogram: 152, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: c
@@ -16847,7 +16989,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 2, name: c}
+                  Variable: {subprogram: 152, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
         - Name: c
@@ -16857,11 +16999,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 2, name: c}
+                  Variable: {subprogram: 152, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1340
+      ID: 1341
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16873,7 +17015,7 @@ Types:
             Type: 264 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -16883,11 +17025,11 @@ Types:
             Type: 264 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1341
+      ID: 1342
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16899,7 +17041,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -16912,7 +17054,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -16925,14 +17067,14 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
                   Bias: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1336
+      ID: 1337
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16944,7 +17086,7 @@ Types:
             Type: 263 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
         - Name: a
@@ -16954,11 +17096,11 @@ Types:
             Type: 263 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1338
+      ID: 1339
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16970,7 +17112,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: t.b
@@ -16980,7 +17122,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 16
                   ByteSize: 16
         - Name: t.c
@@ -16990,17 +17132,17 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1337
+      ID: 1338
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1339
+      ID: 1340
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1335
+      ID: 1336
       Name: Probe[main.testThreeStrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17012,7 +17154,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: x}
+                  Variable: {subprogram: 145, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -17022,7 +17164,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: x}
+                  Variable: {subprogram: 145, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -17032,7 +17174,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 1, name: y}
+                  Variable: {subprogram: 145, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -17042,7 +17184,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 1, name: y}
+                  Variable: {subprogram: 145, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -17052,7 +17194,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 2, name: z}
+                  Variable: {subprogram: 145, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -17062,7 +17204,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 2, name: z}
+                  Variable: {subprogram: 145, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -17222,7 +17364,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1237
+      ID: 1238
       Name: Probe[main.testUintPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17234,7 +17376,7 @@ Types:
             Type: 100 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: x}
+                  Variable: {subprogram: 93, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -17244,11 +17386,11 @@ Types:
             Type: 100 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: x}
+                  Variable: {subprogram: 93, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1319
+      ID: 1320
       Name: Probe[main.testUintSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17260,7 +17402,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: u}
+                  Variable: {subprogram: 131, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -17270,11 +17412,11 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: u}
+                  Variable: {subprogram: 131, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1345
+      ID: 1346
       Name: Probe[main.testUnitializedString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17286,7 +17428,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: x}
+                  Variable: {subprogram: 150, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -17296,11 +17438,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: x}
+                  Variable: {subprogram: 150, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1236
+      ID: 1237
       Name: Probe[main.testUnsafePointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17312,7 +17454,7 @@ Types:
             Type: 19 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: x}
+                  Variable: {subprogram: 92, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -17322,7 +17464,7 @@ Types:
             Type: 19 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: x}
+                  Variable: {subprogram: 92, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -17352,32 +17494,6 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1328
-      Name: Probe[main.testVeryLargeSlice]
-      ByteSize: 49
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: xs
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 252 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: xs
-          Offset: 25
-          Kind: template_segment
-          Expression:
-            Type: 252 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
       ID: 1329
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
@@ -17390,7 +17506,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: xs}
+                  Variable: {subprogram: 140, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -17400,11 +17516,37 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: xs}
+                  Variable: {subprogram: 140, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1317
+      ID: 1330
+      Name: Probe[main.testVeryLargeSlice]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 252 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 140, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: xs
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 252 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 140, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1318
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17416,7 +17558,7 @@ Types:
             Type: 248 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: a}
+                  Variable: {subprogram: 130, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
         - Name: a
@@ -17426,7 +17568,7 @@ Types:
             Type: 248 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: a}
+                  Variable: {subprogram: 130, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
         - Name: b
@@ -17436,7 +17578,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 1, name: b}
+                  Variable: {subprogram: 130, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -17446,11 +17588,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 1, name: b}
+                  Variable: {subprogram: 130, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1318
+      ID: 1319
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -17462,7 +17604,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 2, name: ~r0}
+                  Variable: {subprogram: 130, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -17472,7 +17614,7 @@ Types:
             Type: 248 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 3, name: ~r1}
+                  Variable: {subprogram: 130, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 0
     - __kind: ArrayType
@@ -24525,7 +24667,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 952224
       GoKind: 5
-MaxTypeID: 1376
+MaxTypeID: 1377
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x175d760", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -8,15 +8,15 @@ Probes:
       template: stackC
       segments: [stackC]
       captureSnapshot: true
-      subprogram: {subprogram: 142}
+      subprogram: {subprogram: 143}
       events:
         - Kind: Entry
-          Type: 1507 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0xcdb96a", Frameless: false}]
+          Type: 1508 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0xcdba8a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1508 EventRootType Probe[main.stackC]Return
-          InjectionPoints: [{PC: "0xcdb9a5", Frameless: false}]
+          Type: 1509 EventRootType Probe[main.stackC]Return
+          InjectionPoints: [{PC: "0xcdbac5", Frameless: false}]
           Condition: null
       probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -27,15 +27,15 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 56}
+      subprogram: {subprogram: 57}
       events:
         - Kind: Entry
-          Type: 1371 EventRootType Probe[main.testAny]
-          InjectionPoints: [{PC: "0xcd610a", Frameless: false}]
+          Type: 1372 EventRootType Probe[main.testAny]
+          InjectionPoints: [{PC: "0xcd622a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1372 EventRootType Probe[main.testAny]Return
-          InjectionPoints: [{PC: "0xcd6145", Frameless: false}]
+          Type: 1373 EventRootType Probe[main.testAny]Return
+          InjectionPoints: [{PC: "0xcd6265", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -52,15 +52,15 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 58}
+      subprogram: {subprogram: 59}
       events:
         - Kind: Entry
-          Type: 1374 EventRootType Probe[main.testAnyPtr]
-          InjectionPoints: [{PC: "0xcd61aa", Frameless: false}]
+          Type: 1375 EventRootType Probe[main.testAnyPtr]
+          InjectionPoints: [{PC: "0xcd62ca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1375 EventRootType Probe[main.testAnyPtr]Return
-          InjectionPoints: [{PC: "0xcd61dd", Frameless: false}]
+          Type: 1376 EventRootType Probe[main.testAnyPtr]Return
+          InjectionPoints: [{PC: "0xcd62fd", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -76,15 +76,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 122}
+      subprogram: {subprogram: 123}
       events:
         - Kind: Entry
-          Type: 1478 EventRootType Probe[main.testArrayArgAndReturn]
-          InjectionPoints: [{PC: "0xcda3ae", Frameless: false}]
+          Type: 1479 EventRootType Probe[main.testArrayArgAndReturn]
+          InjectionPoints: [{PC: "0xcda4ce", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1479 EventRootType Probe[main.testArrayArgAndReturn]Return
-          InjectionPoints: [{PC: "0xcda462", Frameless: false}]
+          Type: 1480 EventRootType Probe[main.testArrayArgAndReturn]Return
+          InjectionPoints: [{PC: "0xcda582", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -164,11 +164,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 66}
+      subprogram: {subprogram: 67}
       events:
         - Kind: Entry
-          Type: 1383 EventRootType Probe[main.testArrayOfMaps]
-          InjectionPoints: [{PC: "0xcd6920", Frameless: true}]
+          Type: 1384 EventRootType Probe[main.testArrayOfMaps]
+          InjectionPoints: [{PC: "0xcd6a40", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -226,15 +226,15 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 87}
       events:
         - Kind: Entry
-          Type: 1405 EventRootType Probe[main.testAtomicAdd]
-          InjectionPoints: [{PC: "0xcd8800", Frameless: true}]
+          Type: 1406 EventRootType Probe[main.testAtomicAdd]
+          InjectionPoints: [{PC: "0xcd8920", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1406 EventRootType Probe[main.testAtomicAdd]Return
-          InjectionPoints: [{PC: "0xcd8812", Frameless: true}]
+          Type: 1407 EventRootType Probe[main.testAtomicAdd]Return
+          InjectionPoints: [{PC: "0xcd8932", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -323,15 +323,15 @@ Probes:
           expr:
             dsl: x.aString
             json: {getmember: [{ref: x}, aString]}
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1526 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0xcdbda0", Frameless: true}]
+          Type: 1527 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0xcdbec0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1527 EventRootType Probe[main.testStruct]Return
-          InjectionPoints: [{PC: "0xcdbdc2", Frameless: true}]
+          Type: 1528 EventRootType Probe[main.testStruct]Return
+          InjectionPoints: [{PC: "0xcdbee2", Frameless: true}]
           Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -345,20 +345,20 @@ Probes:
       segments: []
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1536 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1537 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
-            - PC: "0xcd592e"
+            - PC: "0xcd5a4e"
               Frameless: false
-            - PC: "0xcd59b1"
+            - PC: "0xcd5ad1"
               Frameless: false
-            - PC: "0xcd5af2"
+            - PC: "0xcd5c12"
               Frameless: false
-            - PC: "0xcd5b7c"
+            - PC: "0xcd5c9c"
               Frameless: false
-            - PC: "0xcd5c4f"
+            - PC: "0xcd5d6f"
               Frameless: false
           Condition: null
     - id: testCaptureExprLineWithTemplate
@@ -373,20 +373,20 @@ Probes:
       segments: [x=, {json: {ref: x}, dsl: x}]
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1537 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1538 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
-            - PC: "0xcd592e"
+            - PC: "0xcd5a4e"
               Frameless: false
-            - PC: "0xcd59b1"
+            - PC: "0xcd5ad1"
               Frameless: false
-            - PC: "0xcd5af2"
+            - PC: "0xcd5c12"
               Frameless: false
-            - PC: "0xcd5b7c"
+            - PC: "0xcd5c9c"
               Frameless: false
-            - PC: "0xcd5c4f"
+            - PC: "0xcd5d6f"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -409,11 +409,11 @@ Probes:
           expr: {dsl: x, json: {ref: x}}
         - name: w_val
           expr: {dsl: w, json: {ref: w}}
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 85}
       events:
         - Kind: Entry
-          Type: 1402 EventRootType Probe[main.testCombinedString]
-          InjectionPoints: [{PC: "0xcd8460", Frameless: true}]
+          Type: 1403 EventRootType Probe[main.testCombinedString]
+          InjectionPoints: [{PC: "0xcd8580", Frameless: true}]
           Condition: null
     - id: testCaptureExprWithTemplate
       version: 0
@@ -427,11 +427,11 @@ Probes:
           expr: {dsl: x, json: {ref: x}}
         - name: w_val
           expr: {dsl: w, json: {ref: w}}
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 85}
       events:
         - Kind: Entry
-          Type: 1403 EventRootType Probe[main.testCombinedString]
-          InjectionPoints: [{PC: "0xcd8460", Frameless: true}]
+          Type: 1404 EventRootType Probe[main.testCombinedString]
+          InjectionPoints: [{PC: "0xcd8580", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: x={x}
@@ -449,11 +449,11 @@ Probes:
       template: '{c}'
       segments: [{json: {ref: c}, dsl: c}]
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 88}
       events:
         - Kind: Entry
-          Type: 1407 EventRootType Probe[main.testChannel]
-          InjectionPoints: [{PC: "0xcd8820", Frameless: true}]
+          Type: 1408 EventRootType Probe[main.testChannel]
+          InjectionPoints: [{PC: "0xcd8940", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{c}'
@@ -478,11 +478,11 @@ Probes:
         - json: {ref: y}
           dsl: y
       captureSnapshot: true
-      subprogram: {subprogram: 83}
+      subprogram: {subprogram: 84}
       events:
         - Kind: Entry
-          Type: 1401 EventRootType Probe[main.testCombinedByte]
-          InjectionPoints: [{PC: "0xcd8420", Frameless: true}]
+          Type: 1402 EventRootType Probe[main.testCombinedByte]
+          InjectionPoints: [{PC: "0xcd8540", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{w}, {x}, {y}'
@@ -509,11 +509,11 @@ Probes:
       template: '{t}'
       segments: [{json: {ref: t}, dsl: t}]
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 96}
       events:
         - Kind: Entry
-          Type: 1415 EventRootType Probe[main.testCycle]
-          InjectionPoints: [{PC: "0xcd8c00", Frameless: true}]
+          Type: 1416 EventRootType Probe[main.testCycle]
+          InjectionPoints: [{PC: "0xcd8d20", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{t}'
@@ -530,11 +530,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 42}
+      subprogram: {subprogram: 43}
       events:
         - Kind: Entry
-          Type: 1346 EventRootType Probe[main.testDeepMap1]
-          InjectionPoints: [{PC: "0xcd4e40", Frameless: true}]
+          Type: 1347 EventRootType Probe[main.testDeepMap1]
+          InjectionPoints: [{PC: "0xcd4f60", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -551,11 +551,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 43}
+      subprogram: {subprogram: 44}
       events:
         - Kind: Entry
-          Type: 1347 EventRootType Probe[main.testDeepMap7]
-          InjectionPoints: [{PC: "0xcd4e60", Frameless: true}]
+          Type: 1348 EventRootType Probe[main.testDeepMap7]
+          InjectionPoints: [{PC: "0xcd4f80", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -572,11 +572,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 38}
+      subprogram: {subprogram: 39}
       events:
         - Kind: Entry
-          Type: 1342 EventRootType Probe[main.testDeepPtr1]
-          InjectionPoints: [{PC: "0xcd4b20", Frameless: true}]
+          Type: 1343 EventRootType Probe[main.testDeepPtr1]
+          InjectionPoints: [{PC: "0xcd4c40", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -593,11 +593,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 39}
+      subprogram: {subprogram: 40}
       events:
         - Kind: Entry
-          Type: 1343 EventRootType Probe[main.testDeepPtr7]
-          InjectionPoints: [{PC: "0xcd4b40", Frameless: true}]
+          Type: 1344 EventRootType Probe[main.testDeepPtr7]
+          InjectionPoints: [{PC: "0xcd4c60", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -614,11 +614,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 40}
+      subprogram: {subprogram: 41}
       events:
         - Kind: Entry
-          Type: 1344 EventRootType Probe[main.testDeepSlice1]
-          InjectionPoints: [{PC: "0xcd4cc0", Frameless: true}]
+          Type: 1345 EventRootType Probe[main.testDeepSlice1]
+          InjectionPoints: [{PC: "0xcd4de0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -635,11 +635,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 41}
+      subprogram: {subprogram: 42}
       events:
         - Kind: Entry
-          Type: 1345 EventRootType Probe[main.testDeepSlice7]
-          InjectionPoints: [{PC: "0xcd4ce0", Frameless: true}]
+          Type: 1346 EventRootType Probe[main.testDeepSlice7]
+          InjectionPoints: [{PC: "0xcd4e00", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -656,11 +656,11 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 131}
+      subprogram: {subprogram: 132}
       events:
         - Kind: Entry
-          Type: 1495 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0xcdb480", Frameless: true}]
+          Type: 1496 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0xcdb5a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{u}'
@@ -682,11 +682,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 134}
+      subprogram: {subprogram: 135}
       events:
         - Kind: Entry
-          Type: 1498 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0xcdb4e0", Frameless: true}]
+          Type: 1499 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0xcdb600", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}, {a}'
@@ -709,11 +709,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 150}
+      subprogram: {subprogram: 151}
       events:
         - Kind: Entry
-          Type: 1521 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0xcdbaa0", Frameless: true}]
+          Type: 1522 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0xcdbbc0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -730,11 +730,11 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 156}
+      subprogram: {subprogram: 157}
       events:
         - Kind: Entry
-          Type: 1534 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0xcdbf20", Frameless: true}]
+          Type: 1535 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0xcdc040", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -750,11 +750,11 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 157}
+      subprogram: {subprogram: 158}
       events:
         - Kind: Entry
-          Type: 1535 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0xcdbf40", Frameless: true}]
+          Type: 1536 EventRootType Probe[main.testEmptyStructPointer]
+          InjectionPoints: [{PC: "0xcdc060", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -771,11 +771,11 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 57}
+      subprogram: {subprogram: 58}
       events:
         - Kind: Entry
-          Type: 1373 EventRootType Probe[main.testError]
-          InjectionPoints: [{PC: "0xcd6180", Frameless: true}]
+          Type: 1374 EventRootType Probe[main.testError]
+          InjectionPoints: [{PC: "0xcd62a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -784,6 +784,45 @@ Probes:
               DSL: e
               EventKind: Entry
               EventExpressionIndex: 1
+    - id: testErrorAtLine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testErrorAtLine
+        sourceFile: complex.go
+        lines: ["108"]
+      tags:
+        - config_diff:arch=amd64,toolchain=go1.26rc1
+        - skip_integration:arch=arm64,toolchain=go1.25.0
+      sampling: {snapshotsPerSecond: 100}
+      template: x={x}, err={err}
+      segments:
+        - x=
+        - json: {ref: x}
+          dsl: x
+        - ', err='
+        - json: {ref: err}
+          dsl: err
+      captureSnapshot: true
+      subprogram: {subprogram: 38}
+      events:
+        - Kind: Line
+          Type: 1342 EventRootType Probe[main.testErrorAtLine]Line
+          InjectionPoints: [{PC: "0xcd4afb", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: x={x}, err={err}
+        Segments:
+            - x=
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Line
+              EventExpressionIndex: 2
+            - ', err='
+            - JSON: {Ref: err}
+              DSL: err
+              EventKind: Line
+              EventExpressionIndex: 4
     - id: testEsotericHeap
       version: 0
       type: LOG_PROBE
@@ -792,15 +831,15 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 48}
+      subprogram: {subprogram: 49}
       events:
         - Kind: Entry
-          Type: 1355 EventRootType Probe[main.testEsotericHeap]
-          InjectionPoints: [{PC: "0xcd568a", Frameless: false}]
+          Type: 1356 EventRootType Probe[main.testEsotericHeap]
+          InjectionPoints: [{PC: "0xcd57aa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1356 EventRootType Probe[main.testEsotericHeap]Return
-          InjectionPoints: [{PC: "0xcd56cc", Frameless: false}]
+          Type: 1357 EventRootType Probe[main.testEsotericHeap]Return
+          InjectionPoints: [{PC: "0xcd57ec", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -817,15 +856,15 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 47}
+      subprogram: {subprogram: 48}
       events:
         - Kind: Entry
-          Type: 1353 EventRootType Probe[main.testEsotericStack]
-          InjectionPoints: [{PC: "0xcd556e", Frameless: false}]
+          Type: 1354 EventRootType Probe[main.testEsotericStack]
+          InjectionPoints: [{PC: "0xcd568e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1354 EventRootType Probe[main.testEsotericStack]Return
-          InjectionPoints: [{PC: "0xcd55fb", Frameless: false}]
+          Type: 1355 EventRootType Probe[main.testEsotericStack]Return
+          InjectionPoints: [{PC: "0xcd571b", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -842,15 +881,15 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 53}
+      subprogram: {subprogram: 54}
       events:
         - Kind: Entry
-          Type: 1365 EventRootType Probe[main.testFrameless]
-          InjectionPoints: [{PC: "0xcd5de0", Frameless: true}]
+          Type: 1366 EventRootType Probe[main.testFrameless]
+          InjectionPoints: [{PC: "0xcd5f00", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1366 EventRootType Probe[main.testFrameless]Return
-          InjectionPoints: [{PC: "0xcd5de5", Frameless: true}]
+          Type: 1367 EventRootType Probe[main.testFrameless]Return
+          InjectionPoints: [{PC: "0xcd5f05", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -867,15 +906,15 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 54}
+      subprogram: {subprogram: 55}
       events:
         - Kind: Entry
-          Type: 1367 EventRootType Probe[main.testFramelessArray]
-          InjectionPoints: [{PC: "0xcd5e04", Frameless: false}]
+          Type: 1368 EventRootType Probe[main.testFramelessArray]
+          InjectionPoints: [{PC: "0xcd5f24", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1368 EventRootType Probe[main.testFramelessArray]Return
-          InjectionPoints: [{PC: "0xcd5e3d", Frameless: false}]
+          Type: 1369 EventRootType Probe[main.testFramelessArray]Return
+          InjectionPoints: [{PC: "0xcd5f5d", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -895,11 +934,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 54}
+      subprogram: {subprogram: 55}
       events:
         - Kind: Line
-          Type: 1369 EventRootType Probe[main.testFramelessArray]Line
-          InjectionPoints: [{PC: "0xcd5e08", Frameless: false}]
+          Type: 1370 EventRootType Probe[main.testFramelessArray]Line
+          InjectionPoints: [{PC: "0xcd5f28", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -916,15 +955,15 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 49}
+      subprogram: {subprogram: 50}
       events:
         - Kind: Entry
-          Type: 1357 EventRootType Probe[main.testInlinedBA]
-          InjectionPoints: [{PC: "0xcd5aca", Frameless: false}]
+          Type: 1358 EventRootType Probe[main.testInlinedBA]
+          InjectionPoints: [{PC: "0xcd5bea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1358 EventRootType Probe[main.testInlinedBA]Return
-          InjectionPoints: [{PC: "0xcd5b2e", Frameless: false}]
+          Type: 1359 EventRootType Probe[main.testInlinedBA]Return
+          InjectionPoints: [{PC: "0xcd5c4e", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -946,15 +985,15 @@ Probes:
         - json: {ref: y}
           dsl: y
       captureSnapshot: true
-      subprogram: {subprogram: 50}
+      subprogram: {subprogram: 51}
       events:
         - Kind: Entry
-          Type: 1359 EventRootType Probe[main.testInlinedBB]
-          InjectionPoints: [{PC: "0xcd5b6e", Frameless: false}]
+          Type: 1360 EventRootType Probe[main.testInlinedBB]
+          InjectionPoints: [{PC: "0xcd5c8e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1360 EventRootType Probe[main.testInlinedBB]Return
-          InjectionPoints: [{PC: "0xcd5bfe", Frameless: false}]
+          Type: 1361 EventRootType Probe[main.testInlinedBB]Return
+          InjectionPoints: [{PC: "0xcd5d1e", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}, {y}'
@@ -976,15 +1015,15 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 51}
+      subprogram: {subprogram: 52}
       events:
         - Kind: Entry
-          Type: 1361 EventRootType Probe[main.testInlinedBBA]
-          InjectionPoints: [{PC: "0xcd5c4a", Frameless: false}]
+          Type: 1362 EventRootType Probe[main.testInlinedBBA]
+          InjectionPoints: [{PC: "0xcd5d6a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1362 EventRootType Probe[main.testInlinedBBA]Return
-          InjectionPoints: [{PC: "0xcd5c8b", Frameless: false}]
+          Type: 1363 EventRootType Probe[main.testInlinedBBA]Return
+          InjectionPoints: [{PC: "0xcd5dab", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1001,11 +1040,11 @@ Probes:
       template: testInlinedBBB
       segments: [testInlinedBBB]
       captureSnapshot: true
-      subprogram: {subprogram: 159}
+      subprogram: {subprogram: 160}
       events:
         - Kind: Entry
-          Type: 1541 EventRootType Probe[main.testInlinedBBB]
-          InjectionPoints: [{PC: "0xcd5bc6", Frameless: false}]
+          Type: 1542 EventRootType Probe[main.testInlinedBBB]
+          InjectionPoints: [{PC: "0xcd5ce6", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBBB
@@ -1018,15 +1057,15 @@ Probes:
       template: testInlinedBC
       segments: [testInlinedBC]
       captureSnapshot: true
-      subprogram: {subprogram: 52}
+      subprogram: {subprogram: 53}
       events:
         - Kind: Entry
-          Type: 1363 EventRootType Probe[main.testInlinedBC]
-          InjectionPoints: [{PC: "0xcd5cce", Frameless: false}]
+          Type: 1364 EventRootType Probe[main.testInlinedBC]
+          InjectionPoints: [{PC: "0xcd5dee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1364 EventRootType Probe[main.testInlinedBC]Return
-          InjectionPoints: [{PC: "0xcd5dbe", Frameless: false}]
+          Type: 1365 EventRootType Probe[main.testInlinedBC]Return
+          InjectionPoints: [{PC: "0xcd5ede", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBC
@@ -1039,11 +1078,11 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Entry
-          Type: 1542 EventRootType Probe[main.testInlinedBCA]
-          InjectionPoints: [{PC: "0xcd5cd3", Frameless: false}]
+          Type: 1543 EventRootType Probe[main.testInlinedBCA]
+          InjectionPoints: [{PC: "0xcd5df3", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBCA
@@ -1059,11 +1098,11 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Line
-          Type: 1543 EventRootType Probe[main.testInlinedBCA]Line
-          InjectionPoints: [{PC: "0xcd5cd3", Frameless: false}]
+          Type: 1544 EventRootType Probe[main.testInlinedBCA]Line
+          InjectionPoints: [{PC: "0xcd5df3", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBCA
@@ -1076,11 +1115,11 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Entry
-          Type: 1544 EventRootType Probe[main.testInlinedBCB]
-          InjectionPoints: [{PC: "0xcd5d86", Frameless: false}]
+          Type: 1545 EventRootType Probe[main.testInlinedBCB]
+          InjectionPoints: [{PC: "0xcd5ea6", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBCB
@@ -1096,11 +1135,11 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Line
-          Type: 1545 EventRootType Probe[main.testInlinedBCB]Line
-          InjectionPoints: [{PC: "0xcd5d86", Frameless: false}]
+          Type: 1546 EventRootType Probe[main.testInlinedBCB]Line
+          InjectionPoints: [{PC: "0xcd5ea6", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBCB
@@ -1113,14 +1152,14 @@ Probes:
       template: testInlinedFuncFromOtherPackage
       segments: [testInlinedFuncFromOtherPackage]
       captureSnapshot: true
-      subprogram: {subprogram: 165}
+      subprogram: {subprogram: 166}
       events:
         - Kind: Entry
-          Type: 1551 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
+          Type: 1552 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
           InjectionPoints:
             - PC: "0xcd3c41"
               Frameless: true
-            - PC: "0xcd67ab"
+            - PC: "0xcd68cb"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -1135,25 +1174,25 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Entry
-          Type: 1538 EventRootType Probe[main.testInlinedPrint]
+          Type: 1539 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
-            - PC: "0xcd592a"
+            - PC: "0xcd5a4a"
               Frameless: false
-            - PC: "0xcd59b1"
+            - PC: "0xcd5ad1"
               Frameless: false
-            - PC: "0xcd5af2"
+            - PC: "0xcd5c12"
               Frameless: false
-            - PC: "0xcd5b7c"
+            - PC: "0xcd5c9c"
               Frameless: false
-            - PC: "0xcd5c4f"
+            - PC: "0xcd5d6f"
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1539 EventRootType Probe[main.testInlinedPrint]Return
-          InjectionPoints: [{PC: "0xcd596a", Frameless: false}]
+          Type: 1540 EventRootType Probe[main.testInlinedPrint]Return
+          InjectionPoints: [{PC: "0xcd5a8a", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1173,20 +1212,20 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1540 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1541 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
-            - PC: "0xcd592e"
+            - PC: "0xcd5a4e"
               Frameless: false
-            - PC: "0xcd59b1"
+            - PC: "0xcd5ad1"
               Frameless: false
-            - PC: "0xcd5af2"
+            - PC: "0xcd5c12"
               Frameless: false
-            - PC: "0xcd5b7c"
+            - PC: "0xcd5c9c"
               Frameless: false
-            - PC: "0xcd5c4f"
+            - PC: "0xcd5d6f"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -1204,11 +1243,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 162}
+      subprogram: {subprogram: 163}
       events:
         - Kind: Entry
-          Type: 1546 EventRootType Probe[main.testInlinedSq]
-          InjectionPoints: [{PC: "0xcd5de1", Frameless: true}]
+          Type: 1547 EventRootType Probe[main.testInlinedSq]
+          InjectionPoints: [{PC: "0xcd5f01", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1228,11 +1267,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 162}
+      subprogram: {subprogram: 163}
       events:
         - Kind: Line
-          Type: 1547 EventRootType Probe[main.testInlinedSq]Line
-          InjectionPoints: [{PC: "0xcd5de1", Frameless: true}]
+          Type: 1548 EventRootType Probe[main.testInlinedSq]Line
+          InjectionPoints: [{PC: "0xcd5f01", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1250,14 +1289,14 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 163}
+      subprogram: {subprogram: 164}
       events:
         - Kind: Entry
-          Type: 1548 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1549 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
-            - PC: "0xcd5e25"
+            - PC: "0xcd5f45"
               Frameless: false
-            - PC: "0xcd5ec5"
+            - PC: "0xcd5fe5"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -1380,11 +1419,11 @@ Probes:
       template: '{b}'
       segments: [{json: {ref: b}, dsl: b}]
       captureSnapshot: true
-      subprogram: {subprogram: 55}
+      subprogram: {subprogram: 56}
       events:
         - Kind: Entry
-          Type: 1370 EventRootType Probe[main.testInterface]
-          InjectionPoints: [{PC: "0xcd60e0", Frameless: true}]
+          Type: 1371 EventRootType Probe[main.testInterface]
+          InjectionPoints: [{PC: "0xcd6200", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{b}'
@@ -1400,15 +1439,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 121}
+      subprogram: {subprogram: 122}
       events:
         - Kind: Entry
-          Type: 1476 EventRootType Probe[main.testLargeArgAndReturn]
-          InjectionPoints: [{PC: "0xcda20e", Frameless: false}]
+          Type: 1477 EventRootType Probe[main.testLargeArgAndReturn]
+          InjectionPoints: [{PC: "0xcda32e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1477 EventRootType Probe[main.testLargeArgAndReturn]Return
-          InjectionPoints: [{PC: "0xcda373", Frameless: false}]
+          Type: 1478 EventRootType Probe[main.testLargeArgAndReturn]Return
+          InjectionPoints: [{PC: "0xcda493", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -1425,11 +1464,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 90}
       events:
         - Kind: Entry
-          Type: 1409 EventRootType Probe[main.testLinkedList]
-          InjectionPoints: [{PC: "0xcd8a20", Frameless: true}]
+          Type: 1410 EventRootType Probe[main.testLinkedList]
+          InjectionPoints: [{PC: "0xcd8b40", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -1444,16 +1483,16 @@ Probes:
       where:
         methodName: main.testLongFunctionWithChangingState
         sourceFile: complex.go
-        lines: ["211"]
+        lines: ["230"]
       sampling: {snapshotsPerSecond: 100}
       template: testLongFunctionWithChangingState
       segments: [testLongFunctionWithChangingState]
       captureSnapshot: true
-      subprogram: {subprogram: 46}
+      subprogram: {subprogram: 47}
       events:
         - Kind: Line
-          Type: 1350 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-          InjectionPoints: [{PC: "0xcd4eda", Frameless: false}]
+          Type: 1351 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          InjectionPoints: [{PC: "0xcd4ffa", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testLongFunctionWithChangingState
@@ -1464,17 +1503,17 @@ Probes:
       where:
         methodName: main.testLongFunctionWithChangingState
         sourceFile: complex.go
-        lines: ["218"]
+        lines: ["237"]
       tags: ['version_diff:go1.26rc1']
       sampling: {snapshotsPerSecond: 100}
       template: testLongFunctionWithChangingState
       segments: [testLongFunctionWithChangingState]
       captureSnapshot: true
-      subprogram: {subprogram: 46}
+      subprogram: {subprogram: 47}
       events:
         - Kind: Line
-          Type: 1351 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-          InjectionPoints: [{PC: "0xcd4f8d", Frameless: false}]
+          Type: 1352 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          InjectionPoints: [{PC: "0xcd50ad", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testLongFunctionWithChangingState
@@ -1485,17 +1524,17 @@ Probes:
       where:
         methodName: main.testLongFunctionWithChangingState
         sourceFile: complex.go
-        lines: ["223"]
+        lines: ["242"]
       tags: ['version_diff:go1.26rc1']
       sampling: {snapshotsPerSecond: 100}
       template: testLongFunctionWithChangingState
       segments: [testLongFunctionWithChangingState]
       captureSnapshot: true
-      subprogram: {subprogram: 46}
+      subprogram: {subprogram: 47}
       events:
         - Kind: Line
-          Type: 1352 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-          InjectionPoints: [{PC: "0xcd5054", Frameless: false}]
+          Type: 1353 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          InjectionPoints: [{PC: "0xcd5174", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testLongFunctionWithChangingState
@@ -1533,15 +1572,15 @@ Probes:
         - json: {ref: i}
           dsl: i
       captureSnapshot: true
-      subprogram: {subprogram: 124}
+      subprogram: {subprogram: 125}
       events:
         - Kind: Entry
-          Type: 1482 EventRootType Probe[main.testManyArgsArrayReturn]
-          InjectionPoints: [{PC: "0xcda6d3", Frameless: false}]
+          Type: 1483 EventRootType Probe[main.testManyArgsArrayReturn]
+          InjectionPoints: [{PC: "0xcda7f3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1483 EventRootType Probe[main.testManyArgsArrayReturn]Return
-          InjectionPoints: [{PC: "0xcda8e2", Frameless: false}]
+          Type: 1484 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          InjectionPoints: [{PC: "0xcdaa02", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -1598,11 +1637,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 64}
+      subprogram: {subprogram: 65}
       events:
         - Kind: Entry
-          Type: 1381 EventRootType Probe[main.testMapArrayToArray]
-          InjectionPoints: [{PC: "0xcd68e0", Frameless: true}]
+          Type: 1382 EventRootType Probe[main.testMapArrayToArray]
+          InjectionPoints: [{PC: "0xcd6a00", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1619,11 +1658,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 70}
+      subprogram: {subprogram: 71}
       events:
         - Kind: Entry
-          Type: 1388 EventRootType Probe[main.testMapEmbeddedMaps]
-          InjectionPoints: [{PC: "0xcd69a0", Frameless: true}]
+          Type: 1389 EventRootType Probe[main.testMapEmbeddedMaps]
+          InjectionPoints: [{PC: "0xcd6ac0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1640,11 +1679,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 80}
+      subprogram: {subprogram: 81}
       events:
         - Kind: Entry
-          Type: 1398 EventRootType Probe[main.testMapEmptyKey]
-          InjectionPoints: [{PC: "0xcd6ae0", Frameless: true}]
+          Type: 1399 EventRootType Probe[main.testMapEmptyKey]
+          InjectionPoints: [{PC: "0xcd6c00", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1661,11 +1700,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 82}
+      subprogram: {subprogram: 83}
       events:
         - Kind: Entry
-          Type: 1400 EventRootType Probe[main.testMapEmptyKeyAndValue]
-          InjectionPoints: [{PC: "0xcd6b20", Frameless: true}]
+          Type: 1401 EventRootType Probe[main.testMapEmptyKeyAndValue]
+          InjectionPoints: [{PC: "0xcd6c40", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1682,11 +1721,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 81}
+      subprogram: {subprogram: 82}
       events:
         - Kind: Entry
-          Type: 1399 EventRootType Probe[main.testMapEmptyValue]
-          InjectionPoints: [{PC: "0xcd6b00", Frameless: true}]
+          Type: 1400 EventRootType Probe[main.testMapEmptyValue]
+          InjectionPoints: [{PC: "0xcd6c20", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1703,11 +1742,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 68}
+      subprogram: {subprogram: 69}
       events:
         - Kind: Entry
-          Type: 1385 EventRootType Probe[main.testMapIntToInt]
-          InjectionPoints: [{PC: "0xcd6960", Frameless: true}]
+          Type: 1386 EventRootType Probe[main.testMapIntToInt]
+          InjectionPoints: [{PC: "0xcd6a80", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1724,11 +1763,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 79}
+      subprogram: {subprogram: 80}
       events:
         - Kind: Entry
-          Type: 1397 EventRootType Probe[main.testMapLargeKeyLargeValue]
-          InjectionPoints: [{PC: "0xcd6ac0", Frameless: true}]
+          Type: 1398 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          InjectionPoints: [{PC: "0xcd6be0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1745,11 +1784,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 78}
+      subprogram: {subprogram: 79}
       events:
         - Kind: Entry
-          Type: 1396 EventRootType Probe[main.testMapLargeKeySmallValue]
-          InjectionPoints: [{PC: "0xcd6aa0", Frameless: true}]
+          Type: 1397 EventRootType Probe[main.testMapLargeKeySmallValue]
+          InjectionPoints: [{PC: "0xcd6bc0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1768,11 +1807,11 @@ Probes:
         - json: {ref: redactMyEntries}
           dsl: redactMyEntries
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 70}
       events:
         - Kind: Entry
-          Type: 1386 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0xcd6980", Frameless: true}]
+          Type: 1387 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0xcd6aa0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{redactMyEntries}'
@@ -1791,11 +1830,11 @@ Probes:
         - json: {ref: redactMyEntries}
           dsl: redactMyEntries
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 70}
       events:
         - Kind: Entry
-          Type: 1387 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0xcd6980", Frameless: true}]
+          Type: 1388 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0xcd6aa0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{redactMyEntries}'
@@ -1812,11 +1851,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 77}
+      subprogram: {subprogram: 78}
       events:
         - Kind: Entry
-          Type: 1395 EventRootType Probe[main.testMapSmallKeyLargeValue]
-          InjectionPoints: [{PC: "0xcd6a80", Frameless: true}]
+          Type: 1396 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          InjectionPoints: [{PC: "0xcd6ba0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1833,11 +1872,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 76}
+      subprogram: {subprogram: 77}
       events:
         - Kind: Entry
-          Type: 1394 EventRootType Probe[main.testMapSmallKeySmallValue]
-          InjectionPoints: [{PC: "0xcd6a60", Frameless: true}]
+          Type: 1395 EventRootType Probe[main.testMapSmallKeySmallValue]
+          InjectionPoints: [{PC: "0xcd6b80", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1854,11 +1893,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 62}
+      subprogram: {subprogram: 63}
       events:
         - Kind: Entry
-          Type: 1379 EventRootType Probe[main.testMapStringToInt]
-          InjectionPoints: [{PC: "0xcd68a0", Frameless: true}]
+          Type: 1380 EventRootType Probe[main.testMapStringToInt]
+          InjectionPoints: [{PC: "0xcd69c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1875,11 +1914,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 63}
+      subprogram: {subprogram: 64}
       events:
         - Kind: Entry
-          Type: 1380 EventRootType Probe[main.testMapStringToSlice]
-          InjectionPoints: [{PC: "0xcd68c0", Frameless: true}]
+          Type: 1381 EventRootType Probe[main.testMapStringToSlice]
+          InjectionPoints: [{PC: "0xcd69e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1896,11 +1935,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 61}
+      subprogram: {subprogram: 62}
       events:
         - Kind: Entry
-          Type: 1378 EventRootType Probe[main.testMapStringToStruct]
-          InjectionPoints: [{PC: "0xcd6880", Frameless: true}]
+          Type: 1379 EventRootType Probe[main.testMapStringToStruct]
+          InjectionPoints: [{PC: "0xcd69a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1917,11 +1956,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 71}
+      subprogram: {subprogram: 72}
       events:
         - Kind: Entry
-          Type: 1389 EventRootType Probe[main.testMapWithLinkedList]
-          InjectionPoints: [{PC: "0xcd69c0", Frameless: true}]
+          Type: 1390 EventRootType Probe[main.testMapWithLinkedList]
+          InjectionPoints: [{PC: "0xcd6ae0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1938,11 +1977,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 74}
+      subprogram: {subprogram: 75}
       events:
         - Kind: Entry
-          Type: 1392 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-          InjectionPoints: [{PC: "0xcd6a20", Frameless: true}]
+          Type: 1393 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          InjectionPoints: [{PC: "0xcd6b40", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1959,11 +1998,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 75}
+      subprogram: {subprogram: 76}
       events:
         - Kind: Entry
-          Type: 1393 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-          InjectionPoints: [{PC: "0xcd6a40", Frameless: true}]
+          Type: 1394 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          InjectionPoints: [{PC: "0xcd6b60", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1980,11 +2019,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 72}
+      subprogram: {subprogram: 73}
       events:
         - Kind: Entry
-          Type: 1390 EventRootType Probe[main.testMapWithSmallValue]
-          InjectionPoints: [{PC: "0xcd69e0", Frameless: true}]
+          Type: 1391 EventRootType Probe[main.testMapWithSmallValue]
+          InjectionPoints: [{PC: "0xcd6b00", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -2003,11 +2042,11 @@ Probes:
         - json: {ref: redactMyEntries}
           dsl: redactMyEntries
       captureSnapshot: true
-      subprogram: {subprogram: 73}
+      subprogram: {subprogram: 74}
       events:
         - Kind: Entry
-          Type: 1391 EventRootType Probe[main.testMapWithSmallValueMassive]
-          InjectionPoints: [{PC: "0xcd6a00", Frameless: true}]
+          Type: 1392 EventRootType Probe[main.testMapWithSmallValueMassive]
+          InjectionPoints: [{PC: "0xcd6b20", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{redactMyEntries}'
@@ -2024,11 +2063,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 148}
+      subprogram: {subprogram: 149}
       events:
         - Kind: Entry
-          Type: 1518 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0xcdba60", Frameless: true}]
+          Type: 1519 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0xcdbb80", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -2046,11 +2085,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 148}
+      subprogram: {subprogram: 149}
       events:
         - Kind: Entry
-          Type: 1519 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0xcdba60", Frameless: true}]
+          Type: 1520 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0xcdbb80", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -2092,15 +2131,15 @@ Probes:
         - json: {ref: s}
           dsl: s
       captureSnapshot: true
-      subprogram: {subprogram: 125}
+      subprogram: {subprogram: 126}
       events:
         - Kind: Entry
-          Type: 1484 EventRootType Probe[main.testMixedArgsStackReturn]
-          InjectionPoints: [{PC: "0xcda973", Frameless: false}]
+          Type: 1485 EventRootType Probe[main.testMixedArgsStackReturn]
+          InjectionPoints: [{PC: "0xcdaa93", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1485 EventRootType Probe[main.testMixedArgsStackReturn]Return
-          InjectionPoints: [{PC: "0xcdabab", Frameless: false}]
+          Type: 1486 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          InjectionPoints: [{PC: "0xcdaccb", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -2161,15 +2200,15 @@ Probes:
         - json: {ref: b}
           dsl: b
       captureSnapshot: true
-      subprogram: {subprogram: 127}
+      subprogram: {subprogram: 128}
       events:
         - Kind: Entry
-          Type: 1488 EventRootType Probe[main.testMultipleArrayArgs]
-          InjectionPoints: [{PC: "0xcdacee", Frameless: false}]
+          Type: 1489 EventRootType Probe[main.testMultipleArrayArgs]
+          InjectionPoints: [{PC: "0xcdae0e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1489 EventRootType Probe[main.testMultipleArrayArgs]Return
-          InjectionPoints: [{PC: "0xcdadbe", Frameless: false}]
+          Type: 1490 EventRootType Probe[main.testMultipleArrayArgs]Return
+          InjectionPoints: [{PC: "0xcdaede", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}'
@@ -2195,15 +2234,15 @@ Probes:
         - json: {ref: s2}
           dsl: s2
       captureSnapshot: true
-      subprogram: {subprogram: 123}
+      subprogram: {subprogram: 124}
       events:
         - Kind: Entry
-          Type: 1480 EventRootType Probe[main.testMultipleLargeArgs]
-          InjectionPoints: [{PC: "0xcda48e", Frameless: false}]
+          Type: 1481 EventRootType Probe[main.testMultipleLargeArgs]
+          InjectionPoints: [{PC: "0xcda5ae", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1481 EventRootType Probe[main.testMultipleLargeArgs]Return
-          InjectionPoints: [{PC: "0xcda6aa", Frameless: false}]
+          Type: 1482 EventRootType Probe[main.testMultipleLargeArgs]Return
+          InjectionPoints: [{PC: "0xcda7ca", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{s1}, {s2}'
@@ -2224,15 +2263,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1434 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0xcd982e", Frameless: false}]
+          Type: 1435 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xcd994e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1435 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0xcd98cf", Frameless: false}]
+          Type: 1436 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xcd99ef", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2263,11 +2302,11 @@ Probes:
         - json: {ref: e}
           dsl: e
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 86}
       events:
         - Kind: Entry
-          Type: 1404 EventRootType Probe[main.testMultipleSimpleParams]
-          InjectionPoints: [{PC: "0xcd85e0", Frameless: true}]
+          Type: 1405 EventRootType Probe[main.testMultipleSimpleParams]
+          InjectionPoints: [{PC: "0xcd8700", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}, {d}, {e}'
@@ -2303,15 +2342,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1430 EventRootType Probe[main.testNamedReturn]
-          InjectionPoints: [{PC: "0xcd978a", Frameless: false}]
+          Type: 1431 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0xcd98aa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1431 EventRootType Probe[main.testNamedReturn]Return
-          InjectionPoints: [{PC: "0xcd97f5", Frameless: false}]
+          Type: 1432 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0xcd9915", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2333,15 +2372,15 @@ Probes:
         - json: {ref: result}
           dsl: result
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1432 EventRootType Probe[main.testNamedReturn]
-          InjectionPoints: [{PC: "0xcd978a", Frameless: false}]
+          Type: 1433 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0xcd98aa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1433 EventRootType Probe[main.testNamedReturn]Return
-          InjectionPoints: [{PC: "0xcd97f5", Frameless: false}]
+          Type: 1434 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0xcd9915", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: Parameter {i} * 2 = result {result}
@@ -2364,11 +2403,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 155}
+      subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1530 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0xcdbea0", Frameless: true}]
+          Type: 1531 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0xcdbfc0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -2388,11 +2427,11 @@ Probes:
             getmember: [{getmember: [{ref: x}, nested]}, anotherString]
           dsl: x.nested.anotherString
       captureSnapshot: false
-      subprogram: {subprogram: 155}
+      subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1531 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0xcdbea0", Frameless: true}]
+          Type: 1532 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0xcdbfc0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x.nested.anotherString}'
@@ -2418,11 +2457,11 @@ Probes:
         - json: {getmember: [{ref: x}, notAMember]}
           dsl: x.notAMember
       captureSnapshot: false
-      subprogram: {subprogram: 155}
+      subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1532 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0xcdbea0", Frameless: true}]
+          Type: 1533 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0xcdbfc0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -2442,11 +2481,11 @@ Probes:
         - json: {getmember: [{ref: x}, nested]}
           dsl: x.nested
       captureSnapshot: false
-      subprogram: {subprogram: 155}
+      subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1533 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0xcdbea0", Frameless: true}]
+          Type: 1534 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0xcdbfc0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x.nested}'
@@ -2468,11 +2507,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 95}
       events:
         - Kind: Entry
-          Type: 1414 EventRootType Probe[main.testNilPointer]
-          InjectionPoints: [{PC: "0xcd8bc0", Frameless: true}]
+          Type: 1415 EventRootType Probe[main.testNilPointer]
+          InjectionPoints: [{PC: "0xcd8ce0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{z}, {a}'
@@ -2494,11 +2533,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 138}
+      subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1502 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0xcdb560", Frameless: true}]
+          Type: 1503 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0xcdb680", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -2520,11 +2559,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 135}
+      subprogram: {subprogram: 136}
       events:
         - Kind: Entry
-          Type: 1499 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0xcdb500", Frameless: true}]
+          Type: 1500 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0xcdb620", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}, {a}'
@@ -2554,11 +2593,11 @@ Probes:
         - json: {ref: x}
           dsl: x
       captureSnapshot: true
-      subprogram: {subprogram: 137}
+      subprogram: {subprogram: 138}
       events:
         - Kind: Entry
-          Type: 1501 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0xcdb540", Frameless: true}]
+          Type: 1502 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0xcdb660", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {s}, {x}'
@@ -2585,11 +2624,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 147}
+      subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1517 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0xcdba40", Frameless: true}]
+          Type: 1518 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0xcdbb60", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -2606,11 +2645,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 91}
       events:
         - Kind: Entry
-          Type: 1410 EventRootType Probe[main.testPointerLoop]
-          InjectionPoints: [{PC: "0xcd8a40", Frameless: true}]
+          Type: 1411 EventRootType Probe[main.testPointerLoop]
+          InjectionPoints: [{PC: "0xcd8b60", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -2627,11 +2666,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 67}
+      subprogram: {subprogram: 68}
       events:
         - Kind: Entry
-          Type: 1384 EventRootType Probe[main.testPointerToMap]
-          InjectionPoints: [{PC: "0xcd6940", Frameless: true}]
+          Type: 1385 EventRootType Probe[main.testPointerToMap]
+          InjectionPoints: [{PC: "0xcd6a60", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -2648,11 +2687,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 89}
       events:
         - Kind: Entry
-          Type: 1408 EventRootType Probe[main.testPointerToSimpleStruct]
-          InjectionPoints: [{PC: "0xcd8a00", Frameless: true}]
+          Type: 1409 EventRootType Probe[main.testPointerToSimpleStruct]
+          InjectionPoints: [{PC: "0xcd8b20", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -2669,22 +2708,22 @@ Probes:
       template: '{v}'
       segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
         - Kind: Entry
-          Type: 1426 EventRootType Probe[main.testReturnsAny]
-          InjectionPoints: [{PC: "0xcd942e", Frameless: false}]
+          Type: 1427 EventRootType Probe[main.testReturnsAny]
+          InjectionPoints: [{PC: "0xcd954e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1427 EventRootType Probe[main.testReturnsAny]Return
+          Type: 1428 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints:
-            - PC: "0xcd94e4"
+            - PC: "0xcd9604"
               Frameless: false
-            - PC: "0xcd951f"
+            - PC: "0xcd963f"
               Frameless: false
-            - PC: "0xcd95e2"
+            - PC: "0xcd9702"
               Frameless: false
-            - PC: "0xcd95ec"
+            - PC: "0xcd970c"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2707,22 +2746,22 @@ Probes:
         - json: {ref: failed}
           dsl: failed
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 101}
       events:
         - Kind: Entry
-          Type: 1424 EventRootType Probe[main.testReturnsAnyAndError]
-          InjectionPoints: [{PC: "0xcd92ce", Frameless: false}]
+          Type: 1425 EventRootType Probe[main.testReturnsAnyAndError]
+          InjectionPoints: [{PC: "0xcd93ee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1425 EventRootType Probe[main.testReturnsAnyAndError]Return
+          Type: 1426 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
-            - PC: "0xcd9324"
+            - PC: "0xcd9444"
               Frameless: false
-            - PC: "0xcd9373"
+            - PC: "0xcd9493"
               Frameless: false
-            - PC: "0xcd93a7"
+            - PC: "0xcd94c7"
               Frameless: false
-            - PC: "0xcd93d9"
+            - PC: "0xcd94f9"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2744,15 +2783,15 @@ Probes:
       template: testReturnsArray
       segments: [testReturnsArray]
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 111}
       events:
         - Kind: Entry
-          Type: 1454 EventRootType Probe[main.testReturnsArray]
-          InjectionPoints: [{PC: "0xcd9caa", Frameless: false}]
+          Type: 1455 EventRootType Probe[main.testReturnsArray]
+          InjectionPoints: [{PC: "0xcd9dca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1455 EventRootType Probe[main.testReturnsArray]Return
-          InjectionPoints: [{PC: "0xcd9d0d", Frameless: false}]
+          Type: 1456 EventRootType Probe[main.testReturnsArray]Return
+          InjectionPoints: [{PC: "0xcd9e2d", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsArray
@@ -2764,15 +2803,15 @@ Probes:
       template: testReturnsArrayOne
       segments: [testReturnsArrayOne]
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 112}
       events:
         - Kind: Entry
-          Type: 1456 EventRootType Probe[main.testReturnsArrayOne]
-          InjectionPoints: [{PC: "0xcd9d2a", Frameless: false}]
+          Type: 1457 EventRootType Probe[main.testReturnsArrayOne]
+          InjectionPoints: [{PC: "0xcd9e4a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1457 EventRootType Probe[main.testReturnsArrayOne]Return
-          InjectionPoints: [{PC: "0xcd9d6b", Frameless: false}]
+          Type: 1458 EventRootType Probe[main.testReturnsArrayOne]Return
+          InjectionPoints: [{PC: "0xcd9e8b", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsArrayOne
@@ -2784,15 +2823,15 @@ Probes:
       template: testReturnsArrayZero
       segments: [testReturnsArrayZero]
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 113}
       events:
         - Kind: Entry
-          Type: 1458 EventRootType Probe[main.testReturnsArrayZero]
-          InjectionPoints: [{PC: "0xcd9d8a", Frameless: false}]
+          Type: 1459 EventRootType Probe[main.testReturnsArrayZero]
+          InjectionPoints: [{PC: "0xcd9eaa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1459 EventRootType Probe[main.testReturnsArrayZero]Return
-          InjectionPoints: [{PC: "0xcd9dc6", Frameless: false}]
+          Type: 1460 EventRootType Probe[main.testReturnsArrayZero]Return
+          InjectionPoints: [{PC: "0xcd9ee6", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsArrayZero
@@ -2804,15 +2843,15 @@ Probes:
       template: testReturnsBacktrackInt
       segments: [testReturnsBacktrackInt]
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 115}
       events:
         - Kind: Entry
-          Type: 1462 EventRootType Probe[main.testReturnsBacktrackInt]
-          InjectionPoints: [{PC: "0xcd9e6e", Frameless: false}]
+          Type: 1463 EventRootType Probe[main.testReturnsBacktrackInt]
+          InjectionPoints: [{PC: "0xcd9f8e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1463 EventRootType Probe[main.testReturnsBacktrackInt]Return
-          InjectionPoints: [{PC: "0xcd9eea", Frameless: false}]
+          Type: 1464 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          InjectionPoints: [{PC: "0xcda00a", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsBacktrackInt
@@ -2824,15 +2863,15 @@ Probes:
       template: testReturnsBoolAndUintptr
       segments: [testReturnsBoolAndUintptr]
       captureSnapshot: true
-      subprogram: {subprogram: 120}
+      subprogram: {subprogram: 121}
       events:
         - Kind: Entry
-          Type: 1474 EventRootType Probe[main.testReturnsBoolAndUintptr]
-          InjectionPoints: [{PC: "0xcda1aa", Frameless: false}]
+          Type: 1475 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          InjectionPoints: [{PC: "0xcda2ca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1475 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-          InjectionPoints: [{PC: "0xcda1f0", Frameless: false}]
+          Type: 1476 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          InjectionPoints: [{PC: "0xcda310", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsBoolAndUintptr
@@ -2844,15 +2883,15 @@ Probes:
       template: testReturnsComplex
       segments: [testReturnsComplex]
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 109}
       events:
         - Kind: Entry
-          Type: 1450 EventRootType Probe[main.testReturnsComplex]
-          InjectionPoints: [{PC: "0xcd9b6a", Frameless: false}]
+          Type: 1451 EventRootType Probe[main.testReturnsComplex]
+          InjectionPoints: [{PC: "0xcd9c8a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1451 EventRootType Probe[main.testReturnsComplex]Return
-          InjectionPoints: [{PC: "0xcd9bc6", Frameless: false}]
+          Type: 1452 EventRootType Probe[main.testReturnsComplex]Return
+          InjectionPoints: [{PC: "0xcd9ce6", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsComplex
@@ -2865,18 +2904,18 @@ Probes:
       template: '{failed}'
       segments: [{json: {ref: failed}, dsl: failed}]
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 100}
       events:
         - Kind: Entry
-          Type: 1422 EventRootType Probe[main.testReturnsError]
-          InjectionPoints: [{PC: "0xcd926a", Frameless: false}]
+          Type: 1423 EventRootType Probe[main.testReturnsError]
+          InjectionPoints: [{PC: "0xcd938a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1423 EventRootType Probe[main.testReturnsError]Return
+          Type: 1424 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
-            - PC: "0xcd929a"
+            - PC: "0xcd93ba"
               Frameless: false
-            - PC: "0xcd92a5"
+            - PC: "0xcd93c5"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2893,15 +2932,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 97}
       events:
         - Kind: Entry
-          Type: 1416 EventRootType Probe[main.testReturnsInt]
-          InjectionPoints: [{PC: "0xcd906a", Frameless: false}]
+          Type: 1417 EventRootType Probe[main.testReturnsInt]
+          InjectionPoints: [{PC: "0xcd918a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1417 EventRootType Probe[main.testReturnsInt]Return
-          InjectionPoints: [{PC: "0xcd90bb", Frameless: false}]
+          Type: 1418 EventRootType Probe[main.testReturnsInt]Return
+          InjectionPoints: [{PC: "0xcd91db", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2917,15 +2956,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 99}
       events:
         - Kind: Entry
-          Type: 1420 EventRootType Probe[main.testReturnsIntAndFloat]
-          InjectionPoints: [{PC: "0xcd918e", Frameless: false}]
+          Type: 1421 EventRootType Probe[main.testReturnsIntAndFloat]
+          InjectionPoints: [{PC: "0xcd92ae", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1421 EventRootType Probe[main.testReturnsIntAndFloat]Return
-          InjectionPoints: [{PC: "0xcd9244", Frameless: false}]
+          Type: 1422 EventRootType Probe[main.testReturnsIntAndFloat]Return
+          InjectionPoints: [{PC: "0xcd9364", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2941,15 +2980,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 98}
       events:
         - Kind: Entry
-          Type: 1418 EventRootType Probe[main.testReturnsIntPointer]
-          InjectionPoints: [{PC: "0xcd90ea", Frameless: false}]
+          Type: 1419 EventRootType Probe[main.testReturnsIntPointer]
+          InjectionPoints: [{PC: "0xcd920a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1419 EventRootType Probe[main.testReturnsIntPointer]Return
-          InjectionPoints: [{PC: "0xcd9154", Frameless: false}]
+          Type: 1420 EventRootType Probe[main.testReturnsIntPointer]Return
+          InjectionPoints: [{PC: "0xcd9274", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2966,18 +3005,18 @@ Probes:
       template: '{v}'
       segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1428 EventRootType Probe[main.testReturnsInterface]
-          InjectionPoints: [{PC: "0xcd962e", Frameless: false}]
+          Type: 1429 EventRootType Probe[main.testReturnsInterface]
+          InjectionPoints: [{PC: "0xcd974e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1429 EventRootType Probe[main.testReturnsInterface]Return
+          Type: 1430 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
-            - PC: "0xcd970f"
+            - PC: "0xcd982f"
               Frameless: false
-            - PC: "0xcd9719"
+            - PC: "0xcd9839"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2994,15 +3033,15 @@ Probes:
       template: testReturnsLargeStruct
       segments: [testReturnsLargeStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 110}
       events:
         - Kind: Entry
-          Type: 1452 EventRootType Probe[main.testReturnsLargeStruct]
-          InjectionPoints: [{PC: "0xcd9bee", Frameless: false}]
+          Type: 1453 EventRootType Probe[main.testReturnsLargeStruct]
+          InjectionPoints: [{PC: "0xcd9d0e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1453 EventRootType Probe[main.testReturnsLargeStruct]Return
-          InjectionPoints: [{PC: "0xcd9c73", Frameless: false}]
+          Type: 1454 EventRootType Probe[main.testReturnsLargeStruct]Return
+          InjectionPoints: [{PC: "0xcd9d93", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsLargeStruct
@@ -3014,15 +3053,15 @@ Probes:
       template: testReturnsManyFloats
       segments: [testReturnsManyFloats]
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 108}
       events:
         - Kind: Entry
-          Type: 1448 EventRootType Probe[main.testReturnsManyFloats]
-          InjectionPoints: [{PC: "0xcd9a6e", Frameless: false}]
+          Type: 1449 EventRootType Probe[main.testReturnsManyFloats]
+          InjectionPoints: [{PC: "0xcd9b8e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1449 EventRootType Probe[main.testReturnsManyFloats]Return
-          InjectionPoints: [{PC: "0xcd9b47", Frameless: false}]
+          Type: 1450 EventRootType Probe[main.testReturnsManyFloats]Return
+          InjectionPoints: [{PC: "0xcd9c67", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsManyFloats
@@ -3034,15 +3073,15 @@ Probes:
       template: testReturnsMixed
       segments: [testReturnsMixed]
       captureSnapshot: true
-      subprogram: {subprogram: 116}
+      subprogram: {subprogram: 117}
       events:
         - Kind: Entry
-          Type: 1466 EventRootType Probe[main.testReturnsMixed]
-          InjectionPoints: [{PC: "0xcd9fca", Frameless: false}]
+          Type: 1467 EventRootType Probe[main.testReturnsMixed]
+          InjectionPoints: [{PC: "0xcda0ea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1467 EventRootType Probe[main.testReturnsMixed]Return
-          InjectionPoints: [{PC: "0xcda02c", Frameless: false}]
+          Type: 1468 EventRootType Probe[main.testReturnsMixed]Return
+          InjectionPoints: [{PC: "0xcda14c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsMixed
@@ -3054,15 +3093,15 @@ Probes:
       template: testReturnsMixedStruct
       segments: [testReturnsMixedStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 114}
       events:
         - Kind: Entry
-          Type: 1460 EventRootType Probe[main.testReturnsMixedStruct]
-          InjectionPoints: [{PC: "0xcd9dea", Frameless: false}]
+          Type: 1461 EventRootType Probe[main.testReturnsMixedStruct]
+          InjectionPoints: [{PC: "0xcd9f0a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1461 EventRootType Probe[main.testReturnsMixedStruct]Return
-          InjectionPoints: [{PC: "0xcd9e38", Frameless: false}]
+          Type: 1462 EventRootType Probe[main.testReturnsMixedStruct]Return
+          InjectionPoints: [{PC: "0xcd9f58", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsMixedStruct
@@ -3074,15 +3113,15 @@ Probes:
       template: testReturnsMultipleFloats
       segments: [testReturnsMultipleFloats]
       captureSnapshot: true
-      subprogram: {subprogram: 119}
+      subprogram: {subprogram: 120}
       events:
         - Kind: Entry
-          Type: 1472 EventRootType Probe[main.testReturnsMultipleFloats]
-          InjectionPoints: [{PC: "0xcda12a", Frameless: false}]
+          Type: 1473 EventRootType Probe[main.testReturnsMultipleFloats]
+          InjectionPoints: [{PC: "0xcda24a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1473 EventRootType Probe[main.testReturnsMultipleFloats]Return
-          InjectionPoints: [{PC: "0xcda176", Frameless: false}]
+          Type: 1474 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          InjectionPoints: [{PC: "0xcda296", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsMultipleFloats
@@ -3094,15 +3133,15 @@ Probes:
       template: testReturnsOnlyFloat
       segments: [testReturnsOnlyFloat]
       captureSnapshot: true
-      subprogram: {subprogram: 118}
+      subprogram: {subprogram: 119}
       events:
         - Kind: Entry
-          Type: 1470 EventRootType Probe[main.testReturnsOnlyFloat]
-          InjectionPoints: [{PC: "0xcda0ca", Frameless: false}]
+          Type: 1471 EventRootType Probe[main.testReturnsOnlyFloat]
+          InjectionPoints: [{PC: "0xcda1ea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1471 EventRootType Probe[main.testReturnsOnlyFloat]Return
-          InjectionPoints: [{PC: "0xcda10e", Frameless: false}]
+          Type: 1472 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          InjectionPoints: [{PC: "0xcda22e", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsOnlyFloat
@@ -3114,15 +3153,15 @@ Probes:
       template: testReturnsPrimitives
       segments: [testReturnsPrimitives]
       captureSnapshot: true
-      subprogram: {subprogram: 106}
+      subprogram: {subprogram: 107}
       events:
         - Kind: Entry
-          Type: 1446 EventRootType Probe[main.testReturnsPrimitives]
-          InjectionPoints: [{PC: "0xcd99ea", Frameless: false}]
+          Type: 1447 EventRootType Probe[main.testReturnsPrimitives]
+          InjectionPoints: [{PC: "0xcd9b0a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1447 EventRootType Probe[main.testReturnsPrimitives]Return
-          InjectionPoints: [{PC: "0xcd9a51", Frameless: false}]
+          Type: 1448 EventRootType Probe[main.testReturnsPrimitives]Return
+          InjectionPoints: [{PC: "0xcd9b71", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsPrimitives
@@ -3134,15 +3173,15 @@ Probes:
       template: testReturnsStructWithArray
       segments: [testReturnsStructWithArray]
       captureSnapshot: true
-      subprogram: {subprogram: 117}
+      subprogram: {subprogram: 118}
       events:
         - Kind: Entry
-          Type: 1468 EventRootType Probe[main.testReturnsStructWithArray]
-          InjectionPoints: [{PC: "0xcda04a", Frameless: false}]
+          Type: 1469 EventRootType Probe[main.testReturnsStructWithArray]
+          InjectionPoints: [{PC: "0xcda16a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1469 EventRootType Probe[main.testReturnsStructWithArray]Return
-          InjectionPoints: [{PC: "0xcda0ad", Frameless: false}]
+          Type: 1470 EventRootType Probe[main.testReturnsStructWithArray]Return
+          InjectionPoints: [{PC: "0xcda1cd", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsStructWithArray
@@ -3154,15 +3193,15 @@ Probes:
       template: testReturnsWideStruct
       segments: [testReturnsWideStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 115}
+      subprogram: {subprogram: 116}
       events:
         - Kind: Entry
-          Type: 1464 EventRootType Probe[main.testReturnsWideStruct]
-          InjectionPoints: [{PC: "0xcd9f0e", Frameless: false}]
+          Type: 1465 EventRootType Probe[main.testReturnsWideStruct]
+          InjectionPoints: [{PC: "0xcda02e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1465 EventRootType Probe[main.testReturnsWideStruct]Return
-          InjectionPoints: [{PC: "0xcd9f94", Frameless: false}]
+          Type: 1466 EventRootType Probe[main.testReturnsWideStruct]Return
+          InjectionPoints: [{PC: "0xcda0b4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsWideStruct
@@ -3209,15 +3248,15 @@ Probes:
         - json: {ref: result}
           dsl: result
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1436 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0xcd982e", Frameless: false}]
+          Type: 1437 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xcd994e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1437 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0xcd98cf", Frameless: false}]
+          Type: 1438 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xcd99ef", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -3485,11 +3524,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 143}
+      subprogram: {subprogram: 144}
       events:
         - Kind: Entry
-          Type: 1509 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0xcdb9c0", Frameless: true}]
+          Type: 1510 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0xcdbae0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -3611,11 +3650,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 140}
+      subprogram: {subprogram: 141}
       events:
         - Kind: Entry
-          Type: 1505 EventRootType Probe[main.testSliceEmptyStructs]
-          InjectionPoints: [{PC: "0xcdb5a0", Frameless: true}]
+          Type: 1506 EventRootType Probe[main.testSliceEmptyStructs]
+          InjectionPoints: [{PC: "0xcdb6c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -3632,11 +3671,11 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 132}
+      subprogram: {subprogram: 133}
       events:
         - Kind: Entry
-          Type: 1496 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0xcdb4a0", Frameless: true}]
+          Type: 1497 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0xcdb5c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{u}'
@@ -3653,11 +3692,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 65}
+      subprogram: {subprogram: 66}
       events:
         - Kind: Entry
-          Type: 1382 EventRootType Probe[main.testSmallMap]
-          InjectionPoints: [{PC: "0xcd6900", Frameless: true}]
+          Type: 1383 EventRootType Probe[main.testSmallMap]
+          InjectionPoints: [{PC: "0xcd6a20", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -3673,15 +3712,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 105}
+      subprogram: {subprogram: 106}
       events:
         - Kind: Entry
-          Type: 1444 EventRootType Probe[main.testSomeNamedReturn]
-          InjectionPoints: [{PC: "0xcd990e", Frameless: false}]
+          Type: 1445 EventRootType Probe[main.testSomeNamedReturn]
+          InjectionPoints: [{PC: "0xcd9a2e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1445 EventRootType Probe[main.testSomeNamedReturn]Return
-          InjectionPoints: [{PC: "0xcd99ab", Frameless: false}]
+          Type: 1446 EventRootType Probe[main.testSomeNamedReturn]Return
+          InjectionPoints: [{PC: "0xcd9acb", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -3697,15 +3736,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 126}
+      subprogram: {subprogram: 127}
       events:
         - Kind: Entry
-          Type: 1486 EventRootType Probe[main.testStackArgRegReturns]
-          InjectionPoints: [{PC: "0xcdac4a", Frameless: false}]
+          Type: 1487 EventRootType Probe[main.testStackArgRegReturns]
+          InjectionPoints: [{PC: "0xcdad6a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1487 EventRootType Probe[main.testStackArgRegReturns]Return
-          InjectionPoints: [{PC: "0xcdacbc", Frameless: false}]
+          Type: 1488 EventRootType Probe[main.testStackArgRegReturns]Return
+          InjectionPoints: [{PC: "0xcdaddc", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -3743,11 +3782,11 @@ Probes:
       template: '{z}'
       segments: [{json: {ref: z}, dsl: z}]
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 94}
       events:
         - Kind: Entry
-          Type: 1413 EventRootType Probe[main.testStringPointer]
-          InjectionPoints: [{PC: "0xcd8b80", Frameless: true}]
+          Type: 1414 EventRootType Probe[main.testStringPointer]
+          InjectionPoints: [{PC: "0xcd8ca0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{z}'
@@ -3764,11 +3803,11 @@ Probes:
       template: '{s}'
       segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
-      subprogram: {subprogram: 136}
+      subprogram: {subprogram: 137}
       events:
         - Kind: Entry
-          Type: 1500 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0xcdb520", Frameless: true}]
+          Type: 1501 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0xcdb640", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{s}'
@@ -3785,11 +3824,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 44}
+      subprogram: {subprogram: 45}
       events:
         - Kind: Entry
-          Type: 1348 EventRootType Probe[main.testStringType1]
-          InjectionPoints: [{PC: "0xcd4e80", Frameless: true}]
+          Type: 1349 EventRootType Probe[main.testStringType1]
+          InjectionPoints: [{PC: "0xcd4fa0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3806,11 +3845,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 45}
+      subprogram: {subprogram: 46}
       events:
         - Kind: Entry
-          Type: 1349 EventRootType Probe[main.testStringType2]
-          InjectionPoints: [{PC: "0xcd4ea0", Frameless: true}]
+          Type: 1350 EventRootType Probe[main.testStringType2]
+          InjectionPoints: [{PC: "0xcd4fc0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3827,15 +3866,15 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1528 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0xcdbda0", Frameless: true}]
+          Type: 1529 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0xcdbec0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1529 EventRootType Probe[main.testStruct]Return
-          InjectionPoints: [{PC: "0xcdbdc2", Frameless: true}]
+          Type: 1530 EventRootType Probe[main.testStruct]Return
+          InjectionPoints: [{PC: "0xcdbee2", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -3857,11 +3896,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 133}
+      subprogram: {subprogram: 134}
       events:
         - Kind: Entry
-          Type: 1497 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0xcdb4c0", Frameless: true}]
+          Type: 1498 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0xcdb5e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}, {a}'
@@ -3883,11 +3922,11 @@ Probes:
       template: '{s}'
       segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
-      subprogram: {subprogram: 59}
+      subprogram: {subprogram: 60}
       events:
         - Kind: Entry
-          Type: 1376 EventRootType Probe[main.testStructWithAny]
-          InjectionPoints: [{PC: "0xcd6200", Frameless: true}]
+          Type: 1377 EventRootType Probe[main.testStructWithAny]
+          InjectionPoints: [{PC: "0xcd6320", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{s}'
@@ -3903,15 +3942,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 128}
+      subprogram: {subprogram: 129}
       events:
         - Kind: Entry
-          Type: 1490 EventRootType Probe[main.testStructWithArrayArg]
-          InjectionPoints: [{PC: "0xcdadee", Frameless: false}]
+          Type: 1491 EventRootType Probe[main.testStructWithArrayArg]
+          InjectionPoints: [{PC: "0xcdaf0e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1491 EventRootType Probe[main.testStructWithArrayArg]Return
-          InjectionPoints: [{PC: "0xcdae9a", Frameless: false}]
+          Type: 1492 EventRootType Probe[main.testStructWithArrayArg]Return
+          InjectionPoints: [{PC: "0xcdafba", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -3928,15 +3967,15 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 153}
+      subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1524 EventRootType Probe[main.testStructWithCyclicMaps]
-          InjectionPoints: [{PC: "0xcdbc60", Frameless: true}]
+          Type: 1525 EventRootType Probe[main.testStructWithCyclicMaps]
+          InjectionPoints: [{PC: "0xcdbd80", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1525 EventRootType Probe[main.testStructWithCyclicMaps]Return
-          InjectionPoints: [{PC: "0xcdbc7e", Frameless: true}]
+          Type: 1526 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          InjectionPoints: [{PC: "0xcdbd9e", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3952,11 +3991,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 152}
+      subprogram: {subprogram: 153}
       events:
         - Kind: Entry
-          Type: 1523 EventRootType Probe[main.testStructWithCyclicSlices]
-          InjectionPoints: [{PC: "0xcdbc40", Frameless: true}]
+          Type: 1524 EventRootType Probe[main.testStructWithCyclicSlices]
+          InjectionPoints: [{PC: "0xcdbd60", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3978,11 +4017,11 @@ Probes:
         - json: {ref: '@duration'}
           dsl: '@duration'
       captureSnapshot: true
-      subprogram: {subprogram: 60}
+      subprogram: {subprogram: 61}
       events:
         - Kind: Entry
-          Type: 1377 EventRootType Probe[main.testStructWithMap]
-          InjectionPoints: [{PC: "0xcd6860", Frameless: true}]
+          Type: 1378 EventRootType Probe[main.testStructWithMap]
+          InjectionPoints: [{PC: "0xcd6980", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{s} {@duration}'
@@ -4009,11 +4048,11 @@ Probes:
         - json: {ref: cs}
           dsl: cs
       captureSnapshot: true
-      subprogram: {subprogram: 141}
+      subprogram: {subprogram: 142}
       events:
         - Kind: Entry
-          Type: 1506 EventRootType Probe[main.testSubslices]
-          InjectionPoints: [{PC: "0xcdb5c0", Frameless: true}]
+          Type: 1507 EventRootType Probe[main.testSubslices]
+          InjectionPoints: [{PC: "0xcdb6e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{as}, {bs}, {cs}'
@@ -4048,11 +4087,11 @@ Probes:
         - json: {ref: c}
           dsl: c
       captureSnapshot: true
-      subprogram: {subprogram: 151}
+      subprogram: {subprogram: 152}
       events:
         - Kind: Entry
-          Type: 1522 EventRootType Probe[main.testSubstrings]
-          InjectionPoints: [{PC: "0xcdbac0", Frameless: true}]
+          Type: 1523 EventRootType Probe[main.testSubstrings]
+          InjectionPoints: [{PC: "0xcdbbe0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}'
@@ -4080,15 +4119,15 @@ Probes:
         - json: {ref: nonexistentVariable}
           dsl: nonexistentVariable
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1438 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0xcd982e", Frameless: false}]
+          Type: 1439 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xcd994e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1439 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0xcd98cf", Frameless: false}]
+          Type: 1440 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xcd99ef", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{nonexistentVariable}'
@@ -4104,15 +4143,15 @@ Probes:
         - json: {foobar: unsupportedExpression}
           dsl: unsupportedExpression
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1440 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0xcd982e", Frameless: false}]
+          Type: 1441 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xcd994e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1441 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0xcd98cf", Frameless: false}]
+          Type: 1442 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xcd99ef", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{unsupportedExpression}'
@@ -4130,15 +4169,15 @@ Probes:
           dsl: '@duration'
         - ms
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1442 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0xcd982e", Frameless: false}]
+          Type: 1443 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xcd994e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1443 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0xcd98cf", Frameless: false}]
+          Type: 1444 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xcd99ef", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -4162,11 +4201,11 @@ Probes:
         - json: {ref: z}
           dsl: z
       captureSnapshot: true
-      subprogram: {subprogram: 144}
+      subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1510 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0xcdb9e0", Frameless: true}]
+          Type: 1511 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0xcdbb00", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}, {y}, {z}'
@@ -4193,15 +4232,15 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 145}
+      subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1511 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0xcdba00", Frameless: true}]
+          Type: 1512 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0xcdbb20", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1512 EventRootType Probe[main.testThreeStringsInStruct]Return
-          InjectionPoints: [{PC: "0xcdba1e", Frameless: true}]
+          Type: 1513 EventRootType Probe[main.testThreeStringsInStruct]Return
+          InjectionPoints: [{PC: "0xcdbb3e", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -4226,15 +4265,15 @@ Probes:
         - json: {getmember: [{ref: a}, c]}
           dsl: t.c
       captureSnapshot: false
-      subprogram: {subprogram: 145}
+      subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1513 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0xcdba00", Frameless: true}]
+          Type: 1514 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0xcdbb20", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1514 EventRootType Probe[main.testThreeStringsInStruct]Return
-          InjectionPoints: [{PC: "0xcdba1e", Frameless: true}]
+          Type: 1515 EventRootType Probe[main.testThreeStringsInStruct]Return
+          InjectionPoints: [{PC: "0xcdbb3e", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a.a} {a.b} {a.c}'
@@ -4261,11 +4300,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 146}
+      subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1515 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0xcdba20", Frameless: true}]
+          Type: 1516 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0xcdbb40", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -4290,11 +4329,11 @@ Probes:
         - json: {getmember: [{ref: a}, c]}
           dsl: a.c
       captureSnapshot: false
-      subprogram: {subprogram: 146}
+      subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1516 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0xcdba20", Frameless: true}]
+          Type: 1517 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0xcdbb40", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a.a} {a.b} {a.c}'
@@ -4447,11 +4486,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 93}
       events:
         - Kind: Entry
-          Type: 1412 EventRootType Probe[main.testUintPointer]
-          InjectionPoints: [{PC: "0xcd8aa0", Frameless: true}]
+          Type: 1413 EventRootType Probe[main.testUintPointer]
+          InjectionPoints: [{PC: "0xcd8bc0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4468,11 +4507,11 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 130}
+      subprogram: {subprogram: 131}
       events:
         - Kind: Entry
-          Type: 1494 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0xcdb460", Frameless: true}]
+          Type: 1495 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0xcdb580", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{u}'
@@ -4489,11 +4528,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 149}
+      subprogram: {subprogram: 150}
       events:
         - Kind: Entry
-          Type: 1520 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0xcdba80", Frameless: true}]
+          Type: 1521 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0xcdbba0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4510,11 +4549,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 92}
       events:
         - Kind: Entry
-          Type: 1411 EventRootType Probe[main.testUnsafePointer]
-          InjectionPoints: [{PC: "0xcd8a60", Frameless: true}]
+          Type: 1412 EventRootType Probe[main.testUnsafePointer]
+          InjectionPoints: [{PC: "0xcd8b80", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4552,11 +4591,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 139}
+      subprogram: {subprogram: 140}
       events:
         - Kind: Entry
-          Type: 1503 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0xcdb580", Frameless: true}]
+          Type: 1504 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0xcdb6a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -4573,11 +4612,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 139}
+      subprogram: {subprogram: 140}
       events:
         - Kind: Entry
-          Type: 1504 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0xcdb580", Frameless: true}]
+          Type: 1505 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0xcdb6a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -4593,19 +4632,19 @@ Probes:
       template: testWhollyInlinedSubroutine
       segments: [testWhollyInlinedSubroutine]
       captureSnapshot: true
-      subprogram: {subprogram: 164}
+      subprogram: {subprogram: 165}
       events:
         - Kind: Entry
-          Type: 1549 EventRootType Probe[main.firstBehavior.DoSomething]
+          Type: 1550 EventRootType Probe[main.firstBehavior.DoSomething]
           InjectionPoints:
-            - PC: "0xcd600a"
+            - PC: "0xcd612a"
               Frameless: false
-            - PC: "0xcdd483"
+            - PC: "0xcdd5a3"
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1550 EventRootType Probe[main.firstBehavior.DoSomething]Return
-          InjectionPoints: [{PC: "0xcd6050", Frameless: false}]
+          Type: 1551 EventRootType Probe[main.firstBehavior.DoSomething]Return
+          InjectionPoints: [{PC: "0xcd6170", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testWhollyInlinedSubroutine
@@ -4622,15 +4661,15 @@ Probes:
         - json: {ref: b}
           dsl: b
       captureSnapshot: true
-      subprogram: {subprogram: 129}
+      subprogram: {subprogram: 130}
       events:
         - Kind: Entry
-          Type: 1492 EventRootType Probe[main.testZeroSizeArgAndReturn]
-          InjectionPoints: [{PC: "0xcdaece", Frameless: false}]
+          Type: 1493 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          InjectionPoints: [{PC: "0xcdafee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1493 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-          InjectionPoints: [{PC: "0xcdaf4c", Frameless: false}]
+          Type: 1494 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          InjectionPoints: [{PC: "0xcdb06c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}'
@@ -5065,36 +5104,83 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
     - ID: 38
+      Name: main.testErrorAtLine
+      OutOfLinePCRanges: [0xcd4ac0..0xcd4bd2]
+      InlinePCRanges: []
+      Variables:
+        - Name: shouldErr
+          Type: 4 BaseType bool
+          Locations:
+            - Range: 0xcd4ac0..0xcd4ad8
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+        - Name: ~r0
+          Type: 7 BaseType int
+          Locations: [{Range: 0xcd4ac0..0xcd4bd2, Pieces: []}]
+          Role: Return
+        - Name: x
+          Type: 7 BaseType int
+          Locations: [{Range: 0xcd4ac0..0xcd4bd2, Pieces: []}]
+          Role: Local
+        - Name: err
+          Type: 13 GoInterfaceType error
+          Locations:
+            - Range: 0xcd4ae9..0xcd4b05
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+            - Range: 0xcd4b05..0xcd4b28
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xcd4b28..0xcd4b3e
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: -80}
+                - Size: 8
+                  Op: {CfaOffset: -72}
+            - Range: 0xcd4b3e..0xcd4bd2
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: -80}
+                - Size: 8
+                  Op: {CfaOffset: -72}
+          Role: Local
+    - ID: 39
       Name: main.testDeepPtr1
-      OutOfLinePCRanges: [0xcd4b20..0xcd4b21]
+      OutOfLinePCRanges: [0xcd4c40..0xcd4c41]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 130 StructureType main.deepPtr1
           Locations:
-            - Range: 0xcd4b20..0xcd4b21
+            - Range: 0xcd4c40..0xcd4c41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 39
+    - ID: 40
       Name: main.testDeepPtr7
-      OutOfLinePCRanges: [0xcd4b40..0xcd4b41]
+      OutOfLinePCRanges: [0xcd4c60..0xcd4c61]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 133 PointerType *main.deepPtr7
           Locations:
-            - Range: 0xcd4b40..0xcd4b41
+            - Range: 0xcd4c60..0xcd4c61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 40
+    - ID: 41
       Name: main.testDeepSlice1
-      OutOfLinePCRanges: [0xcd4cc0..0xcd4cc1]
+      OutOfLinePCRanges: [0xcd4de0..0xcd4de1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 135 StructureType main.deepSlice1
           Locations:
-            - Range: 0xcd4cc0..0xcd4cc1
+            - Range: 0xcd4de0..0xcd4de1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -5103,117 +5189,117 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 41
+    - ID: 42
       Name: main.testDeepSlice7
-      OutOfLinePCRanges: [0xcd4ce0..0xcd4ce1]
+      OutOfLinePCRanges: [0xcd4e00..0xcd4e01]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 139 PointerType *main.deepSlice7
           Locations:
-            - Range: 0xcd4ce0..0xcd4ce1
+            - Range: 0xcd4e00..0xcd4e01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 42
+    - ID: 43
       Name: main.testDeepMap1
-      OutOfLinePCRanges: [0xcd4e40..0xcd4e41]
+      OutOfLinePCRanges: [0xcd4f60..0xcd4f61]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 141 StructureType main.deepMap1
           Locations:
-            - Range: 0xcd4e40..0xcd4e41
+            - Range: 0xcd4f60..0xcd4f61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 43
+    - ID: 44
       Name: main.testDeepMap7
-      OutOfLinePCRanges: [0xcd4e60..0xcd4e61]
+      OutOfLinePCRanges: [0xcd4f80..0xcd4f81]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 147 PointerType *main.deepMap7
           Locations:
-            - Range: 0xcd4e60..0xcd4e61
+            - Range: 0xcd4f80..0xcd4f81
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 44
+    - ID: 45
       Name: main.testStringType1
-      OutOfLinePCRanges: [0xcd4e80..0xcd4e81]
+      OutOfLinePCRanges: [0xcd4fa0..0xcd4fa1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 149 PointerType *main.stringType1
           Locations:
-            - Range: 0xcd4e80..0xcd4e81
+            - Range: 0xcd4fa0..0xcd4fa1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 45
+    - ID: 46
       Name: main.testStringType2
-      OutOfLinePCRanges: [0xcd4ea0..0xcd4ea1]
+      OutOfLinePCRanges: [0xcd4fc0..0xcd4fc1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 151 PointerType **main.stringType2
           Locations:
-            - Range: 0xcd4ea0..0xcd4ea1
+            - Range: 0xcd4fc0..0xcd4fc1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 46
+    - ID: 47
       Name: main.testLongFunctionWithChangingState
-      OutOfLinePCRanges: [0xcd4ec0..0xcd510a]
+      OutOfLinePCRanges: [0xcd4fe0..0xcd522a]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd4fa4..0xcd4fc5
+            - Range: 0xcd50c4..0xcd50e5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd5078..0xcd508f
+            - Range: 0xcd5198..0xcd51af
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
         - Name: aPerArch
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd4f8d..0xcd4f90
+            - Range: 0xcd50ad..0xcd50b0
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcd4f90..0xcd4fc5
+            - Range: 0xcd50b0..0xcd50e5
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcd4fc5..0xcd506b
+            - Range: 0xcd50e5..0xcd518b
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0xcd506b..0xcd5078
+            - Range: 0xcd518b..0xcd5198
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0xcd5078..0xcd510a
+            - Range: 0xcd5198..0xcd522a
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
           Role: Local
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd4f8a..0xcd4f90
+            - Range: 0xcd50aa..0xcd50b0
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcd4f90..0xcd4f90
+            - Range: 0xcd50b0..0xcd50b0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcd4f90..0xcd4fc5
+            - Range: 0xcd50b0..0xcd50e5
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcd4fc5..0xcd506b
+            - Range: 0xcd50e5..0xcd518b
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0xcd506b..0xcd5070
+            - Range: 0xcd518b..0xcd5190
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0xcd5070..0xcd5078
+            - Range: 0xcd5190..0xcd5198
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
-            - Range: 0xcd5078..0xcd508f
+            - Range: 0xcd5198..0xcd51af
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
-            - Range: 0xcd508f..0xcd510a
+            - Range: 0xcd51af..0xcd522a
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
           Role: Local
-    - ID: 47
+    - ID: 48
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0xcd5560..0xcd5665]
+      OutOfLinePCRanges: [0xcd5680..0xcd5785]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 153 StructureType main.esotericStack
           Locations:
-            - Range: 0xcd5560..0xcd55b3
+            - Range: 0xcd5680..0xcd56d3
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -5233,7 +5319,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
-            - Range: 0xcd55b3..0xcd55b8
+            - Range: 0xcd56d3..0xcd56d8
               Pieces:
                 - Size: 4
                   Op: null
@@ -5253,7 +5339,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
-            - Range: 0xcd55b8..0xcd55bd
+            - Range: 0xcd56d8..0xcd56dd
               Pieces:
                 - Size: 4
                   Op: null
@@ -5274,226 +5360,136 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
           Role: Parameter
-    - ID: 48
+    - ID: 49
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0xcd5680..0xcd56e3]
+      OutOfLinePCRanges: [0xcd57a0..0xcd5803]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 157 PointerType *main.esotericHeap
           Locations:
-            - Range: 0xcd5680..0xcd56ad
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-    - ID: 49
-      Name: main.testInlinedBA
-      OutOfLinePCRanges: [0xcd5ac0..0xcd5b48]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcd5ac0..0xcd5ad5
+            - Range: 0xcd57a0..0xcd57cd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 50
-      Name: main.testInlinedBB
-      OutOfLinePCRanges: [0xcd5b60..0xcd5c25]
+      Name: main.testInlinedBA
+      OutOfLinePCRanges: [0xcd5be0..0xcd5c68]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd5b60..0xcd5b76
+            - Range: 0xcd5be0..0xcd5bf5
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+    - ID: 51
+      Name: main.testInlinedBB
+      OutOfLinePCRanges: [0xcd5c80..0xcd5d45]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcd5c80..0xcd5c96
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: y
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd5b60..0xcd5b87
+            - Range: 0xcd5c80..0xcd5ca7
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
         - Name: z
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd5b76..0xcd5b87
+            - Range: 0xcd5c96..0xcd5ca7
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd5b87..0xcd5c25
+            - Range: 0xcd5ca7..0xcd5d45
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Local
-    - ID: 51
+    - ID: 52
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0xcd5c40..0xcd5ca2]
+      OutOfLinePCRanges: [0xcd5d60..0xcd5dc2]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd5c40..0xcd5c5a
+            - Range: 0xcd5d60..0xcd5d7a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 52
+    - ID: 53
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0xcd5cc0..0xcd5dce]
+      OutOfLinePCRanges: [0xcd5de0..0xcd5eee]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd5d1b..0xcd5d25
+            - Range: 0xcd5e3b..0xcd5e45
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xcd5d25..0xcd5d40
+            - Range: 0xcd5e45..0xcd5e60
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xcd5d40..0xcd5d54
+            - Range: 0xcd5e60..0xcd5e74
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd5d16..0xcd5d20
+            - Range: 0xcd5e36..0xcd5e40
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xcd5d20..0xcd5d40
+            - Range: 0xcd5e40..0xcd5e60
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xcd5d40..0xcd5d4f
+            - Range: 0xcd5e60..0xcd5e6f
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 53
+    - ID: 54
       Name: main.testFrameless
-      OutOfLinePCRanges: [0xcd5de0..0xcd5de6]
+      OutOfLinePCRanges: [0xcd5f00..0xcd5f06]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd5de0..0xcd5de5
+            - Range: 0xcd5f00..0xcd5f05
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd5de0..0xcd5de5
+            - Range: 0xcd5f00..0xcd5f05
               Pieces: []
-            - Range: 0xcd5de5..0xcd5de6
+            - Range: 0xcd5f05..0xcd5f06
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
-    - ID: 54
+    - ID: 55
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0xcd5e00..0xcd5e43]
+      OutOfLinePCRanges: [0xcd5f20..0xcd5f63]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 159 ArrayType [5]int
           Locations:
-            - Range: 0xcd5e00..0xcd5e43
+            - Range: 0xcd5f20..0xcd5f63
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd5e00..0xcd5e3d
+            - Range: 0xcd5f20..0xcd5f5d
               Pieces: []
-            - Range: 0xcd5e3d..0xcd5e3e
+            - Range: 0xcd5f5d..0xcd5f5e
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd5e3e..0xcd5e43
+            - Range: 0xcd5f5e..0xcd5f63
               Pieces: []
           Role: Return
-    - ID: 55
+    - ID: 56
       Name: main.testInterface
-      OutOfLinePCRanges: [0xcd60e0..0xcd60e1]
+      OutOfLinePCRanges: [0xcd6200..0xcd6201]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 160 GoInterfaceType main.behavior
-          Locations:
-            - Range: 0xcd60e0..0xcd60e1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          Role: Parameter
-    - ID: 56
-      Name: main.testAny
-      OutOfLinePCRanges: [0xcd6100..0xcd6166]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 155 GoEmptyInterfaceType interface {}
-          Locations:
-            - Range: 0xcd6100..0xcd6129
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd6129..0xcd612e
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          Role: Parameter
-        - Name: ~r0
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xcd6100..0xcd6145
-              Pieces: []
-            - Range: 0xcd6145..0xcd6146
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd6146..0xcd6166
-              Pieces: []
-          Role: Return
-    - ID: 57
-      Name: main.testError
-      OutOfLinePCRanges: [0xcd6180..0xcd6181]
-      InlinePCRanges: []
-      Variables:
-        - Name: e
-          Type: 13 GoInterfaceType error
-          Locations:
-            - Range: 0xcd6180..0xcd6181
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          Role: Parameter
-    - ID: 58
-      Name: main.testAnyPtr
-      OutOfLinePCRanges: [0xcd61a0..0xcd61f4]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 161 PointerType *interface {}
-          Locations:
-            - Range: 0xcd61a0..0xcd61c6
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-        - Name: ~r0
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xcd61a0..0xcd61dd
-              Pieces: []
-            - Range: 0xcd61dd..0xcd61de
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd61de..0xcd61f4
-              Pieces: []
-          Role: Return
-    - ID: 59
-      Name: main.testStructWithAny
-      OutOfLinePCRanges: [0xcd6200..0xcd6201]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 162 StructureType main.structWithAny
           Locations:
             - Range: 0xcd6200..0xcd6201
               Pieces:
@@ -5502,297 +5498,387 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
+    - ID: 57
+      Name: main.testAny
+      OutOfLinePCRanges: [0xcd6220..0xcd6286]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 155 GoEmptyInterfaceType interface {}
+          Locations:
+            - Range: 0xcd6220..0xcd6249
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcd6249..0xcd624e
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Parameter
+        - Name: ~r0
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xcd6220..0xcd6265
+              Pieces: []
+            - Range: 0xcd6265..0xcd6266
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcd6266..0xcd6286
+              Pieces: []
+          Role: Return
+    - ID: 58
+      Name: main.testError
+      OutOfLinePCRanges: [0xcd62a0..0xcd62a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: e
+          Type: 13 GoInterfaceType error
+          Locations:
+            - Range: 0xcd62a0..0xcd62a1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Parameter
+    - ID: 59
+      Name: main.testAnyPtr
+      OutOfLinePCRanges: [0xcd62c0..0xcd6314]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 161 PointerType *interface {}
+          Locations:
+            - Range: 0xcd62c0..0xcd62e6
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+        - Name: ~r0
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xcd62c0..0xcd62fd
+              Pieces: []
+            - Range: 0xcd62fd..0xcd62fe
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcd62fe..0xcd6314
+              Pieces: []
+          Role: Return
     - ID: 60
+      Name: main.testStructWithAny
+      OutOfLinePCRanges: [0xcd6320..0xcd6321]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 162 StructureType main.structWithAny
+          Locations:
+            - Range: 0xcd6320..0xcd6321
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Parameter
+    - ID: 61
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0xcd6860..0xcd6861]
+      OutOfLinePCRanges: [0xcd6980..0xcd6981]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 163 StructureType main.structWithMap
           Locations:
-            - Range: 0xcd6860..0xcd6861
+            - Range: 0xcd6980..0xcd6981
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 61
+    - ID: 62
       Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0xcd6880..0xcd6881]
+      OutOfLinePCRanges: [0xcd69a0..0xcd69a1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 169 GoMapType map[string]main.nestedStruct
           Locations:
-            - Range: 0xcd6880..0xcd6881
+            - Range: 0xcd69a0..0xcd69a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 62
+    - ID: 63
       Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0xcd68a0..0xcd68a1]
+      OutOfLinePCRanges: [0xcd69c0..0xcd69c1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 174 GoMapType map[string]int
           Locations:
-            - Range: 0xcd68a0..0xcd68a1
+            - Range: 0xcd69c0..0xcd69c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 63
+    - ID: 64
       Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0xcd68c0..0xcd68c1]
+      OutOfLinePCRanges: [0xcd69e0..0xcd69e1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 179 GoMapType map[string][]string
           Locations:
-            - Range: 0xcd68c0..0xcd68c1
+            - Range: 0xcd69e0..0xcd69e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 64
+    - ID: 65
       Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0xcd68e0..0xcd68e1]
+      OutOfLinePCRanges: [0xcd6a00..0xcd6a01]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 184 GoMapType map[[4]string][2]int
           Locations:
-            - Range: 0xcd68e0..0xcd68e1
+            - Range: 0xcd6a00..0xcd6a01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 65
+    - ID: 66
       Name: main.testSmallMap
-      OutOfLinePCRanges: [0xcd6900..0xcd6901]
+      OutOfLinePCRanges: [0xcd6a20..0xcd6a21]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 174 GoMapType map[string]int
           Locations:
-            - Range: 0xcd6900..0xcd6901
+            - Range: 0xcd6a20..0xcd6a21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 66
+    - ID: 67
       Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0xcd6920..0xcd6921]
+      OutOfLinePCRanges: [0xcd6a40..0xcd6a41]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 189 ArrayType [2]map[string]int
           Locations:
-            - Range: 0xcd6920..0xcd6921
+            - Range: 0xcd6a40..0xcd6a41
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
-    - ID: 67
+    - ID: 68
       Name: main.testPointerToMap
-      OutOfLinePCRanges: [0xcd6940..0xcd6941]
+      OutOfLinePCRanges: [0xcd6a60..0xcd6a61]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 190 PointerType *map[string]int
           Locations:
-            - Range: 0xcd6940..0xcd6941
+            - Range: 0xcd6a60..0xcd6a61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 68
+    - ID: 69
       Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0xcd6960..0xcd6961]
+      OutOfLinePCRanges: [0xcd6a80..0xcd6a81]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 164 GoMapType map[int]int
           Locations:
-            - Range: 0xcd6960..0xcd6961
+            - Range: 0xcd6a80..0xcd6a81
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 69
+    - ID: 70
       Name: main.testMapMassive
-      OutOfLinePCRanges: [0xcd6980..0xcd6981]
+      OutOfLinePCRanges: [0xcd6aa0..0xcd6aa1]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 191 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0xcd6980..0xcd6981
+            - Range: 0xcd6aa0..0xcd6aa1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 70
+    - ID: 71
       Name: main.testMapEmbeddedMaps
-      OutOfLinePCRanges: [0xcd69a0..0xcd69a1]
+      OutOfLinePCRanges: [0xcd6ac0..0xcd6ac1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 191 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0xcd69a0..0xcd69a1
+            - Range: 0xcd6ac0..0xcd6ac1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 71
+    - ID: 72
       Name: main.testMapWithLinkedList
-      OutOfLinePCRanges: [0xcd69c0..0xcd69c1]
+      OutOfLinePCRanges: [0xcd6ae0..0xcd6ae1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 196 GoMapType map[bool]main.node
           Locations:
-            - Range: 0xcd69c0..0xcd69c1
+            - Range: 0xcd6ae0..0xcd6ae1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 72
+    - ID: 73
       Name: main.testMapWithSmallValue
-      OutOfLinePCRanges: [0xcd69e0..0xcd69e1]
+      OutOfLinePCRanges: [0xcd6b00..0xcd6b01]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 201 GoMapType map[int]uint8
           Locations:
-            - Range: 0xcd69e0..0xcd69e1
+            - Range: 0xcd6b00..0xcd6b01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 73
+    - ID: 74
       Name: main.testMapWithSmallValueMassive
-      OutOfLinePCRanges: [0xcd6a00..0xcd6a01]
+      OutOfLinePCRanges: [0xcd6b20..0xcd6b21]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 201 GoMapType map[int]uint8
           Locations:
-            - Range: 0xcd6a00..0xcd6a01
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-    - ID: 74
-      Name: main.testMapWithSmallKeyAndValue
-      OutOfLinePCRanges: [0xcd6a20..0xcd6a21]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 206 GoMapType map[uint8]uint8
-          Locations:
-            - Range: 0xcd6a20..0xcd6a21
+            - Range: 0xcd6b20..0xcd6b21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 75
-      Name: main.testMapWithSmallKeyAndValueMassive
-      OutOfLinePCRanges: [0xcd6a40..0xcd6a41]
+      Name: main.testMapWithSmallKeyAndValue
+      OutOfLinePCRanges: [0xcd6b40..0xcd6b41]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 206 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0xcd6a40..0xcd6a41
+            - Range: 0xcd6b40..0xcd6b41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 76
-      Name: main.testMapSmallKeySmallValue
-      OutOfLinePCRanges: [0xcd6a60..0xcd6a61]
+      Name: main.testMapWithSmallKeyAndValueMassive
+      OutOfLinePCRanges: [0xcd6b60..0xcd6b61]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 206 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0xcd6a60..0xcd6a61
+            - Range: 0xcd6b60..0xcd6b61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 77
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0xcd6b80..0xcd6b81]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 206 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xcd6b80..0xcd6b81
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+    - ID: 78
       Name: main.testMapSmallKeyLargeValue
-      OutOfLinePCRanges: [0xcd6a80..0xcd6a81]
+      OutOfLinePCRanges: [0xcd6ba0..0xcd6ba1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 211 GoMapType map[uint8][4]int
           Locations:
-            - Range: 0xcd6a80..0xcd6a81
+            - Range: 0xcd6ba0..0xcd6ba1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 78
+    - ID: 79
       Name: main.testMapLargeKeySmallValue
-      OutOfLinePCRanges: [0xcd6aa0..0xcd6aa1]
+      OutOfLinePCRanges: [0xcd6bc0..0xcd6bc1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 216 GoMapType map[[4]int]uint8
           Locations:
-            - Range: 0xcd6aa0..0xcd6aa1
+            - Range: 0xcd6bc0..0xcd6bc1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 79
+    - ID: 80
       Name: main.testMapLargeKeyLargeValue
-      OutOfLinePCRanges: [0xcd6ac0..0xcd6ac1]
+      OutOfLinePCRanges: [0xcd6be0..0xcd6be1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 221 GoMapType map[[4]int][4]int
           Locations:
-            - Range: 0xcd6ac0..0xcd6ac1
+            - Range: 0xcd6be0..0xcd6be1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 80
+    - ID: 81
       Name: main.testMapEmptyKey
-      OutOfLinePCRanges: [0xcd6ae0..0xcd6ae1]
+      OutOfLinePCRanges: [0xcd6c00..0xcd6c01]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 226 GoMapType map[struct {}]int
           Locations:
-            - Range: 0xcd6ae0..0xcd6ae1
+            - Range: 0xcd6c00..0xcd6c01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 81
+    - ID: 82
       Name: main.testMapEmptyValue
-      OutOfLinePCRanges: [0xcd6b00..0xcd6b01]
+      OutOfLinePCRanges: [0xcd6c20..0xcd6c21]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 231 GoMapType map[int]struct {}
           Locations:
-            - Range: 0xcd6b00..0xcd6b01
+            - Range: 0xcd6c20..0xcd6c21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 82
+    - ID: 83
       Name: main.testMapEmptyKeyAndValue
-      OutOfLinePCRanges: [0xcd6b20..0xcd6b21]
+      OutOfLinePCRanges: [0xcd6c40..0xcd6c41]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 236 GoMapType map[struct {}]struct {}
           Locations:
-            - Range: 0xcd6b20..0xcd6b21
+            - Range: 0xcd6c40..0xcd6c41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 83
+    - ID: 84
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0xcd8420..0xcd8421]
+      OutOfLinePCRanges: [0xcd8540..0xcd8541]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcd8420..0xcd8421
+            - Range: 0xcd8540..0xcd8541
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcd8420..0xcd8421
+            - Range: 0xcd8540..0xcd8541
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
         - Name: y
           Type: 17 BaseType float32
           Locations:
-            - Range: 0xcd8420..0xcd8421
+            - Range: 0xcd8540..0xcd8541
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
-    - ID: 84
+    - ID: 85
       Name: main.testCombinedString
-      OutOfLinePCRanges: [0xcd8460..0xcd8461]
+      OutOfLinePCRanges: [0xcd8580..0xcd8581]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcd8460..0xcd8461
+            - Range: 0xcd8580..0xcd8581
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcd8460..0xcd8461
+            - Range: 0xcd8580..0xcd8581
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -5802,343 +5888,343 @@ Subprograms:
         - Name: y
           Type: 17 BaseType float32
           Locations:
-            - Range: 0xcd8460..0xcd8461
+            - Range: 0xcd8580..0xcd8581
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
-    - ID: 85
+    - ID: 86
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0xcd85e0..0xcd85e1]
+      OutOfLinePCRanges: [0xcd8700..0xcd8701]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcd85e0..0xcd85e1
+            - Range: 0xcd8700..0xcd8701
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: b
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcd85e0..0xcd85e1
+            - Range: 0xcd8700..0xcd8701
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
         - Name: c
           Type: 10 BaseType int32
           Locations:
-            - Range: 0xcd85e0..0xcd85e1
+            - Range: 0xcd8700..0xcd8701
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
         - Name: d
           Type: 16 BaseType uint
           Locations:
-            - Range: 0xcd85e0..0xcd85e1
+            - Range: 0xcd8700..0xcd8701
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
         - Name: e
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcd85e0..0xcd85e1
+            - Range: 0xcd8700..0xcd8701
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 86
+    - ID: 87
       Name: main.testAtomicAdd
-      OutOfLinePCRanges: [0xcd8800..0xcd8813]
+      OutOfLinePCRanges: [0xcd8920..0xcd8933]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0xcd8800..0xcd8812
+            - Range: 0xcd8920..0xcd8932
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0xcd8800..0xcd8812
+            - Range: 0xcd8920..0xcd8932
               Pieces: []
-            - Range: 0xcd8812..0xcd8813
+            - Range: 0xcd8932..0xcd8933
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
-    - ID: 87
+    - ID: 88
       Name: main.testChannel
-      OutOfLinePCRanges: [0xcd8820..0xcd8821]
+      OutOfLinePCRanges: [0xcd8940..0xcd8941]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 241 GoChannelType chan bool
           Locations:
-            - Range: 0xcd8820..0xcd8821
+            - Range: 0xcd8940..0xcd8941
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 88
+    - ID: 89
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0xcd8a00..0xcd8a01]
+      OutOfLinePCRanges: [0xcd8b20..0xcd8b21]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 242 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0xcd8a00..0xcd8a01
+            - Range: 0xcd8b20..0xcd8b21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 89
+    - ID: 90
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0xcd8a20..0xcd8a21]
+      OutOfLinePCRanges: [0xcd8b40..0xcd8b41]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 244 StructureType main.node
           Locations:
-            - Range: 0xcd8a20..0xcd8a21
+            - Range: 0xcd8b40..0xcd8b41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
-    - ID: 90
+    - ID: 91
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0xcd8a40..0xcd8a41]
+      OutOfLinePCRanges: [0xcd8b60..0xcd8b61]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 245 PointerType *main.node
           Locations:
-            - Range: 0xcd8a40..0xcd8a41
+            - Range: 0xcd8b60..0xcd8b61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 91
+    - ID: 92
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0xcd8a60..0xcd8a61]
+      OutOfLinePCRanges: [0xcd8b80..0xcd8b81]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 14 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0xcd8a60..0xcd8a61
+            - Range: 0xcd8b80..0xcd8b81
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 92
+    - ID: 93
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0xcd8aa0..0xcd8aa1]
+      OutOfLinePCRanges: [0xcd8bc0..0xcd8bc1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 105 PointerType *uint
           Locations:
-            - Range: 0xcd8aa0..0xcd8aa1
+            - Range: 0xcd8bc0..0xcd8bc1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 93
+    - ID: 94
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0xcd8b80..0xcd8b81]
+      OutOfLinePCRanges: [0xcd8ca0..0xcd8ca1]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 93 PointerType *string
           Locations:
-            - Range: 0xcd8b80..0xcd8b81
+            - Range: 0xcd8ca0..0xcd8ca1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 94
+    - ID: 95
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0xcd8bc0..0xcd8bc1]
+      OutOfLinePCRanges: [0xcd8ce0..0xcd8ce1]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 11 PointerType *bool
           Locations:
-            - Range: 0xcd8bc0..0xcd8bc1
+            - Range: 0xcd8ce0..0xcd8ce1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: a
           Type: 16 BaseType uint
           Locations:
-            - Range: 0xcd8bc0..0xcd8bc1
+            - Range: 0xcd8ce0..0xcd8ce1
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
-    - ID: 95
+    - ID: 96
       Name: main.testCycle
-      OutOfLinePCRanges: [0xcd8c00..0xcd8c01]
+      OutOfLinePCRanges: [0xcd8d20..0xcd8d21]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 246 PointerType *main.t
           Locations:
-            - Range: 0xcd8c00..0xcd8c01
+            - Range: 0xcd8d20..0xcd8d21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 96
+    - ID: 97
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0xcd9060..0xcd90d2]
+      OutOfLinePCRanges: [0xcd9180..0xcd91f2]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9060..0xcd9072
+            - Range: 0xcd9180..0xcd9192
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9060..0xcd90bb
+            - Range: 0xcd9180..0xcd91db
               Pieces: []
-            - Range: 0xcd90bb..0xcd90bc
+            - Range: 0xcd91db..0xcd91dc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd90bc..0xcd90d2
+            - Range: 0xcd91dc..0xcd91f2
               Pieces: []
           Role: Return
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9072..0xcd9085
+            - Range: 0xcd9192..0xcd91a5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd9085..0xcd90d2
+            - Range: 0xcd91a5..0xcd91f2
               Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
           Role: Local
-    - ID: 97
+    - ID: 98
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0xcd90e0..0xcd916f]
+      OutOfLinePCRanges: [0xcd9200..0xcd928f]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd90e0..0xcd90fa
+            - Range: 0xcd9200..0xcd921a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd90fa..0xcd916f
+            - Range: 0xcd921a..0xcd928f
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 98 PointerType *int
           Locations:
-            - Range: 0xcd90e0..0xcd9154
+            - Range: 0xcd9200..0xcd9274
               Pieces: []
-            - Range: 0xcd9154..0xcd9155
+            - Range: 0xcd9274..0xcd9275
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd9155..0xcd916f
+            - Range: 0xcd9275..0xcd928f
               Pieces: []
           Role: Return
         - Name: '&result'
           Type: 98 PointerType *int
           Locations:
-            - Range: 0xcd90ff..0xcd9119
+            - Range: 0xcd921f..0xcd9239
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd9119..0xcd916f
+            - Range: 0xcd9239..0xcd928f
               Pieces: [{Size: 8, Op: {CfaOffset: -24}}]
           Role: Local
-    - ID: 98
+    - ID: 99
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0xcd9180..0xcd925e]
+      OutOfLinePCRanges: [0xcd92a0..0xcd937e]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9180..0xcd91e2
+            - Range: 0xcd92a0..0xcd9302
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9180..0xcd9244
+            - Range: 0xcd92a0..0xcd9364
               Pieces: []
-            - Range: 0xcd9244..0xcd9245
+            - Range: 0xcd9364..0xcd9365
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd9245..0xcd925e
+            - Range: 0xcd9365..0xcd937e
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcd9180..0xcd925e, Pieces: []}]
+          Locations: [{Range: 0xcd92a0..0xcd937e, Pieces: []}]
           Role: Return
         - Name: resultInt
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9196..0xcd91e7
+            - Range: 0xcd92b6..0xcd9307
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcd91e7..0xcd925e
+            - Range: 0xcd9307..0xcd937e
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
           Role: Local
         - Name: resultFloat
           Type: 18 BaseType float64
           Locations:
-            - Range: 0xcd91af..0xcd91e7
+            - Range: 0xcd92cf..0xcd9307
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
-            - Range: 0xcd91e7..0xcd925e
+            - Range: 0xcd9307..0xcd937e
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
-    - ID: 99
+    - ID: 100
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0xcd9260..0xcd92bb]
+      OutOfLinePCRanges: [0xcd9380..0xcd93db]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcd9260..0xcd9279
+            - Range: 0xcd9380..0xcd9399
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 13 GoInterfaceType error
           Locations:
-            - Range: 0xcd9260..0xcd929a
+            - Range: 0xcd9380..0xcd93ba
               Pieces: []
-            - Range: 0xcd929a..0xcd929b
+            - Range: 0xcd93ba..0xcd93bb
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd929b..0xcd92a5
+            - Range: 0xcd93bb..0xcd93c5
               Pieces: []
-            - Range: 0xcd92a5..0xcd92a6
+            - Range: 0xcd93c5..0xcd93c6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd92a6..0xcd92bb
+            - Range: 0xcd93c6..0xcd93db
               Pieces: []
           Role: Return
-    - ID: 100
+    - ID: 101
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0xcd92c0..0xcd9406]
+      OutOfLinePCRanges: [0xcd93e0..0xcd9526]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcd92c0..0xcd930b
+            - Range: 0xcd93e0..0xcd942b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd930b..0xcd9316
+            - Range: 0xcd942b..0xcd9436
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd9347..0xcd934a
+            - Range: 0xcd9467..0xcd946a
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd9380..0xcd9385
+            - Range: 0xcd94a0..0xcd94a5
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd93b4..0xcd93b9
+            - Range: 0xcd94d4..0xcd94d9
               Pieces:
                 - Size: 8
                   Op: null
@@ -6148,112 +6234,112 @@ Subprograms:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcd92c0..0xcd9303
+            - Range: 0xcd93e0..0xcd9423
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcd92c0..0xcd9324
+            - Range: 0xcd93e0..0xcd9444
               Pieces: []
-            - Range: 0xcd9324..0xcd9325
+            - Range: 0xcd9444..0xcd9445
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd9325..0xcd9373
+            - Range: 0xcd9445..0xcd9493
               Pieces: []
-            - Range: 0xcd9373..0xcd9374
+            - Range: 0xcd9493..0xcd9494
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd9374..0xcd93a7
+            - Range: 0xcd9494..0xcd94c7
               Pieces: []
-            - Range: 0xcd93a7..0xcd93a8
+            - Range: 0xcd94c7..0xcd94c8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd93a8..0xcd93d9
+            - Range: 0xcd94c8..0xcd94f9
               Pieces: []
-            - Range: 0xcd93d9..0xcd93da
+            - Range: 0xcd94f9..0xcd94fa
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd93da..0xcd9406
+            - Range: 0xcd94fa..0xcd9526
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 13 GoInterfaceType error
           Locations:
-            - Range: 0xcd92c0..0xcd9324
+            - Range: 0xcd93e0..0xcd9444
               Pieces: []
-            - Range: 0xcd9324..0xcd9325
+            - Range: 0xcd9444..0xcd9445
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcd9325..0xcd9373
+            - Range: 0xcd9445..0xcd9493
               Pieces: []
-            - Range: 0xcd9373..0xcd9374
+            - Range: 0xcd9493..0xcd9494
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcd9374..0xcd93a7
+            - Range: 0xcd9494..0xcd94c7
               Pieces: []
-            - Range: 0xcd93a7..0xcd93a8
+            - Range: 0xcd94c7..0xcd94c8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcd93a8..0xcd93d9
+            - Range: 0xcd94c8..0xcd94f9
               Pieces: []
-            - Range: 0xcd93d9..0xcd93da
+            - Range: 0xcd94f9..0xcd94fa
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcd93da..0xcd9406
+            - Range: 0xcd94fa..0xcd9526
               Pieces: []
           Role: Return
         - Name: val
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd930b..0xcd9311
+            - Range: 0xcd942b..0xcd9431
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 101
+    - ID: 102
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0xcd9420..0xcd9614]
+      OutOfLinePCRanges: [0xcd9540..0xcd9734]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcd9420..0xcd946b
+            - Range: 0xcd9540..0xcd958b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd946b..0xcd9472
+            - Range: 0xcd958b..0xcd9592
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcd9472..0xcd9614
+            - Range: 0xcd9592..0xcd9734
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -6263,941 +6349,941 @@ Subprograms:
         - Name: ~r0
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcd9420..0xcd94e4
+            - Range: 0xcd9540..0xcd9604
               Pieces: []
-            - Range: 0xcd94e4..0xcd94e5
+            - Range: 0xcd9604..0xcd9605
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd94e5..0xcd951f
+            - Range: 0xcd9605..0xcd963f
               Pieces: []
-            - Range: 0xcd951f..0xcd9520
+            - Range: 0xcd963f..0xcd9640
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd9520..0xcd95e2
+            - Range: 0xcd9640..0xcd9702
               Pieces: []
-            - Range: 0xcd95e2..0xcd95e3
+            - Range: 0xcd9702..0xcd9703
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd95e3..0xcd95ec
+            - Range: 0xcd9703..0xcd970c
               Pieces: []
-            - Range: 0xcd95ec..0xcd95ed
+            - Range: 0xcd970c..0xcd970d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd95ed..0xcd9614
+            - Range: 0xcd970d..0xcd9734
               Pieces: []
           Role: Return
         - Name: val
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd950a..0xcd9510
+            - Range: 0xcd962a..0xcd9630
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
         - Name: '&result'
           Type: 98 PointerType *int
           Locations:
-            - Range: 0xcd94c5..0xcd94e4
+            - Range: 0xcd95e5..0xcd9604
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 102
+    - ID: 103
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0xcd9620..0xcd977d]
+      OutOfLinePCRanges: [0xcd9740..0xcd989d]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcd9620..0xcd9660
+            - Range: 0xcd9740..0xcd9780
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd9660..0xcd96ae
+            - Range: 0xcd9780..0xcd97ce
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcd96ae..0xcd971f
+            - Range: 0xcd97ce..0xcd983f
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcd971f..0xcd973f
+            - Range: 0xcd983f..0xcd985f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcd973f..0xcd9746
+            - Range: 0xcd985f..0xcd9866
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcd9746..0xcd977d
+            - Range: 0xcd9866..0xcd989d
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 160 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xcd9620..0xcd970f
+            - Range: 0xcd9740..0xcd982f
               Pieces: []
-            - Range: 0xcd970f..0xcd9710
+            - Range: 0xcd982f..0xcd9830
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd9710..0xcd9719
+            - Range: 0xcd9830..0xcd9839
               Pieces: []
-            - Range: 0xcd9719..0xcd971a
+            - Range: 0xcd9839..0xcd983a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd971a..0xcd977d
+            - Range: 0xcd983a..0xcd989d
               Pieces: []
           Role: Return
         - Name: b
           Type: 160 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xcd9620..0xcd9660
+            - Range: 0xcd9740..0xcd9780
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd9660..0xcd96ae
+            - Range: 0xcd9780..0xcd97ce
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcd96ae..0xcd96b5
+            - Range: 0xcd97ce..0xcd97d5
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -72}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcd96b5..0xcd9715
+            - Range: 0xcd97d5..0xcd9835
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -72}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcd9715..0xcd9717
+            - Range: 0xcd9835..0xcd9837
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcd9717..0xcd9719
+            - Range: 0xcd9837..0xcd9839
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcd9719..0xcd977d
+            - Range: 0xcd9839..0xcd989d
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           Role: Local
-    - ID: 103
+    - ID: 104
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0xcd9780..0xcd980f]
+      OutOfLinePCRanges: [0xcd98a0..0xcd992f]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9780..0xcd9791
+            - Range: 0xcd98a0..0xcd98b1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9780..0xcd97f5
+            - Range: 0xcd98a0..0xcd9915
               Pieces: []
-            - Range: 0xcd97f5..0xcd97f6
+            - Range: 0xcd9915..0xcd9916
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd97f6..0xcd980f
+            - Range: 0xcd9916..0xcd992f
               Pieces: []
           Role: Return
-    - ID: 104
+    - ID: 105
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0xcd9820..0xcd98e9]
+      OutOfLinePCRanges: [0xcd9940..0xcd9a09]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9820..0xcd9873
+            - Range: 0xcd9940..0xcd9993
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9820..0xcd98cf
+            - Range: 0xcd9940..0xcd99ef
               Pieces: []
-            - Range: 0xcd98cf..0xcd98d0
+            - Range: 0xcd99ef..0xcd99f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd98d0..0xcd98e9
+            - Range: 0xcd99f0..0xcd9a09
               Pieces: []
           Role: Return
         - Name: result2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9820..0xcd98cf
+            - Range: 0xcd9940..0xcd99ef
               Pieces: []
-            - Range: 0xcd98cf..0xcd98d0
+            - Range: 0xcd99ef..0xcd99f0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcd98d0..0xcd98e9
+            - Range: 0xcd99f0..0xcd9a09
               Pieces: []
           Role: Return
-    - ID: 105
+    - ID: 106
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0xcd9900..0xcd99c5]
+      OutOfLinePCRanges: [0xcd9a20..0xcd9ae5]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9900..0xcd9945
+            - Range: 0xcd9a20..0xcd9a65
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd9945..0xcd99c5
+            - Range: 0xcd9a65..0xcd9ae5
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9900..0xcd99ab
+            - Range: 0xcd9a20..0xcd9acb
               Pieces: []
-            - Range: 0xcd99ab..0xcd99ac
+            - Range: 0xcd9acb..0xcd9acc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd99ac..0xcd99c5
+            - Range: 0xcd9acc..0xcd9ae5
               Pieces: []
           Role: Return
         - Name: result2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9900..0xcd99ab
+            - Range: 0xcd9a20..0xcd9acb
               Pieces: []
-            - Range: 0xcd99ab..0xcd99ac
+            - Range: 0xcd9acb..0xcd9acc
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcd99ac..0xcd99c5
+            - Range: 0xcd9acc..0xcd9ae5
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9900..0xcd99ab
+            - Range: 0xcd9a20..0xcd9acb
               Pieces: []
-            - Range: 0xcd99ab..0xcd99ac
+            - Range: 0xcd9acb..0xcd9acc
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcd99ac..0xcd99c5
+            - Range: 0xcd9acc..0xcd9ae5
               Pieces: []
           Role: Return
-    - ID: 106
+    - ID: 107
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0xcd99e0..0xcd9a5e]
+      OutOfLinePCRanges: [0xcd9b00..0xcd9b7e]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 15 BaseType int8
           Locations:
-            - Range: 0xcd99e0..0xcd9a51
+            - Range: 0xcd9b00..0xcd9b71
               Pieces: []
-            - Range: 0xcd9a51..0xcd9a52
+            - Range: 0xcd9b71..0xcd9b72
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd9a52..0xcd9a5e
+            - Range: 0xcd9b72..0xcd9b7e
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 102 BaseType int16
           Locations:
-            - Range: 0xcd99e0..0xcd9a51
+            - Range: 0xcd9b00..0xcd9b71
               Pieces: []
-            - Range: 0xcd9a51..0xcd9a52
+            - Range: 0xcd9b71..0xcd9b72
               Pieces: [{Size: 2, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcd9a52..0xcd9a5e
+            - Range: 0xcd9b72..0xcd9b7e
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 10 BaseType int32
           Locations:
-            - Range: 0xcd99e0..0xcd9a51
+            - Range: 0xcd9b00..0xcd9b71
               Pieces: []
-            - Range: 0xcd9a51..0xcd9a52
+            - Range: 0xcd9b71..0xcd9b72
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcd9a52..0xcd9a5e
+            - Range: 0xcd9b72..0xcd9b7e
               Pieces: []
           Role: Return
         - Name: ~r3
           Type: 12 BaseType int64
           Locations:
-            - Range: 0xcd99e0..0xcd9a51
+            - Range: 0xcd9b00..0xcd9b71
               Pieces: []
-            - Range: 0xcd9a51..0xcd9a52
+            - Range: 0xcd9b71..0xcd9b72
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xcd9a52..0xcd9a5e
+            - Range: 0xcd9b72..0xcd9b7e
               Pieces: []
           Role: Return
         - Name: ~r4
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcd99e0..0xcd9a51
+            - Range: 0xcd9b00..0xcd9b71
               Pieces: []
-            - Range: 0xcd9a51..0xcd9a52
+            - Range: 0xcd9b71..0xcd9b72
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcd9a52..0xcd9a5e
+            - Range: 0xcd9b72..0xcd9b7e
               Pieces: []
           Role: Return
         - Name: ~r5
           Type: 6 BaseType uint16
           Locations:
-            - Range: 0xcd99e0..0xcd9a51
+            - Range: 0xcd9b00..0xcd9b71
               Pieces: []
-            - Range: 0xcd9a51..0xcd9a52
+            - Range: 0xcd9b71..0xcd9b72
               Pieces: [{Size: 2, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xcd9a52..0xcd9a5e
+            - Range: 0xcd9b72..0xcd9b7e
               Pieces: []
           Role: Return
         - Name: ~r6
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0xcd99e0..0xcd9a51
+            - Range: 0xcd9b00..0xcd9b71
               Pieces: []
-            - Range: 0xcd9a51..0xcd9a52
+            - Range: 0xcd9b71..0xcd9b72
               Pieces: [{Size: 4, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xcd9a52..0xcd9a5e
+            - Range: 0xcd9b72..0xcd9b7e
               Pieces: []
           Role: Return
         - Name: ~r7
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0xcd99e0..0xcd9a51
+            - Range: 0xcd9b00..0xcd9b71
               Pieces: []
-            - Range: 0xcd9a51..0xcd9a52
+            - Range: 0xcd9b71..0xcd9b72
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xcd9a52..0xcd9a5e
+            - Range: 0xcd9b72..0xcd9b7e
               Pieces: []
           Role: Return
-    - ID: 107
+    - ID: 108
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0xcd9a60..0xcd9b57]
+      OutOfLinePCRanges: [0xcd9b80..0xcd9c77]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcd9a60..0xcd9b57, Pieces: []}]
+          Locations: [{Range: 0xcd9b80..0xcd9c77, Pieces: []}]
           Role: Return
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcd9a60..0xcd9b57, Pieces: []}]
+          Locations: [{Range: 0xcd9b80..0xcd9c77, Pieces: []}]
           Role: Return
         - Name: ~r2
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcd9a60..0xcd9b57, Pieces: []}]
+          Locations: [{Range: 0xcd9b80..0xcd9c77, Pieces: []}]
           Role: Return
         - Name: ~r3
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcd9a60..0xcd9b57, Pieces: []}]
+          Locations: [{Range: 0xcd9b80..0xcd9c77, Pieces: []}]
           Role: Return
         - Name: ~r4
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcd9a60..0xcd9b57, Pieces: []}]
+          Locations: [{Range: 0xcd9b80..0xcd9c77, Pieces: []}]
           Role: Return
         - Name: ~r5
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcd9a60..0xcd9b57, Pieces: []}]
+          Locations: [{Range: 0xcd9b80..0xcd9c77, Pieces: []}]
           Role: Return
         - Name: ~r6
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcd9a60..0xcd9b57, Pieces: []}]
+          Locations: [{Range: 0xcd9b80..0xcd9c77, Pieces: []}]
           Role: Return
         - Name: ~r7
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcd9a60..0xcd9b57, Pieces: []}]
+          Locations: [{Range: 0xcd9b80..0xcd9c77, Pieces: []}]
           Role: Return
         - Name: ~r8
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcd9a60..0xcd9b57, Pieces: []}]
+          Locations: [{Range: 0xcd9b80..0xcd9c77, Pieces: []}]
           Role: Return
         - Name: ~r9
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcd9a60..0xcd9b57, Pieces: []}]
+          Locations: [{Range: 0xcd9b80..0xcd9c77, Pieces: []}]
           Role: Return
         - Name: ~r10
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcd9a60..0xcd9b57, Pieces: []}]
+          Locations: [{Range: 0xcd9b80..0xcd9c77, Pieces: []}]
           Role: Return
         - Name: ~r11
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcd9a60..0xcd9b57, Pieces: []}]
+          Locations: [{Range: 0xcd9b80..0xcd9c77, Pieces: []}]
           Role: Return
         - Name: ~r12
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcd9a60..0xcd9b57, Pieces: []}]
+          Locations: [{Range: 0xcd9b80..0xcd9c77, Pieces: []}]
           Role: Return
         - Name: ~r13
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcd9a60..0xcd9b57, Pieces: []}]
+          Locations: [{Range: 0xcd9b80..0xcd9c77, Pieces: []}]
           Role: Return
         - Name: ~r14
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcd9a60..0xcd9b57, Pieces: []}]
+          Locations: [{Range: 0xcd9b80..0xcd9c77, Pieces: []}]
           Role: Return
         - Name: onlyOnAmd64_16
           Type: 18 BaseType float64
           Locations:
-            - Range: 0xcd9a60..0xcd9b47
+            - Range: 0xcd9b80..0xcd9c67
               Pieces: []
-            - Range: 0xcd9b47..0xcd9b48
+            - Range: 0xcd9c67..0xcd9c68
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xcd9b48..0xcd9b57
+            - Range: 0xcd9c68..0xcd9c77
               Pieces: []
           Role: Return
         - Name: bothArmAndAmd64
           Type: 18 BaseType float64
           Locations:
-            - Range: 0xcd9a60..0xcd9b47
+            - Range: 0xcd9b80..0xcd9c67
               Pieces: []
-            - Range: 0xcd9b47..0xcd9b48
+            - Range: 0xcd9c67..0xcd9c68
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcd9b48..0xcd9b57
+            - Range: 0xcd9c68..0xcd9c77
               Pieces: []
           Role: Return
-    - ID: 108
+    - ID: 109
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0xcd9b60..0xcd9bd3]
+      OutOfLinePCRanges: [0xcd9c80..0xcd9cf3]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 94 BaseType complex64
-          Locations: [{Range: 0xcd9b60..0xcd9bd3, Pieces: []}]
+          Locations: [{Range: 0xcd9c80..0xcd9cf3, Pieces: []}]
           Role: Return
         - Name: ~r1
           Type: 95 BaseType complex128
-          Locations: [{Range: 0xcd9b60..0xcd9bd3, Pieces: []}]
+          Locations: [{Range: 0xcd9c80..0xcd9cf3, Pieces: []}]
           Role: Return
-    - ID: 109
+    - ID: 110
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0xcd9be0..0xcd9c85]
+      OutOfLinePCRanges: [0xcd9d00..0xcd9da5]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0xcd9be0..0xcd9c73
+            - Range: 0xcd9d00..0xcd9d93
               Pieces: []
-            - Range: 0xcd9c73..0xcd9c74
+            - Range: 0xcd9d93..0xcd9d94
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
-            - Range: 0xcd9c74..0xcd9c85
+            - Range: 0xcd9d94..0xcd9da5
               Pieces: []
           Role: Return
-    - ID: 110
+    - ID: 111
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0xcd9ca0..0xcd9d1a]
+      OutOfLinePCRanges: [0xcd9dc0..0xcd9e3a]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 249 ArrayType [3]int
           Locations:
-            - Range: 0xcd9ca0..0xcd9d0d
+            - Range: 0xcd9dc0..0xcd9e2d
               Pieces: []
-            - Range: 0xcd9d0d..0xcd9d0e
+            - Range: 0xcd9e2d..0xcd9e2e
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xcd9d0e..0xcd9d1a
+            - Range: 0xcd9e2e..0xcd9e3a
               Pieces: []
           Role: Return
-    - ID: 111
+    - ID: 112
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0xcd9d20..0xcd9d78]
+      OutOfLinePCRanges: [0xcd9e40..0xcd9e98]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 250 ArrayType [1]int
           Locations:
-            - Range: 0xcd9d20..0xcd9d6b
+            - Range: 0xcd9e40..0xcd9e8b
               Pieces: []
-            - Range: 0xcd9d6b..0xcd9d6c
+            - Range: 0xcd9e8b..0xcd9e8c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd9d6c..0xcd9d78
+            - Range: 0xcd9e8c..0xcd9e98
               Pieces: []
           Role: Return
-    - ID: 112
+    - ID: 113
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0xcd9d80..0xcd9dd3]
+      OutOfLinePCRanges: [0xcd9ea0..0xcd9ef3]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 251 ArrayType [0]int
           Locations:
-            - Range: 0xcd9d80..0xcd9dc6
+            - Range: 0xcd9ea0..0xcd9ee6
               Pieces: []
-            - Range: 0xcd9dc6..0xcd9dc7
+            - Range: 0xcd9ee6..0xcd9ee7
               Pieces: []
-            - Range: 0xcd9dc7..0xcd9dd3
+            - Range: 0xcd9ee7..0xcd9ef3
               Pieces: []
           Role: Return
-    - ID: 113
+    - ID: 114
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0xcd9de0..0xcd9e47]
+      OutOfLinePCRanges: [0xcd9f00..0xcd9f67]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 252 StructureType main.mixedStruct
-          Locations: [{Range: 0xcd9de0..0xcd9e47, Pieces: []}]
+          Locations: [{Range: 0xcd9f00..0xcd9f67, Pieces: []}]
           Role: Return
-    - ID: 114
+    - ID: 115
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0xcd9e60..0xcd9efa]
+      OutOfLinePCRanges: [0xcd9f80..0xcda01a]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9e60..0xcd9eea
+            - Range: 0xcd9f80..0xcda00a
               Pieces: []
-            - Range: 0xcd9eea..0xcd9eeb
+            - Range: 0xcda00a..0xcda00b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd9eeb..0xcd9efa
+            - Range: 0xcda00b..0xcda01a
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9e60..0xcd9eea
+            - Range: 0xcd9f80..0xcda00a
               Pieces: []
-            - Range: 0xcd9eea..0xcd9eeb
+            - Range: 0xcda00a..0xcda00b
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcd9eeb..0xcd9efa
+            - Range: 0xcda00b..0xcda01a
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9e60..0xcd9eea
+            - Range: 0xcd9f80..0xcda00a
               Pieces: []
-            - Range: 0xcd9eea..0xcd9eeb
+            - Range: 0xcda00a..0xcda00b
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcd9eeb..0xcd9efa
+            - Range: 0xcda00b..0xcda01a
               Pieces: []
           Role: Return
         - Name: ~r3
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9e60..0xcd9eea
+            - Range: 0xcd9f80..0xcda00a
               Pieces: []
-            - Range: 0xcd9eea..0xcd9eeb
+            - Range: 0xcda00a..0xcda00b
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xcd9eeb..0xcd9efa
+            - Range: 0xcda00b..0xcda01a
               Pieces: []
           Role: Return
         - Name: ~r4
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9e60..0xcd9eea
+            - Range: 0xcd9f80..0xcda00a
               Pieces: []
-            - Range: 0xcd9eea..0xcd9eeb
+            - Range: 0xcda00a..0xcda00b
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcd9eeb..0xcd9efa
+            - Range: 0xcda00b..0xcda01a
               Pieces: []
           Role: Return
         - Name: ~r5
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9e60..0xcd9eea
+            - Range: 0xcd9f80..0xcda00a
               Pieces: []
-            - Range: 0xcd9eea..0xcd9eeb
+            - Range: 0xcda00a..0xcda00b
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xcd9eeb..0xcd9efa
+            - Range: 0xcda00b..0xcda01a
               Pieces: []
           Role: Return
         - Name: ~r6
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9e60..0xcd9eea
+            - Range: 0xcd9f80..0xcda00a
               Pieces: []
-            - Range: 0xcd9eea..0xcd9eeb
+            - Range: 0xcda00a..0xcda00b
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xcd9eeb..0xcd9efa
+            - Range: 0xcda00b..0xcda01a
               Pieces: []
           Role: Return
         - Name: ~r7
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9e60..0xcd9eea
+            - Range: 0xcd9f80..0xcda00a
               Pieces: []
-            - Range: 0xcd9eea..0xcd9eeb
+            - Range: 0xcda00a..0xcda00b
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xcd9eeb..0xcd9efa
+            - Range: 0xcda00b..0xcda01a
               Pieces: []
           Role: Return
         - Name: ~r8
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcd9e60..0xcd9eea
+            - Range: 0xcd9f80..0xcda00a
               Pieces: []
-            - Range: 0xcd9eea..0xcd9eeb
+            - Range: 0xcda00a..0xcda00b
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xcd9eeb..0xcd9efa
+            - Range: 0xcda00b..0xcda01a
               Pieces: []
           Role: Return
-    - ID: 115
+    - ID: 116
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0xcd9f00..0xcd9fa5]
+      OutOfLinePCRanges: [0xcda020..0xcda0c5]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 253 StructureType main.wideStruct
           Locations:
-            - Range: 0xcd9f00..0xcd9f94
+            - Range: 0xcda020..0xcda0b4
               Pieces: []
-            - Range: 0xcd9f94..0xcd9f95
+            - Range: 0xcda0b4..0xcda0b5
               Pieces: [{Size: 88, Op: {CfaOffset: 0}}]
-            - Range: 0xcd9f95..0xcd9fa5
+            - Range: 0xcda0b5..0xcda0c5
               Pieces: []
           Role: Return
-    - ID: 116
+    - ID: 117
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0xcd9fc0..0xcda039]
+      OutOfLinePCRanges: [0xcda0e0..0xcda159]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9fc0..0xcda02c
+            - Range: 0xcda0e0..0xcda14c
               Pieces: []
-            - Range: 0xcda02c..0xcda02d
+            - Range: 0xcda14c..0xcda14d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcda02d..0xcda039
+            - Range: 0xcda14d..0xcda159
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcd9fc0..0xcda039, Pieces: []}]
+          Locations: [{Range: 0xcda0e0..0xcda159, Pieces: []}]
           Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9fc0..0xcda02c
+            - Range: 0xcda0e0..0xcda14c
               Pieces: []
-            - Range: 0xcda02c..0xcda02d
+            - Range: 0xcda14c..0xcda14d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcda02d..0xcda039
+            - Range: 0xcda14d..0xcda159
               Pieces: []
           Role: Return
         - Name: ~r3
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcd9fc0..0xcda039, Pieces: []}]
+          Locations: [{Range: 0xcda0e0..0xcda159, Pieces: []}]
           Role: Return
         - Name: ~r4
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcd9fc0..0xcda02c
+            - Range: 0xcda0e0..0xcda14c
               Pieces: []
-            - Range: 0xcda02c..0xcda02d
+            - Range: 0xcda14c..0xcda14d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcda02d..0xcda039
+            - Range: 0xcda14d..0xcda159
               Pieces: []
           Role: Return
-    - ID: 117
+    - ID: 118
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0xcda040..0xcda0ba]
+      OutOfLinePCRanges: [0xcda160..0xcda1da]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 254 StructureType main.structWithArray
           Locations:
-            - Range: 0xcda040..0xcda0ad
+            - Range: 0xcda160..0xcda1cd
               Pieces: []
-            - Range: 0xcda0ad..0xcda0ae
+            - Range: 0xcda1cd..0xcda1ce
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xcda0ae..0xcda0ba
+            - Range: 0xcda1ce..0xcda1da
               Pieces: []
           Role: Return
-    - ID: 118
+    - ID: 119
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0xcda0c0..0xcda11b]
+      OutOfLinePCRanges: [0xcda1e0..0xcda23b]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcda0c0..0xcda11b, Pieces: []}]
+          Locations: [{Range: 0xcda1e0..0xcda23b, Pieces: []}]
           Role: Return
-    - ID: 119
+    - ID: 120
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0xcda120..0xcda187]
+      OutOfLinePCRanges: [0xcda240..0xcda2a7]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType float32
-          Locations: [{Range: 0xcda120..0xcda187, Pieces: []}]
+          Locations: [{Range: 0xcda240..0xcda2a7, Pieces: []}]
           Role: Return
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcda120..0xcda187, Pieces: []}]
+          Locations: [{Range: 0xcda240..0xcda2a7, Pieces: []}]
           Role: Return
-    - ID: 120
+    - ID: 121
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0xcda1a0..0xcda1fd]
+      OutOfLinePCRanges: [0xcda2c0..0xcda31d]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcda1a0..0xcda1f0
+            - Range: 0xcda2c0..0xcda310
               Pieces: []
-            - Range: 0xcda1f0..0xcda1f1
+            - Range: 0xcda310..0xcda311
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcda1f1..0xcda1fd
+            - Range: 0xcda311..0xcda31d
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 1 BaseType uintptr
           Locations:
-            - Range: 0xcda1a0..0xcda1f0
+            - Range: 0xcda2c0..0xcda310
               Pieces: []
-            - Range: 0xcda1f0..0xcda1f1
+            - Range: 0xcda310..0xcda311
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcda1f1..0xcda1fd
+            - Range: 0xcda311..0xcda31d
               Pieces: []
           Role: Return
-    - ID: 121
+    - ID: 122
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0xcda200..0xcda385]
+      OutOfLinePCRanges: [0xcda320..0xcda4a5]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0xcda200..0xcda385
+            - Range: 0xcda320..0xcda4a5
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0xcda200..0xcda373
+            - Range: 0xcda320..0xcda493
               Pieces: []
-            - Range: 0xcda373..0xcda374
+            - Range: 0xcda493..0xcda494
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
-            - Range: 0xcda374..0xcda385
+            - Range: 0xcda494..0xcda4a5
               Pieces: []
           Role: Return
-    - ID: 122
+    - ID: 123
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0xcda3a0..0xcda472]
+      OutOfLinePCRanges: [0xcda4c0..0xcda592]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 249 ArrayType [3]int
           Locations:
-            - Range: 0xcda3a0..0xcda472
+            - Range: 0xcda4c0..0xcda592
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 249 ArrayType [3]int
           Locations:
-            - Range: 0xcda3a0..0xcda462
+            - Range: 0xcda4c0..0xcda582
               Pieces: []
-            - Range: 0xcda462..0xcda463
+            - Range: 0xcda582..0xcda583
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xcda463..0xcda472
+            - Range: 0xcda583..0xcda592
               Pieces: []
           Role: Return
-    - ID: 123
+    - ID: 124
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0xcda480..0xcda6ba]
+      OutOfLinePCRanges: [0xcda5a0..0xcda7da]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0xcda480..0xcda6ba
+            - Range: 0xcda5a0..0xcda7da
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: s2
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0xcda480..0xcda6ba
+            - Range: 0xcda5a0..0xcda7da
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
           Role: Parameter
         - Name: ~r0
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0xcda480..0xcda6aa
+            - Range: 0xcda5a0..0xcda7ca
               Pieces: []
-            - Range: 0xcda6aa..0xcda6ab
+            - Range: 0xcda7ca..0xcda7cb
               Pieces: [{Size: 80, Op: {CfaOffset: 160}}]
-            - Range: 0xcda6ab..0xcda6ba
+            - Range: 0xcda7cb..0xcda7da
               Pieces: []
           Role: Return
-    - ID: 124
+    - ID: 125
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0xcda6c0..0xcda94f]
+      OutOfLinePCRanges: [0xcda7e0..0xcdaa6f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda6c0..0xcda770
+            - Range: 0xcda7e0..0xcda890
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcda770..0xcda94f
+            - Range: 0xcda890..0xcdaa6f
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda6c0..0xcda770
+            - Range: 0xcda7e0..0xcda890
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcda770..0xcda94f
+            - Range: 0xcda890..0xcdaa6f
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda6c0..0xcda75a
+            - Range: 0xcda7e0..0xcda87a
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcda75a..0xcda94f
+            - Range: 0xcda87a..0xcdaa6f
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda6c0..0xcda730
+            - Range: 0xcda7e0..0xcda850
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xcda730..0xcda94f
+            - Range: 0xcda850..0xcdaa6f
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda6c0..0xcda770
+            - Range: 0xcda7e0..0xcda890
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcda770..0xcda94f
+            - Range: 0xcda890..0xcdaa6f
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda6c0..0xcda770
+            - Range: 0xcda7e0..0xcda890
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xcda770..0xcda94f
+            - Range: 0xcda890..0xcdaa6f
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda6c0..0xcda770
+            - Range: 0xcda7e0..0xcda890
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xcda770..0xcda94f
+            - Range: 0xcda890..0xcdaa6f
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda6c0..0xcda770
+            - Range: 0xcda7e0..0xcda890
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xcda770..0xcda94f
+            - Range: 0xcda890..0xcdaa6f
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda6c0..0xcda770
+            - Range: 0xcda7e0..0xcda890
               Pieces: [{Size: 8, Op: {RegNo: 11, Shift: 0}}]
-            - Range: 0xcda770..0xcda94f
+            - Range: 0xcda890..0xcdaa6f
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
         - Name: ~r0
           Type: 111 ArrayType [2]int
           Locations:
-            - Range: 0xcda6c0..0xcda8e2
+            - Range: 0xcda7e0..0xcdaa02
               Pieces: []
-            - Range: 0xcda8e2..0xcda8e3
+            - Range: 0xcdaa02..0xcdaa03
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xcda8e3..0xcda94f
+            - Range: 0xcdaa03..0xcdaa6f
               Pieces: []
           Role: Return
-    - ID: 125
+    - ID: 126
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0xcda960..0xcdac2c]
+      OutOfLinePCRanges: [0xcdaa80..0xcdad4c]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda960..0xcdaa0b
+            - Range: 0xcdaa80..0xcdab2b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdaa0b..0xcdac2c
+            - Range: 0xcdab2b..0xcdad4c
               Pieces: [{Size: 8, Op: {CfaOffset: 96}}]
           Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda960..0xcdaa0b
+            - Range: 0xcdaa80..0xcdab2b
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcdaa0b..0xcdac2c
+            - Range: 0xcdab2b..0xcdad4c
               Pieces: [{Size: 8, Op: {CfaOffset: 104}}]
           Role: Parameter
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda960..0xcda9f5
+            - Range: 0xcdaa80..0xcdab15
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcda9f5..0xcdac2c
+            - Range: 0xcdab15..0xcdad4c
               Pieces: [{Size: 8, Op: {CfaOffset: 112}}]
           Role: Parameter
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda960..0xcda9c2
+            - Range: 0xcdaa80..0xcdaae2
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xcda9c2..0xcdac2c
+            - Range: 0xcdaae2..0xcdad4c
               Pieces: [{Size: 8, Op: {CfaOffset: 120}}]
           Role: Parameter
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda960..0xcdaa0b
+            - Range: 0xcdaa80..0xcdab2b
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcdaa0b..0xcdac2c
+            - Range: 0xcdab2b..0xcdad4c
               Pieces: [{Size: 8, Op: {CfaOffset: 128}}]
           Role: Parameter
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda960..0xcdaa0b
+            - Range: 0xcdaa80..0xcdab2b
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xcdaa0b..0xcdac2c
+            - Range: 0xcdab2b..0xcdad4c
               Pieces: [{Size: 8, Op: {CfaOffset: 136}}]
           Role: Parameter
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda960..0xcdaa0b
+            - Range: 0xcdaa80..0xcdab2b
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xcdaa0b..0xcdac2c
+            - Range: 0xcdab2b..0xcdad4c
               Pieces: [{Size: 8, Op: {CfaOffset: 144}}]
           Role: Parameter
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda960..0xcdaa0b
+            - Range: 0xcdaa80..0xcdab2b
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xcdaa0b..0xcdac2c
+            - Range: 0xcdab2b..0xcdad4c
               Pieces: [{Size: 8, Op: {CfaOffset: 152}}]
           Role: Parameter
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcda960..0xcdac2c
+            - Range: 0xcdaa80..0xcdad4c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -7207,358 +7293,175 @@ Subprograms:
         - Name: ~r0
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0xcda960..0xcdabab
+            - Range: 0xcdaa80..0xcdaccb
               Pieces: []
-            - Range: 0xcdabab..0xcdabac
+            - Range: 0xcdaccb..0xcdaccc
               Pieces: [{Size: 80, Op: {CfaOffset: 16}}]
-            - Range: 0xcdabac..0xcdac2c
+            - Range: 0xcdaccc..0xcdad4c
               Pieces: []
           Role: Return
-    - ID: 126
+    - ID: 127
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0xcdac40..0xcdaccc]
+      OutOfLinePCRanges: [0xcdad60..0xcdadec]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 159 ArrayType [5]int
           Locations:
-            - Range: 0xcdac40..0xcdaccc
+            - Range: 0xcdad60..0xcdadec
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdac40..0xcdacbc
+            - Range: 0xcdad60..0xcdaddc
               Pieces: []
-            - Range: 0xcdacbc..0xcdacbd
+            - Range: 0xcdaddc..0xcdaddd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdacbd..0xcdaccc
+            - Range: 0xcdaddd..0xcdadec
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdac40..0xcdacbc
+            - Range: 0xcdad60..0xcdaddc
               Pieces: []
-            - Range: 0xcdacbc..0xcdacbd
+            - Range: 0xcdaddc..0xcdaddd
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcdacbd..0xcdaccc
+            - Range: 0xcdaddd..0xcdadec
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdac40..0xcdacbc
+            - Range: 0xcdad60..0xcdaddc
               Pieces: []
-            - Range: 0xcdacbc..0xcdacbd
+            - Range: 0xcdaddc..0xcdaddd
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcdacbd..0xcdaccc
+            - Range: 0xcdaddd..0xcdadec
               Pieces: []
           Role: Return
-    - ID: 127
+    - ID: 128
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0xcdace0..0xcdadce]
+      OutOfLinePCRanges: [0xcdae00..0xcdaeee]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 111 ArrayType [2]int
           Locations:
-            - Range: 0xcdace0..0xcdadce
+            - Range: 0xcdae00..0xcdaeee
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: b
           Type: 249 ArrayType [3]int
           Locations:
-            - Range: 0xcdace0..0xcdadce
+            - Range: 0xcdae00..0xcdaeee
               Pieces: [{Size: 24, Op: {CfaOffset: 16}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdace0..0xcdadbe
+            - Range: 0xcdae00..0xcdaede
               Pieces: []
-            - Range: 0xcdadbe..0xcdadbf
+            - Range: 0xcdaede..0xcdaedf
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdadbf..0xcdadce
+            - Range: 0xcdaedf..0xcdaeee
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 111 ArrayType [2]int
           Locations:
-            - Range: 0xcdace0..0xcdadbe
+            - Range: 0xcdae00..0xcdaede
               Pieces: []
-            - Range: 0xcdadbe..0xcdadbf
+            - Range: 0xcdaede..0xcdaedf
               Pieces: [{Size: 16, Op: {CfaOffset: 40}}]
-            - Range: 0xcdadbf..0xcdadce
+            - Range: 0xcdaedf..0xcdaeee
               Pieces: []
           Role: Return
-    - ID: 128
+    - ID: 129
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0xcdade0..0xcdaeab]
+      OutOfLinePCRanges: [0xcdaf00..0xcdafcb]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 254 StructureType main.structWithArray
           Locations:
-            - Range: 0xcdade0..0xcdaeab
+            - Range: 0xcdaf00..0xcdafcb
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdade0..0xcdae9a
+            - Range: 0xcdaf00..0xcdafba
               Pieces: []
-            - Range: 0xcdae9a..0xcdae9b
+            - Range: 0xcdafba..0xcdafbb
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdae9b..0xcdaeab
+            - Range: 0xcdafbb..0xcdafcb
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 254 StructureType main.structWithArray
           Locations:
-            - Range: 0xcdade0..0xcdae9a
+            - Range: 0xcdaf00..0xcdafba
               Pieces: []
-            - Range: 0xcdae9a..0xcdae9b
+            - Range: 0xcdafba..0xcdafbb
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xcdae9b..0xcdaeab
+            - Range: 0xcdafbb..0xcdafcb
               Pieces: []
           Role: Return
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdae66..0xcdaeab
+            - Range: 0xcdaf86..0xcdafcb
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
-    - ID: 129
+    - ID: 130
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0xcdaec0..0xcdaf66]
+      OutOfLinePCRanges: [0xcdafe0..0xcdb086]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 251 ArrayType [0]int
-          Locations: [{Range: 0xcdaec0..0xcdaf66, Pieces: []}]
+          Locations: [{Range: 0xcdafe0..0xcdb086, Pieces: []}]
           Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdaec0..0xcdaf05
+            - Range: 0xcdafe0..0xcdb025
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdaf05..0xcdaf27
+            - Range: 0xcdb025..0xcdb047
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xcdaf27..0xcdaf3a
+            - Range: 0xcdb047..0xcdb05a
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xcdaf3a..0xcdaf66
+            - Range: 0xcdb05a..0xcdb086
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdaec0..0xcdaf4c
+            - Range: 0xcdafe0..0xcdb06c
               Pieces: []
-            - Range: 0xcdaf4c..0xcdaf4d
+            - Range: 0xcdb06c..0xcdb06d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdaf4d..0xcdaf66
+            - Range: 0xcdb06d..0xcdb086
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 251 ArrayType [0]int
           Locations:
-            - Range: 0xcdaec0..0xcdaf4c
+            - Range: 0xcdafe0..0xcdb06c
               Pieces: []
-            - Range: 0xcdaf4c..0xcdaf4d
+            - Range: 0xcdb06c..0xcdb06d
               Pieces: []
-            - Range: 0xcdaf4d..0xcdaf66
+            - Range: 0xcdb06d..0xcdb086
               Pieces: []
           Role: Return
-    - ID: 130
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0xcdb460..0xcdb461]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 255 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xcdb460..0xcdb461
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
     - ID: 131
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0xcdb480..0xcdb481]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 255 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xcdb480..0xcdb481
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-    - ID: 132
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0xcdb4a0..0xcdb4a1]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 256 GoSliceHeaderType [][]uint
-          Locations:
-            - Range: 0xcdb4a0..0xcdb4a1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-    - ID: 133
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0xcdb4c0..0xcdb4c1]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 258 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xcdb4c0..0xcdb4c1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcdb4c0..0xcdb4c1
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          Role: Parameter
-    - ID: 134
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0xcdb4e0..0xcdb4e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 258 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xcdb4e0..0xcdb4e1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcdb4e0..0xcdb4e1
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          Role: Parameter
-    - ID: 135
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0xcdb500..0xcdb501]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 258 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xcdb500..0xcdb501
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcdb500..0xcdb501
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          Role: Parameter
-    - ID: 136
-      Name: main.testStringSlice
-      OutOfLinePCRanges: [0xcdb520..0xcdb521]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 261 GoSliceHeaderType []string
-          Locations:
-            - Range: 0xcdb520..0xcdb521
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-    - ID: 137
-      Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0xcdb540..0xcdb541]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 15 BaseType int8
-          Locations:
-            - Range: 0xcdb540..0xcdb541
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-        - Name: s
-          Type: 262 GoSliceHeaderType []bool
-          Locations:
-            - Range: 0xcdb540..0xcdb541
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-          Role: Parameter
-        - Name: x
-          Type: 16 BaseType uint
-          Locations:
-            - Range: 0xcdb540..0xcdb541
-              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-          Role: Parameter
-    - ID: 138
-      Name: main.testNilSlice
-      OutOfLinePCRanges: [0xcdb560..0xcdb561]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 263 GoSliceHeaderType []uint16
-          Locations:
-            - Range: 0xcdb560..0xcdb561
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-    - ID: 139
-      Name: main.testVeryLargeSlice
+      Name: main.testUintSlice
       OutOfLinePCRanges: [0xcdb580..0xcdb581]
       InlinePCRanges: []
       Variables:
-        - Name: xs
+        - Name: u
           Type: 255 GoSliceHeaderType []uint
           Locations:
             - Range: 0xcdb580..0xcdb581
@@ -7570,13 +7473,13 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 140
-      Name: main.testSliceEmptyStructs
+    - ID: 132
+      Name: main.testEmptySlice
       OutOfLinePCRanges: [0xcdb5a0..0xcdb5a1]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 264 GoSliceHeaderType []struct {}
+        - Name: u
+          Type: 255 GoSliceHeaderType []uint
           Locations:
             - Range: 0xcdb5a0..0xcdb5a1
               Pieces:
@@ -7587,15 +7490,198 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 141
-      Name: main.testSubslices
+    - ID: 133
+      Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0xcdb5c0..0xcdb5c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: u
+          Type: 256 GoSliceHeaderType [][]uint
+          Locations:
+            - Range: 0xcdb5c0..0xcdb5c1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+    - ID: 134
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0xcdb5e0..0xcdb5e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 258 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xcdb5e0..0xcdb5e1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdb5e0..0xcdb5e1
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          Role: Parameter
+    - ID: 135
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0xcdb600..0xcdb601]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 258 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xcdb600..0xcdb601
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdb600..0xcdb601
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          Role: Parameter
+    - ID: 136
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0xcdb620..0xcdb621]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 258 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xcdb620..0xcdb621
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdb620..0xcdb621
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          Role: Parameter
+    - ID: 137
+      Name: main.testStringSlice
+      OutOfLinePCRanges: [0xcdb640..0xcdb641]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 261 GoSliceHeaderType []string
+          Locations:
+            - Range: 0xcdb640..0xcdb641
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+    - ID: 138
+      Name: main.testNilSliceWithOtherParams
+      OutOfLinePCRanges: [0xcdb660..0xcdb661]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 15 BaseType int8
+          Locations:
+            - Range: 0xcdb660..0xcdb661
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+        - Name: s
+          Type: 262 GoSliceHeaderType []bool
+          Locations:
+            - Range: 0xcdb660..0xcdb661
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+          Role: Parameter
+        - Name: x
+          Type: 16 BaseType uint
+          Locations:
+            - Range: 0xcdb660..0xcdb661
+              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
+          Role: Parameter
+    - ID: 139
+      Name: main.testNilSlice
+      OutOfLinePCRanges: [0xcdb680..0xcdb681]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 263 GoSliceHeaderType []uint16
+          Locations:
+            - Range: 0xcdb680..0xcdb681
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+    - ID: 140
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0xcdb6a0..0xcdb6a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 255 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0xcdb6a0..0xcdb6a1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+    - ID: 141
+      Name: main.testSliceEmptyStructs
+      OutOfLinePCRanges: [0xcdb6c0..0xcdb6c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 264 GoSliceHeaderType []struct {}
+          Locations:
+            - Range: 0xcdb6c0..0xcdb6c1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+    - ID: 142
+      Name: main.testSubslices
+      OutOfLinePCRanges: [0xcdb6e0..0xcdb6e1]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 255 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcdb5c0..0xcdb5c1
+            - Range: 0xcdb6e0..0xcdb6e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7607,7 +7693,7 @@ Subprograms:
         - Name: bs
           Type: 255 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcdb5c0..0xcdb5c1
+            - Range: 0xcdb6e0..0xcdb6e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -7619,7 +7705,7 @@ Subprograms:
         - Name: cs
           Type: 255 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcdb5c0..0xcdb5c1
+            - Range: 0xcdb6e0..0xcdb6e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
@@ -7628,49 +7714,49 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
           Role: Parameter
-    - ID: 142
+    - ID: 143
       Name: main.stackC
-      OutOfLinePCRanges: [0xcdb960..0xcdb9b2]
+      OutOfLinePCRanges: [0xcdba80..0xcdbad2]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdb960..0xcdb9a5
+            - Range: 0xcdba80..0xcdbac5
               Pieces: []
-            - Range: 0xcdb9a5..0xcdb9a6
+            - Range: 0xcdbac5..0xcdbac6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdb9a6..0xcdb9b2
+            - Range: 0xcdbac6..0xcdbad2
               Pieces: []
           Role: Return
-    - ID: 143
+    - ID: 144
       Name: main.testSingleString
-      OutOfLinePCRanges: [0xcdb9c0..0xcdb9c1]
+      OutOfLinePCRanges: [0xcdbae0..0xcdbae1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdb9c0..0xcdb9c1
+            - Range: 0xcdbae0..0xcdbae1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
-    - ID: 144
+    - ID: 145
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0xcdb9e0..0xcdb9e1]
+      OutOfLinePCRanges: [0xcdbb00..0xcdbb01]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdb9e0..0xcdb9e1
+            - Range: 0xcdbb00..0xcdbb01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7680,7 +7766,7 @@ Subprograms:
         - Name: y
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdb9e0..0xcdb9e1
+            - Range: 0xcdbb00..0xcdbb01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -7690,22 +7776,22 @@ Subprograms:
         - Name: z
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdb9e0..0xcdb9e1
+            - Range: 0xcdbb00..0xcdbb01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 145
+    - ID: 146
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0xcdba00..0xcdba1f]
+      OutOfLinePCRanges: [0xcdbb20..0xcdbb3f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 266 StructureType main.threeStringStruct
           Locations:
-            - Range: 0xcdba00..0xcdba1f
+            - Range: 0xcdbb20..0xcdbb3f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7720,52 +7806,37 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 146
+    - ID: 147
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0xcdba20..0xcdba21]
+      OutOfLinePCRanges: [0xcdbb40..0xcdbb41]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 267 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0xcdba20..0xcdba21
+            - Range: 0xcdbb40..0xcdbb41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 147
+    - ID: 148
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0xcdba40..0xcdba41]
+      OutOfLinePCRanges: [0xcdbb60..0xcdbb61]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 268 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0xcdba40..0xcdba41
+            - Range: 0xcdbb60..0xcdbb61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 148
-      Name: main.testMassiveString
-      OutOfLinePCRanges: [0xcdba60..0xcdba61]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xcdba60..0xcdba61
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          Role: Parameter
     - ID: 149
-      Name: main.testUnitializedString
-      OutOfLinePCRanges: [0xcdba80..0xcdba81]
+      Name: main.testMassiveString
+      OutOfLinePCRanges: [0xcdbb80..0xcdbb81]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdba80..0xcdba81
+            - Range: 0xcdbb80..0xcdbb81
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7773,14 +7844,14 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
     - ID: 150
-      Name: main.testEmptyString
-      OutOfLinePCRanges: [0xcdbaa0..0xcdbaa1]
+      Name: main.testUnitializedString
+      OutOfLinePCRanges: [0xcdbba0..0xcdbba1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdbaa0..0xcdbaa1
+            - Range: 0xcdbba0..0xcdbba1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7788,14 +7859,29 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
     - ID: 151
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0xcdbbc0..0xcdbbc1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xcdbbc0..0xcdbbc1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Parameter
+    - ID: 152
       Name: main.testSubstrings
-      OutOfLinePCRanges: [0xcdbac0..0xcdbac1]
+      OutOfLinePCRanges: [0xcdbbe0..0xcdbbe1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdbac0..0xcdbac1
+            - Range: 0xcdbbe0..0xcdbbe1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7805,7 +7891,7 @@ Subprograms:
         - Name: b
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdbac0..0xcdbac1
+            - Range: 0xcdbbe0..0xcdbbe1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -7815,33 +7901,33 @@ Subprograms:
         - Name: c
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdbac0..0xcdbac1
+            - Range: 0xcdbbe0..0xcdbbe1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 152
+    - ID: 153
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0xcdbc40..0xcdbc41]
+      OutOfLinePCRanges: [0xcdbd60..0xcdbd61]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 270 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0xcdbc40..0xcdbc41
+            - Range: 0xcdbd60..0xcdbd61
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
-    - ID: 153
+    - ID: 154
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0xcdbc60..0xcdbc7f]
+      OutOfLinePCRanges: [0xcdbd80..0xcdbd9f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 283 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0xcdbc60..0xcdbc7f
+            - Range: 0xcdbd80..0xcdbd9f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7856,15 +7942,15 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 154
+    - ID: 155
       Name: main.testStruct
-      OutOfLinePCRanges: [0xcdbda0..0xcdbdc3]
+      OutOfLinePCRanges: [0xcdbec0..0xcdbee3]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 314 StructureType main.aStruct
           Locations:
-            - Range: 0xcdbda0..0xcdbdc3
+            - Range: 0xcdbec0..0xcdbee3
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -7881,134 +7967,134 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
           Role: Parameter
-    - ID: 155
+    - ID: 156
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0xcdbea0..0xcdbea1]
+      OutOfLinePCRanges: [0xcdbfc0..0xcdbfc1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 315 PointerType *main.anotherStruct
           Locations:
-            - Range: 0xcdbea0..0xcdbea1
+            - Range: 0xcdbfc0..0xcdbfc1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 156
+    - ID: 157
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xcdbf20..0xcdbf21]
+      OutOfLinePCRanges: [0xcdc040..0xcdc041]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 317 StructureType main.emptyStruct
-          Locations: [{Range: 0xcdbf20..0xcdbf21, Pieces: []}]
+          Locations: [{Range: 0xcdc040..0xcdc041, Pieces: []}]
           Role: Parameter
-    - ID: 157
+    - ID: 158
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0xcdbf40..0xcdbf41]
+      OutOfLinePCRanges: [0xcdc060..0xcdc061]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 318 PointerType *main.emptyStruct
           Locations:
-            - Range: 0xcdbf40..0xcdbf41
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-    - ID: 158
-      Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0xcd5920..0xcd5982]
-      InlinePCRanges:
-        - Ranges: [0xcd59b1..0xcd59ed]
-          RootRanges: [0xcd59a0..0xcd5a11]
-        - Ranges: [0xcd5af2..0xcd5b2e]
-          RootRanges: [0xcd5ac0..0xcd5b48]
-        - Ranges: [0xcd5b7c..0xcd5bb8]
-          RootRanges: [0xcd5b60..0xcd5c25]
-        - Ranges: [0xcd5c4f..0xcd5c8b]
-          RootRanges: [0xcd5c40..0xcd5ca2]
-      Variables:
-        - Name: x
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcd5920..0xcd5939
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd59b1..0xcd59bc
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd5af2..0xcd5afd
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd5b76..0xcd5b87
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd5b87..0xcd5c25
-              Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xcd5c40..0xcd5c5a
+            - Range: 0xcdc060..0xcdc061
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 159
-      Name: main.testInlinedBBB
-      OutOfLinePCRanges: []
+      Name: main.testInlinedPrint
+      OutOfLinePCRanges: [0xcd5a40..0xcd5aa2]
       InlinePCRanges:
-        - Ranges: [0xcd5bc6..0xcd5bfe]
-          RootRanges: [0xcd5b60..0xcd5c25]
-      Variables: []
-    - ID: 160
-      Name: main.testInlinedBCA
-      OutOfLinePCRanges: []
-      InlinePCRanges:
-        - Ranges: [0xcd5cd3..0xcd5d11]
-          RootRanges: [0xcd5cc0..0xcd5dce]
-      Variables: []
-    - ID: 161
-      Name: main.testInlinedBCB
-      OutOfLinePCRanges: []
-      InlinePCRanges:
-        - Ranges: [0xcd5d86..0xcd5dbe]
-          RootRanges: [0xcd5cc0..0xcd5dce]
-      Variables: []
-    - ID: 162
-      Name: main.testInlinedSq
-      OutOfLinePCRanges: []
-      InlinePCRanges:
-        - Ranges: [0xcd5de1..0xcd5de5]
-          RootRanges: [0xcd5de0..0xcd5de6]
+        - Ranges: [0xcd5ad1..0xcd5b0d]
+          RootRanges: [0xcd5ac0..0xcd5b31]
+        - Ranges: [0xcd5c12..0xcd5c4e]
+          RootRanges: [0xcd5be0..0xcd5c68]
+        - Ranges: [0xcd5c9c..0xcd5cd8]
+          RootRanges: [0xcd5c80..0xcd5d45]
+        - Ranges: [0xcd5d6f..0xcd5dab]
+          RootRanges: [0xcd5d60..0xcd5dc2]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd5de0..0xcd5de5
+            - Range: 0xcd5a40..0xcd5a59
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcd5ad1..0xcd5adc
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcd5c12..0xcd5c1d
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcd5c96..0xcd5ca7
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcd5ca7..0xcd5d45
+              Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
+            - Range: 0xcd5d60..0xcd5d7a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
+    - ID: 160
+      Name: main.testInlinedBBB
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0xcd5ce6..0xcd5d1e]
+          RootRanges: [0xcd5c80..0xcd5d45]
+      Variables: []
+    - ID: 161
+      Name: main.testInlinedBCA
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0xcd5df3..0xcd5e31]
+          RootRanges: [0xcd5de0..0xcd5eee]
+      Variables: []
+    - ID: 162
+      Name: main.testInlinedBCB
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0xcd5ea6..0xcd5ede]
+          RootRanges: [0xcd5de0..0xcd5eee]
+      Variables: []
     - ID: 163
+      Name: main.testInlinedSq
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0xcd5f01..0xcd5f05]
+          RootRanges: [0xcd5f00..0xcd5f06]
+      Variables:
+        - Name: x
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcd5f00..0xcd5f05
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+    - ID: 164
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcd5e25..0xcd5e3d]
-          RootRanges: [0xcd5e00..0xcd5e43]
-        - Ranges: [0xcd5ec5..0xcd5ee3]
-          RootRanges: [0xcd5e60..0xcd5fe5]
+        - Ranges: [0xcd5f45..0xcd5f5d]
+          RootRanges: [0xcd5f20..0xcd5f63]
+        - Ranges: [0xcd5fe5..0xcd6003]
+          RootRanges: [0xcd5f80..0xcd6105]
       Variables:
         - Name: a
           Type: 159 ArrayType [5]int
           Locations:
-            - Range: 0xcd5e0d..0xcd5e43
+            - Range: 0xcd5f2d..0xcd5f63
               Pieces: [{Size: 40, Op: {CfaOffset: -56}}]
-            - Range: 0xcd5eac..0xcd5fe5
+            - Range: 0xcd5fcc..0xcd6105
               Pieces: [{Size: 40, Op: {CfaOffset: -128}}]
           Role: Parameter
-    - ID: 164
+    - ID: 165
       Name: main.firstBehavior.DoSomething
-      OutOfLinePCRanges: [0xcd6000..0xcd6071]
+      OutOfLinePCRanges: [0xcd6120..0xcd6191]
       InlinePCRanges:
-        - Ranges: [0xcdd483..0xcdd4c5]
-          RootRanges: [0xcdd460..0xcdd4f6]
+        - Ranges: [0xcdd5a3..0xcdd5e5]
+          RootRanges: [0xcdd580..0xcdd616]
       Variables:
         - Name: b
           Type: 319 StructureType main.firstBehavior
           Locations:
-            - Range: 0xcd6000..0xcd6028
+            - Range: 0xcd6120..0xcd6148
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd6028..0xcd602d
+            - Range: 0xcd6148..0xcd614d
               Pieces:
                 - Size: 8
                   Op: null
@@ -8018,23 +8104,23 @@ Subprograms:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcd6000..0xcd6050
+            - Range: 0xcd6120..0xcd6170
               Pieces: []
-            - Range: 0xcd6050..0xcd6051
+            - Range: 0xcd6170..0xcd6171
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd6051..0xcd6071
+            - Range: 0xcd6171..0xcd6191
               Pieces: []
           Role: Return
-    - ID: 165
+    - ID: 166
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcd67ab..0xcd67b2]
-          RootRanges: [0xcd6660..0xcd67ee]
+        - Ranges: [0xcd68cb..0xcd68d2]
+          RootRanges: [0xcd6780..0xcd690e]
         - Ranges: [0xcd3c41..0xcd3c49]
           RootRanges: [0xcd3c40..0xcd3c4a]
       Variables: []
@@ -11296,10 +11382,10 @@ Types:
       GoKind: 22
       Pointee: 811 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1551
+      ID: 1552
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
     - __kind: EventRootType
-      ID: 1549
+      ID: 1550
       Name: Probe[main.firstBehavior.DoSomething]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11311,11 +11397,11 @@ Types:
             Type: 319 StructureType main.firstBehavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 0, name: b}
+                  Variable: {subprogram: 165, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1550
+      ID: 1551
       Name: Probe[main.firstBehavior.DoSomething]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11327,14 +11413,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 1, name: ~r0}
+                  Variable: {subprogram: 165, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1507
+      ID: 1508
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1508
+      ID: 1509
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11346,11 +11432,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: ~r0}
+                  Variable: {subprogram: 143, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1374
+      ID: 1375
       Name: Probe[main.testAnyPtr]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11362,7 +11448,7 @@ Types:
             Type: 161 PointerType *interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: a}
+                  Variable: {subprogram: 59, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -11372,11 +11458,11 @@ Types:
             Type: 161 PointerType *interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: a}
+                  Variable: {subprogram: 59, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1375
+      ID: 1376
       Name: Probe[main.testAnyPtr]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11388,11 +11474,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 1, name: ~r0}
+                  Variable: {subprogram: 59, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1371
+      ID: 1372
       Name: Probe[main.testAny]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11404,7 +11490,7 @@ Types:
             Type: 155 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: a}
+                  Variable: {subprogram: 57, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -11414,11 +11500,11 @@ Types:
             Type: 155 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: a}
+                  Variable: {subprogram: 57, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1372
+      ID: 1373
       Name: Probe[main.testAny]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11430,11 +11516,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 1, name: ~r0}
+                  Variable: {subprogram: 57, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1478
+      ID: 1479
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11446,7 +11532,7 @@ Types:
             Type: 249 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: arg}
+                  Variable: {subprogram: 123, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
         - Name: arg
@@ -11456,11 +11542,11 @@ Types:
             Type: 249 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: arg}
+                  Variable: {subprogram: 123, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1479
+      ID: 1480
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11472,7 +11558,7 @@ Types:
             Type: 249 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 1, name: ~r0}
+                  Variable: {subprogram: 123, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -11554,7 +11640,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1383
+      ID: 1384
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11566,7 +11652,7 @@ Types:
             Type: 189 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: m}
+                  Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
         - Name: m
@@ -11576,7 +11662,7 @@ Types:
             Type: 189 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: m}
+                  Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -11632,7 +11718,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1405
+      ID: 1406
       Name: Probe[main.testAtomicAdd]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11644,7 +11730,7 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: x}
+                  Variable: {subprogram: 87, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -11654,11 +11740,11 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: x}
+                  Variable: {subprogram: 87, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1406
+      ID: 1407
       Name: Probe[main.testAtomicAdd]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11670,7 +11756,7 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 1, name: ~r0}
+                  Variable: {subprogram: 87, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -11755,7 +11841,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1407
+      ID: 1408
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11767,7 +11853,7 @@ Types:
             Type: 241 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: c}
+                  Variable: {subprogram: 88, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
         - Name: c
@@ -11777,11 +11863,11 @@ Types:
             Type: 241 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: c}
+                  Variable: {subprogram: 88, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1401
+      ID: 1402
       Name: Probe[main.testCombinedByte]
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -11793,7 +11879,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: w}
+                  Variable: {subprogram: 84, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: w
@@ -11803,7 +11889,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: w}
+                  Variable: {subprogram: 84, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: x
@@ -11813,7 +11899,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 1, name: x}
+                  Variable: {subprogram: 84, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: x
@@ -11823,7 +11909,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 1, name: x}
+                  Variable: {subprogram: 84, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: y
@@ -11833,7 +11919,7 @@ Types:
             Type: 17 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 2, name: y}
+                  Variable: {subprogram: 84, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
         - Name: y
@@ -11843,11 +11929,11 @@ Types:
             Type: 17 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 2, name: y}
+                  Variable: {subprogram: 84, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1402
+      ID: 1403
       Name: Probe[main.testCombinedString]
       ByteSize: 18
       PresenceBitsetSize: 1
@@ -11859,7 +11945,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 1, name: x}
+                  Variable: {subprogram: 85, index: 1, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: w_val
@@ -11869,11 +11955,11 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: w}
+                  Variable: {subprogram: 85, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1403
+      ID: 1404
       Name: Probe[main.testCombinedString]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -11885,7 +11971,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 1, name: x}
+                  Variable: {subprogram: 85, index: 1, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x_val
@@ -11895,7 +11981,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 1, name: x}
+                  Variable: {subprogram: 85, index: 1, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: w_val
@@ -11905,11 +11991,11 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: w}
+                  Variable: {subprogram: 85, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1415
+      ID: 1416
       Name: Probe[main.testCycle]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11921,7 +12007,7 @@ Types:
             Type: 246 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: t}
+                  Variable: {subprogram: 96, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
         - Name: t
@@ -11931,11 +12017,11 @@ Types:
             Type: 246 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: t}
+                  Variable: {subprogram: 96, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1346
+      ID: 1347
       Name: Probe[main.testDeepMap1]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11947,7 +12033,7 @@ Types:
             Type: 141 StructureType main.deepMap1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: a}
+                  Variable: {subprogram: 43, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -11957,11 +12043,11 @@ Types:
             Type: 141 StructureType main.deepMap1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: a}
+                  Variable: {subprogram: 43, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1347
+      ID: 1348
       Name: Probe[main.testDeepMap7]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11973,7 +12059,7 @@ Types:
             Type: 147 PointerType *main.deepMap7
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 0, name: a}
+                  Variable: {subprogram: 44, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -11983,11 +12069,11 @@ Types:
             Type: 147 PointerType *main.deepMap7
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 0, name: a}
+                  Variable: {subprogram: 44, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1342
+      ID: 1343
       Name: Probe[main.testDeepPtr1]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11999,7 +12085,7 @@ Types:
             Type: 130 StructureType main.deepPtr1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: a}
+                  Variable: {subprogram: 39, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12009,11 +12095,11 @@ Types:
             Type: 130 StructureType main.deepPtr1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: a}
+                  Variable: {subprogram: 39, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1343
+      ID: 1344
       Name: Probe[main.testDeepPtr7]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12025,7 +12111,7 @@ Types:
             Type: 133 PointerType *main.deepPtr7
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: a}
+                  Variable: {subprogram: 40, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12035,11 +12121,11 @@ Types:
             Type: 133 PointerType *main.deepPtr7
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: a}
+                  Variable: {subprogram: 40, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1344
+      ID: 1345
       Name: Probe[main.testDeepSlice1]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12051,7 +12137,7 @@ Types:
             Type: 135 StructureType main.deepSlice1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: a}
+                  Variable: {subprogram: 41, index: 0, name: a}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -12061,11 +12147,11 @@ Types:
             Type: 135 StructureType main.deepSlice1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: a}
+                  Variable: {subprogram: 41, index: 0, name: a}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1345
+      ID: 1346
       Name: Probe[main.testDeepSlice7]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12077,7 +12163,7 @@ Types:
             Type: 139 PointerType *main.deepSlice7
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: a}
+                  Variable: {subprogram: 42, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12087,11 +12173,11 @@ Types:
             Type: 139 PointerType *main.deepSlice7
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: a}
+                  Variable: {subprogram: 42, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1498
+      ID: 1499
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -12103,7 +12189,7 @@ Types:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: xs}
+                  Variable: {subprogram: 135, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -12113,7 +12199,7 @@ Types:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: xs}
+                  Variable: {subprogram: 135, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -12123,7 +12209,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 1, name: a}
+                  Variable: {subprogram: 135, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12133,11 +12219,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 1, name: a}
+                  Variable: {subprogram: 135, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1495
+      ID: 1496
       Name: Probe[main.testEmptySlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12149,7 +12235,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: u}
+                  Variable: {subprogram: 132, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -12159,11 +12245,11 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: u}
+                  Variable: {subprogram: 132, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1521
+      ID: 1522
       Name: Probe[main.testEmptyString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12175,7 +12261,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: x}
+                  Variable: {subprogram: 151, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -12185,11 +12271,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: x}
+                  Variable: {subprogram: 151, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1535
+      ID: 1536
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12201,7 +12287,7 @@ Types:
             Type: 318 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: e}
+                  Variable: {subprogram: 158, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -12211,11 +12297,11 @@ Types:
             Type: 318 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: e}
+                  Variable: {subprogram: 158, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1534
+      ID: 1535
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -12227,7 +12313,7 @@ Types:
             Type: 317 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: e}
+                  Variable: {subprogram: 157, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
         - Name: e
@@ -12237,11 +12323,67 @@ Types:
             Type: 317 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: e}
+                  Variable: {subprogram: 157, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1373
+      ID: 1342
+      Name: Probe[main.testErrorAtLine]Line
+      ByteSize: 57
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 2, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 2, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: err
+          Offset: 25
+          Kind: local
+          Expression:
+            Type: 13 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 3, name: err}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: err
+          Offset: 41
+          Kind: template_segment
+          Expression:
+            Type: 13 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 3, name: err}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1374
       Name: Probe[main.testError]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12253,7 +12395,7 @@ Types:
             Type: 13 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: e}
+                  Variable: {subprogram: 58, index: 0, name: e}
                   Offset: 0
                   ByteSize: 16
         - Name: e
@@ -12263,11 +12405,11 @@ Types:
             Type: 13 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: e}
+                  Variable: {subprogram: 58, index: 0, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1355
+      ID: 1356
       Name: Probe[main.testEsotericHeap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12279,7 +12421,7 @@ Types:
             Type: 157 PointerType *main.esotericHeap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 48, index: 0, name: e}
+                  Variable: {subprogram: 49, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -12289,14 +12431,14 @@ Types:
             Type: 157 PointerType *main.esotericHeap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 48, index: 0, name: e}
+                  Variable: {subprogram: 49, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1356
+      ID: 1357
       Name: Probe[main.testEsotericHeap]Return
     - __kind: EventRootType
-      ID: 1353
+      ID: 1354
       Name: Probe[main.testEsotericStack]
       ByteSize: 129
       PresenceBitsetSize: 1
@@ -12308,7 +12450,7 @@ Types:
             Type: 153 StructureType main.esotericStack
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 0, name: e}
+                  Variable: {subprogram: 48, index: 0, name: e}
                   Offset: 0
                   ByteSize: 64
         - Name: e
@@ -12318,14 +12460,14 @@ Types:
             Type: 153 StructureType main.esotericStack
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 0, name: e}
+                  Variable: {subprogram: 48, index: 0, name: e}
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1354
+      ID: 1355
       Name: Probe[main.testEsotericStack]Return
     - __kind: EventRootType
-      ID: 1367
+      ID: 1368
       Name: Probe[main.testFramelessArray]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12337,7 +12479,7 @@ Types:
             Type: 159 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: a}
+                  Variable: {subprogram: 55, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: a
@@ -12347,11 +12489,11 @@ Types:
             Type: 159 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: a}
+                  Variable: {subprogram: 55, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1369
+      ID: 1370
       Name: Probe[main.testFramelessArray]Line
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -12363,7 +12505,7 @@ Types:
             Type: 159 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: a}
+                  Variable: {subprogram: 55, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: a
@@ -12373,7 +12515,7 @@ Types:
             Type: 159 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: a}
+                  Variable: {subprogram: 55, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: ~r0
@@ -12383,11 +12525,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 1, name: ~r0}
+                  Variable: {subprogram: 55, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1368
+      ID: 1369
       Name: Probe[main.testFramelessArray]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12399,11 +12541,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 1, name: ~r0}
+                  Variable: {subprogram: 55, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1365
+      ID: 1366
       Name: Probe[main.testFrameless]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12415,7 +12557,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: x}
+                  Variable: {subprogram: 54, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12425,11 +12567,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: x}
+                  Variable: {subprogram: 54, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1366
+      ID: 1367
       Name: Probe[main.testFrameless]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12441,11 +12583,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 1, name: ~r0}
+                  Variable: {subprogram: 54, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1357
+      ID: 1358
       Name: Probe[main.testInlinedBA]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12457,7 +12599,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: x}
+                  Variable: {subprogram: 50, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12467,14 +12609,14 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: x}
+                  Variable: {subprogram: 50, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1358
+      ID: 1359
       Name: Probe[main.testInlinedBA]Return
     - __kind: EventRootType
-      ID: 1361
+      ID: 1362
       Name: Probe[main.testInlinedBBA]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12486,7 +12628,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: x}
+                  Variable: {subprogram: 52, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12496,17 +12638,17 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: x}
+                  Variable: {subprogram: 52, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1362
+      ID: 1363
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1541
+      ID: 1542
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 1359
+      ID: 1360
       Name: Probe[main.testInlinedBB]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12518,7 +12660,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: x}
+                  Variable: {subprogram: 51, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12528,7 +12670,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: x}
+                  Variable: {subprogram: 51, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: y
@@ -12538,7 +12680,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 1, name: y}
+                  Variable: {subprogram: 51, index: 1, name: y}
                   Offset: 0
                   ByteSize: 8
         - Name: y
@@ -12548,32 +12690,32 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 1, name: y}
+                  Variable: {subprogram: 51, index: 1, name: y}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1360
+      ID: 1361
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1542
+      ID: 1543
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1543
+      ID: 1544
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1544
+      ID: 1545
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1545
+      ID: 1546
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
-      ID: 1363
+      ID: 1364
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 1364
+      ID: 1365
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1538
+      ID: 1539
       Name: Probe[main.testInlinedPrint]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12585,7 +12727,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12595,11 +12737,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1536
+      ID: 1537
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12611,11 +12753,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1537
+      ID: 1538
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12627,7 +12769,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x_val
@@ -12637,11 +12779,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1540
+      ID: 1541
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12653,7 +12795,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12663,14 +12805,14 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1539
+      ID: 1540
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1546
+      ID: 1547
       Name: Probe[main.testInlinedSq]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12682,7 +12824,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12692,11 +12834,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1547
+      ID: 1548
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12708,7 +12850,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12718,11 +12860,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1548
+      ID: 1549
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12734,7 +12876,7 @@ Types:
             Type: 159 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: a}
+                  Variable: {subprogram: 164, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: a
@@ -12744,7 +12886,7 @@ Types:
             Type: 159 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: a}
+                  Variable: {subprogram: 164, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
@@ -12878,7 +13020,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1370
+      ID: 1371
       Name: Probe[main.testInterface]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12890,7 +13032,7 @@ Types:
             Type: 160 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: b}
+                  Variable: {subprogram: 56, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -12900,11 +13042,11 @@ Types:
             Type: 160 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: b}
+                  Variable: {subprogram: 56, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1476
+      ID: 1477
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 161
       PresenceBitsetSize: 1
@@ -12916,7 +13058,7 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: arg}
+                  Variable: {subprogram: 122, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
         - Name: arg
@@ -12926,11 +13068,11 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: arg}
+                  Variable: {subprogram: 122, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1477
+      ID: 1478
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12942,11 +13084,11 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 1, name: ~r0}
+                  Variable: {subprogram: 122, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1409
+      ID: 1410
       Name: Probe[main.testLinkedList]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12958,7 +13100,7 @@ Types:
             Type: 244 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: a}
+                  Variable: {subprogram: 90, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -12968,38 +13110,12 @@ Types:
             Type: 244 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: a}
+                  Variable: {subprogram: 90, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1350
-      Name: Probe[main.testLongFunctionWithChangingState]Line
-    - __kind: EventRootType
       ID: 1351
       Name: Probe[main.testLongFunctionWithChangingState]Line
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: aPerArch
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 1, name: aPerArch}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: b
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 2, name: b}
-                  Offset: 0
-                  ByteSize: 8
     - __kind: EventRootType
       ID: 1352
       Name: Probe[main.testLongFunctionWithChangingState]Line
@@ -13013,7 +13129,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 1, name: aPerArch}
+                  Variable: {subprogram: 47, index: 1, name: aPerArch}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13023,11 +13139,37 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 2, name: b}
+                  Variable: {subprogram: 47, index: 2, name: b}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1482
+      ID: 1353
+      Name: Probe[main.testLongFunctionWithChangingState]Line
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: aPerArch
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 47, index: 1, name: aPerArch}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 47, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1483
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 147
       PresenceBitsetSize: 3
@@ -13039,7 +13181,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: a}
+                  Variable: {subprogram: 125, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -13049,7 +13191,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: a}
+                  Variable: {subprogram: 125, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13059,7 +13201,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 1, name: b}
+                  Variable: {subprogram: 125, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13069,7 +13211,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 1, name: b}
+                  Variable: {subprogram: 125, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13079,7 +13221,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 2, name: c}
+                  Variable: {subprogram: 125, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13089,7 +13231,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 2, name: c}
+                  Variable: {subprogram: 125, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13099,7 +13241,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 3, name: d}
+                  Variable: {subprogram: 125, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13109,7 +13251,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 3, name: d}
+                  Variable: {subprogram: 125, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13119,7 +13261,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 4, name: e}
+                  Variable: {subprogram: 125, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13129,7 +13271,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 4, name: e}
+                  Variable: {subprogram: 125, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13139,7 +13281,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 5, name: f}
+                  Variable: {subprogram: 125, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13149,7 +13291,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 5, name: f}
+                  Variable: {subprogram: 125, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13159,7 +13301,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 6, name: g}
+                  Variable: {subprogram: 125, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13169,7 +13311,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 6, name: g}
+                  Variable: {subprogram: 125, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13179,7 +13321,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 7, name: h}
+                  Variable: {subprogram: 125, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13189,7 +13331,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 7, name: h}
+                  Variable: {subprogram: 125, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13199,7 +13341,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 8, name: i}
+                  Variable: {subprogram: 125, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13209,11 +13351,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 8, name: i}
+                  Variable: {subprogram: 125, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1483
+      ID: 1484
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13225,11 +13367,11 @@ Types:
             Type: 111 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 9, name: ~r0}
+                  Variable: {subprogram: 125, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1381
+      ID: 1382
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13241,7 +13383,7 @@ Types:
             Type: 184 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13251,11 +13393,11 @@ Types:
             Type: 184 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1388
+      ID: 1389
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13267,7 +13409,7 @@ Types:
             Type: 191 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: m}
+                  Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13277,11 +13419,11 @@ Types:
             Type: 191 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: m}
+                  Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1400
+      ID: 1401
       Name: Probe[main.testMapEmptyKeyAndValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13293,7 +13435,7 @@ Types:
             Type: 236 GoMapType map[struct {}]struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: m}
+                  Variable: {subprogram: 83, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13303,11 +13445,11 @@ Types:
             Type: 236 GoMapType map[struct {}]struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: m}
+                  Variable: {subprogram: 83, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1398
+      ID: 1399
       Name: Probe[main.testMapEmptyKey]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13319,7 +13461,7 @@ Types:
             Type: 226 GoMapType map[struct {}]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: m}
+                  Variable: {subprogram: 81, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13329,11 +13471,11 @@ Types:
             Type: 226 GoMapType map[struct {}]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: m}
+                  Variable: {subprogram: 81, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1399
+      ID: 1400
       Name: Probe[main.testMapEmptyValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13345,7 +13487,7 @@ Types:
             Type: 231 GoMapType map[int]struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: m}
+                  Variable: {subprogram: 82, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13355,11 +13497,11 @@ Types:
             Type: 231 GoMapType map[int]struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: m}
+                  Variable: {subprogram: 82, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1385
+      ID: 1386
       Name: Probe[main.testMapIntToInt]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13371,7 +13513,7 @@ Types:
             Type: 164 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
+                  Variable: {subprogram: 69, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13381,11 +13523,11 @@ Types:
             Type: 164 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
+                  Variable: {subprogram: 69, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1397
+      ID: 1398
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13397,7 +13539,7 @@ Types:
             Type: 221 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: m}
+                  Variable: {subprogram: 80, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13407,11 +13549,11 @@ Types:
             Type: 221 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: m}
+                  Variable: {subprogram: 80, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1396
+      ID: 1397
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13423,7 +13565,7 @@ Types:
             Type: 216 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: m}
+                  Variable: {subprogram: 79, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13433,33 +13575,7 @@ Types:
             Type: 216 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1386
-      Name: Probe[main.testMapMassive]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: redactMyEntries
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 191 GoMapType map[string][]main.structWithMap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: redactMyEntries
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 191 GoMapType map[string][]main.structWithMap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 79, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -13475,7 +13591,7 @@ Types:
             Type: 191 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 70, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
         - Name: redactMyEntries
@@ -13485,11 +13601,37 @@ Types:
             Type: 191 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 70, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1395
+      ID: 1388
+      Name: Probe[main.testMapMassive]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: redactMyEntries
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 191 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 70, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: redactMyEntries
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 191 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 70, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1396
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13501,7 +13643,7 @@ Types:
             Type: 211 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: m}
+                  Variable: {subprogram: 78, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13511,11 +13653,11 @@ Types:
             Type: 211 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: m}
+                  Variable: {subprogram: 78, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1394
+      ID: 1395
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13527,6 +13669,136 @@ Types:
             Type: 206 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
+                  Variable: {subprogram: 77, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 206 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 77, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1380
+      Name: Probe[main.testMapStringToInt]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 174 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 63, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 174 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 63, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1381
+      Name: Probe[main.testMapStringToSlice]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 179 GoMapType map[string][]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 64, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 179 GoMapType map[string][]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 64, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1379
+      Name: Probe[main.testMapStringToStruct]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 169 GoMapType map[string]main.nestedStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 62, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 169 GoMapType map[string]main.nestedStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 62, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1390
+      Name: Probe[main.testMapWithLinkedList]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 196 GoMapType map[bool]main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 72, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 196 GoMapType map[bool]main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 72, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1394
+      Name: Probe[main.testMapWithSmallKeyAndValueMassive]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 206 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
                   Variable: {subprogram: 76, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
@@ -13541,112 +13813,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1379
-      Name: Probe[main.testMapStringToInt]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 174 GoMapType map[string]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: m
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 174 GoMapType map[string]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1380
-      Name: Probe[main.testMapStringToSlice]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 179 GoMapType map[string][]string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: m
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 179 GoMapType map[string][]string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1378
-      Name: Probe[main.testMapStringToStruct]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 169 GoMapType map[string]main.nestedStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: m
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 169 GoMapType map[string]main.nestedStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1389
-      Name: Probe[main.testMapWithLinkedList]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 196 GoMapType map[bool]main.node
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: m
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 196 GoMapType map[bool]main.node
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
       ID: 1393
-      Name: Probe[main.testMapWithSmallKeyAndValueMassive]
+      Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
@@ -13672,32 +13840,6 @@ Types:
                   ByteSize: 8
     - __kind: EventRootType
       ID: 1392
-      Name: Probe[main.testMapWithSmallKeyAndValue]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 206 GoMapType map[uint8]uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: m
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 206 GoMapType map[uint8]uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1391
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13709,7 +13851,7 @@ Types:
             Type: 201 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 74, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
         - Name: redactMyEntries
@@ -13719,11 +13861,11 @@ Types:
             Type: 201 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 74, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1390
+      ID: 1391
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13735,7 +13877,7 @@ Types:
             Type: 201 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: m}
+                  Variable: {subprogram: 73, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13745,35 +13887,9 @@ Types:
             Type: 201 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: m}
+                  Variable: {subprogram: 73, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
-    - __kind: EventRootType
-      ID: 1518
-      Name: Probe[main.testMassiveString]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: x
-          Offset: 17
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
     - __kind: EventRootType
       ID: 1519
       Name: Probe[main.testMassiveString]
@@ -13787,7 +13903,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
+                  Variable: {subprogram: 149, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -13797,11 +13913,37 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
+                  Variable: {subprogram: 149, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1484
+      ID: 1520
+      Name: Probe[main.testMassiveString]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 149, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 149, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1485
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 163
       PresenceBitsetSize: 3
@@ -13813,7 +13955,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: a}
+                  Variable: {subprogram: 126, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -13823,7 +13965,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: a}
+                  Variable: {subprogram: 126, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13833,7 +13975,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: b}
+                  Variable: {subprogram: 126, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13843,7 +13985,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: b}
+                  Variable: {subprogram: 126, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13853,7 +13995,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: c}
+                  Variable: {subprogram: 126, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13863,7 +14005,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: c}
+                  Variable: {subprogram: 126, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13873,7 +14015,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 3, name: d}
+                  Variable: {subprogram: 126, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13883,7 +14025,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 3, name: d}
+                  Variable: {subprogram: 126, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13893,7 +14035,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 4, name: e}
+                  Variable: {subprogram: 126, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13903,7 +14045,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 4, name: e}
+                  Variable: {subprogram: 126, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13913,7 +14055,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 5, name: f}
+                  Variable: {subprogram: 126, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13923,7 +14065,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 5, name: f}
+                  Variable: {subprogram: 126, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13933,7 +14075,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 6, name: g}
+                  Variable: {subprogram: 126, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13943,7 +14085,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 6, name: g}
+                  Variable: {subprogram: 126, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13953,7 +14095,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 7, name: h}
+                  Variable: {subprogram: 126, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13963,7 +14105,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 7, name: h}
+                  Variable: {subprogram: 126, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: s
@@ -13973,7 +14115,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 8, name: s}
+                  Variable: {subprogram: 126, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
         - Name: s
@@ -13983,11 +14125,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 8, name: s}
+                  Variable: {subprogram: 126, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1485
+      ID: 1486
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13999,11 +14141,11 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 9, name: ~r0}
+                  Variable: {subprogram: 126, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1488
+      ID: 1489
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -14015,7 +14157,7 @@ Types:
             Type: 111 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -14025,7 +14167,7 @@ Types:
             Type: 111 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -14035,7 +14177,7 @@ Types:
             Type: 249 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: b}
+                  Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
         - Name: b
@@ -14045,11 +14187,11 @@ Types:
             Type: 249 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: b}
+                  Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1489
+      ID: 1490
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -14061,7 +14203,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 2, name: ~r0}
+                  Variable: {subprogram: 128, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -14071,11 +14213,11 @@ Types:
             Type: 111 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 3, name: ~r1}
+                  Variable: {subprogram: 128, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1480
+      ID: 1481
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 321
       PresenceBitsetSize: 1
@@ -14087,7 +14229,7 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: s1}
+                  Variable: {subprogram: 124, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
         - Name: s1
@@ -14097,7 +14239,7 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: s1}
+                  Variable: {subprogram: 124, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
         - Name: s2
@@ -14107,7 +14249,7 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: s2}
+                  Variable: {subprogram: 124, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
         - Name: s2
@@ -14117,11 +14259,11 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: s2}
+                  Variable: {subprogram: 124, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1481
+      ID: 1482
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -14133,11 +14275,11 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 2, name: ~r0}
+                  Variable: {subprogram: 124, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1434
+      ID: 1435
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14149,7 +14291,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14159,11 +14301,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1436
+      ID: 1437
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14175,7 +14317,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14185,7 +14327,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14195,7 +14337,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14205,11 +14347,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1438
+      ID: 1439
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14221,11 +14363,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1440
+      ID: 1441
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14237,11 +14379,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1442
+      ID: 1443
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14253,11 +14395,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1435
+      ID: 1436
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14269,7 +14411,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14279,11 +14421,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1437
+      ID: 1438
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -14295,7 +14437,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14305,7 +14447,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14315,7 +14457,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14325,7 +14467,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14335,7 +14477,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14345,11 +14487,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1439
+      ID: 1440
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14361,7 +14503,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14371,11 +14513,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1441
+      ID: 1442
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14387,7 +14529,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14397,11 +14539,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1443
+      ID: 1444
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14413,7 +14555,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14423,11 +14565,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1404
+      ID: 1405
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 62
       PresenceBitsetSize: 2
@@ -14439,7 +14581,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: a}
+                  Variable: {subprogram: 86, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: a
@@ -14449,7 +14591,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: a}
+                  Variable: {subprogram: 86, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -14459,7 +14601,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 1, name: b}
+                  Variable: {subprogram: 86, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -14469,7 +14611,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 1, name: b}
+                  Variable: {subprogram: 86, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: c
@@ -14479,7 +14621,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 2, name: c}
+                  Variable: {subprogram: 86, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: c
@@ -14489,7 +14631,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 2, name: c}
+                  Variable: {subprogram: 86, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: d
@@ -14499,7 +14641,7 @@ Types:
             Type: 16 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 3, name: d}
+                  Variable: {subprogram: 86, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -14509,7 +14651,7 @@ Types:
             Type: 16 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 3, name: d}
+                  Variable: {subprogram: 86, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -14519,7 +14661,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 4, name: e}
+                  Variable: {subprogram: 86, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
         - Name: e
@@ -14529,11 +14671,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 4, name: e}
+                  Variable: {subprogram: 86, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1430
+      ID: 1431
       Name: Probe[main.testNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14545,7 +14687,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14555,37 +14697,37 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1433
+      Name: Probe[main.testNamedReturn]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
       ID: 1432
-      Name: Probe[main.testNamedReturn]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1431
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14597,11 +14739,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1433
+      ID: 1434
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14613,7 +14755,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14623,11 +14765,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1530
+      ID: 1531
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14639,7 +14781,7 @@ Types:
             Type: 315 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: x}
+                  Variable: {subprogram: 156, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -14649,11 +14791,11 @@ Types:
             Type: 315 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: x}
+                  Variable: {subprogram: 156, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1531
+      ID: 1532
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14665,7 +14807,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: x}
+                  Variable: {subprogram: 156, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -14675,10 +14817,10 @@ Types:
                   Bias: 8
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1532
+      ID: 1533
       Name: Probe[main.testNestedPointer]
     - __kind: EventRootType
-      ID: 1533
+      ID: 1534
       Name: Probe[main.testNestedPointer]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -14690,7 +14832,7 @@ Types:
             Type: 121 StructureType main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: x}
+                  Variable: {subprogram: 156, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -14700,7 +14842,7 @@ Types:
                   Bias: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1414
+      ID: 1415
       Name: Probe[main.testNilPointer]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14712,7 +14854,7 @@ Types:
             Type: 11 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: z}
+                  Variable: {subprogram: 95, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: z
@@ -14722,7 +14864,7 @@ Types:
             Type: 11 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: z}
+                  Variable: {subprogram: 95, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14732,7 +14874,7 @@ Types:
             Type: 16 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 1, name: a}
+                  Variable: {subprogram: 95, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14742,11 +14884,11 @@ Types:
             Type: 16 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 1, name: a}
+                  Variable: {subprogram: 95, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1499
+      ID: 1500
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -14758,7 +14900,7 @@ Types:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: xs}
+                  Variable: {subprogram: 136, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -14768,7 +14910,7 @@ Types:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: xs}
+                  Variable: {subprogram: 136, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -14778,7 +14920,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 1, name: a}
+                  Variable: {subprogram: 136, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14788,11 +14930,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 1, name: a}
+                  Variable: {subprogram: 136, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1501
+      ID: 1502
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 67
       PresenceBitsetSize: 1
@@ -14804,7 +14946,7 @@ Types:
             Type: 15 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: a}
+                  Variable: {subprogram: 138, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: a
@@ -14814,7 +14956,7 @@ Types:
             Type: 15 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: a}
+                  Variable: {subprogram: 138, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
@@ -14824,7 +14966,7 @@ Types:
             Type: 262 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 1, name: s}
+                  Variable: {subprogram: 138, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: s
@@ -14834,7 +14976,7 @@ Types:
             Type: 262 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 1, name: s}
+                  Variable: {subprogram: 138, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -14844,7 +14986,7 @@ Types:
             Type: 16 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 2, name: x}
+                  Variable: {subprogram: 138, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -14854,11 +14996,11 @@ Types:
             Type: 16 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 2, name: x}
+                  Variable: {subprogram: 138, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1502
+      ID: 1503
       Name: Probe[main.testNilSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -14870,7 +15012,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -14880,11 +15022,11 @@ Types:
             Type: 263 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1517
+      ID: 1518
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14896,7 +15038,7 @@ Types:
             Type: 268 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14906,11 +15048,11 @@ Types:
             Type: 268 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1410
+      ID: 1411
       Name: Probe[main.testPointerLoop]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14922,7 +15064,7 @@ Types:
             Type: 245 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: a}
+                  Variable: {subprogram: 91, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14932,11 +15074,11 @@ Types:
             Type: 245 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: a}
+                  Variable: {subprogram: 91, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1384
+      ID: 1385
       Name: Probe[main.testPointerToMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14948,7 +15090,7 @@ Types:
             Type: 190 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: m}
+                  Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -14958,11 +15100,11 @@ Types:
             Type: 190 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: m}
+                  Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1408
+      ID: 1409
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14974,7 +15116,7 @@ Types:
             Type: 242 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: a}
+                  Variable: {subprogram: 89, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14984,11 +15126,11 @@ Types:
             Type: 242 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: a}
+                  Variable: {subprogram: 89, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1424
+      ID: 1425
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 35
       PresenceBitsetSize: 1
@@ -15000,7 +15142,7 @@ Types:
             Type: 155 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: v}
+                  Variable: {subprogram: 101, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: v
@@ -15010,7 +15152,7 @@ Types:
             Type: 155 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: v}
+                  Variable: {subprogram: 101, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: failed
@@ -15020,7 +15162,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 1, name: failed}
+                  Variable: {subprogram: 101, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
         - Name: failed
@@ -15030,11 +15172,11 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 1, name: failed}
+                  Variable: {subprogram: 101, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1425
+      ID: 1426
       Name: Probe[main.testReturnsAnyAndError]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15046,7 +15188,7 @@ Types:
             Type: 155 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 2, name: ~r0}
+                  Variable: {subprogram: 101, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
         - Name: ~r1
@@ -15056,11 +15198,11 @@ Types:
             Type: 13 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 3, name: ~r1}
+                  Variable: {subprogram: 101, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1426
+      ID: 1427
       Name: Probe[main.testReturnsAny]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15072,7 +15214,7 @@ Types:
             Type: 155 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: v}
+                  Variable: {subprogram: 102, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: v
@@ -15082,11 +15224,11 @@ Types:
             Type: 155 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: v}
+                  Variable: {subprogram: 102, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1427
+      ID: 1428
       Name: Probe[main.testReturnsAny]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15098,14 +15240,14 @@ Types:
             Type: 155 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 1, name: ~r0}
+                  Variable: {subprogram: 102, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1456
+      ID: 1457
       Name: Probe[main.testReturnsArrayOne]
     - __kind: EventRootType
-      ID: 1457
+      ID: 1458
       Name: Probe[main.testReturnsArrayOne]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15117,14 +15259,14 @@ Types:
             Type: 250 ArrayType [1]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 0, name: ~r0}
+                  Variable: {subprogram: 112, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1458
+      ID: 1459
       Name: Probe[main.testReturnsArrayZero]
     - __kind: EventRootType
-      ID: 1459
+      ID: 1460
       Name: Probe[main.testReturnsArrayZero]Return
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -15136,14 +15278,14 @@ Types:
             Type: 251 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 0, name: ~r0}
+                  Variable: {subprogram: 113, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1454
+      ID: 1455
       Name: Probe[main.testReturnsArray]
     - __kind: EventRootType
-      ID: 1455
+      ID: 1456
       Name: Probe[main.testReturnsArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15155,14 +15297,14 @@ Types:
             Type: 249 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 0, name: ~r0}
+                  Variable: {subprogram: 111, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1462
+      ID: 1463
       Name: Probe[main.testReturnsBacktrackInt]
     - __kind: EventRootType
-      ID: 1463
+      ID: 1464
       Name: Probe[main.testReturnsBacktrackInt]Return
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -15174,7 +15316,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: ~r0}
+                  Variable: {subprogram: 115, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15184,7 +15326,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 1, name: ~r1}
+                  Variable: {subprogram: 115, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15194,7 +15336,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 2, name: ~r2}
+                  Variable: {subprogram: 115, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -15204,7 +15346,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 3, name: ~r3}
+                  Variable: {subprogram: 115, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15214,7 +15356,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 4, name: ~r4}
+                  Variable: {subprogram: 115, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r5
@@ -15224,7 +15366,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 5, name: ~r5}
+                  Variable: {subprogram: 115, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r6
@@ -15234,7 +15376,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 6, name: ~r6}
+                  Variable: {subprogram: 115, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r7
@@ -15244,7 +15386,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 7, name: ~r7}
+                  Variable: {subprogram: 115, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r8
@@ -15254,14 +15396,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 8, name: ~r8}
+                  Variable: {subprogram: 115, index: 8, name: ~r8}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1474
+      ID: 1475
       Name: Probe[main.testReturnsBoolAndUintptr]
     - __kind: EventRootType
-      ID: 1475
+      ID: 1476
       Name: Probe[main.testReturnsBoolAndUintptr]Return
       ByteSize: 10
       PresenceBitsetSize: 1
@@ -15273,7 +15415,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: ~r0}
+                  Variable: {subprogram: 121, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r1
@@ -15283,14 +15425,14 @@ Types:
             Type: 1 BaseType uintptr
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 1, name: ~r1}
+                  Variable: {subprogram: 121, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1450
+      ID: 1451
       Name: Probe[main.testReturnsComplex]
     - __kind: EventRootType
-      ID: 1451
+      ID: 1452
       Name: Probe[main.testReturnsComplex]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15302,7 +15444,7 @@ Types:
             Type: 94 BaseType complex64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: ~r0}
+                  Variable: {subprogram: 109, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15312,11 +15454,11 @@ Types:
             Type: 95 BaseType complex128
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: ~r1}
+                  Variable: {subprogram: 109, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1422
+      ID: 1423
       Name: Probe[main.testReturnsError]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -15328,7 +15470,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: failed}
+                  Variable: {subprogram: 100, index: 0, name: failed}
                   Offset: 0
                   ByteSize: 1
         - Name: failed
@@ -15338,11 +15480,11 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: failed}
+                  Variable: {subprogram: 100, index: 0, name: failed}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1423
+      ID: 1424
       Name: Probe[main.testReturnsError]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15354,11 +15496,11 @@ Types:
             Type: 13 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 1, name: ~r0}
+                  Variable: {subprogram: 100, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1420
+      ID: 1421
       Name: Probe[main.testReturnsIntAndFloat]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15370,7 +15512,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: i}
+                  Variable: {subprogram: 99, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -15380,11 +15522,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: i}
+                  Variable: {subprogram: 99, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1421
+      ID: 1422
       Name: Probe[main.testReturnsIntAndFloat]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15396,7 +15538,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 1, name: ~r0}
+                  Variable: {subprogram: 99, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15406,11 +15548,11 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 2, name: ~r1}
+                  Variable: {subprogram: 99, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1418
+      ID: 1419
       Name: Probe[main.testReturnsIntPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15422,7 +15564,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: i}
+                  Variable: {subprogram: 98, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -15432,11 +15574,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: i}
+                  Variable: {subprogram: 98, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1419
+      ID: 1420
       Name: Probe[main.testReturnsIntPointer]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15448,11 +15590,11 @@ Types:
             Type: 98 PointerType *int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 1, name: ~r0}
+                  Variable: {subprogram: 98, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1416
+      ID: 1417
       Name: Probe[main.testReturnsInt]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15464,7 +15606,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: i}
+                  Variable: {subprogram: 97, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -15474,11 +15616,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: i}
+                  Variable: {subprogram: 97, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1417
+      ID: 1418
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15490,11 +15632,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 1, name: ~r0}
+                  Variable: {subprogram: 97, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1428
+      ID: 1429
       Name: Probe[main.testReturnsInterface]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15506,7 +15648,7 @@ Types:
             Type: 155 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: v}
+                  Variable: {subprogram: 103, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: v
@@ -15516,11 +15658,11 @@ Types:
             Type: 155 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: v}
+                  Variable: {subprogram: 103, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1429
+      ID: 1430
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15532,14 +15674,14 @@ Types:
             Type: 160 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: ~r0}
+                  Variable: {subprogram: 103, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1452
+      ID: 1453
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1453
+      ID: 1454
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -15551,14 +15693,14 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: ~r0}
+                  Variable: {subprogram: 110, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1448
+      ID: 1449
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1449
+      ID: 1450
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 139
       PresenceBitsetSize: 3
@@ -15570,7 +15712,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: ~r0}
+                  Variable: {subprogram: 108, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15580,7 +15722,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 1, name: ~r1}
+                  Variable: {subprogram: 108, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15590,7 +15732,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 2, name: ~r2}
+                  Variable: {subprogram: 108, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -15600,7 +15742,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 3, name: ~r3}
+                  Variable: {subprogram: 108, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15610,7 +15752,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 4, name: ~r4}
+                  Variable: {subprogram: 108, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r5
@@ -15620,7 +15762,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 5, name: ~r5}
+                  Variable: {subprogram: 108, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r6
@@ -15630,7 +15772,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 6, name: ~r6}
+                  Variable: {subprogram: 108, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r7
@@ -15640,7 +15782,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 7, name: ~r7}
+                  Variable: {subprogram: 108, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r8
@@ -15650,7 +15792,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 8, name: ~r8}
+                  Variable: {subprogram: 108, index: 8, name: ~r8}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r9
@@ -15660,7 +15802,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 9, name: ~r9}
+                  Variable: {subprogram: 108, index: 9, name: ~r9}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r10
@@ -15670,7 +15812,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 10, name: ~r10}
+                  Variable: {subprogram: 108, index: 10, name: ~r10}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r11
@@ -15680,7 +15822,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 11, name: ~r11}
+                  Variable: {subprogram: 108, index: 11, name: ~r11}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r12
@@ -15690,7 +15832,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 12, name: ~r12}
+                  Variable: {subprogram: 108, index: 12, name: ~r12}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r13
@@ -15700,7 +15842,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 13, name: ~r13}
+                  Variable: {subprogram: 108, index: 13, name: ~r13}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r14
@@ -15710,7 +15852,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 14, name: ~r14}
+                  Variable: {subprogram: 108, index: 14, name: ~r14}
                   Offset: 0
                   ByteSize: 8
         - Name: onlyOnAmd64_16
@@ -15720,7 +15862,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 15, name: onlyOnAmd64_16}
+                  Variable: {subprogram: 108, index: 15, name: onlyOnAmd64_16}
                   Offset: 0
                   ByteSize: 8
         - Name: bothArmAndAmd64
@@ -15730,14 +15872,14 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 16, name: bothArmAndAmd64}
+                  Variable: {subprogram: 108, index: 16, name: bothArmAndAmd64}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1460
+      ID: 1461
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1461
+      ID: 1462
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15749,14 +15891,14 @@ Types:
             Type: 252 StructureType main.mixedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: ~r0}
+                  Variable: {subprogram: 114, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1466
+      ID: 1467
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1467
+      ID: 1468
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -15768,7 +15910,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 0, name: ~r0}
+                  Variable: {subprogram: 117, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15778,7 +15920,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 1, name: ~r1}
+                  Variable: {subprogram: 117, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15788,7 +15930,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 2, name: ~r2}
+                  Variable: {subprogram: 117, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -15798,7 +15940,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 3, name: ~r3}
+                  Variable: {subprogram: 117, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15808,14 +15950,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 4, name: ~r4}
+                  Variable: {subprogram: 117, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1472
+      ID: 1473
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1473
+      ID: 1474
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -15827,7 +15969,7 @@ Types:
             Type: 17 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: ~r0}
+                  Variable: {subprogram: 120, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r1
@@ -15837,14 +15979,14 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 1, name: ~r1}
+                  Variable: {subprogram: 120, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1470
+      ID: 1471
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1471
+      ID: 1472
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15856,14 +15998,14 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 0, name: ~r0}
+                  Variable: {subprogram: 119, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1446
+      ID: 1447
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1447
+      ID: 1448
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -15875,7 +16017,7 @@ Types:
             Type: 15 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 0, name: ~r0}
+                  Variable: {subprogram: 107, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r1
@@ -15885,7 +16027,7 @@ Types:
             Type: 102 BaseType int16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 1, name: ~r1}
+                  Variable: {subprogram: 107, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 2
         - Name: ~r2
@@ -15895,7 +16037,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 2, name: ~r2}
+                  Variable: {subprogram: 107, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r3
@@ -15905,7 +16047,7 @@ Types:
             Type: 12 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 3, name: ~r3}
+                  Variable: {subprogram: 107, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15915,7 +16057,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 4, name: ~r4}
+                  Variable: {subprogram: 107, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r5
@@ -15925,7 +16067,7 @@ Types:
             Type: 6 BaseType uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 5, name: ~r5}
+                  Variable: {subprogram: 107, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 2
         - Name: ~r6
@@ -15935,7 +16077,7 @@ Types:
             Type: 2 BaseType uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 6, name: ~r6}
+                  Variable: {subprogram: 107, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r7
@@ -15945,14 +16087,14 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 7, name: ~r7}
+                  Variable: {subprogram: 107, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1468
+      ID: 1469
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1469
+      ID: 1470
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15964,14 +16106,14 @@ Types:
             Type: 254 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 0, name: ~r0}
+                  Variable: {subprogram: 118, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1464
+      ID: 1465
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1465
+      ID: 1466
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -15983,7 +16125,7 @@ Types:
             Type: 253 StructureType main.wideStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 0, name: ~r0}
+                  Variable: {subprogram: 116, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 88
     - __kind: EventRootType
@@ -16293,7 +16435,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1509
+      ID: 1510
       Name: Probe[main.testSingleString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16305,7 +16447,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: x}
+                  Variable: {subprogram: 144, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -16315,7 +16457,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: x}
+                  Variable: {subprogram: 144, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -16449,7 +16591,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1505
+      ID: 1506
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16461,7 +16603,7 @@ Types:
             Type: 264 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: xs}
+                  Variable: {subprogram: 141, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -16471,11 +16613,11 @@ Types:
             Type: 264 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: xs}
+                  Variable: {subprogram: 141, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1496
+      ID: 1497
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16487,7 +16629,7 @@ Types:
             Type: 256 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: u}
+                  Variable: {subprogram: 133, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -16497,11 +16639,11 @@ Types:
             Type: 256 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: u}
+                  Variable: {subprogram: 133, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1382
+      ID: 1383
       Name: Probe[main.testSmallMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16513,7 +16655,7 @@ Types:
             Type: 174 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -16523,11 +16665,11 @@ Types:
             Type: 174 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1444
+      ID: 1445
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16539,7 +16681,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: i}
+                  Variable: {subprogram: 106, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -16549,11 +16691,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: i}
+                  Variable: {subprogram: 106, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1445
+      ID: 1446
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16565,7 +16707,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 1, name: ~r0}
+                  Variable: {subprogram: 106, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -16575,7 +16717,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 2, name: result2}
+                  Variable: {subprogram: 106, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -16585,11 +16727,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 3, name: ~r2}
+                  Variable: {subprogram: 106, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1486
+      ID: 1487
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -16601,7 +16743,7 @@ Types:
             Type: 159 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: arg}
+                  Variable: {subprogram: 127, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
         - Name: arg
@@ -16611,11 +16753,11 @@ Types:
             Type: 159 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: arg}
+                  Variable: {subprogram: 127, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1487
+      ID: 1488
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16627,7 +16769,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: ~r0}
+                  Variable: {subprogram: 127, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -16637,7 +16779,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: ~r1}
+                  Variable: {subprogram: 127, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -16647,7 +16789,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 3, name: ~r2}
+                  Variable: {subprogram: 127, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -16677,7 +16819,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1413
+      ID: 1414
       Name: Probe[main.testStringPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16689,7 +16831,7 @@ Types:
             Type: 93 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: z}
+                  Variable: {subprogram: 94, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: z
@@ -16699,11 +16841,11 @@ Types:
             Type: 93 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: z}
+                  Variable: {subprogram: 94, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1500
+      ID: 1501
       Name: Probe[main.testStringSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16715,7 +16857,7 @@ Types:
             Type: 261 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: s}
+                  Variable: {subprogram: 137, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: s
@@ -16725,11 +16867,11 @@ Types:
             Type: 261 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: s}
+                  Variable: {subprogram: 137, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1348
+      ID: 1349
       Name: Probe[main.testStringType1]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16741,7 +16883,7 @@ Types:
             Type: 149 PointerType *main.stringType1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 0, name: a}
+                  Variable: {subprogram: 45, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -16751,11 +16893,11 @@ Types:
             Type: 149 PointerType *main.stringType1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 0, name: a}
+                  Variable: {subprogram: 45, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1349
+      ID: 1350
       Name: Probe[main.testStringType2]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16767,7 +16909,7 @@ Types:
             Type: 151 PointerType **main.stringType2
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: a}
+                  Variable: {subprogram: 46, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -16777,11 +16919,11 @@ Types:
             Type: 151 PointerType **main.stringType2
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: a}
+                  Variable: {subprogram: 46, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1497
+      ID: 1498
       Name: Probe[main.testStructSlice]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -16793,7 +16935,7 @@ Types:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Variable: {subprogram: 134, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -16803,7 +16945,7 @@ Types:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Variable: {subprogram: 134, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -16813,7 +16955,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 1, name: a}
+                  Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -16823,11 +16965,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 1, name: a}
+                  Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1376
+      ID: 1377
       Name: Probe[main.testStructWithAny]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16839,7 +16981,7 @@ Types:
             Type: 162 StructureType main.structWithAny
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: s}
+                  Variable: {subprogram: 60, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
         - Name: s
@@ -16849,11 +16991,11 @@ Types:
             Type: 162 StructureType main.structWithAny
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: s}
+                  Variable: {subprogram: 60, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1490
+      ID: 1491
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16865,7 +17007,7 @@ Types:
             Type: 254 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: arg}
+                  Variable: {subprogram: 129, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
         - Name: arg
@@ -16875,11 +17017,11 @@ Types:
             Type: 254 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: arg}
+                  Variable: {subprogram: 129, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1491
+      ID: 1492
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16891,7 +17033,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 1, name: ~r0}
+                  Variable: {subprogram: 129, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -16901,11 +17043,11 @@ Types:
             Type: 254 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 2, name: ~r1}
+                  Variable: {subprogram: 129, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1524
+      ID: 1525
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16917,7 +17059,7 @@ Types:
             Type: 283 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: a}
+                  Variable: {subprogram: 154, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
         - Name: a
@@ -16927,14 +17069,14 @@ Types:
             Type: 283 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: a}
+                  Variable: {subprogram: 154, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1525
+      ID: 1526
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1523
+      ID: 1524
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 289
       PresenceBitsetSize: 1
@@ -16946,7 +17088,7 @@ Types:
             Type: 270 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: a}
+                  Variable: {subprogram: 153, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
         - Name: a
@@ -16956,11 +17098,11 @@ Types:
             Type: 270 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: a}
+                  Variable: {subprogram: 153, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
     - __kind: EventRootType
-      ID: 1377
+      ID: 1378
       Name: Probe[main.testStructWithMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16972,7 +17114,7 @@ Types:
             Type: 163 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: s}
+                  Variable: {subprogram: 61, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
         - Name: s
@@ -16982,11 +17124,11 @@ Types:
             Type: 163 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: s}
+                  Variable: {subprogram: 61, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1526
+      ID: 1527
       Name: Probe[main.testStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16998,11 +17140,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 8
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1528
+      ID: 1529
       Name: Probe[main.testStruct]
       ByteSize: 113
       PresenceBitsetSize: 1
@@ -17014,7 +17156,7 @@ Types:
             Type: 314 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
         - Name: x
@@ -17024,17 +17166,17 @@ Types:
             Type: 314 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1527
+      ID: 1528
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1529
+      ID: 1530
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1506
+      ID: 1507
       Name: Probe[main.testSubslices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -17046,7 +17188,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: as}
+                  Variable: {subprogram: 142, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
         - Name: as
@@ -17056,7 +17198,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: as}
+                  Variable: {subprogram: 142, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
         - Name: bs
@@ -17066,7 +17208,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 1, name: bs}
+                  Variable: {subprogram: 142, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
         - Name: bs
@@ -17076,7 +17218,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 1, name: bs}
+                  Variable: {subprogram: 142, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
         - Name: cs
@@ -17086,7 +17228,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 2, name: cs}
+                  Variable: {subprogram: 142, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
         - Name: cs
@@ -17096,11 +17238,11 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 2, name: cs}
+                  Variable: {subprogram: 142, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1522
+      ID: 1523
       Name: Probe[main.testSubstrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17112,7 +17254,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: a}
+                  Variable: {subprogram: 152, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -17122,7 +17264,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: a}
+                  Variable: {subprogram: 152, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -17132,7 +17274,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 1, name: b}
+                  Variable: {subprogram: 152, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -17142,7 +17284,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 1, name: b}
+                  Variable: {subprogram: 152, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: c
@@ -17152,7 +17294,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 2, name: c}
+                  Variable: {subprogram: 152, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
         - Name: c
@@ -17162,11 +17304,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 2, name: c}
+                  Variable: {subprogram: 152, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1515
+      ID: 1516
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17178,7 +17320,7 @@ Types:
             Type: 267 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -17188,11 +17330,11 @@ Types:
             Type: 267 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1516
+      ID: 1517
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17204,7 +17346,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -17217,7 +17359,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -17230,14 +17372,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
                   Bias: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1511
+      ID: 1512
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17249,7 +17391,7 @@ Types:
             Type: 266 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
         - Name: a
@@ -17259,11 +17401,11 @@ Types:
             Type: 266 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1513
+      ID: 1514
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17275,7 +17417,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: t.b
@@ -17285,7 +17427,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 16
                   ByteSize: 16
         - Name: t.c
@@ -17295,17 +17437,17 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1512
+      ID: 1513
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1514
+      ID: 1515
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1510
+      ID: 1511
       Name: Probe[main.testThreeStrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17317,7 +17459,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: x}
+                  Variable: {subprogram: 145, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -17327,7 +17469,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: x}
+                  Variable: {subprogram: 145, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -17337,7 +17479,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 1, name: y}
+                  Variable: {subprogram: 145, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -17347,7 +17489,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 1, name: y}
+                  Variable: {subprogram: 145, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -17357,7 +17499,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 2, name: z}
+                  Variable: {subprogram: 145, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -17367,7 +17509,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 2, name: z}
+                  Variable: {subprogram: 145, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -17527,7 +17669,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1412
+      ID: 1413
       Name: Probe[main.testUintPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17539,7 +17681,7 @@ Types:
             Type: 105 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: x}
+                  Variable: {subprogram: 93, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -17549,11 +17691,11 @@ Types:
             Type: 105 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: x}
+                  Variable: {subprogram: 93, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1494
+      ID: 1495
       Name: Probe[main.testUintSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17565,7 +17707,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: u}
+                  Variable: {subprogram: 131, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -17575,11 +17717,11 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: u}
+                  Variable: {subprogram: 131, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1520
+      ID: 1521
       Name: Probe[main.testUnitializedString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17591,7 +17733,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: x}
+                  Variable: {subprogram: 150, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -17601,11 +17743,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: x}
+                  Variable: {subprogram: 150, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1411
+      ID: 1412
       Name: Probe[main.testUnsafePointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17617,7 +17759,7 @@ Types:
             Type: 14 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: x}
+                  Variable: {subprogram: 92, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -17627,7 +17769,7 @@ Types:
             Type: 14 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: x}
+                  Variable: {subprogram: 92, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -17657,32 +17799,6 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1503
-      Name: Probe[main.testVeryLargeSlice]
-      ByteSize: 49
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: xs
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 255 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: xs
-          Offset: 25
-          Kind: template_segment
-          Expression:
-            Type: 255 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
       ID: 1504
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
@@ -17695,7 +17811,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: xs}
+                  Variable: {subprogram: 140, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -17705,11 +17821,37 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: xs}
+                  Variable: {subprogram: 140, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1492
+      ID: 1505
+      Name: Probe[main.testVeryLargeSlice]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 255 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 140, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: xs
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 255 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 140, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1493
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17721,7 +17863,7 @@ Types:
             Type: 251 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: a}
+                  Variable: {subprogram: 130, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
         - Name: a
@@ -17731,7 +17873,7 @@ Types:
             Type: 251 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: a}
+                  Variable: {subprogram: 130, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
         - Name: b
@@ -17741,7 +17883,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 1, name: b}
+                  Variable: {subprogram: 130, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -17751,11 +17893,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 1, name: b}
+                  Variable: {subprogram: 130, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1493
+      ID: 1494
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -17767,7 +17909,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 2, name: ~r0}
+                  Variable: {subprogram: 130, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -17777,7 +17919,7 @@ Types:
             Type: 251 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 3, name: ~r1}
+                  Variable: {subprogram: 130, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 0
     - __kind: ArrayType
@@ -26285,7 +26427,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 990432
       GoKind: 5
-MaxTypeID: 1551
+MaxTypeID: 1552
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x18013a0", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -8,15 +8,15 @@ Probes:
       template: stackC
       segments: [stackC]
       captureSnapshot: true
-      subprogram: {subprogram: 142}
+      subprogram: {subprogram: 143}
       events:
         - Kind: Entry
-          Type: 1526 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0xce018a", Frameless: false}]
+          Type: 1527 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0xce02aa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1527 EventRootType Probe[main.stackC]Return
-          InjectionPoints: [{PC: "0xce01c5", Frameless: false}]
+          Type: 1528 EventRootType Probe[main.stackC]Return
+          InjectionPoints: [{PC: "0xce02e5", Frameless: false}]
           Condition: null
       probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -27,15 +27,15 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 56}
+      subprogram: {subprogram: 57}
       events:
         - Kind: Entry
-          Type: 1390 EventRootType Probe[main.testAny]
-          InjectionPoints: [{PC: "0xcda9ea", Frameless: false}]
+          Type: 1391 EventRootType Probe[main.testAny]
+          InjectionPoints: [{PC: "0xcdab0a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1391 EventRootType Probe[main.testAny]Return
-          InjectionPoints: [{PC: "0xcdaa25", Frameless: false}]
+          Type: 1392 EventRootType Probe[main.testAny]Return
+          InjectionPoints: [{PC: "0xcdab45", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -52,15 +52,15 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 58}
+      subprogram: {subprogram: 59}
       events:
         - Kind: Entry
-          Type: 1393 EventRootType Probe[main.testAnyPtr]
-          InjectionPoints: [{PC: "0xcdaa8a", Frameless: false}]
+          Type: 1394 EventRootType Probe[main.testAnyPtr]
+          InjectionPoints: [{PC: "0xcdabaa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1394 EventRootType Probe[main.testAnyPtr]Return
-          InjectionPoints: [{PC: "0xcdaabd", Frameless: false}]
+          Type: 1395 EventRootType Probe[main.testAnyPtr]Return
+          InjectionPoints: [{PC: "0xcdabdd", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -76,15 +76,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 122}
+      subprogram: {subprogram: 123}
       events:
         - Kind: Entry
-          Type: 1497 EventRootType Probe[main.testArrayArgAndReturn]
-          InjectionPoints: [{PC: "0xcdebee", Frameless: false}]
+          Type: 1498 EventRootType Probe[main.testArrayArgAndReturn]
+          InjectionPoints: [{PC: "0xcded0e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1498 EventRootType Probe[main.testArrayArgAndReturn]Return
-          InjectionPoints: [{PC: "0xcdeca2", Frameless: false}]
+          Type: 1499 EventRootType Probe[main.testArrayArgAndReturn]Return
+          InjectionPoints: [{PC: "0xcdedc2", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -164,11 +164,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 66}
+      subprogram: {subprogram: 67}
       events:
         - Kind: Entry
-          Type: 1402 EventRootType Probe[main.testArrayOfMaps]
-          InjectionPoints: [{PC: "0xcdb1a0", Frameless: true}]
+          Type: 1403 EventRootType Probe[main.testArrayOfMaps]
+          InjectionPoints: [{PC: "0xcdb2c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -226,15 +226,15 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 87}
       events:
         - Kind: Entry
-          Type: 1424 EventRootType Probe[main.testAtomicAdd]
-          InjectionPoints: [{PC: "0xcdd080", Frameless: true}]
+          Type: 1425 EventRootType Probe[main.testAtomicAdd]
+          InjectionPoints: [{PC: "0xcdd1a0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1425 EventRootType Probe[main.testAtomicAdd]Return
-          InjectionPoints: [{PC: "0xcdd092", Frameless: true}]
+          Type: 1426 EventRootType Probe[main.testAtomicAdd]Return
+          InjectionPoints: [{PC: "0xcdd1b2", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -323,15 +323,15 @@ Probes:
           expr:
             dsl: x.aString
             json: {getmember: [{ref: x}, aString]}
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1545 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0xce05c0", Frameless: true}]
+          Type: 1546 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0xce06e0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1546 EventRootType Probe[main.testStruct]Return
-          InjectionPoints: [{PC: "0xce05e2", Frameless: true}]
+          Type: 1547 EventRootType Probe[main.testStruct]Return
+          InjectionPoints: [{PC: "0xce0702", Frameless: true}]
           Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -345,20 +345,20 @@ Probes:
       segments: []
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1555 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1556 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
-            - PC: "0xcda20e"
+            - PC: "0xcda32e"
               Frameless: false
-            - PC: "0xcda291"
+            - PC: "0xcda3b1"
               Frameless: false
-            - PC: "0xcda3d2"
+            - PC: "0xcda4f2"
               Frameless: false
-            - PC: "0xcda45c"
+            - PC: "0xcda57c"
               Frameless: false
-            - PC: "0xcda52f"
+            - PC: "0xcda64f"
               Frameless: false
           Condition: null
     - id: testCaptureExprLineWithTemplate
@@ -373,20 +373,20 @@ Probes:
       segments: [x=, {json: {ref: x}, dsl: x}]
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1556 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1557 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
-            - PC: "0xcda20e"
+            - PC: "0xcda32e"
               Frameless: false
-            - PC: "0xcda291"
+            - PC: "0xcda3b1"
               Frameless: false
-            - PC: "0xcda3d2"
+            - PC: "0xcda4f2"
               Frameless: false
-            - PC: "0xcda45c"
+            - PC: "0xcda57c"
               Frameless: false
-            - PC: "0xcda52f"
+            - PC: "0xcda64f"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -409,11 +409,11 @@ Probes:
           expr: {dsl: x, json: {ref: x}}
         - name: w_val
           expr: {dsl: w, json: {ref: w}}
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 85}
       events:
         - Kind: Entry
-          Type: 1421 EventRootType Probe[main.testCombinedString]
-          InjectionPoints: [{PC: "0xcdcce0", Frameless: true}]
+          Type: 1422 EventRootType Probe[main.testCombinedString]
+          InjectionPoints: [{PC: "0xcdce00", Frameless: true}]
           Condition: null
     - id: testCaptureExprWithTemplate
       version: 0
@@ -427,11 +427,11 @@ Probes:
           expr: {dsl: x, json: {ref: x}}
         - name: w_val
           expr: {dsl: w, json: {ref: w}}
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 85}
       events:
         - Kind: Entry
-          Type: 1422 EventRootType Probe[main.testCombinedString]
-          InjectionPoints: [{PC: "0xcdcce0", Frameless: true}]
+          Type: 1423 EventRootType Probe[main.testCombinedString]
+          InjectionPoints: [{PC: "0xcdce00", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: x={x}
@@ -449,11 +449,11 @@ Probes:
       template: '{c}'
       segments: [{json: {ref: c}, dsl: c}]
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 88}
       events:
         - Kind: Entry
-          Type: 1426 EventRootType Probe[main.testChannel]
-          InjectionPoints: [{PC: "0xcdd0a0", Frameless: true}]
+          Type: 1427 EventRootType Probe[main.testChannel]
+          InjectionPoints: [{PC: "0xcdd1c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{c}'
@@ -478,11 +478,11 @@ Probes:
         - json: {ref: y}
           dsl: y
       captureSnapshot: true
-      subprogram: {subprogram: 83}
+      subprogram: {subprogram: 84}
       events:
         - Kind: Entry
-          Type: 1420 EventRootType Probe[main.testCombinedByte]
-          InjectionPoints: [{PC: "0xcdcca0", Frameless: true}]
+          Type: 1421 EventRootType Probe[main.testCombinedByte]
+          InjectionPoints: [{PC: "0xcdcdc0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{w}, {x}, {y}'
@@ -509,11 +509,11 @@ Probes:
       template: '{t}'
       segments: [{json: {ref: t}, dsl: t}]
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 96}
       events:
         - Kind: Entry
-          Type: 1434 EventRootType Probe[main.testCycle]
-          InjectionPoints: [{PC: "0xcdd460", Frameless: true}]
+          Type: 1435 EventRootType Probe[main.testCycle]
+          InjectionPoints: [{PC: "0xcdd580", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{t}'
@@ -530,11 +530,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 42}
+      subprogram: {subprogram: 43}
       events:
         - Kind: Entry
-          Type: 1365 EventRootType Probe[main.testDeepMap1]
-          InjectionPoints: [{PC: "0xcd9740", Frameless: true}]
+          Type: 1366 EventRootType Probe[main.testDeepMap1]
+          InjectionPoints: [{PC: "0xcd9840", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -551,11 +551,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 43}
+      subprogram: {subprogram: 44}
       events:
         - Kind: Entry
-          Type: 1366 EventRootType Probe[main.testDeepMap7]
-          InjectionPoints: [{PC: "0xcd9760", Frameless: true}]
+          Type: 1367 EventRootType Probe[main.testDeepMap7]
+          InjectionPoints: [{PC: "0xcd9860", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -572,11 +572,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 38}
+      subprogram: {subprogram: 39}
       events:
         - Kind: Entry
-          Type: 1361 EventRootType Probe[main.testDeepPtr1]
-          InjectionPoints: [{PC: "0xcd9420", Frameless: true}]
+          Type: 1362 EventRootType Probe[main.testDeepPtr1]
+          InjectionPoints: [{PC: "0xcd9520", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -593,11 +593,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 39}
+      subprogram: {subprogram: 40}
       events:
         - Kind: Entry
-          Type: 1362 EventRootType Probe[main.testDeepPtr7]
-          InjectionPoints: [{PC: "0xcd9440", Frameless: true}]
+          Type: 1363 EventRootType Probe[main.testDeepPtr7]
+          InjectionPoints: [{PC: "0xcd9540", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -614,11 +614,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 40}
+      subprogram: {subprogram: 41}
       events:
         - Kind: Entry
-          Type: 1363 EventRootType Probe[main.testDeepSlice1]
-          InjectionPoints: [{PC: "0xcd95c0", Frameless: true}]
+          Type: 1364 EventRootType Probe[main.testDeepSlice1]
+          InjectionPoints: [{PC: "0xcd96c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -635,11 +635,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 41}
+      subprogram: {subprogram: 42}
       events:
         - Kind: Entry
-          Type: 1364 EventRootType Probe[main.testDeepSlice7]
-          InjectionPoints: [{PC: "0xcd95e0", Frameless: true}]
+          Type: 1365 EventRootType Probe[main.testDeepSlice7]
+          InjectionPoints: [{PC: "0xcd96e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -656,11 +656,11 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 131}
+      subprogram: {subprogram: 132}
       events:
         - Kind: Entry
-          Type: 1514 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0xcdfca0", Frameless: true}]
+          Type: 1515 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0xcdfdc0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{u}'
@@ -682,11 +682,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 134}
+      subprogram: {subprogram: 135}
       events:
         - Kind: Entry
-          Type: 1517 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0xcdfd00", Frameless: true}]
+          Type: 1518 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0xcdfe20", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}, {a}'
@@ -709,11 +709,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 150}
+      subprogram: {subprogram: 151}
       events:
         - Kind: Entry
-          Type: 1540 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0xce02c0", Frameless: true}]
+          Type: 1541 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0xce03e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -730,11 +730,11 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 156}
+      subprogram: {subprogram: 157}
       events:
         - Kind: Entry
-          Type: 1553 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0xce0740", Frameless: true}]
+          Type: 1554 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0xce0860", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -750,11 +750,11 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 157}
+      subprogram: {subprogram: 158}
       events:
         - Kind: Entry
-          Type: 1554 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0xce0760", Frameless: true}]
+          Type: 1555 EventRootType Probe[main.testEmptyStructPointer]
+          InjectionPoints: [{PC: "0xce0880", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -771,11 +771,11 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 57}
+      subprogram: {subprogram: 58}
       events:
         - Kind: Entry
-          Type: 1392 EventRootType Probe[main.testError]
-          InjectionPoints: [{PC: "0xcdaa60", Frameless: true}]
+          Type: 1393 EventRootType Probe[main.testError]
+          InjectionPoints: [{PC: "0xcdab80", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -784,6 +784,45 @@ Probes:
               DSL: e
               EventKind: Entry
               EventExpressionIndex: 1
+    - id: testErrorAtLine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testErrorAtLine
+        sourceFile: complex.go
+        lines: ["108"]
+      tags:
+        - config_diff:arch=amd64,toolchain=go1.26rc1
+        - skip_integration:arch=arm64,toolchain=go1.25.0
+      sampling: {snapshotsPerSecond: 100}
+      template: x={x}, err={err}
+      segments:
+        - x=
+        - json: {ref: x}
+          dsl: x
+        - ', err='
+        - json: {ref: err}
+          dsl: err
+      captureSnapshot: true
+      subprogram: {subprogram: 38}
+      events:
+        - Kind: Line
+          Type: 1361 EventRootType Probe[main.testErrorAtLine]Line
+          InjectionPoints: [{PC: "0xcd93fb", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: x={x}, err={err}
+        Segments:
+            - x=
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Line
+              EventExpressionIndex: 2
+            - ', err='
+            - JSON: {Ref: err}
+              DSL: err
+              EventKind: Line
+              EventExpressionIndex: 4
     - id: testEsotericHeap
       version: 0
       type: LOG_PROBE
@@ -792,15 +831,15 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 48}
+      subprogram: {subprogram: 49}
       events:
         - Kind: Entry
-          Type: 1374 EventRootType Probe[main.testEsotericHeap]
-          InjectionPoints: [{PC: "0xcd9f6a", Frameless: false}]
+          Type: 1375 EventRootType Probe[main.testEsotericHeap]
+          InjectionPoints: [{PC: "0xcda08a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1375 EventRootType Probe[main.testEsotericHeap]Return
-          InjectionPoints: [{PC: "0xcd9fac", Frameless: false}]
+          Type: 1376 EventRootType Probe[main.testEsotericHeap]Return
+          InjectionPoints: [{PC: "0xcda0cc", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -817,15 +856,15 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 47}
+      subprogram: {subprogram: 48}
       events:
         - Kind: Entry
-          Type: 1372 EventRootType Probe[main.testEsotericStack]
-          InjectionPoints: [{PC: "0xcd9e4e", Frameless: false}]
+          Type: 1373 EventRootType Probe[main.testEsotericStack]
+          InjectionPoints: [{PC: "0xcd9f6e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1373 EventRootType Probe[main.testEsotericStack]Return
-          InjectionPoints: [{PC: "0xcd9edb", Frameless: false}]
+          Type: 1374 EventRootType Probe[main.testEsotericStack]Return
+          InjectionPoints: [{PC: "0xcd9ffb", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -842,15 +881,15 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 53}
+      subprogram: {subprogram: 54}
       events:
         - Kind: Entry
-          Type: 1384 EventRootType Probe[main.testFrameless]
-          InjectionPoints: [{PC: "0xcda6c0", Frameless: true}]
+          Type: 1385 EventRootType Probe[main.testFrameless]
+          InjectionPoints: [{PC: "0xcda7e0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1385 EventRootType Probe[main.testFrameless]Return
-          InjectionPoints: [{PC: "0xcda6c5", Frameless: true}]
+          Type: 1386 EventRootType Probe[main.testFrameless]Return
+          InjectionPoints: [{PC: "0xcda7e5", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -867,15 +906,15 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 54}
+      subprogram: {subprogram: 55}
       events:
         - Kind: Entry
-          Type: 1386 EventRootType Probe[main.testFramelessArray]
-          InjectionPoints: [{PC: "0xcda6e4", Frameless: false}]
+          Type: 1387 EventRootType Probe[main.testFramelessArray]
+          InjectionPoints: [{PC: "0xcda804", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1387 EventRootType Probe[main.testFramelessArray]Return
-          InjectionPoints: [{PC: "0xcda71d", Frameless: false}]
+          Type: 1388 EventRootType Probe[main.testFramelessArray]Return
+          InjectionPoints: [{PC: "0xcda83d", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -895,11 +934,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 54}
+      subprogram: {subprogram: 55}
       events:
         - Kind: Line
-          Type: 1388 EventRootType Probe[main.testFramelessArray]Line
-          InjectionPoints: [{PC: "0xcda6e8", Frameless: false}]
+          Type: 1389 EventRootType Probe[main.testFramelessArray]Line
+          InjectionPoints: [{PC: "0xcda808", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -916,15 +955,15 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 49}
+      subprogram: {subprogram: 50}
       events:
         - Kind: Entry
-          Type: 1376 EventRootType Probe[main.testInlinedBA]
-          InjectionPoints: [{PC: "0xcda3aa", Frameless: false}]
+          Type: 1377 EventRootType Probe[main.testInlinedBA]
+          InjectionPoints: [{PC: "0xcda4ca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1377 EventRootType Probe[main.testInlinedBA]Return
-          InjectionPoints: [{PC: "0xcda40e", Frameless: false}]
+          Type: 1378 EventRootType Probe[main.testInlinedBA]Return
+          InjectionPoints: [{PC: "0xcda52e", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -946,15 +985,15 @@ Probes:
         - json: {ref: y}
           dsl: y
       captureSnapshot: true
-      subprogram: {subprogram: 50}
+      subprogram: {subprogram: 51}
       events:
         - Kind: Entry
-          Type: 1378 EventRootType Probe[main.testInlinedBB]
-          InjectionPoints: [{PC: "0xcda44e", Frameless: false}]
+          Type: 1379 EventRootType Probe[main.testInlinedBB]
+          InjectionPoints: [{PC: "0xcda56e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1379 EventRootType Probe[main.testInlinedBB]Return
-          InjectionPoints: [{PC: "0xcda4de", Frameless: false}]
+          Type: 1380 EventRootType Probe[main.testInlinedBB]Return
+          InjectionPoints: [{PC: "0xcda5fe", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}, {y}'
@@ -976,15 +1015,15 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 51}
+      subprogram: {subprogram: 52}
       events:
         - Kind: Entry
-          Type: 1380 EventRootType Probe[main.testInlinedBBA]
-          InjectionPoints: [{PC: "0xcda52a", Frameless: false}]
+          Type: 1381 EventRootType Probe[main.testInlinedBBA]
+          InjectionPoints: [{PC: "0xcda64a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1381 EventRootType Probe[main.testInlinedBBA]Return
-          InjectionPoints: [{PC: "0xcda56b", Frameless: false}]
+          Type: 1382 EventRootType Probe[main.testInlinedBBA]Return
+          InjectionPoints: [{PC: "0xcda68b", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1001,11 +1040,11 @@ Probes:
       template: testInlinedBBB
       segments: [testInlinedBBB]
       captureSnapshot: true
-      subprogram: {subprogram: 159}
+      subprogram: {subprogram: 160}
       events:
         - Kind: Entry
-          Type: 1560 EventRootType Probe[main.testInlinedBBB]
-          InjectionPoints: [{PC: "0xcda4a6", Frameless: false}]
+          Type: 1561 EventRootType Probe[main.testInlinedBBB]
+          InjectionPoints: [{PC: "0xcda5c6", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBBB
@@ -1018,15 +1057,15 @@ Probes:
       template: testInlinedBC
       segments: [testInlinedBC]
       captureSnapshot: true
-      subprogram: {subprogram: 52}
+      subprogram: {subprogram: 53}
       events:
         - Kind: Entry
-          Type: 1382 EventRootType Probe[main.testInlinedBC]
-          InjectionPoints: [{PC: "0xcda5ae", Frameless: false}]
+          Type: 1383 EventRootType Probe[main.testInlinedBC]
+          InjectionPoints: [{PC: "0xcda6ce", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1383 EventRootType Probe[main.testInlinedBC]Return
-          InjectionPoints: [{PC: "0xcda693", Frameless: false}]
+          Type: 1384 EventRootType Probe[main.testInlinedBC]Return
+          InjectionPoints: [{PC: "0xcda7b3", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBC
@@ -1039,11 +1078,11 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Entry
-          Type: 1561 EventRootType Probe[main.testInlinedBCA]
-          InjectionPoints: [{PC: "0xcda5b3", Frameless: false}]
+          Type: 1562 EventRootType Probe[main.testInlinedBCA]
+          InjectionPoints: [{PC: "0xcda6d3", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBCA
@@ -1059,11 +1098,11 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Line
-          Type: 1562 EventRootType Probe[main.testInlinedBCA]Line
-          InjectionPoints: [{PC: "0xcda5b3", Frameless: false}]
+          Type: 1563 EventRootType Probe[main.testInlinedBCA]Line
+          InjectionPoints: [{PC: "0xcda6d3", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBCA
@@ -1076,11 +1115,11 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Entry
-          Type: 1563 EventRootType Probe[main.testInlinedBCB]
-          InjectionPoints: [{PC: "0xcda65b", Frameless: false}]
+          Type: 1564 EventRootType Probe[main.testInlinedBCB]
+          InjectionPoints: [{PC: "0xcda77b", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBCB
@@ -1096,11 +1135,11 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Line
-          Type: 1564 EventRootType Probe[main.testInlinedBCB]Line
-          InjectionPoints: [{PC: "0xcda65b", Frameless: false}]
+          Type: 1565 EventRootType Probe[main.testInlinedBCB]Line
+          InjectionPoints: [{PC: "0xcda77b", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBCB
@@ -1113,14 +1152,14 @@ Probes:
       template: testInlinedFuncFromOtherPackage
       segments: [testInlinedFuncFromOtherPackage]
       captureSnapshot: true
-      subprogram: {subprogram: 165}
+      subprogram: {subprogram: 166}
       events:
         - Kind: Entry
-          Type: 1570 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
+          Type: 1571 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
           InjectionPoints:
             - PC: "0xcd8541"
               Frameless: true
-            - PC: "0xcdb02b"
+            - PC: "0xcdb14b"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -1135,25 +1174,25 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Entry
-          Type: 1557 EventRootType Probe[main.testInlinedPrint]
+          Type: 1558 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
-            - PC: "0xcda20a"
+            - PC: "0xcda32a"
               Frameless: false
-            - PC: "0xcda291"
+            - PC: "0xcda3b1"
               Frameless: false
-            - PC: "0xcda3d2"
+            - PC: "0xcda4f2"
               Frameless: false
-            - PC: "0xcda45c"
+            - PC: "0xcda57c"
               Frameless: false
-            - PC: "0xcda52f"
+            - PC: "0xcda64f"
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1558 EventRootType Probe[main.testInlinedPrint]Return
-          InjectionPoints: [{PC: "0xcda24a", Frameless: false}]
+          Type: 1559 EventRootType Probe[main.testInlinedPrint]Return
+          InjectionPoints: [{PC: "0xcda36a", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1173,20 +1212,20 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1559 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1560 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
-            - PC: "0xcda20e"
+            - PC: "0xcda32e"
               Frameless: false
-            - PC: "0xcda291"
+            - PC: "0xcda3b1"
               Frameless: false
-            - PC: "0xcda3d2"
+            - PC: "0xcda4f2"
               Frameless: false
-            - PC: "0xcda45c"
+            - PC: "0xcda57c"
               Frameless: false
-            - PC: "0xcda52f"
+            - PC: "0xcda64f"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -1204,11 +1243,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 162}
+      subprogram: {subprogram: 163}
       events:
         - Kind: Entry
-          Type: 1565 EventRootType Probe[main.testInlinedSq]
-          InjectionPoints: [{PC: "0xcda6c1", Frameless: true}]
+          Type: 1566 EventRootType Probe[main.testInlinedSq]
+          InjectionPoints: [{PC: "0xcda7e1", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1228,11 +1267,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 162}
+      subprogram: {subprogram: 163}
       events:
         - Kind: Line
-          Type: 1566 EventRootType Probe[main.testInlinedSq]Line
-          InjectionPoints: [{PC: "0xcda6c1", Frameless: true}]
+          Type: 1567 EventRootType Probe[main.testInlinedSq]Line
+          InjectionPoints: [{PC: "0xcda7e1", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1250,14 +1289,14 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 163}
+      subprogram: {subprogram: 164}
       events:
         - Kind: Entry
-          Type: 1567 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1568 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
-            - PC: "0xcda705"
+            - PC: "0xcda825"
               Frameless: false
-            - PC: "0xcda7a5"
+            - PC: "0xcda8c5"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -1380,11 +1419,11 @@ Probes:
       template: '{b}'
       segments: [{json: {ref: b}, dsl: b}]
       captureSnapshot: true
-      subprogram: {subprogram: 55}
+      subprogram: {subprogram: 56}
       events:
         - Kind: Entry
-          Type: 1389 EventRootType Probe[main.testInterface]
-          InjectionPoints: [{PC: "0xcda9c0", Frameless: true}]
+          Type: 1390 EventRootType Probe[main.testInterface]
+          InjectionPoints: [{PC: "0xcdaae0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{b}'
@@ -1400,15 +1439,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 121}
+      subprogram: {subprogram: 122}
       events:
         - Kind: Entry
-          Type: 1495 EventRootType Probe[main.testLargeArgAndReturn]
-          InjectionPoints: [{PC: "0xcdea4e", Frameless: false}]
+          Type: 1496 EventRootType Probe[main.testLargeArgAndReturn]
+          InjectionPoints: [{PC: "0xcdeb6e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1496 EventRootType Probe[main.testLargeArgAndReturn]Return
-          InjectionPoints: [{PC: "0xcdebb3", Frameless: false}]
+          Type: 1497 EventRootType Probe[main.testLargeArgAndReturn]Return
+          InjectionPoints: [{PC: "0xcdecd3", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -1425,11 +1464,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 90}
       events:
         - Kind: Entry
-          Type: 1428 EventRootType Probe[main.testLinkedList]
-          InjectionPoints: [{PC: "0xcdd280", Frameless: true}]
+          Type: 1429 EventRootType Probe[main.testLinkedList]
+          InjectionPoints: [{PC: "0xcdd3a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -1444,16 +1483,16 @@ Probes:
       where:
         methodName: main.testLongFunctionWithChangingState
         sourceFile: complex.go
-        lines: ["211"]
+        lines: ["230"]
       sampling: {snapshotsPerSecond: 100}
       template: testLongFunctionWithChangingState
       segments: [testLongFunctionWithChangingState]
       captureSnapshot: true
-      subprogram: {subprogram: 46}
+      subprogram: {subprogram: 47}
       events:
         - Kind: Line
-          Type: 1369 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-          InjectionPoints: [{PC: "0xcd97da", Frameless: false}]
+          Type: 1370 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          InjectionPoints: [{PC: "0xcd98da", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testLongFunctionWithChangingState
@@ -1464,17 +1503,17 @@ Probes:
       where:
         methodName: main.testLongFunctionWithChangingState
         sourceFile: complex.go
-        lines: ["218"]
+        lines: ["237"]
       tags: ['version_diff:go1.26rc1']
       sampling: {snapshotsPerSecond: 100}
       template: testLongFunctionWithChangingState
       segments: [testLongFunctionWithChangingState]
       captureSnapshot: true
-      subprogram: {subprogram: 46}
+      subprogram: {subprogram: 47}
       events:
         - Kind: Line
-          Type: 1370 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-          InjectionPoints: [{PC: "0xcd988d", Frameless: false}]
+          Type: 1371 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          InjectionPoints: [{PC: "0xcd998d", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testLongFunctionWithChangingState
@@ -1485,17 +1524,17 @@ Probes:
       where:
         methodName: main.testLongFunctionWithChangingState
         sourceFile: complex.go
-        lines: ["223"]
+        lines: ["242"]
       tags: ['version_diff:go1.26rc1']
       sampling: {snapshotsPerSecond: 100}
       template: testLongFunctionWithChangingState
       segments: [testLongFunctionWithChangingState]
       captureSnapshot: true
-      subprogram: {subprogram: 46}
+      subprogram: {subprogram: 47}
       events:
         - Kind: Line
-          Type: 1371 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-          InjectionPoints: [{PC: "0xcd9954", Frameless: false}]
+          Type: 1372 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          InjectionPoints: [{PC: "0xcd9a54", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testLongFunctionWithChangingState
@@ -1533,15 +1572,15 @@ Probes:
         - json: {ref: i}
           dsl: i
       captureSnapshot: true
-      subprogram: {subprogram: 124}
+      subprogram: {subprogram: 125}
       events:
         - Kind: Entry
-          Type: 1501 EventRootType Probe[main.testManyArgsArrayReturn]
-          InjectionPoints: [{PC: "0xcdef13", Frameless: false}]
+          Type: 1502 EventRootType Probe[main.testManyArgsArrayReturn]
+          InjectionPoints: [{PC: "0xcdf033", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1502 EventRootType Probe[main.testManyArgsArrayReturn]Return
-          InjectionPoints: [{PC: "0xcdf122", Frameless: false}]
+          Type: 1503 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          InjectionPoints: [{PC: "0xcdf242", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -1598,11 +1637,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 64}
+      subprogram: {subprogram: 65}
       events:
         - Kind: Entry
-          Type: 1400 EventRootType Probe[main.testMapArrayToArray]
-          InjectionPoints: [{PC: "0xcdb160", Frameless: true}]
+          Type: 1401 EventRootType Probe[main.testMapArrayToArray]
+          InjectionPoints: [{PC: "0xcdb280", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1619,11 +1658,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 70}
+      subprogram: {subprogram: 71}
       events:
         - Kind: Entry
-          Type: 1407 EventRootType Probe[main.testMapEmbeddedMaps]
-          InjectionPoints: [{PC: "0xcdb220", Frameless: true}]
+          Type: 1408 EventRootType Probe[main.testMapEmbeddedMaps]
+          InjectionPoints: [{PC: "0xcdb340", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1640,11 +1679,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 80}
+      subprogram: {subprogram: 81}
       events:
         - Kind: Entry
-          Type: 1417 EventRootType Probe[main.testMapEmptyKey]
-          InjectionPoints: [{PC: "0xcdb360", Frameless: true}]
+          Type: 1418 EventRootType Probe[main.testMapEmptyKey]
+          InjectionPoints: [{PC: "0xcdb480", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1661,11 +1700,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 82}
+      subprogram: {subprogram: 83}
       events:
         - Kind: Entry
-          Type: 1419 EventRootType Probe[main.testMapEmptyKeyAndValue]
-          InjectionPoints: [{PC: "0xcdb3a0", Frameless: true}]
+          Type: 1420 EventRootType Probe[main.testMapEmptyKeyAndValue]
+          InjectionPoints: [{PC: "0xcdb4c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1682,11 +1721,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 81}
+      subprogram: {subprogram: 82}
       events:
         - Kind: Entry
-          Type: 1418 EventRootType Probe[main.testMapEmptyValue]
-          InjectionPoints: [{PC: "0xcdb380", Frameless: true}]
+          Type: 1419 EventRootType Probe[main.testMapEmptyValue]
+          InjectionPoints: [{PC: "0xcdb4a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1703,11 +1742,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 68}
+      subprogram: {subprogram: 69}
       events:
         - Kind: Entry
-          Type: 1404 EventRootType Probe[main.testMapIntToInt]
-          InjectionPoints: [{PC: "0xcdb1e0", Frameless: true}]
+          Type: 1405 EventRootType Probe[main.testMapIntToInt]
+          InjectionPoints: [{PC: "0xcdb300", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1724,11 +1763,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 79}
+      subprogram: {subprogram: 80}
       events:
         - Kind: Entry
-          Type: 1416 EventRootType Probe[main.testMapLargeKeyLargeValue]
-          InjectionPoints: [{PC: "0xcdb340", Frameless: true}]
+          Type: 1417 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          InjectionPoints: [{PC: "0xcdb460", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1745,11 +1784,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 78}
+      subprogram: {subprogram: 79}
       events:
         - Kind: Entry
-          Type: 1415 EventRootType Probe[main.testMapLargeKeySmallValue]
-          InjectionPoints: [{PC: "0xcdb320", Frameless: true}]
+          Type: 1416 EventRootType Probe[main.testMapLargeKeySmallValue]
+          InjectionPoints: [{PC: "0xcdb440", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1768,11 +1807,11 @@ Probes:
         - json: {ref: redactMyEntries}
           dsl: redactMyEntries
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 70}
       events:
         - Kind: Entry
-          Type: 1405 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0xcdb200", Frameless: true}]
+          Type: 1406 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0xcdb320", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{redactMyEntries}'
@@ -1791,11 +1830,11 @@ Probes:
         - json: {ref: redactMyEntries}
           dsl: redactMyEntries
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 70}
       events:
         - Kind: Entry
-          Type: 1406 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0xcdb200", Frameless: true}]
+          Type: 1407 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0xcdb320", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{redactMyEntries}'
@@ -1812,11 +1851,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 77}
+      subprogram: {subprogram: 78}
       events:
         - Kind: Entry
-          Type: 1414 EventRootType Probe[main.testMapSmallKeyLargeValue]
-          InjectionPoints: [{PC: "0xcdb300", Frameless: true}]
+          Type: 1415 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          InjectionPoints: [{PC: "0xcdb420", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1833,11 +1872,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 76}
+      subprogram: {subprogram: 77}
       events:
         - Kind: Entry
-          Type: 1413 EventRootType Probe[main.testMapSmallKeySmallValue]
-          InjectionPoints: [{PC: "0xcdb2e0", Frameless: true}]
+          Type: 1414 EventRootType Probe[main.testMapSmallKeySmallValue]
+          InjectionPoints: [{PC: "0xcdb400", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1854,11 +1893,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 62}
+      subprogram: {subprogram: 63}
       events:
         - Kind: Entry
-          Type: 1398 EventRootType Probe[main.testMapStringToInt]
-          InjectionPoints: [{PC: "0xcdb120", Frameless: true}]
+          Type: 1399 EventRootType Probe[main.testMapStringToInt]
+          InjectionPoints: [{PC: "0xcdb240", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1875,11 +1914,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 63}
+      subprogram: {subprogram: 64}
       events:
         - Kind: Entry
-          Type: 1399 EventRootType Probe[main.testMapStringToSlice]
-          InjectionPoints: [{PC: "0xcdb140", Frameless: true}]
+          Type: 1400 EventRootType Probe[main.testMapStringToSlice]
+          InjectionPoints: [{PC: "0xcdb260", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1896,11 +1935,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 61}
+      subprogram: {subprogram: 62}
       events:
         - Kind: Entry
-          Type: 1397 EventRootType Probe[main.testMapStringToStruct]
-          InjectionPoints: [{PC: "0xcdb100", Frameless: true}]
+          Type: 1398 EventRootType Probe[main.testMapStringToStruct]
+          InjectionPoints: [{PC: "0xcdb220", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1917,11 +1956,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 71}
+      subprogram: {subprogram: 72}
       events:
         - Kind: Entry
-          Type: 1408 EventRootType Probe[main.testMapWithLinkedList]
-          InjectionPoints: [{PC: "0xcdb240", Frameless: true}]
+          Type: 1409 EventRootType Probe[main.testMapWithLinkedList]
+          InjectionPoints: [{PC: "0xcdb360", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1938,11 +1977,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 74}
+      subprogram: {subprogram: 75}
       events:
         - Kind: Entry
-          Type: 1411 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-          InjectionPoints: [{PC: "0xcdb2a0", Frameless: true}]
+          Type: 1412 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          InjectionPoints: [{PC: "0xcdb3c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1959,11 +1998,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 75}
+      subprogram: {subprogram: 76}
       events:
         - Kind: Entry
-          Type: 1412 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-          InjectionPoints: [{PC: "0xcdb2c0", Frameless: true}]
+          Type: 1413 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          InjectionPoints: [{PC: "0xcdb3e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1980,11 +2019,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 72}
+      subprogram: {subprogram: 73}
       events:
         - Kind: Entry
-          Type: 1409 EventRootType Probe[main.testMapWithSmallValue]
-          InjectionPoints: [{PC: "0xcdb260", Frameless: true}]
+          Type: 1410 EventRootType Probe[main.testMapWithSmallValue]
+          InjectionPoints: [{PC: "0xcdb380", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -2003,11 +2042,11 @@ Probes:
         - json: {ref: redactMyEntries}
           dsl: redactMyEntries
       captureSnapshot: true
-      subprogram: {subprogram: 73}
+      subprogram: {subprogram: 74}
       events:
         - Kind: Entry
-          Type: 1410 EventRootType Probe[main.testMapWithSmallValueMassive]
-          InjectionPoints: [{PC: "0xcdb280", Frameless: true}]
+          Type: 1411 EventRootType Probe[main.testMapWithSmallValueMassive]
+          InjectionPoints: [{PC: "0xcdb3a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{redactMyEntries}'
@@ -2024,11 +2063,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 148}
+      subprogram: {subprogram: 149}
       events:
         - Kind: Entry
-          Type: 1537 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0xce0280", Frameless: true}]
+          Type: 1538 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0xce03a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -2046,11 +2085,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 148}
+      subprogram: {subprogram: 149}
       events:
         - Kind: Entry
-          Type: 1538 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0xce0280", Frameless: true}]
+          Type: 1539 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0xce03a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -2092,15 +2131,15 @@ Probes:
         - json: {ref: s}
           dsl: s
       captureSnapshot: true
-      subprogram: {subprogram: 125}
+      subprogram: {subprogram: 126}
       events:
         - Kind: Entry
-          Type: 1503 EventRootType Probe[main.testMixedArgsStackReturn]
-          InjectionPoints: [{PC: "0xcdf1b3", Frameless: false}]
+          Type: 1504 EventRootType Probe[main.testMixedArgsStackReturn]
+          InjectionPoints: [{PC: "0xcdf2d3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1504 EventRootType Probe[main.testMixedArgsStackReturn]Return
-          InjectionPoints: [{PC: "0xcdf3eb", Frameless: false}]
+          Type: 1505 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          InjectionPoints: [{PC: "0xcdf50b", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -2161,15 +2200,15 @@ Probes:
         - json: {ref: b}
           dsl: b
       captureSnapshot: true
-      subprogram: {subprogram: 127}
+      subprogram: {subprogram: 128}
       events:
         - Kind: Entry
-          Type: 1507 EventRootType Probe[main.testMultipleArrayArgs]
-          InjectionPoints: [{PC: "0xcdf52e", Frameless: false}]
+          Type: 1508 EventRootType Probe[main.testMultipleArrayArgs]
+          InjectionPoints: [{PC: "0xcdf64e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1508 EventRootType Probe[main.testMultipleArrayArgs]Return
-          InjectionPoints: [{PC: "0xcdf5ff", Frameless: false}]
+          Type: 1509 EventRootType Probe[main.testMultipleArrayArgs]Return
+          InjectionPoints: [{PC: "0xcdf71f", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}'
@@ -2195,15 +2234,15 @@ Probes:
         - json: {ref: s2}
           dsl: s2
       captureSnapshot: true
-      subprogram: {subprogram: 123}
+      subprogram: {subprogram: 124}
       events:
         - Kind: Entry
-          Type: 1499 EventRootType Probe[main.testMultipleLargeArgs]
-          InjectionPoints: [{PC: "0xcdecce", Frameless: false}]
+          Type: 1500 EventRootType Probe[main.testMultipleLargeArgs]
+          InjectionPoints: [{PC: "0xcdedee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1500 EventRootType Probe[main.testMultipleLargeArgs]Return
-          InjectionPoints: [{PC: "0xcdeeea", Frameless: false}]
+          Type: 1501 EventRootType Probe[main.testMultipleLargeArgs]Return
+          InjectionPoints: [{PC: "0xcdf00a", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{s1}, {s2}'
@@ -2224,15 +2263,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1453 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0xcde06e", Frameless: false}]
+          Type: 1454 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xcde18e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1454 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0xcde10f", Frameless: false}]
+          Type: 1455 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xcde22f", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2263,11 +2302,11 @@ Probes:
         - json: {ref: e}
           dsl: e
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 86}
       events:
         - Kind: Entry
-          Type: 1423 EventRootType Probe[main.testMultipleSimpleParams]
-          InjectionPoints: [{PC: "0xcdce60", Frameless: true}]
+          Type: 1424 EventRootType Probe[main.testMultipleSimpleParams]
+          InjectionPoints: [{PC: "0xcdcf80", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}, {d}, {e}'
@@ -2303,15 +2342,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1449 EventRootType Probe[main.testNamedReturn]
-          InjectionPoints: [{PC: "0xcddfca", Frameless: false}]
+          Type: 1450 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0xcde0ea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1450 EventRootType Probe[main.testNamedReturn]Return
-          InjectionPoints: [{PC: "0xcde035", Frameless: false}]
+          Type: 1451 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0xcde155", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2333,15 +2372,15 @@ Probes:
         - json: {ref: result}
           dsl: result
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1451 EventRootType Probe[main.testNamedReturn]
-          InjectionPoints: [{PC: "0xcddfca", Frameless: false}]
+          Type: 1452 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0xcde0ea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1452 EventRootType Probe[main.testNamedReturn]Return
-          InjectionPoints: [{PC: "0xcde035", Frameless: false}]
+          Type: 1453 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0xcde155", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: Parameter {i} * 2 = result {result}
@@ -2364,11 +2403,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 155}
+      subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1549 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0xce06c0", Frameless: true}]
+          Type: 1550 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0xce07e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -2388,11 +2427,11 @@ Probes:
             getmember: [{getmember: [{ref: x}, nested]}, anotherString]
           dsl: x.nested.anotherString
       captureSnapshot: false
-      subprogram: {subprogram: 155}
+      subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1550 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0xce06c0", Frameless: true}]
+          Type: 1551 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0xce07e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x.nested.anotherString}'
@@ -2418,11 +2457,11 @@ Probes:
         - json: {getmember: [{ref: x}, notAMember]}
           dsl: x.notAMember
       captureSnapshot: false
-      subprogram: {subprogram: 155}
+      subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1551 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0xce06c0", Frameless: true}]
+          Type: 1552 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0xce07e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -2442,11 +2481,11 @@ Probes:
         - json: {getmember: [{ref: x}, nested]}
           dsl: x.nested
       captureSnapshot: false
-      subprogram: {subprogram: 155}
+      subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1552 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0xce06c0", Frameless: true}]
+          Type: 1553 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0xce07e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x.nested}'
@@ -2468,11 +2507,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 95}
       events:
         - Kind: Entry
-          Type: 1433 EventRootType Probe[main.testNilPointer]
-          InjectionPoints: [{PC: "0xcdd420", Frameless: true}]
+          Type: 1434 EventRootType Probe[main.testNilPointer]
+          InjectionPoints: [{PC: "0xcdd540", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{z}, {a}'
@@ -2494,11 +2533,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 138}
+      subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1521 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0xcdfd80", Frameless: true}]
+          Type: 1522 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0xcdfea0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -2520,11 +2559,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 135}
+      subprogram: {subprogram: 136}
       events:
         - Kind: Entry
-          Type: 1518 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0xcdfd20", Frameless: true}]
+          Type: 1519 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0xcdfe40", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}, {a}'
@@ -2554,11 +2593,11 @@ Probes:
         - json: {ref: x}
           dsl: x
       captureSnapshot: true
-      subprogram: {subprogram: 137}
+      subprogram: {subprogram: 138}
       events:
         - Kind: Entry
-          Type: 1520 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0xcdfd60", Frameless: true}]
+          Type: 1521 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0xcdfe80", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {s}, {x}'
@@ -2585,11 +2624,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 147}
+      subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1536 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0xce0260", Frameless: true}]
+          Type: 1537 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0xce0380", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -2606,11 +2645,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 91}
       events:
         - Kind: Entry
-          Type: 1429 EventRootType Probe[main.testPointerLoop]
-          InjectionPoints: [{PC: "0xcdd2a0", Frameless: true}]
+          Type: 1430 EventRootType Probe[main.testPointerLoop]
+          InjectionPoints: [{PC: "0xcdd3c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -2627,11 +2666,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 67}
+      subprogram: {subprogram: 68}
       events:
         - Kind: Entry
-          Type: 1403 EventRootType Probe[main.testPointerToMap]
-          InjectionPoints: [{PC: "0xcdb1c0", Frameless: true}]
+          Type: 1404 EventRootType Probe[main.testPointerToMap]
+          InjectionPoints: [{PC: "0xcdb2e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -2648,11 +2687,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 89}
       events:
         - Kind: Entry
-          Type: 1427 EventRootType Probe[main.testPointerToSimpleStruct]
-          InjectionPoints: [{PC: "0xcdd260", Frameless: true}]
+          Type: 1428 EventRootType Probe[main.testPointerToSimpleStruct]
+          InjectionPoints: [{PC: "0xcdd380", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -2669,22 +2708,22 @@ Probes:
       template: '{v}'
       segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
         - Kind: Entry
-          Type: 1445 EventRootType Probe[main.testReturnsAny]
-          InjectionPoints: [{PC: "0xcddc6e", Frameless: false}]
+          Type: 1446 EventRootType Probe[main.testReturnsAny]
+          InjectionPoints: [{PC: "0xcddd8e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1446 EventRootType Probe[main.testReturnsAny]Return
+          Type: 1447 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints:
-            - PC: "0xcddd15"
+            - PC: "0xcdde35"
               Frameless: false
-            - PC: "0xcddd64"
+            - PC: "0xcdde84"
               Frameless: false
-            - PC: "0xcdde20"
+            - PC: "0xcddf40"
               Frameless: false
-            - PC: "0xcdde2a"
+            - PC: "0xcddf4a"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2707,22 +2746,22 @@ Probes:
         - json: {ref: failed}
           dsl: failed
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 101}
       events:
         - Kind: Entry
-          Type: 1443 EventRootType Probe[main.testReturnsAnyAndError]
-          InjectionPoints: [{PC: "0xcddb0e", Frameless: false}]
+          Type: 1444 EventRootType Probe[main.testReturnsAnyAndError]
+          InjectionPoints: [{PC: "0xcddc2e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1444 EventRootType Probe[main.testReturnsAnyAndError]Return
+          Type: 1445 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
-            - PC: "0xcddb64"
+            - PC: "0xcddc84"
               Frameless: false
-            - PC: "0xcddbb3"
+            - PC: "0xcddcd3"
               Frameless: false
-            - PC: "0xcddbe7"
+            - PC: "0xcddd07"
               Frameless: false
-            - PC: "0xcddc19"
+            - PC: "0xcddd39"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2744,15 +2783,15 @@ Probes:
       template: testReturnsArray
       segments: [testReturnsArray]
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 111}
       events:
         - Kind: Entry
-          Type: 1473 EventRootType Probe[main.testReturnsArray]
-          InjectionPoints: [{PC: "0xcde4ea", Frameless: false}]
+          Type: 1474 EventRootType Probe[main.testReturnsArray]
+          InjectionPoints: [{PC: "0xcde60a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1474 EventRootType Probe[main.testReturnsArray]Return
-          InjectionPoints: [{PC: "0xcde54d", Frameless: false}]
+          Type: 1475 EventRootType Probe[main.testReturnsArray]Return
+          InjectionPoints: [{PC: "0xcde66d", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsArray
@@ -2764,15 +2803,15 @@ Probes:
       template: testReturnsArrayOne
       segments: [testReturnsArrayOne]
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 112}
       events:
         - Kind: Entry
-          Type: 1475 EventRootType Probe[main.testReturnsArrayOne]
-          InjectionPoints: [{PC: "0xcde56a", Frameless: false}]
+          Type: 1476 EventRootType Probe[main.testReturnsArrayOne]
+          InjectionPoints: [{PC: "0xcde68a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1476 EventRootType Probe[main.testReturnsArrayOne]Return
-          InjectionPoints: [{PC: "0xcde5ab", Frameless: false}]
+          Type: 1477 EventRootType Probe[main.testReturnsArrayOne]Return
+          InjectionPoints: [{PC: "0xcde6cb", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsArrayOne
@@ -2784,15 +2823,15 @@ Probes:
       template: testReturnsArrayZero
       segments: [testReturnsArrayZero]
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 113}
       events:
         - Kind: Entry
-          Type: 1477 EventRootType Probe[main.testReturnsArrayZero]
-          InjectionPoints: [{PC: "0xcde5ca", Frameless: false}]
+          Type: 1478 EventRootType Probe[main.testReturnsArrayZero]
+          InjectionPoints: [{PC: "0xcde6ea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1478 EventRootType Probe[main.testReturnsArrayZero]Return
-          InjectionPoints: [{PC: "0xcde606", Frameless: false}]
+          Type: 1479 EventRootType Probe[main.testReturnsArrayZero]Return
+          InjectionPoints: [{PC: "0xcde726", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsArrayZero
@@ -2804,15 +2843,15 @@ Probes:
       template: testReturnsBacktrackInt
       segments: [testReturnsBacktrackInt]
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 115}
       events:
         - Kind: Entry
-          Type: 1481 EventRootType Probe[main.testReturnsBacktrackInt]
-          InjectionPoints: [{PC: "0xcde6ae", Frameless: false}]
+          Type: 1482 EventRootType Probe[main.testReturnsBacktrackInt]
+          InjectionPoints: [{PC: "0xcde7ce", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1482 EventRootType Probe[main.testReturnsBacktrackInt]Return
-          InjectionPoints: [{PC: "0xcde72a", Frameless: false}]
+          Type: 1483 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          InjectionPoints: [{PC: "0xcde84a", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsBacktrackInt
@@ -2824,15 +2863,15 @@ Probes:
       template: testReturnsBoolAndUintptr
       segments: [testReturnsBoolAndUintptr]
       captureSnapshot: true
-      subprogram: {subprogram: 120}
+      subprogram: {subprogram: 121}
       events:
         - Kind: Entry
-          Type: 1493 EventRootType Probe[main.testReturnsBoolAndUintptr]
-          InjectionPoints: [{PC: "0xcde9ea", Frameless: false}]
+          Type: 1494 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          InjectionPoints: [{PC: "0xcdeb0a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1494 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-          InjectionPoints: [{PC: "0xcdea30", Frameless: false}]
+          Type: 1495 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          InjectionPoints: [{PC: "0xcdeb50", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsBoolAndUintptr
@@ -2844,15 +2883,15 @@ Probes:
       template: testReturnsComplex
       segments: [testReturnsComplex]
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 109}
       events:
         - Kind: Entry
-          Type: 1469 EventRootType Probe[main.testReturnsComplex]
-          InjectionPoints: [{PC: "0xcde3aa", Frameless: false}]
+          Type: 1470 EventRootType Probe[main.testReturnsComplex]
+          InjectionPoints: [{PC: "0xcde4ca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1470 EventRootType Probe[main.testReturnsComplex]Return
-          InjectionPoints: [{PC: "0xcde406", Frameless: false}]
+          Type: 1471 EventRootType Probe[main.testReturnsComplex]Return
+          InjectionPoints: [{PC: "0xcde526", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsComplex
@@ -2865,18 +2904,18 @@ Probes:
       template: '{failed}'
       segments: [{json: {ref: failed}, dsl: failed}]
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 100}
       events:
         - Kind: Entry
-          Type: 1441 EventRootType Probe[main.testReturnsError]
-          InjectionPoints: [{PC: "0xcddaaa", Frameless: false}]
+          Type: 1442 EventRootType Probe[main.testReturnsError]
+          InjectionPoints: [{PC: "0xcddbca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1442 EventRootType Probe[main.testReturnsError]Return
+          Type: 1443 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
-            - PC: "0xcddada"
+            - PC: "0xcddbfa"
               Frameless: false
-            - PC: "0xcddae5"
+            - PC: "0xcddc05"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2893,15 +2932,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 97}
       events:
         - Kind: Entry
-          Type: 1435 EventRootType Probe[main.testReturnsInt]
-          InjectionPoints: [{PC: "0xcdd8aa", Frameless: false}]
+          Type: 1436 EventRootType Probe[main.testReturnsInt]
+          InjectionPoints: [{PC: "0xcdd9ca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1436 EventRootType Probe[main.testReturnsInt]Return
-          InjectionPoints: [{PC: "0xcdd8fb", Frameless: false}]
+          Type: 1437 EventRootType Probe[main.testReturnsInt]Return
+          InjectionPoints: [{PC: "0xcdda1b", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2917,15 +2956,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 99}
       events:
         - Kind: Entry
-          Type: 1439 EventRootType Probe[main.testReturnsIntAndFloat]
-          InjectionPoints: [{PC: "0xcdd9ce", Frameless: false}]
+          Type: 1440 EventRootType Probe[main.testReturnsIntAndFloat]
+          InjectionPoints: [{PC: "0xcddaee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1440 EventRootType Probe[main.testReturnsIntAndFloat]Return
-          InjectionPoints: [{PC: "0xcdda84", Frameless: false}]
+          Type: 1441 EventRootType Probe[main.testReturnsIntAndFloat]Return
+          InjectionPoints: [{PC: "0xcddba4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2941,15 +2980,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 98}
       events:
         - Kind: Entry
-          Type: 1437 EventRootType Probe[main.testReturnsIntPointer]
-          InjectionPoints: [{PC: "0xcdd92a", Frameless: false}]
+          Type: 1438 EventRootType Probe[main.testReturnsIntPointer]
+          InjectionPoints: [{PC: "0xcdda4a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1438 EventRootType Probe[main.testReturnsIntPointer]Return
-          InjectionPoints: [{PC: "0xcdd994", Frameless: false}]
+          Type: 1439 EventRootType Probe[main.testReturnsIntPointer]Return
+          InjectionPoints: [{PC: "0xcddab4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2966,18 +3005,18 @@ Probes:
       template: '{v}'
       segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1447 EventRootType Probe[main.testReturnsInterface]
-          InjectionPoints: [{PC: "0xcdde6e", Frameless: false}]
+          Type: 1448 EventRootType Probe[main.testReturnsInterface]
+          InjectionPoints: [{PC: "0xcddf8e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1448 EventRootType Probe[main.testReturnsInterface]Return
+          Type: 1449 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
-            - PC: "0xcddf3f"
+            - PC: "0xcde05f"
               Frameless: false
-            - PC: "0xcddf49"
+            - PC: "0xcde069"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2994,15 +3033,15 @@ Probes:
       template: testReturnsLargeStruct
       segments: [testReturnsLargeStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 110}
       events:
         - Kind: Entry
-          Type: 1471 EventRootType Probe[main.testReturnsLargeStruct]
-          InjectionPoints: [{PC: "0xcde42e", Frameless: false}]
+          Type: 1472 EventRootType Probe[main.testReturnsLargeStruct]
+          InjectionPoints: [{PC: "0xcde54e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1472 EventRootType Probe[main.testReturnsLargeStruct]Return
-          InjectionPoints: [{PC: "0xcde4b3", Frameless: false}]
+          Type: 1473 EventRootType Probe[main.testReturnsLargeStruct]Return
+          InjectionPoints: [{PC: "0xcde5d3", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsLargeStruct
@@ -3014,15 +3053,15 @@ Probes:
       template: testReturnsManyFloats
       segments: [testReturnsManyFloats]
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 108}
       events:
         - Kind: Entry
-          Type: 1467 EventRootType Probe[main.testReturnsManyFloats]
-          InjectionPoints: [{PC: "0xcde2ae", Frameless: false}]
+          Type: 1468 EventRootType Probe[main.testReturnsManyFloats]
+          InjectionPoints: [{PC: "0xcde3ce", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1468 EventRootType Probe[main.testReturnsManyFloats]Return
-          InjectionPoints: [{PC: "0xcde387", Frameless: false}]
+          Type: 1469 EventRootType Probe[main.testReturnsManyFloats]Return
+          InjectionPoints: [{PC: "0xcde4a7", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsManyFloats
@@ -3034,15 +3073,15 @@ Probes:
       template: testReturnsMixed
       segments: [testReturnsMixed]
       captureSnapshot: true
-      subprogram: {subprogram: 116}
+      subprogram: {subprogram: 117}
       events:
         - Kind: Entry
-          Type: 1485 EventRootType Probe[main.testReturnsMixed]
-          InjectionPoints: [{PC: "0xcde80a", Frameless: false}]
+          Type: 1486 EventRootType Probe[main.testReturnsMixed]
+          InjectionPoints: [{PC: "0xcde92a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1486 EventRootType Probe[main.testReturnsMixed]Return
-          InjectionPoints: [{PC: "0xcde86c", Frameless: false}]
+          Type: 1487 EventRootType Probe[main.testReturnsMixed]Return
+          InjectionPoints: [{PC: "0xcde98c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsMixed
@@ -3054,15 +3093,15 @@ Probes:
       template: testReturnsMixedStruct
       segments: [testReturnsMixedStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 114}
       events:
         - Kind: Entry
-          Type: 1479 EventRootType Probe[main.testReturnsMixedStruct]
-          InjectionPoints: [{PC: "0xcde62a", Frameless: false}]
+          Type: 1480 EventRootType Probe[main.testReturnsMixedStruct]
+          InjectionPoints: [{PC: "0xcde74a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1480 EventRootType Probe[main.testReturnsMixedStruct]Return
-          InjectionPoints: [{PC: "0xcde678", Frameless: false}]
+          Type: 1481 EventRootType Probe[main.testReturnsMixedStruct]Return
+          InjectionPoints: [{PC: "0xcde798", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsMixedStruct
@@ -3074,15 +3113,15 @@ Probes:
       template: testReturnsMultipleFloats
       segments: [testReturnsMultipleFloats]
       captureSnapshot: true
-      subprogram: {subprogram: 119}
+      subprogram: {subprogram: 120}
       events:
         - Kind: Entry
-          Type: 1491 EventRootType Probe[main.testReturnsMultipleFloats]
-          InjectionPoints: [{PC: "0xcde96a", Frameless: false}]
+          Type: 1492 EventRootType Probe[main.testReturnsMultipleFloats]
+          InjectionPoints: [{PC: "0xcdea8a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1492 EventRootType Probe[main.testReturnsMultipleFloats]Return
-          InjectionPoints: [{PC: "0xcde9b6", Frameless: false}]
+          Type: 1493 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          InjectionPoints: [{PC: "0xcdead6", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsMultipleFloats
@@ -3094,15 +3133,15 @@ Probes:
       template: testReturnsOnlyFloat
       segments: [testReturnsOnlyFloat]
       captureSnapshot: true
-      subprogram: {subprogram: 118}
+      subprogram: {subprogram: 119}
       events:
         - Kind: Entry
-          Type: 1489 EventRootType Probe[main.testReturnsOnlyFloat]
-          InjectionPoints: [{PC: "0xcde90a", Frameless: false}]
+          Type: 1490 EventRootType Probe[main.testReturnsOnlyFloat]
+          InjectionPoints: [{PC: "0xcdea2a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1490 EventRootType Probe[main.testReturnsOnlyFloat]Return
-          InjectionPoints: [{PC: "0xcde94e", Frameless: false}]
+          Type: 1491 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          InjectionPoints: [{PC: "0xcdea6e", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsOnlyFloat
@@ -3114,15 +3153,15 @@ Probes:
       template: testReturnsPrimitives
       segments: [testReturnsPrimitives]
       captureSnapshot: true
-      subprogram: {subprogram: 106}
+      subprogram: {subprogram: 107}
       events:
         - Kind: Entry
-          Type: 1465 EventRootType Probe[main.testReturnsPrimitives]
-          InjectionPoints: [{PC: "0xcde22a", Frameless: false}]
+          Type: 1466 EventRootType Probe[main.testReturnsPrimitives]
+          InjectionPoints: [{PC: "0xcde34a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1466 EventRootType Probe[main.testReturnsPrimitives]Return
-          InjectionPoints: [{PC: "0xcde291", Frameless: false}]
+          Type: 1467 EventRootType Probe[main.testReturnsPrimitives]Return
+          InjectionPoints: [{PC: "0xcde3b1", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsPrimitives
@@ -3134,15 +3173,15 @@ Probes:
       template: testReturnsStructWithArray
       segments: [testReturnsStructWithArray]
       captureSnapshot: true
-      subprogram: {subprogram: 117}
+      subprogram: {subprogram: 118}
       events:
         - Kind: Entry
-          Type: 1487 EventRootType Probe[main.testReturnsStructWithArray]
-          InjectionPoints: [{PC: "0xcde88a", Frameless: false}]
+          Type: 1488 EventRootType Probe[main.testReturnsStructWithArray]
+          InjectionPoints: [{PC: "0xcde9aa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1488 EventRootType Probe[main.testReturnsStructWithArray]Return
-          InjectionPoints: [{PC: "0xcde8ed", Frameless: false}]
+          Type: 1489 EventRootType Probe[main.testReturnsStructWithArray]Return
+          InjectionPoints: [{PC: "0xcdea0d", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsStructWithArray
@@ -3154,15 +3193,15 @@ Probes:
       template: testReturnsWideStruct
       segments: [testReturnsWideStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 115}
+      subprogram: {subprogram: 116}
       events:
         - Kind: Entry
-          Type: 1483 EventRootType Probe[main.testReturnsWideStruct]
-          InjectionPoints: [{PC: "0xcde74e", Frameless: false}]
+          Type: 1484 EventRootType Probe[main.testReturnsWideStruct]
+          InjectionPoints: [{PC: "0xcde86e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1484 EventRootType Probe[main.testReturnsWideStruct]Return
-          InjectionPoints: [{PC: "0xcde7d4", Frameless: false}]
+          Type: 1485 EventRootType Probe[main.testReturnsWideStruct]Return
+          InjectionPoints: [{PC: "0xcde8f4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsWideStruct
@@ -3209,15 +3248,15 @@ Probes:
         - json: {ref: result}
           dsl: result
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1455 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0xcde06e", Frameless: false}]
+          Type: 1456 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xcde18e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1456 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0xcde10f", Frameless: false}]
+          Type: 1457 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xcde22f", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -3485,11 +3524,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 143}
+      subprogram: {subprogram: 144}
       events:
         - Kind: Entry
-          Type: 1528 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0xce01e0", Frameless: true}]
+          Type: 1529 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0xce0300", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -3611,11 +3650,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 140}
+      subprogram: {subprogram: 141}
       events:
         - Kind: Entry
-          Type: 1524 EventRootType Probe[main.testSliceEmptyStructs]
-          InjectionPoints: [{PC: "0xcdfdc0", Frameless: true}]
+          Type: 1525 EventRootType Probe[main.testSliceEmptyStructs]
+          InjectionPoints: [{PC: "0xcdfee0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -3632,11 +3671,11 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 132}
+      subprogram: {subprogram: 133}
       events:
         - Kind: Entry
-          Type: 1515 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0xcdfcc0", Frameless: true}]
+          Type: 1516 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0xcdfde0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{u}'
@@ -3653,11 +3692,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 65}
+      subprogram: {subprogram: 66}
       events:
         - Kind: Entry
-          Type: 1401 EventRootType Probe[main.testSmallMap]
-          InjectionPoints: [{PC: "0xcdb180", Frameless: true}]
+          Type: 1402 EventRootType Probe[main.testSmallMap]
+          InjectionPoints: [{PC: "0xcdb2a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -3673,15 +3712,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 105}
+      subprogram: {subprogram: 106}
       events:
         - Kind: Entry
-          Type: 1463 EventRootType Probe[main.testSomeNamedReturn]
-          InjectionPoints: [{PC: "0xcde14e", Frameless: false}]
+          Type: 1464 EventRootType Probe[main.testSomeNamedReturn]
+          InjectionPoints: [{PC: "0xcde26e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1464 EventRootType Probe[main.testSomeNamedReturn]Return
-          InjectionPoints: [{PC: "0xcde1ed", Frameless: false}]
+          Type: 1465 EventRootType Probe[main.testSomeNamedReturn]Return
+          InjectionPoints: [{PC: "0xcde30d", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -3697,15 +3736,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 126}
+      subprogram: {subprogram: 127}
       events:
         - Kind: Entry
-          Type: 1505 EventRootType Probe[main.testStackArgRegReturns]
-          InjectionPoints: [{PC: "0xcdf48a", Frameless: false}]
+          Type: 1506 EventRootType Probe[main.testStackArgRegReturns]
+          InjectionPoints: [{PC: "0xcdf5aa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1506 EventRootType Probe[main.testStackArgRegReturns]Return
-          InjectionPoints: [{PC: "0xcdf4fc", Frameless: false}]
+          Type: 1507 EventRootType Probe[main.testStackArgRegReturns]Return
+          InjectionPoints: [{PC: "0xcdf61c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -3743,11 +3782,11 @@ Probes:
       template: '{z}'
       segments: [{json: {ref: z}, dsl: z}]
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 94}
       events:
         - Kind: Entry
-          Type: 1432 EventRootType Probe[main.testStringPointer]
-          InjectionPoints: [{PC: "0xcdd3e0", Frameless: true}]
+          Type: 1433 EventRootType Probe[main.testStringPointer]
+          InjectionPoints: [{PC: "0xcdd500", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{z}'
@@ -3764,11 +3803,11 @@ Probes:
       template: '{s}'
       segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
-      subprogram: {subprogram: 136}
+      subprogram: {subprogram: 137}
       events:
         - Kind: Entry
-          Type: 1519 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0xcdfd40", Frameless: true}]
+          Type: 1520 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0xcdfe60", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{s}'
@@ -3785,11 +3824,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 44}
+      subprogram: {subprogram: 45}
       events:
         - Kind: Entry
-          Type: 1367 EventRootType Probe[main.testStringType1]
-          InjectionPoints: [{PC: "0xcd9780", Frameless: true}]
+          Type: 1368 EventRootType Probe[main.testStringType1]
+          InjectionPoints: [{PC: "0xcd9880", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3806,11 +3845,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 45}
+      subprogram: {subprogram: 46}
       events:
         - Kind: Entry
-          Type: 1368 EventRootType Probe[main.testStringType2]
-          InjectionPoints: [{PC: "0xcd97a0", Frameless: true}]
+          Type: 1369 EventRootType Probe[main.testStringType2]
+          InjectionPoints: [{PC: "0xcd98a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3827,15 +3866,15 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1547 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0xce05c0", Frameless: true}]
+          Type: 1548 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0xce06e0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1548 EventRootType Probe[main.testStruct]Return
-          InjectionPoints: [{PC: "0xce05e2", Frameless: true}]
+          Type: 1549 EventRootType Probe[main.testStruct]Return
+          InjectionPoints: [{PC: "0xce0702", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -3857,11 +3896,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 133}
+      subprogram: {subprogram: 134}
       events:
         - Kind: Entry
-          Type: 1516 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0xcdfce0", Frameless: true}]
+          Type: 1517 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0xcdfe00", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}, {a}'
@@ -3883,11 +3922,11 @@ Probes:
       template: '{s}'
       segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
-      subprogram: {subprogram: 59}
+      subprogram: {subprogram: 60}
       events:
         - Kind: Entry
-          Type: 1395 EventRootType Probe[main.testStructWithAny]
-          InjectionPoints: [{PC: "0xcdaae0", Frameless: true}]
+          Type: 1396 EventRootType Probe[main.testStructWithAny]
+          InjectionPoints: [{PC: "0xcdac00", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{s}'
@@ -3903,15 +3942,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 128}
+      subprogram: {subprogram: 129}
       events:
         - Kind: Entry
-          Type: 1509 EventRootType Probe[main.testStructWithArrayArg]
-          InjectionPoints: [{PC: "0xcdf62e", Frameless: false}]
+          Type: 1510 EventRootType Probe[main.testStructWithArrayArg]
+          InjectionPoints: [{PC: "0xcdf74e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1510 EventRootType Probe[main.testStructWithArrayArg]Return
-          InjectionPoints: [{PC: "0xcdf6dc", Frameless: false}]
+          Type: 1511 EventRootType Probe[main.testStructWithArrayArg]Return
+          InjectionPoints: [{PC: "0xcdf7fc", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -3928,15 +3967,15 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 153}
+      subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1543 EventRootType Probe[main.testStructWithCyclicMaps]
-          InjectionPoints: [{PC: "0xce0480", Frameless: true}]
+          Type: 1544 EventRootType Probe[main.testStructWithCyclicMaps]
+          InjectionPoints: [{PC: "0xce05a0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1544 EventRootType Probe[main.testStructWithCyclicMaps]Return
-          InjectionPoints: [{PC: "0xce049e", Frameless: true}]
+          Type: 1545 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          InjectionPoints: [{PC: "0xce05be", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3952,11 +3991,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 152}
+      subprogram: {subprogram: 153}
       events:
         - Kind: Entry
-          Type: 1542 EventRootType Probe[main.testStructWithCyclicSlices]
-          InjectionPoints: [{PC: "0xce0460", Frameless: true}]
+          Type: 1543 EventRootType Probe[main.testStructWithCyclicSlices]
+          InjectionPoints: [{PC: "0xce0580", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3978,11 +4017,11 @@ Probes:
         - json: {ref: '@duration'}
           dsl: '@duration'
       captureSnapshot: true
-      subprogram: {subprogram: 60}
+      subprogram: {subprogram: 61}
       events:
         - Kind: Entry
-          Type: 1396 EventRootType Probe[main.testStructWithMap]
-          InjectionPoints: [{PC: "0xcdb0e0", Frameless: true}]
+          Type: 1397 EventRootType Probe[main.testStructWithMap]
+          InjectionPoints: [{PC: "0xcdb200", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{s} {@duration}'
@@ -4009,11 +4048,11 @@ Probes:
         - json: {ref: cs}
           dsl: cs
       captureSnapshot: true
-      subprogram: {subprogram: 141}
+      subprogram: {subprogram: 142}
       events:
         - Kind: Entry
-          Type: 1525 EventRootType Probe[main.testSubslices]
-          InjectionPoints: [{PC: "0xcdfde0", Frameless: true}]
+          Type: 1526 EventRootType Probe[main.testSubslices]
+          InjectionPoints: [{PC: "0xcdff00", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{as}, {bs}, {cs}'
@@ -4048,11 +4087,11 @@ Probes:
         - json: {ref: c}
           dsl: c
       captureSnapshot: true
-      subprogram: {subprogram: 151}
+      subprogram: {subprogram: 152}
       events:
         - Kind: Entry
-          Type: 1541 EventRootType Probe[main.testSubstrings]
-          InjectionPoints: [{PC: "0xce02e0", Frameless: true}]
+          Type: 1542 EventRootType Probe[main.testSubstrings]
+          InjectionPoints: [{PC: "0xce0400", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}'
@@ -4080,15 +4119,15 @@ Probes:
         - json: {ref: nonexistentVariable}
           dsl: nonexistentVariable
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1457 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0xcde06e", Frameless: false}]
+          Type: 1458 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xcde18e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1458 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0xcde10f", Frameless: false}]
+          Type: 1459 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xcde22f", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{nonexistentVariable}'
@@ -4104,15 +4143,15 @@ Probes:
         - json: {foobar: unsupportedExpression}
           dsl: unsupportedExpression
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1459 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0xcde06e", Frameless: false}]
+          Type: 1460 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xcde18e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1460 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0xcde10f", Frameless: false}]
+          Type: 1461 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xcde22f", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{unsupportedExpression}'
@@ -4130,15 +4169,15 @@ Probes:
           dsl: '@duration'
         - ms
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1461 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0xcde06e", Frameless: false}]
+          Type: 1462 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xcde18e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1462 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0xcde10f", Frameless: false}]
+          Type: 1463 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xcde22f", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -4162,11 +4201,11 @@ Probes:
         - json: {ref: z}
           dsl: z
       captureSnapshot: true
-      subprogram: {subprogram: 144}
+      subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1529 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0xce0200", Frameless: true}]
+          Type: 1530 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0xce0320", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}, {y}, {z}'
@@ -4193,15 +4232,15 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 145}
+      subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1530 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0xce0220", Frameless: true}]
+          Type: 1531 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0xce0340", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1531 EventRootType Probe[main.testThreeStringsInStruct]Return
-          InjectionPoints: [{PC: "0xce023e", Frameless: true}]
+          Type: 1532 EventRootType Probe[main.testThreeStringsInStruct]Return
+          InjectionPoints: [{PC: "0xce035e", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -4226,15 +4265,15 @@ Probes:
         - json: {getmember: [{ref: a}, c]}
           dsl: t.c
       captureSnapshot: false
-      subprogram: {subprogram: 145}
+      subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1532 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0xce0220", Frameless: true}]
+          Type: 1533 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0xce0340", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1533 EventRootType Probe[main.testThreeStringsInStruct]Return
-          InjectionPoints: [{PC: "0xce023e", Frameless: true}]
+          Type: 1534 EventRootType Probe[main.testThreeStringsInStruct]Return
+          InjectionPoints: [{PC: "0xce035e", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a.a} {a.b} {a.c}'
@@ -4261,11 +4300,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 146}
+      subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1534 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0xce0240", Frameless: true}]
+          Type: 1535 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0xce0360", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -4290,11 +4329,11 @@ Probes:
         - json: {getmember: [{ref: a}, c]}
           dsl: a.c
       captureSnapshot: false
-      subprogram: {subprogram: 146}
+      subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1535 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0xce0240", Frameless: true}]
+          Type: 1536 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0xce0360", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a.a} {a.b} {a.c}'
@@ -4447,11 +4486,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 93}
       events:
         - Kind: Entry
-          Type: 1431 EventRootType Probe[main.testUintPointer]
-          InjectionPoints: [{PC: "0xcdd300", Frameless: true}]
+          Type: 1432 EventRootType Probe[main.testUintPointer]
+          InjectionPoints: [{PC: "0xcdd420", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4468,11 +4507,11 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 130}
+      subprogram: {subprogram: 131}
       events:
         - Kind: Entry
-          Type: 1513 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0xcdfc80", Frameless: true}]
+          Type: 1514 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0xcdfda0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{u}'
@@ -4489,11 +4528,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 149}
+      subprogram: {subprogram: 150}
       events:
         - Kind: Entry
-          Type: 1539 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0xce02a0", Frameless: true}]
+          Type: 1540 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0xce03c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4510,11 +4549,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 92}
       events:
         - Kind: Entry
-          Type: 1430 EventRootType Probe[main.testUnsafePointer]
-          InjectionPoints: [{PC: "0xcdd2c0", Frameless: true}]
+          Type: 1431 EventRootType Probe[main.testUnsafePointer]
+          InjectionPoints: [{PC: "0xcdd3e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4552,11 +4591,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 139}
+      subprogram: {subprogram: 140}
       events:
         - Kind: Entry
-          Type: 1522 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0xcdfda0", Frameless: true}]
+          Type: 1523 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0xcdfec0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -4573,11 +4612,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 139}
+      subprogram: {subprogram: 140}
       events:
         - Kind: Entry
-          Type: 1523 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0xcdfda0", Frameless: true}]
+          Type: 1524 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0xcdfec0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -4593,19 +4632,19 @@ Probes:
       template: testWhollyInlinedSubroutine
       segments: [testWhollyInlinedSubroutine]
       captureSnapshot: true
-      subprogram: {subprogram: 164}
+      subprogram: {subprogram: 165}
       events:
         - Kind: Entry
-          Type: 1568 EventRootType Probe[main.firstBehavior.DoSomething]
+          Type: 1569 EventRootType Probe[main.firstBehavior.DoSomething]
           InjectionPoints:
-            - PC: "0xcda8ea"
+            - PC: "0xcdaa0a"
               Frameless: false
-            - PC: "0xce1b03"
+            - PC: "0xce1c23"
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1569 EventRootType Probe[main.firstBehavior.DoSomething]Return
-          InjectionPoints: [{PC: "0xcda925", Frameless: false}]
+          Type: 1570 EventRootType Probe[main.firstBehavior.DoSomething]Return
+          InjectionPoints: [{PC: "0xcdaa45", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testWhollyInlinedSubroutine
@@ -4622,15 +4661,15 @@ Probes:
         - json: {ref: b}
           dsl: b
       captureSnapshot: true
-      subprogram: {subprogram: 129}
+      subprogram: {subprogram: 130}
       events:
         - Kind: Entry
-          Type: 1511 EventRootType Probe[main.testZeroSizeArgAndReturn]
-          InjectionPoints: [{PC: "0xcdf70e", Frameless: false}]
+          Type: 1512 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          InjectionPoints: [{PC: "0xcdf82e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1512 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-          InjectionPoints: [{PC: "0xcdf78c", Frameless: false}]
+          Type: 1513 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          InjectionPoints: [{PC: "0xcdf8ac", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}'
@@ -5065,36 +5104,79 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
     - ID: 38
+      Name: main.testErrorAtLine
+      OutOfLinePCRanges: [0xcd93c0..0xcd94ba]
+      InlinePCRanges: []
+      Variables:
+        - Name: shouldErr
+          Type: 4 BaseType bool
+          Locations:
+            - Range: 0xcd93c0..0xcd93d8
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+        - Name: ~r0
+          Type: 7 BaseType int
+          Locations: [{Range: 0xcd93c0..0xcd94ba, Pieces: []}]
+          Role: Return
+        - Name: x
+          Type: 7 BaseType int
+          Locations: [{Range: 0xcd93c0..0xcd94ba, Pieces: []}]
+          Role: Local
+        - Name: err
+          Type: 13 GoInterfaceType error
+          Locations:
+            - Range: 0xcd93e9..0xcd9405
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+            - Range: 0xcd9405..0xcd9472
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xcd9472..0xcd9477
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: -72}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xcd9477..0xcd94ba
+              Pieces: [{Size: 8, Op: {CfaOffset: -72}}, {Size: 8, Op: null}]
+          Role: Local
+    - ID: 39
       Name: main.testDeepPtr1
-      OutOfLinePCRanges: [0xcd9420..0xcd9421]
+      OutOfLinePCRanges: [0xcd9520..0xcd9521]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 132 StructureType main.deepPtr1
           Locations:
-            - Range: 0xcd9420..0xcd9421
+            - Range: 0xcd9520..0xcd9521
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 39
+    - ID: 40
       Name: main.testDeepPtr7
-      OutOfLinePCRanges: [0xcd9440..0xcd9441]
+      OutOfLinePCRanges: [0xcd9540..0xcd9541]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 135 PointerType *main.deepPtr7
           Locations:
-            - Range: 0xcd9440..0xcd9441
+            - Range: 0xcd9540..0xcd9541
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 40
+    - ID: 41
       Name: main.testDeepSlice1
-      OutOfLinePCRanges: [0xcd95c0..0xcd95c1]
+      OutOfLinePCRanges: [0xcd96c0..0xcd96c1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 137 StructureType main.deepSlice1
           Locations:
-            - Range: 0xcd95c0..0xcd95c1
+            - Range: 0xcd96c0..0xcd96c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -5103,117 +5185,117 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 41
+    - ID: 42
       Name: main.testDeepSlice7
-      OutOfLinePCRanges: [0xcd95e0..0xcd95e1]
+      OutOfLinePCRanges: [0xcd96e0..0xcd96e1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 141 PointerType *main.deepSlice7
           Locations:
-            - Range: 0xcd95e0..0xcd95e1
+            - Range: 0xcd96e0..0xcd96e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 42
+    - ID: 43
       Name: main.testDeepMap1
-      OutOfLinePCRanges: [0xcd9740..0xcd9741]
+      OutOfLinePCRanges: [0xcd9840..0xcd9841]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 143 StructureType main.deepMap1
           Locations:
-            - Range: 0xcd9740..0xcd9741
+            - Range: 0xcd9840..0xcd9841
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 43
+    - ID: 44
       Name: main.testDeepMap7
-      OutOfLinePCRanges: [0xcd9760..0xcd9761]
+      OutOfLinePCRanges: [0xcd9860..0xcd9861]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 149 PointerType *main.deepMap7
           Locations:
-            - Range: 0xcd9760..0xcd9761
+            - Range: 0xcd9860..0xcd9861
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 44
+    - ID: 45
       Name: main.testStringType1
-      OutOfLinePCRanges: [0xcd9780..0xcd9781]
+      OutOfLinePCRanges: [0xcd9880..0xcd9881]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 151 PointerType *main.stringType1
           Locations:
-            - Range: 0xcd9780..0xcd9781
+            - Range: 0xcd9880..0xcd9881
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 45
+    - ID: 46
       Name: main.testStringType2
-      OutOfLinePCRanges: [0xcd97a0..0xcd97a1]
+      OutOfLinePCRanges: [0xcd98a0..0xcd98a1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 153 PointerType **main.stringType2
           Locations:
-            - Range: 0xcd97a0..0xcd97a1
+            - Range: 0xcd98a0..0xcd98a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 46
+    - ID: 47
       Name: main.testLongFunctionWithChangingState
-      OutOfLinePCRanges: [0xcd97c0..0xcd9a0a]
+      OutOfLinePCRanges: [0xcd98c0..0xcd9b0a]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd98a4..0xcd98c5
+            - Range: 0xcd99a4..0xcd99c5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd9978..0xcd998f
+            - Range: 0xcd9a78..0xcd9a8f
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
         - Name: aPerArch
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd988d..0xcd9890
+            - Range: 0xcd998d..0xcd9990
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcd9890..0xcd98c5
+            - Range: 0xcd9990..0xcd99c5
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcd98c5..0xcd996b
+            - Range: 0xcd99c5..0xcd9a6b
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0xcd996b..0xcd9978
+            - Range: 0xcd9a6b..0xcd9a78
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0xcd9978..0xcd9a0a
+            - Range: 0xcd9a78..0xcd9b0a
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
           Role: Local
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9887..0xcd9890
+            - Range: 0xcd9987..0xcd9990
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcd9890..0xcd9890
+            - Range: 0xcd9990..0xcd9990
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcd9890..0xcd98c5
+            - Range: 0xcd9990..0xcd99c5
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcd98c5..0xcd996b
+            - Range: 0xcd99c5..0xcd9a6b
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0xcd996b..0xcd9970
+            - Range: 0xcd9a6b..0xcd9a70
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0xcd9970..0xcd9978
+            - Range: 0xcd9a70..0xcd9a78
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
-            - Range: 0xcd9978..0xcd998f
+            - Range: 0xcd9a78..0xcd9a8f
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
-            - Range: 0xcd998f..0xcd9a0a
+            - Range: 0xcd9a8f..0xcd9b0a
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
           Role: Local
-    - ID: 47
+    - ID: 48
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0xcd9e40..0xcd9f45]
+      OutOfLinePCRanges: [0xcd9f60..0xcda065]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 155 StructureType main.esotericStack
           Locations:
-            - Range: 0xcd9e40..0xcd9e93
+            - Range: 0xcd9f60..0xcd9fb3
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -5233,7 +5315,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
-            - Range: 0xcd9e93..0xcd9e98
+            - Range: 0xcd9fb3..0xcd9fb8
               Pieces:
                 - Size: 4
                   Op: null
@@ -5253,7 +5335,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
-            - Range: 0xcd9e98..0xcd9e9d
+            - Range: 0xcd9fb8..0xcd9fbd
               Pieces:
                 - Size: 4
                   Op: null
@@ -5274,226 +5356,136 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
           Role: Parameter
-    - ID: 48
+    - ID: 49
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0xcd9f60..0xcd9fc3]
+      OutOfLinePCRanges: [0xcda080..0xcda0e3]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 159 PointerType *main.esotericHeap
           Locations:
-            - Range: 0xcd9f60..0xcd9f8d
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-    - ID: 49
-      Name: main.testInlinedBA
-      OutOfLinePCRanges: [0xcda3a0..0xcda428]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcda3a0..0xcda3b5
+            - Range: 0xcda080..0xcda0ad
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 50
-      Name: main.testInlinedBB
-      OutOfLinePCRanges: [0xcda440..0xcda505]
+      Name: main.testInlinedBA
+      OutOfLinePCRanges: [0xcda4c0..0xcda548]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda440..0xcda456
+            - Range: 0xcda4c0..0xcda4d5
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+    - ID: 51
+      Name: main.testInlinedBB
+      OutOfLinePCRanges: [0xcda560..0xcda625]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcda560..0xcda576
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: y
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda440..0xcda467
+            - Range: 0xcda560..0xcda587
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
         - Name: z
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda456..0xcda467
+            - Range: 0xcda576..0xcda587
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcda467..0xcda505
+            - Range: 0xcda587..0xcda625
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Local
-    - ID: 51
+    - ID: 52
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0xcda520..0xcda582]
+      OutOfLinePCRanges: [0xcda640..0xcda6a2]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda520..0xcda53a
+            - Range: 0xcda640..0xcda65a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 52
+    - ID: 53
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0xcda5a0..0xcda6a5]
+      OutOfLinePCRanges: [0xcda6c0..0xcda7c5]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda5fb..0xcda605
+            - Range: 0xcda71b..0xcda725
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xcda605..0xcda615
+            - Range: 0xcda725..0xcda735
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xcda615..0xcda629
+            - Range: 0xcda735..0xcda749
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda5f6..0xcda600
+            - Range: 0xcda716..0xcda720
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xcda600..0xcda615
+            - Range: 0xcda720..0xcda735
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xcda615..0xcda624
+            - Range: 0xcda735..0xcda744
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 53
+    - ID: 54
       Name: main.testFrameless
-      OutOfLinePCRanges: [0xcda6c0..0xcda6c6]
+      OutOfLinePCRanges: [0xcda7e0..0xcda7e6]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda6c0..0xcda6c5
+            - Range: 0xcda7e0..0xcda7e5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda6c0..0xcda6c5
+            - Range: 0xcda7e0..0xcda7e5
               Pieces: []
-            - Range: 0xcda6c5..0xcda6c6
+            - Range: 0xcda7e5..0xcda7e6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
-    - ID: 54
+    - ID: 55
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0xcda6e0..0xcda723]
+      OutOfLinePCRanges: [0xcda800..0xcda843]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 161 ArrayType [5]int
           Locations:
-            - Range: 0xcda6e0..0xcda723
+            - Range: 0xcda800..0xcda843
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda6e0..0xcda71d
+            - Range: 0xcda800..0xcda83d
               Pieces: []
-            - Range: 0xcda71d..0xcda71e
+            - Range: 0xcda83d..0xcda83e
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcda71e..0xcda723
+            - Range: 0xcda83e..0xcda843
               Pieces: []
           Role: Return
-    - ID: 55
+    - ID: 56
       Name: main.testInterface
-      OutOfLinePCRanges: [0xcda9c0..0xcda9c1]
+      OutOfLinePCRanges: [0xcdaae0..0xcdaae1]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 162 GoInterfaceType main.behavior
-          Locations:
-            - Range: 0xcda9c0..0xcda9c1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          Role: Parameter
-    - ID: 56
-      Name: main.testAny
-      OutOfLinePCRanges: [0xcda9e0..0xcdaa46]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 157 GoEmptyInterfaceType interface {}
-          Locations:
-            - Range: 0xcda9e0..0xcdaa09
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdaa09..0xcdaa0e
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          Role: Parameter
-        - Name: ~r0
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xcda9e0..0xcdaa25
-              Pieces: []
-            - Range: 0xcdaa25..0xcdaa26
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdaa26..0xcdaa46
-              Pieces: []
-          Role: Return
-    - ID: 57
-      Name: main.testError
-      OutOfLinePCRanges: [0xcdaa60..0xcdaa61]
-      InlinePCRanges: []
-      Variables:
-        - Name: e
-          Type: 13 GoInterfaceType error
-          Locations:
-            - Range: 0xcdaa60..0xcdaa61
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          Role: Parameter
-    - ID: 58
-      Name: main.testAnyPtr
-      OutOfLinePCRanges: [0xcdaa80..0xcdaad4]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 163 PointerType *interface {}
-          Locations:
-            - Range: 0xcdaa80..0xcdaaa6
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-        - Name: ~r0
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xcdaa80..0xcdaabd
-              Pieces: []
-            - Range: 0xcdaabd..0xcdaabe
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdaabe..0xcdaad4
-              Pieces: []
-          Role: Return
-    - ID: 59
-      Name: main.testStructWithAny
-      OutOfLinePCRanges: [0xcdaae0..0xcdaae1]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 164 StructureType main.structWithAny
           Locations:
             - Range: 0xcdaae0..0xcdaae1
               Pieces:
@@ -5502,297 +5494,387 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
+    - ID: 57
+      Name: main.testAny
+      OutOfLinePCRanges: [0xcdab00..0xcdab66]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 157 GoEmptyInterfaceType interface {}
+          Locations:
+            - Range: 0xcdab00..0xcdab29
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcdab29..0xcdab2e
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Parameter
+        - Name: ~r0
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xcdab00..0xcdab45
+              Pieces: []
+            - Range: 0xcdab45..0xcdab46
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcdab46..0xcdab66
+              Pieces: []
+          Role: Return
+    - ID: 58
+      Name: main.testError
+      OutOfLinePCRanges: [0xcdab80..0xcdab81]
+      InlinePCRanges: []
+      Variables:
+        - Name: e
+          Type: 13 GoInterfaceType error
+          Locations:
+            - Range: 0xcdab80..0xcdab81
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Parameter
+    - ID: 59
+      Name: main.testAnyPtr
+      OutOfLinePCRanges: [0xcdaba0..0xcdabf4]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 163 PointerType *interface {}
+          Locations:
+            - Range: 0xcdaba0..0xcdabc6
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+        - Name: ~r0
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xcdaba0..0xcdabdd
+              Pieces: []
+            - Range: 0xcdabdd..0xcdabde
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcdabde..0xcdabf4
+              Pieces: []
+          Role: Return
     - ID: 60
+      Name: main.testStructWithAny
+      OutOfLinePCRanges: [0xcdac00..0xcdac01]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 164 StructureType main.structWithAny
+          Locations:
+            - Range: 0xcdac00..0xcdac01
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Parameter
+    - ID: 61
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0xcdb0e0..0xcdb0e1]
+      OutOfLinePCRanges: [0xcdb200..0xcdb201]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 165 StructureType main.structWithMap
           Locations:
-            - Range: 0xcdb0e0..0xcdb0e1
+            - Range: 0xcdb200..0xcdb201
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 61
+    - ID: 62
       Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0xcdb100..0xcdb101]
+      OutOfLinePCRanges: [0xcdb220..0xcdb221]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 171 GoMapType map[string]main.nestedStruct
           Locations:
-            - Range: 0xcdb100..0xcdb101
+            - Range: 0xcdb220..0xcdb221
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 62
+    - ID: 63
       Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0xcdb120..0xcdb121]
+      OutOfLinePCRanges: [0xcdb240..0xcdb241]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 176 GoMapType map[string]int
           Locations:
-            - Range: 0xcdb120..0xcdb121
+            - Range: 0xcdb240..0xcdb241
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 63
+    - ID: 64
       Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0xcdb140..0xcdb141]
+      OutOfLinePCRanges: [0xcdb260..0xcdb261]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 181 GoMapType map[string][]string
           Locations:
-            - Range: 0xcdb140..0xcdb141
+            - Range: 0xcdb260..0xcdb261
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 64
+    - ID: 65
       Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0xcdb160..0xcdb161]
+      OutOfLinePCRanges: [0xcdb280..0xcdb281]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 186 GoMapType map[[4]string][2]int
           Locations:
-            - Range: 0xcdb160..0xcdb161
+            - Range: 0xcdb280..0xcdb281
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 65
+    - ID: 66
       Name: main.testSmallMap
-      OutOfLinePCRanges: [0xcdb180..0xcdb181]
+      OutOfLinePCRanges: [0xcdb2a0..0xcdb2a1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 176 GoMapType map[string]int
           Locations:
-            - Range: 0xcdb180..0xcdb181
+            - Range: 0xcdb2a0..0xcdb2a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 66
+    - ID: 67
       Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0xcdb1a0..0xcdb1a1]
+      OutOfLinePCRanges: [0xcdb2c0..0xcdb2c1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 191 ArrayType [2]map[string]int
           Locations:
-            - Range: 0xcdb1a0..0xcdb1a1
+            - Range: 0xcdb2c0..0xcdb2c1
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
-    - ID: 67
+    - ID: 68
       Name: main.testPointerToMap
-      OutOfLinePCRanges: [0xcdb1c0..0xcdb1c1]
+      OutOfLinePCRanges: [0xcdb2e0..0xcdb2e1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 192 PointerType *map[string]int
           Locations:
-            - Range: 0xcdb1c0..0xcdb1c1
+            - Range: 0xcdb2e0..0xcdb2e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 68
+    - ID: 69
       Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0xcdb1e0..0xcdb1e1]
+      OutOfLinePCRanges: [0xcdb300..0xcdb301]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 166 GoMapType map[int]int
           Locations:
-            - Range: 0xcdb1e0..0xcdb1e1
+            - Range: 0xcdb300..0xcdb301
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 69
+    - ID: 70
       Name: main.testMapMassive
-      OutOfLinePCRanges: [0xcdb200..0xcdb201]
+      OutOfLinePCRanges: [0xcdb320..0xcdb321]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 193 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0xcdb200..0xcdb201
+            - Range: 0xcdb320..0xcdb321
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 70
+    - ID: 71
       Name: main.testMapEmbeddedMaps
-      OutOfLinePCRanges: [0xcdb220..0xcdb221]
+      OutOfLinePCRanges: [0xcdb340..0xcdb341]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 193 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0xcdb220..0xcdb221
+            - Range: 0xcdb340..0xcdb341
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 71
+    - ID: 72
       Name: main.testMapWithLinkedList
-      OutOfLinePCRanges: [0xcdb240..0xcdb241]
+      OutOfLinePCRanges: [0xcdb360..0xcdb361]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 198 GoMapType map[bool]main.node
           Locations:
-            - Range: 0xcdb240..0xcdb241
+            - Range: 0xcdb360..0xcdb361
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 72
+    - ID: 73
       Name: main.testMapWithSmallValue
-      OutOfLinePCRanges: [0xcdb260..0xcdb261]
+      OutOfLinePCRanges: [0xcdb380..0xcdb381]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 203 GoMapType map[int]uint8
           Locations:
-            - Range: 0xcdb260..0xcdb261
+            - Range: 0xcdb380..0xcdb381
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 73
+    - ID: 74
       Name: main.testMapWithSmallValueMassive
-      OutOfLinePCRanges: [0xcdb280..0xcdb281]
+      OutOfLinePCRanges: [0xcdb3a0..0xcdb3a1]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 203 GoMapType map[int]uint8
           Locations:
-            - Range: 0xcdb280..0xcdb281
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-    - ID: 74
-      Name: main.testMapWithSmallKeyAndValue
-      OutOfLinePCRanges: [0xcdb2a0..0xcdb2a1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 208 GoMapType map[uint8]uint8
-          Locations:
-            - Range: 0xcdb2a0..0xcdb2a1
+            - Range: 0xcdb3a0..0xcdb3a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 75
-      Name: main.testMapWithSmallKeyAndValueMassive
-      OutOfLinePCRanges: [0xcdb2c0..0xcdb2c1]
+      Name: main.testMapWithSmallKeyAndValue
+      OutOfLinePCRanges: [0xcdb3c0..0xcdb3c1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 208 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0xcdb2c0..0xcdb2c1
+            - Range: 0xcdb3c0..0xcdb3c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 76
-      Name: main.testMapSmallKeySmallValue
-      OutOfLinePCRanges: [0xcdb2e0..0xcdb2e1]
+      Name: main.testMapWithSmallKeyAndValueMassive
+      OutOfLinePCRanges: [0xcdb3e0..0xcdb3e1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 208 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0xcdb2e0..0xcdb2e1
+            - Range: 0xcdb3e0..0xcdb3e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 77
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0xcdb400..0xcdb401]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 208 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xcdb400..0xcdb401
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+    - ID: 78
       Name: main.testMapSmallKeyLargeValue
-      OutOfLinePCRanges: [0xcdb300..0xcdb301]
+      OutOfLinePCRanges: [0xcdb420..0xcdb421]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 213 GoMapType map[uint8][4]int
           Locations:
-            - Range: 0xcdb300..0xcdb301
+            - Range: 0xcdb420..0xcdb421
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 78
+    - ID: 79
       Name: main.testMapLargeKeySmallValue
-      OutOfLinePCRanges: [0xcdb320..0xcdb321]
+      OutOfLinePCRanges: [0xcdb440..0xcdb441]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 218 GoMapType map[[4]int]uint8
           Locations:
-            - Range: 0xcdb320..0xcdb321
+            - Range: 0xcdb440..0xcdb441
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 79
+    - ID: 80
       Name: main.testMapLargeKeyLargeValue
-      OutOfLinePCRanges: [0xcdb340..0xcdb341]
+      OutOfLinePCRanges: [0xcdb460..0xcdb461]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 223 GoMapType map[[4]int][4]int
           Locations:
-            - Range: 0xcdb340..0xcdb341
+            - Range: 0xcdb460..0xcdb461
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 80
+    - ID: 81
       Name: main.testMapEmptyKey
-      OutOfLinePCRanges: [0xcdb360..0xcdb361]
+      OutOfLinePCRanges: [0xcdb480..0xcdb481]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 228 GoMapType map[struct {}]int
           Locations:
-            - Range: 0xcdb360..0xcdb361
+            - Range: 0xcdb480..0xcdb481
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 81
+    - ID: 82
       Name: main.testMapEmptyValue
-      OutOfLinePCRanges: [0xcdb380..0xcdb381]
+      OutOfLinePCRanges: [0xcdb4a0..0xcdb4a1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 233 GoMapType map[int]struct {}
           Locations:
-            - Range: 0xcdb380..0xcdb381
+            - Range: 0xcdb4a0..0xcdb4a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 82
+    - ID: 83
       Name: main.testMapEmptyKeyAndValue
-      OutOfLinePCRanges: [0xcdb3a0..0xcdb3a1]
+      OutOfLinePCRanges: [0xcdb4c0..0xcdb4c1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 238 GoMapType map[struct {}]struct {}
           Locations:
-            - Range: 0xcdb3a0..0xcdb3a1
+            - Range: 0xcdb4c0..0xcdb4c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 83
+    - ID: 84
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0xcdcca0..0xcdcca1]
+      OutOfLinePCRanges: [0xcdcdc0..0xcdcdc1]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcdcca0..0xcdcca1
+            - Range: 0xcdcdc0..0xcdcdc1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcdcca0..0xcdcca1
+            - Range: 0xcdcdc0..0xcdcdc1
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
         - Name: y
           Type: 18 BaseType float32
           Locations:
-            - Range: 0xcdcca0..0xcdcca1
+            - Range: 0xcdcdc0..0xcdcdc1
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
-    - ID: 84
+    - ID: 85
       Name: main.testCombinedString
-      OutOfLinePCRanges: [0xcdcce0..0xcdcce1]
+      OutOfLinePCRanges: [0xcdce00..0xcdce01]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcdcce0..0xcdcce1
+            - Range: 0xcdce00..0xcdce01
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdcce0..0xcdcce1
+            - Range: 0xcdce00..0xcdce01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -5802,343 +5884,343 @@ Subprograms:
         - Name: y
           Type: 18 BaseType float32
           Locations:
-            - Range: 0xcdcce0..0xcdcce1
+            - Range: 0xcdce00..0xcdce01
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
-    - ID: 85
+    - ID: 86
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0xcdce60..0xcdce61]
+      OutOfLinePCRanges: [0xcdcf80..0xcdcf81]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcdce60..0xcdce61
+            - Range: 0xcdcf80..0xcdcf81
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: b
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcdce60..0xcdce61
+            - Range: 0xcdcf80..0xcdcf81
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
         - Name: c
           Type: 10 BaseType int32
           Locations:
-            - Range: 0xcdce60..0xcdce61
+            - Range: 0xcdcf80..0xcdcf81
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
         - Name: d
           Type: 17 BaseType uint
           Locations:
-            - Range: 0xcdce60..0xcdce61
+            - Range: 0xcdcf80..0xcdcf81
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
         - Name: e
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdce60..0xcdce61
+            - Range: 0xcdcf80..0xcdcf81
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 86
+    - ID: 87
       Name: main.testAtomicAdd
-      OutOfLinePCRanges: [0xcdd080..0xcdd093]
+      OutOfLinePCRanges: [0xcdd1a0..0xcdd1b3]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0xcdd080..0xcdd092
+            - Range: 0xcdd1a0..0xcdd1b2
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0xcdd080..0xcdd092
+            - Range: 0xcdd1a0..0xcdd1b2
               Pieces: []
-            - Range: 0xcdd092..0xcdd093
+            - Range: 0xcdd1b2..0xcdd1b3
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
-    - ID: 87
+    - ID: 88
       Name: main.testChannel
-      OutOfLinePCRanges: [0xcdd0a0..0xcdd0a1]
+      OutOfLinePCRanges: [0xcdd1c0..0xcdd1c1]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 243 GoChannelType chan bool
           Locations:
-            - Range: 0xcdd0a0..0xcdd0a1
+            - Range: 0xcdd1c0..0xcdd1c1
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 88
+    - ID: 89
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0xcdd260..0xcdd261]
+      OutOfLinePCRanges: [0xcdd380..0xcdd381]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 244 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0xcdd260..0xcdd261
+            - Range: 0xcdd380..0xcdd381
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 89
+    - ID: 90
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0xcdd280..0xcdd281]
+      OutOfLinePCRanges: [0xcdd3a0..0xcdd3a1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 246 StructureType main.node
           Locations:
-            - Range: 0xcdd280..0xcdd281
+            - Range: 0xcdd3a0..0xcdd3a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
-    - ID: 90
+    - ID: 91
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0xcdd2a0..0xcdd2a1]
+      OutOfLinePCRanges: [0xcdd3c0..0xcdd3c1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 247 PointerType *main.node
           Locations:
-            - Range: 0xcdd2a0..0xcdd2a1
+            - Range: 0xcdd3c0..0xcdd3c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 91
+    - ID: 92
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0xcdd2c0..0xcdd2c1]
+      OutOfLinePCRanges: [0xcdd3e0..0xcdd3e1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 14 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0xcdd2c0..0xcdd2c1
+            - Range: 0xcdd3e0..0xcdd3e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 92
+    - ID: 93
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0xcdd300..0xcdd301]
+      OutOfLinePCRanges: [0xcdd420..0xcdd421]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 107 PointerType *uint
           Locations:
-            - Range: 0xcdd300..0xcdd301
+            - Range: 0xcdd420..0xcdd421
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 93
+    - ID: 94
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0xcdd3e0..0xcdd3e1]
+      OutOfLinePCRanges: [0xcdd500..0xcdd501]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 95 PointerType *string
           Locations:
-            - Range: 0xcdd3e0..0xcdd3e1
+            - Range: 0xcdd500..0xcdd501
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 94
+    - ID: 95
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0xcdd420..0xcdd421]
+      OutOfLinePCRanges: [0xcdd540..0xcdd541]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 11 PointerType *bool
           Locations:
-            - Range: 0xcdd420..0xcdd421
+            - Range: 0xcdd540..0xcdd541
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: a
           Type: 17 BaseType uint
           Locations:
-            - Range: 0xcdd420..0xcdd421
+            - Range: 0xcdd540..0xcdd541
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
-    - ID: 95
+    - ID: 96
       Name: main.testCycle
-      OutOfLinePCRanges: [0xcdd460..0xcdd461]
+      OutOfLinePCRanges: [0xcdd580..0xcdd581]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 248 PointerType *main.t
           Locations:
-            - Range: 0xcdd460..0xcdd461
+            - Range: 0xcdd580..0xcdd581
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 96
+    - ID: 97
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0xcdd8a0..0xcdd912]
+      OutOfLinePCRanges: [0xcdd9c0..0xcdda32]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdd8a0..0xcdd8b2
+            - Range: 0xcdd9c0..0xcdd9d2
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdd8a0..0xcdd8fb
+            - Range: 0xcdd9c0..0xcdda1b
               Pieces: []
-            - Range: 0xcdd8fb..0xcdd8fc
+            - Range: 0xcdda1b..0xcdda1c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdd8fc..0xcdd912
+            - Range: 0xcdda1c..0xcdda32
               Pieces: []
           Role: Return
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdd8b2..0xcdd8c5
+            - Range: 0xcdd9d2..0xcdd9e5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdd8c5..0xcdd912
+            - Range: 0xcdd9e5..0xcdda32
               Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
           Role: Local
-    - ID: 97
+    - ID: 98
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0xcdd920..0xcdd9af]
+      OutOfLinePCRanges: [0xcdda40..0xcddacf]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdd920..0xcdd93a
+            - Range: 0xcdda40..0xcdda5a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdd93a..0xcdd9af
+            - Range: 0xcdda5a..0xcddacf
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 99 PointerType *int
           Locations:
-            - Range: 0xcdd920..0xcdd994
+            - Range: 0xcdda40..0xcddab4
               Pieces: []
-            - Range: 0xcdd994..0xcdd995
+            - Range: 0xcddab4..0xcddab5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdd995..0xcdd9af
+            - Range: 0xcddab5..0xcddacf
               Pieces: []
           Role: Return
         - Name: '&result'
           Type: 99 PointerType *int
           Locations:
-            - Range: 0xcdd93f..0xcdd959
+            - Range: 0xcdda5f..0xcdda79
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdd959..0xcdd9af
+            - Range: 0xcdda79..0xcddacf
               Pieces: [{Size: 8, Op: {CfaOffset: -24}}]
           Role: Local
-    - ID: 98
+    - ID: 99
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0xcdd9c0..0xcdda9e]
+      OutOfLinePCRanges: [0xcddae0..0xcddbbe]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdd9c0..0xcdda22
+            - Range: 0xcddae0..0xcddb42
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdd9c0..0xcdda84
+            - Range: 0xcddae0..0xcddba4
               Pieces: []
-            - Range: 0xcdda84..0xcdda85
+            - Range: 0xcddba4..0xcddba5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdda85..0xcdda9e
+            - Range: 0xcddba5..0xcddbbe
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcdd9c0..0xcdda9e, Pieces: []}]
+          Locations: [{Range: 0xcddae0..0xcddbbe, Pieces: []}]
           Role: Return
         - Name: resultInt
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdd9d6..0xcdda27
+            - Range: 0xcddaf6..0xcddb47
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcdda27..0xcdda9e
+            - Range: 0xcddb47..0xcddbbe
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
           Role: Local
         - Name: resultFloat
           Type: 15 BaseType float64
           Locations:
-            - Range: 0xcdd9ef..0xcdda27
+            - Range: 0xcddb0f..0xcddb47
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
-            - Range: 0xcdda27..0xcdda9e
+            - Range: 0xcddb47..0xcddbbe
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
-    - ID: 99
+    - ID: 100
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0xcddaa0..0xcddafb]
+      OutOfLinePCRanges: [0xcddbc0..0xcddc1b]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcddaa0..0xcddab9
+            - Range: 0xcddbc0..0xcddbd9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 13 GoInterfaceType error
           Locations:
-            - Range: 0xcddaa0..0xcddada
+            - Range: 0xcddbc0..0xcddbfa
               Pieces: []
-            - Range: 0xcddada..0xcddadb
+            - Range: 0xcddbfa..0xcddbfb
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcddadb..0xcddae5
+            - Range: 0xcddbfb..0xcddc05
               Pieces: []
-            - Range: 0xcddae5..0xcddae6
+            - Range: 0xcddc05..0xcddc06
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcddae6..0xcddafb
+            - Range: 0xcddc06..0xcddc1b
               Pieces: []
           Role: Return
-    - ID: 100
+    - ID: 101
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0xcddb00..0xcddc46]
+      OutOfLinePCRanges: [0xcddc20..0xcddd66]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcddb00..0xcddb4b
+            - Range: 0xcddc20..0xcddc6b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcddb4b..0xcddb56
+            - Range: 0xcddc6b..0xcddc76
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcddb87..0xcddb8a
+            - Range: 0xcddca7..0xcddcaa
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcddbc0..0xcddbc5
+            - Range: 0xcddce0..0xcddce5
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcddbf4..0xcddbf9
+            - Range: 0xcddd14..0xcddd19
               Pieces:
                 - Size: 8
                   Op: null
@@ -6148,112 +6230,112 @@ Subprograms:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcddb00..0xcddb43
+            - Range: 0xcddc20..0xcddc63
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcddb00..0xcddb64
+            - Range: 0xcddc20..0xcddc84
               Pieces: []
-            - Range: 0xcddb64..0xcddb65
+            - Range: 0xcddc84..0xcddc85
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcddb65..0xcddbb3
+            - Range: 0xcddc85..0xcddcd3
               Pieces: []
-            - Range: 0xcddbb3..0xcddbb4
+            - Range: 0xcddcd3..0xcddcd4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcddbb4..0xcddbe7
+            - Range: 0xcddcd4..0xcddd07
               Pieces: []
-            - Range: 0xcddbe7..0xcddbe8
+            - Range: 0xcddd07..0xcddd08
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcddbe8..0xcddc19
+            - Range: 0xcddd08..0xcddd39
               Pieces: []
-            - Range: 0xcddc19..0xcddc1a
+            - Range: 0xcddd39..0xcddd3a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcddc1a..0xcddc46
+            - Range: 0xcddd3a..0xcddd66
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 13 GoInterfaceType error
           Locations:
-            - Range: 0xcddb00..0xcddb64
+            - Range: 0xcddc20..0xcddc84
               Pieces: []
-            - Range: 0xcddb64..0xcddb65
+            - Range: 0xcddc84..0xcddc85
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcddb65..0xcddbb3
+            - Range: 0xcddc85..0xcddcd3
               Pieces: []
-            - Range: 0xcddbb3..0xcddbb4
+            - Range: 0xcddcd3..0xcddcd4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcddbb4..0xcddbe7
+            - Range: 0xcddcd4..0xcddd07
               Pieces: []
-            - Range: 0xcddbe7..0xcddbe8
+            - Range: 0xcddd07..0xcddd08
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcddbe8..0xcddc19
+            - Range: 0xcddd08..0xcddd39
               Pieces: []
-            - Range: 0xcddc19..0xcddc1a
+            - Range: 0xcddd39..0xcddd3a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcddc1a..0xcddc46
+            - Range: 0xcddd3a..0xcddd66
               Pieces: []
           Role: Return
         - Name: val
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcddb4b..0xcddb51
+            - Range: 0xcddc6b..0xcddc71
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 101
+    - ID: 102
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0xcddc60..0xcdde4e]
+      OutOfLinePCRanges: [0xcddd80..0xcddf6e]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcddc60..0xcddcab
+            - Range: 0xcddd80..0xcdddcb
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcddcab..0xcddcb2
+            - Range: 0xcdddcb..0xcdddd2
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcddcb2..0xcdde4e
+            - Range: 0xcdddd2..0xcddf6e
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -6263,941 +6345,941 @@ Subprograms:
         - Name: ~r0
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcddc60..0xcddd15
+            - Range: 0xcddd80..0xcdde35
               Pieces: []
-            - Range: 0xcddd15..0xcddd16
+            - Range: 0xcdde35..0xcdde36
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcddd16..0xcddd64
+            - Range: 0xcdde36..0xcdde84
               Pieces: []
-            - Range: 0xcddd64..0xcddd65
+            - Range: 0xcdde84..0xcdde85
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcddd65..0xcdde20
+            - Range: 0xcdde85..0xcddf40
               Pieces: []
-            - Range: 0xcdde20..0xcdde21
+            - Range: 0xcddf40..0xcddf41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdde21..0xcdde2a
+            - Range: 0xcddf41..0xcddf4a
               Pieces: []
-            - Range: 0xcdde2a..0xcdde2b
+            - Range: 0xcddf4a..0xcddf4b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdde2b..0xcdde4e
+            - Range: 0xcddf4b..0xcddf6e
               Pieces: []
           Role: Return
         - Name: val
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcddd00..0xcddd06
+            - Range: 0xcdde20..0xcdde26
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
         - Name: '&result'
           Type: 99 PointerType *int
           Locations:
-            - Range: 0xcddd45..0xcddd64
+            - Range: 0xcdde65..0xcdde84
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 102
+    - ID: 103
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0xcdde60..0xcddfb4]
+      OutOfLinePCRanges: [0xcddf80..0xcde0d4]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcdde60..0xcddea0
+            - Range: 0xcddf80..0xcddfc0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcddea0..0xcddeee
+            - Range: 0xcddfc0..0xcde00e
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcddeee..0xcddf4f
+            - Range: 0xcde00e..0xcde06f
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcddf4f..0xcddf71
+            - Range: 0xcde06f..0xcde091
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcddf71..0xcddf78
+            - Range: 0xcde091..0xcde098
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcddf78..0xcddfb4
+            - Range: 0xcde098..0xcde0d4
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 162 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xcdde60..0xcddf3f
+            - Range: 0xcddf80..0xcde05f
               Pieces: []
-            - Range: 0xcddf3f..0xcddf40
+            - Range: 0xcde05f..0xcde060
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcddf40..0xcddf49
+            - Range: 0xcde060..0xcde069
               Pieces: []
-            - Range: 0xcddf49..0xcddf4a
+            - Range: 0xcde069..0xcde06a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcddf4a..0xcddfb4
+            - Range: 0xcde06a..0xcde0d4
               Pieces: []
           Role: Return
         - Name: b
           Type: 162 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xcdde60..0xcddea0
+            - Range: 0xcddf80..0xcddfc0
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcddea0..0xcddeee
+            - Range: 0xcddfc0..0xcde00e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcddeee..0xcddef5
+            - Range: 0xcde00e..0xcde015
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcddef5..0xcddf45
+            - Range: 0xcde015..0xcde065
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcddf45..0xcddf47
+            - Range: 0xcde065..0xcde067
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcddf47..0xcddf49
+            - Range: 0xcde067..0xcde069
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcddf49..0xcddfb4
+            - Range: 0xcde069..0xcde0d4
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           Role: Local
-    - ID: 103
+    - ID: 104
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0xcddfc0..0xcde04f]
+      OutOfLinePCRanges: [0xcde0e0..0xcde16f]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcddfc0..0xcddfd1
+            - Range: 0xcde0e0..0xcde0f1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcddfc0..0xcde035
+            - Range: 0xcde0e0..0xcde155
               Pieces: []
-            - Range: 0xcde035..0xcde036
+            - Range: 0xcde155..0xcde156
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcde036..0xcde04f
+            - Range: 0xcde156..0xcde16f
               Pieces: []
           Role: Return
-    - ID: 104
+    - ID: 105
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0xcde060..0xcde129]
+      OutOfLinePCRanges: [0xcde180..0xcde249]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcde060..0xcde0b1
+            - Range: 0xcde180..0xcde1d1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcde060..0xcde10f
+            - Range: 0xcde180..0xcde22f
               Pieces: []
-            - Range: 0xcde10f..0xcde110
+            - Range: 0xcde22f..0xcde230
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcde110..0xcde129
+            - Range: 0xcde230..0xcde249
               Pieces: []
           Role: Return
         - Name: result2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcde060..0xcde10f
+            - Range: 0xcde180..0xcde22f
               Pieces: []
-            - Range: 0xcde10f..0xcde110
+            - Range: 0xcde22f..0xcde230
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcde110..0xcde129
+            - Range: 0xcde230..0xcde249
               Pieces: []
           Role: Return
-    - ID: 105
+    - ID: 106
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0xcde140..0xcde207]
+      OutOfLinePCRanges: [0xcde260..0xcde327]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcde140..0xcde185
+            - Range: 0xcde260..0xcde2a5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcde185..0xcde207
+            - Range: 0xcde2a5..0xcde327
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcde140..0xcde1ed
+            - Range: 0xcde260..0xcde30d
               Pieces: []
-            - Range: 0xcde1ed..0xcde1ee
+            - Range: 0xcde30d..0xcde30e
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcde1ee..0xcde207
+            - Range: 0xcde30e..0xcde327
               Pieces: []
           Role: Return
         - Name: result2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcde140..0xcde1ed
+            - Range: 0xcde260..0xcde30d
               Pieces: []
-            - Range: 0xcde1ed..0xcde1ee
+            - Range: 0xcde30d..0xcde30e
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcde1ee..0xcde207
+            - Range: 0xcde30e..0xcde327
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcde140..0xcde1ed
+            - Range: 0xcde260..0xcde30d
               Pieces: []
-            - Range: 0xcde1ed..0xcde1ee
+            - Range: 0xcde30d..0xcde30e
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcde1ee..0xcde207
+            - Range: 0xcde30e..0xcde327
               Pieces: []
           Role: Return
-    - ID: 106
+    - ID: 107
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0xcde220..0xcde29e]
+      OutOfLinePCRanges: [0xcde340..0xcde3be]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 16 BaseType int8
           Locations:
-            - Range: 0xcde220..0xcde291
+            - Range: 0xcde340..0xcde3b1
               Pieces: []
-            - Range: 0xcde291..0xcde292
+            - Range: 0xcde3b1..0xcde3b2
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcde292..0xcde29e
+            - Range: 0xcde3b2..0xcde3be
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 104 BaseType int16
           Locations:
-            - Range: 0xcde220..0xcde291
+            - Range: 0xcde340..0xcde3b1
               Pieces: []
-            - Range: 0xcde291..0xcde292
+            - Range: 0xcde3b1..0xcde3b2
               Pieces: [{Size: 2, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcde292..0xcde29e
+            - Range: 0xcde3b2..0xcde3be
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 10 BaseType int32
           Locations:
-            - Range: 0xcde220..0xcde291
+            - Range: 0xcde340..0xcde3b1
               Pieces: []
-            - Range: 0xcde291..0xcde292
+            - Range: 0xcde3b1..0xcde3b2
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcde292..0xcde29e
+            - Range: 0xcde3b2..0xcde3be
               Pieces: []
           Role: Return
         - Name: ~r3
           Type: 12 BaseType int64
           Locations:
-            - Range: 0xcde220..0xcde291
+            - Range: 0xcde340..0xcde3b1
               Pieces: []
-            - Range: 0xcde291..0xcde292
+            - Range: 0xcde3b1..0xcde3b2
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xcde292..0xcde29e
+            - Range: 0xcde3b2..0xcde3be
               Pieces: []
           Role: Return
         - Name: ~r4
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcde220..0xcde291
+            - Range: 0xcde340..0xcde3b1
               Pieces: []
-            - Range: 0xcde291..0xcde292
+            - Range: 0xcde3b1..0xcde3b2
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcde292..0xcde29e
+            - Range: 0xcde3b2..0xcde3be
               Pieces: []
           Role: Return
         - Name: ~r5
           Type: 6 BaseType uint16
           Locations:
-            - Range: 0xcde220..0xcde291
+            - Range: 0xcde340..0xcde3b1
               Pieces: []
-            - Range: 0xcde291..0xcde292
+            - Range: 0xcde3b1..0xcde3b2
               Pieces: [{Size: 2, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xcde292..0xcde29e
+            - Range: 0xcde3b2..0xcde3be
               Pieces: []
           Role: Return
         - Name: ~r6
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0xcde220..0xcde291
+            - Range: 0xcde340..0xcde3b1
               Pieces: []
-            - Range: 0xcde291..0xcde292
+            - Range: 0xcde3b1..0xcde3b2
               Pieces: [{Size: 4, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xcde292..0xcde29e
+            - Range: 0xcde3b2..0xcde3be
               Pieces: []
           Role: Return
         - Name: ~r7
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0xcde220..0xcde291
+            - Range: 0xcde340..0xcde3b1
               Pieces: []
-            - Range: 0xcde291..0xcde292
+            - Range: 0xcde3b1..0xcde3b2
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xcde292..0xcde29e
+            - Range: 0xcde3b2..0xcde3be
               Pieces: []
           Role: Return
-    - ID: 107
+    - ID: 108
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0xcde2a0..0xcde397]
+      OutOfLinePCRanges: [0xcde3c0..0xcde4b7]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcde2a0..0xcde397, Pieces: []}]
+          Locations: [{Range: 0xcde3c0..0xcde4b7, Pieces: []}]
           Role: Return
         - Name: ~r1
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcde2a0..0xcde397, Pieces: []}]
+          Locations: [{Range: 0xcde3c0..0xcde4b7, Pieces: []}]
           Role: Return
         - Name: ~r2
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcde2a0..0xcde397, Pieces: []}]
+          Locations: [{Range: 0xcde3c0..0xcde4b7, Pieces: []}]
           Role: Return
         - Name: ~r3
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcde2a0..0xcde397, Pieces: []}]
+          Locations: [{Range: 0xcde3c0..0xcde4b7, Pieces: []}]
           Role: Return
         - Name: ~r4
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcde2a0..0xcde397, Pieces: []}]
+          Locations: [{Range: 0xcde3c0..0xcde4b7, Pieces: []}]
           Role: Return
         - Name: ~r5
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcde2a0..0xcde397, Pieces: []}]
+          Locations: [{Range: 0xcde3c0..0xcde4b7, Pieces: []}]
           Role: Return
         - Name: ~r6
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcde2a0..0xcde397, Pieces: []}]
+          Locations: [{Range: 0xcde3c0..0xcde4b7, Pieces: []}]
           Role: Return
         - Name: ~r7
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcde2a0..0xcde397, Pieces: []}]
+          Locations: [{Range: 0xcde3c0..0xcde4b7, Pieces: []}]
           Role: Return
         - Name: ~r8
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcde2a0..0xcde397, Pieces: []}]
+          Locations: [{Range: 0xcde3c0..0xcde4b7, Pieces: []}]
           Role: Return
         - Name: ~r9
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcde2a0..0xcde397, Pieces: []}]
+          Locations: [{Range: 0xcde3c0..0xcde4b7, Pieces: []}]
           Role: Return
         - Name: ~r10
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcde2a0..0xcde397, Pieces: []}]
+          Locations: [{Range: 0xcde3c0..0xcde4b7, Pieces: []}]
           Role: Return
         - Name: ~r11
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcde2a0..0xcde397, Pieces: []}]
+          Locations: [{Range: 0xcde3c0..0xcde4b7, Pieces: []}]
           Role: Return
         - Name: ~r12
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcde2a0..0xcde397, Pieces: []}]
+          Locations: [{Range: 0xcde3c0..0xcde4b7, Pieces: []}]
           Role: Return
         - Name: ~r13
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcde2a0..0xcde397, Pieces: []}]
+          Locations: [{Range: 0xcde3c0..0xcde4b7, Pieces: []}]
           Role: Return
         - Name: ~r14
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcde2a0..0xcde397, Pieces: []}]
+          Locations: [{Range: 0xcde3c0..0xcde4b7, Pieces: []}]
           Role: Return
         - Name: onlyOnAmd64_16
           Type: 15 BaseType float64
           Locations:
-            - Range: 0xcde2a0..0xcde387
+            - Range: 0xcde3c0..0xcde4a7
               Pieces: []
-            - Range: 0xcde387..0xcde388
+            - Range: 0xcde4a7..0xcde4a8
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xcde388..0xcde397
+            - Range: 0xcde4a8..0xcde4b7
               Pieces: []
           Role: Return
         - Name: bothArmAndAmd64
           Type: 15 BaseType float64
           Locations:
-            - Range: 0xcde2a0..0xcde387
+            - Range: 0xcde3c0..0xcde4a7
               Pieces: []
-            - Range: 0xcde387..0xcde388
+            - Range: 0xcde4a7..0xcde4a8
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcde388..0xcde397
+            - Range: 0xcde4a8..0xcde4b7
               Pieces: []
           Role: Return
-    - ID: 108
+    - ID: 109
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0xcde3a0..0xcde413]
+      OutOfLinePCRanges: [0xcde4c0..0xcde533]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 96 BaseType complex64
-          Locations: [{Range: 0xcde3a0..0xcde413, Pieces: []}]
+          Locations: [{Range: 0xcde4c0..0xcde533, Pieces: []}]
           Role: Return
         - Name: ~r1
           Type: 97 BaseType complex128
-          Locations: [{Range: 0xcde3a0..0xcde413, Pieces: []}]
+          Locations: [{Range: 0xcde4c0..0xcde533, Pieces: []}]
           Role: Return
-    - ID: 109
+    - ID: 110
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0xcde420..0xcde4c5]
+      OutOfLinePCRanges: [0xcde540..0xcde5e5]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0xcde420..0xcde4b3
+            - Range: 0xcde540..0xcde5d3
               Pieces: []
-            - Range: 0xcde4b3..0xcde4b4
+            - Range: 0xcde5d3..0xcde5d4
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
-            - Range: 0xcde4b4..0xcde4c5
+            - Range: 0xcde5d4..0xcde5e5
               Pieces: []
           Role: Return
-    - ID: 110
+    - ID: 111
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0xcde4e0..0xcde55a]
+      OutOfLinePCRanges: [0xcde600..0xcde67a]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0xcde4e0..0xcde54d
+            - Range: 0xcde600..0xcde66d
               Pieces: []
-            - Range: 0xcde54d..0xcde54e
+            - Range: 0xcde66d..0xcde66e
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xcde54e..0xcde55a
+            - Range: 0xcde66e..0xcde67a
               Pieces: []
           Role: Return
-    - ID: 111
+    - ID: 112
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0xcde560..0xcde5b8]
+      OutOfLinePCRanges: [0xcde680..0xcde6d8]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 252 ArrayType [1]int
           Locations:
-            - Range: 0xcde560..0xcde5ab
+            - Range: 0xcde680..0xcde6cb
               Pieces: []
-            - Range: 0xcde5ab..0xcde5ac
+            - Range: 0xcde6cb..0xcde6cc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcde5ac..0xcde5b8
+            - Range: 0xcde6cc..0xcde6d8
               Pieces: []
           Role: Return
-    - ID: 112
+    - ID: 113
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0xcde5c0..0xcde613]
+      OutOfLinePCRanges: [0xcde6e0..0xcde733]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 253 ArrayType [0]int
           Locations:
-            - Range: 0xcde5c0..0xcde606
+            - Range: 0xcde6e0..0xcde726
               Pieces: []
-            - Range: 0xcde606..0xcde607
+            - Range: 0xcde726..0xcde727
               Pieces: []
-            - Range: 0xcde607..0xcde613
+            - Range: 0xcde727..0xcde733
               Pieces: []
           Role: Return
-    - ID: 113
+    - ID: 114
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0xcde620..0xcde687]
+      OutOfLinePCRanges: [0xcde740..0xcde7a7]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 254 StructureType main.mixedStruct
-          Locations: [{Range: 0xcde620..0xcde687, Pieces: []}]
+          Locations: [{Range: 0xcde740..0xcde7a7, Pieces: []}]
           Role: Return
-    - ID: 114
+    - ID: 115
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0xcde6a0..0xcde73a]
+      OutOfLinePCRanges: [0xcde7c0..0xcde85a]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcde6a0..0xcde72a
+            - Range: 0xcde7c0..0xcde84a
               Pieces: []
-            - Range: 0xcde72a..0xcde72b
+            - Range: 0xcde84a..0xcde84b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcde72b..0xcde73a
+            - Range: 0xcde84b..0xcde85a
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcde6a0..0xcde72a
+            - Range: 0xcde7c0..0xcde84a
               Pieces: []
-            - Range: 0xcde72a..0xcde72b
+            - Range: 0xcde84a..0xcde84b
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcde72b..0xcde73a
+            - Range: 0xcde84b..0xcde85a
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcde6a0..0xcde72a
+            - Range: 0xcde7c0..0xcde84a
               Pieces: []
-            - Range: 0xcde72a..0xcde72b
+            - Range: 0xcde84a..0xcde84b
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcde72b..0xcde73a
+            - Range: 0xcde84b..0xcde85a
               Pieces: []
           Role: Return
         - Name: ~r3
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcde6a0..0xcde72a
+            - Range: 0xcde7c0..0xcde84a
               Pieces: []
-            - Range: 0xcde72a..0xcde72b
+            - Range: 0xcde84a..0xcde84b
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xcde72b..0xcde73a
+            - Range: 0xcde84b..0xcde85a
               Pieces: []
           Role: Return
         - Name: ~r4
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcde6a0..0xcde72a
+            - Range: 0xcde7c0..0xcde84a
               Pieces: []
-            - Range: 0xcde72a..0xcde72b
+            - Range: 0xcde84a..0xcde84b
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcde72b..0xcde73a
+            - Range: 0xcde84b..0xcde85a
               Pieces: []
           Role: Return
         - Name: ~r5
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcde6a0..0xcde72a
+            - Range: 0xcde7c0..0xcde84a
               Pieces: []
-            - Range: 0xcde72a..0xcde72b
+            - Range: 0xcde84a..0xcde84b
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xcde72b..0xcde73a
+            - Range: 0xcde84b..0xcde85a
               Pieces: []
           Role: Return
         - Name: ~r6
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcde6a0..0xcde72a
+            - Range: 0xcde7c0..0xcde84a
               Pieces: []
-            - Range: 0xcde72a..0xcde72b
+            - Range: 0xcde84a..0xcde84b
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xcde72b..0xcde73a
+            - Range: 0xcde84b..0xcde85a
               Pieces: []
           Role: Return
         - Name: ~r7
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcde6a0..0xcde72a
+            - Range: 0xcde7c0..0xcde84a
               Pieces: []
-            - Range: 0xcde72a..0xcde72b
+            - Range: 0xcde84a..0xcde84b
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xcde72b..0xcde73a
+            - Range: 0xcde84b..0xcde85a
               Pieces: []
           Role: Return
         - Name: ~r8
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcde6a0..0xcde72a
+            - Range: 0xcde7c0..0xcde84a
               Pieces: []
-            - Range: 0xcde72a..0xcde72b
+            - Range: 0xcde84a..0xcde84b
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xcde72b..0xcde73a
+            - Range: 0xcde84b..0xcde85a
               Pieces: []
           Role: Return
-    - ID: 115
+    - ID: 116
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0xcde740..0xcde7e5]
+      OutOfLinePCRanges: [0xcde860..0xcde905]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 255 StructureType main.wideStruct
           Locations:
-            - Range: 0xcde740..0xcde7d4
+            - Range: 0xcde860..0xcde8f4
               Pieces: []
-            - Range: 0xcde7d4..0xcde7d5
+            - Range: 0xcde8f4..0xcde8f5
               Pieces: [{Size: 88, Op: {CfaOffset: 0}}]
-            - Range: 0xcde7d5..0xcde7e5
+            - Range: 0xcde8f5..0xcde905
               Pieces: []
           Role: Return
-    - ID: 116
+    - ID: 117
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0xcde800..0xcde879]
+      OutOfLinePCRanges: [0xcde920..0xcde999]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcde800..0xcde86c
+            - Range: 0xcde920..0xcde98c
               Pieces: []
-            - Range: 0xcde86c..0xcde86d
+            - Range: 0xcde98c..0xcde98d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcde86d..0xcde879
+            - Range: 0xcde98d..0xcde999
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcde800..0xcde879, Pieces: []}]
+          Locations: [{Range: 0xcde920..0xcde999, Pieces: []}]
           Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcde800..0xcde86c
+            - Range: 0xcde920..0xcde98c
               Pieces: []
-            - Range: 0xcde86c..0xcde86d
+            - Range: 0xcde98c..0xcde98d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcde86d..0xcde879
+            - Range: 0xcde98d..0xcde999
               Pieces: []
           Role: Return
         - Name: ~r3
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcde800..0xcde879, Pieces: []}]
+          Locations: [{Range: 0xcde920..0xcde999, Pieces: []}]
           Role: Return
         - Name: ~r4
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcde800..0xcde86c
+            - Range: 0xcde920..0xcde98c
               Pieces: []
-            - Range: 0xcde86c..0xcde86d
+            - Range: 0xcde98c..0xcde98d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcde86d..0xcde879
+            - Range: 0xcde98d..0xcde999
               Pieces: []
           Role: Return
-    - ID: 117
+    - ID: 118
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0xcde880..0xcde8fa]
+      OutOfLinePCRanges: [0xcde9a0..0xcdea1a]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 256 StructureType main.structWithArray
           Locations:
-            - Range: 0xcde880..0xcde8ed
+            - Range: 0xcde9a0..0xcdea0d
               Pieces: []
-            - Range: 0xcde8ed..0xcde8ee
+            - Range: 0xcdea0d..0xcdea0e
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xcde8ee..0xcde8fa
+            - Range: 0xcdea0e..0xcdea1a
               Pieces: []
           Role: Return
-    - ID: 118
+    - ID: 119
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0xcde900..0xcde95b]
+      OutOfLinePCRanges: [0xcdea20..0xcdea7b]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcde900..0xcde95b, Pieces: []}]
+          Locations: [{Range: 0xcdea20..0xcdea7b, Pieces: []}]
           Role: Return
-    - ID: 119
+    - ID: 120
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0xcde960..0xcde9c7]
+      OutOfLinePCRanges: [0xcdea80..0xcdeae7]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 18 BaseType float32
-          Locations: [{Range: 0xcde960..0xcde9c7, Pieces: []}]
+          Locations: [{Range: 0xcdea80..0xcdeae7, Pieces: []}]
           Role: Return
         - Name: ~r1
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcde960..0xcde9c7, Pieces: []}]
+          Locations: [{Range: 0xcdea80..0xcdeae7, Pieces: []}]
           Role: Return
-    - ID: 120
+    - ID: 121
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0xcde9e0..0xcdea3d]
+      OutOfLinePCRanges: [0xcdeb00..0xcdeb5d]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcde9e0..0xcdea30
+            - Range: 0xcdeb00..0xcdeb50
               Pieces: []
-            - Range: 0xcdea30..0xcdea31
+            - Range: 0xcdeb50..0xcdeb51
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdea31..0xcdea3d
+            - Range: 0xcdeb51..0xcdeb5d
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 1 BaseType uintptr
           Locations:
-            - Range: 0xcde9e0..0xcdea30
+            - Range: 0xcdeb00..0xcdeb50
               Pieces: []
-            - Range: 0xcdea30..0xcdea31
+            - Range: 0xcdeb50..0xcdeb51
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcdea31..0xcdea3d
+            - Range: 0xcdeb51..0xcdeb5d
               Pieces: []
           Role: Return
-    - ID: 121
+    - ID: 122
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0xcdea40..0xcdebc5]
+      OutOfLinePCRanges: [0xcdeb60..0xcdece5]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0xcdea40..0xcdebc5
+            - Range: 0xcdeb60..0xcdece5
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0xcdea40..0xcdebb3
+            - Range: 0xcdeb60..0xcdecd3
               Pieces: []
-            - Range: 0xcdebb3..0xcdebb4
+            - Range: 0xcdecd3..0xcdecd4
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
-            - Range: 0xcdebb4..0xcdebc5
+            - Range: 0xcdecd4..0xcdece5
               Pieces: []
           Role: Return
-    - ID: 122
+    - ID: 123
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0xcdebe0..0xcdecb2]
+      OutOfLinePCRanges: [0xcded00..0xcdedd2]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0xcdebe0..0xcdecb2
+            - Range: 0xcded00..0xcdedd2
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0xcdebe0..0xcdeca2
+            - Range: 0xcded00..0xcdedc2
               Pieces: []
-            - Range: 0xcdeca2..0xcdeca3
+            - Range: 0xcdedc2..0xcdedc3
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xcdeca3..0xcdecb2
+            - Range: 0xcdedc3..0xcdedd2
               Pieces: []
           Role: Return
-    - ID: 123
+    - ID: 124
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0xcdecc0..0xcdeefa]
+      OutOfLinePCRanges: [0xcdede0..0xcdf01a]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0xcdecc0..0xcdeefa
+            - Range: 0xcdede0..0xcdf01a
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: s2
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0xcdecc0..0xcdeefa
+            - Range: 0xcdede0..0xcdf01a
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
           Role: Parameter
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0xcdecc0..0xcdeeea
+            - Range: 0xcdede0..0xcdf00a
               Pieces: []
-            - Range: 0xcdeeea..0xcdeeeb
+            - Range: 0xcdf00a..0xcdf00b
               Pieces: [{Size: 80, Op: {CfaOffset: 160}}]
-            - Range: 0xcdeeeb..0xcdeefa
+            - Range: 0xcdf00b..0xcdf01a
               Pieces: []
           Role: Return
-    - ID: 124
+    - ID: 125
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0xcdef00..0xcdf18f]
+      OutOfLinePCRanges: [0xcdf020..0xcdf2af]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdef00..0xcdefb0
+            - Range: 0xcdf020..0xcdf0d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdefb0..0xcdf18f
+            - Range: 0xcdf0d0..0xcdf2af
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdef00..0xcdefb0
+            - Range: 0xcdf020..0xcdf0d0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcdefb0..0xcdf18f
+            - Range: 0xcdf0d0..0xcdf2af
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdef00..0xcdef9a
+            - Range: 0xcdf020..0xcdf0ba
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcdef9a..0xcdf18f
+            - Range: 0xcdf0ba..0xcdf2af
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdef00..0xcdef70
+            - Range: 0xcdf020..0xcdf090
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xcdef70..0xcdf18f
+            - Range: 0xcdf090..0xcdf2af
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdef00..0xcdefb0
+            - Range: 0xcdf020..0xcdf0d0
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcdefb0..0xcdf18f
+            - Range: 0xcdf0d0..0xcdf2af
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdef00..0xcdefb0
+            - Range: 0xcdf020..0xcdf0d0
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xcdefb0..0xcdf18f
+            - Range: 0xcdf0d0..0xcdf2af
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdef00..0xcdefb0
+            - Range: 0xcdf020..0xcdf0d0
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xcdefb0..0xcdf18f
+            - Range: 0xcdf0d0..0xcdf2af
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdef00..0xcdefb0
+            - Range: 0xcdf020..0xcdf0d0
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xcdefb0..0xcdf18f
+            - Range: 0xcdf0d0..0xcdf2af
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdef00..0xcdefb0
+            - Range: 0xcdf020..0xcdf0d0
               Pieces: [{Size: 8, Op: {RegNo: 11, Shift: 0}}]
-            - Range: 0xcdefb0..0xcdf18f
+            - Range: 0xcdf0d0..0xcdf2af
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
         - Name: ~r0
           Type: 113 ArrayType [2]int
           Locations:
-            - Range: 0xcdef00..0xcdf122
+            - Range: 0xcdf020..0xcdf242
               Pieces: []
-            - Range: 0xcdf122..0xcdf123
+            - Range: 0xcdf242..0xcdf243
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xcdf123..0xcdf18f
+            - Range: 0xcdf243..0xcdf2af
               Pieces: []
           Role: Return
-    - ID: 125
+    - ID: 126
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0xcdf1a0..0xcdf46c]
+      OutOfLinePCRanges: [0xcdf2c0..0xcdf58c]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdf1a0..0xcdf24b
+            - Range: 0xcdf2c0..0xcdf36b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdf24b..0xcdf46c
+            - Range: 0xcdf36b..0xcdf58c
               Pieces: [{Size: 8, Op: {CfaOffset: 96}}]
           Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdf1a0..0xcdf24b
+            - Range: 0xcdf2c0..0xcdf36b
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcdf24b..0xcdf46c
+            - Range: 0xcdf36b..0xcdf58c
               Pieces: [{Size: 8, Op: {CfaOffset: 104}}]
           Role: Parameter
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdf1a0..0xcdf235
+            - Range: 0xcdf2c0..0xcdf355
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcdf235..0xcdf46c
+            - Range: 0xcdf355..0xcdf58c
               Pieces: [{Size: 8, Op: {CfaOffset: 112}}]
           Role: Parameter
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdf1a0..0xcdf202
+            - Range: 0xcdf2c0..0xcdf322
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xcdf202..0xcdf46c
+            - Range: 0xcdf322..0xcdf58c
               Pieces: [{Size: 8, Op: {CfaOffset: 120}}]
           Role: Parameter
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdf1a0..0xcdf24b
+            - Range: 0xcdf2c0..0xcdf36b
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcdf24b..0xcdf46c
+            - Range: 0xcdf36b..0xcdf58c
               Pieces: [{Size: 8, Op: {CfaOffset: 128}}]
           Role: Parameter
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdf1a0..0xcdf24b
+            - Range: 0xcdf2c0..0xcdf36b
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xcdf24b..0xcdf46c
+            - Range: 0xcdf36b..0xcdf58c
               Pieces: [{Size: 8, Op: {CfaOffset: 136}}]
           Role: Parameter
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdf1a0..0xcdf24b
+            - Range: 0xcdf2c0..0xcdf36b
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xcdf24b..0xcdf46c
+            - Range: 0xcdf36b..0xcdf58c
               Pieces: [{Size: 8, Op: {CfaOffset: 144}}]
           Role: Parameter
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdf1a0..0xcdf24b
+            - Range: 0xcdf2c0..0xcdf36b
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xcdf24b..0xcdf46c
+            - Range: 0xcdf36b..0xcdf58c
               Pieces: [{Size: 8, Op: {CfaOffset: 152}}]
           Role: Parameter
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdf1a0..0xcdf46c
+            - Range: 0xcdf2c0..0xcdf58c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -7207,358 +7289,175 @@ Subprograms:
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0xcdf1a0..0xcdf3eb
+            - Range: 0xcdf2c0..0xcdf50b
               Pieces: []
-            - Range: 0xcdf3eb..0xcdf3ec
+            - Range: 0xcdf50b..0xcdf50c
               Pieces: [{Size: 80, Op: {CfaOffset: 16}}]
-            - Range: 0xcdf3ec..0xcdf46c
+            - Range: 0xcdf50c..0xcdf58c
               Pieces: []
           Role: Return
-    - ID: 126
+    - ID: 127
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0xcdf480..0xcdf50c]
+      OutOfLinePCRanges: [0xcdf5a0..0xcdf62c]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 161 ArrayType [5]int
           Locations:
-            - Range: 0xcdf480..0xcdf50c
+            - Range: 0xcdf5a0..0xcdf62c
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdf480..0xcdf4fc
+            - Range: 0xcdf5a0..0xcdf61c
               Pieces: []
-            - Range: 0xcdf4fc..0xcdf4fd
+            - Range: 0xcdf61c..0xcdf61d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdf4fd..0xcdf50c
+            - Range: 0xcdf61d..0xcdf62c
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdf480..0xcdf4fc
+            - Range: 0xcdf5a0..0xcdf61c
               Pieces: []
-            - Range: 0xcdf4fc..0xcdf4fd
+            - Range: 0xcdf61c..0xcdf61d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcdf4fd..0xcdf50c
+            - Range: 0xcdf61d..0xcdf62c
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdf480..0xcdf4fc
+            - Range: 0xcdf5a0..0xcdf61c
               Pieces: []
-            - Range: 0xcdf4fc..0xcdf4fd
+            - Range: 0xcdf61c..0xcdf61d
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcdf4fd..0xcdf50c
+            - Range: 0xcdf61d..0xcdf62c
               Pieces: []
           Role: Return
-    - ID: 127
+    - ID: 128
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0xcdf520..0xcdf60f]
+      OutOfLinePCRanges: [0xcdf640..0xcdf72f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 113 ArrayType [2]int
           Locations:
-            - Range: 0xcdf520..0xcdf60f
+            - Range: 0xcdf640..0xcdf72f
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: b
           Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0xcdf520..0xcdf60f
+            - Range: 0xcdf640..0xcdf72f
               Pieces: [{Size: 24, Op: {CfaOffset: 16}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdf520..0xcdf5ff
+            - Range: 0xcdf640..0xcdf71f
               Pieces: []
-            - Range: 0xcdf5ff..0xcdf600
+            - Range: 0xcdf71f..0xcdf720
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdf600..0xcdf60f
+            - Range: 0xcdf720..0xcdf72f
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 113 ArrayType [2]int
           Locations:
-            - Range: 0xcdf520..0xcdf5ff
+            - Range: 0xcdf640..0xcdf71f
               Pieces: []
-            - Range: 0xcdf5ff..0xcdf600
+            - Range: 0xcdf71f..0xcdf720
               Pieces: [{Size: 16, Op: {CfaOffset: 40}}]
-            - Range: 0xcdf600..0xcdf60f
+            - Range: 0xcdf720..0xcdf72f
               Pieces: []
           Role: Return
-    - ID: 128
+    - ID: 129
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0xcdf620..0xcdf6ec]
+      OutOfLinePCRanges: [0xcdf740..0xcdf80c]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 256 StructureType main.structWithArray
           Locations:
-            - Range: 0xcdf620..0xcdf6ec
+            - Range: 0xcdf740..0xcdf80c
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdf620..0xcdf6dc
+            - Range: 0xcdf740..0xcdf7fc
               Pieces: []
-            - Range: 0xcdf6dc..0xcdf6dd
+            - Range: 0xcdf7fc..0xcdf7fd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdf6dd..0xcdf6ec
+            - Range: 0xcdf7fd..0xcdf80c
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 256 StructureType main.structWithArray
           Locations:
-            - Range: 0xcdf620..0xcdf6dc
+            - Range: 0xcdf740..0xcdf7fc
               Pieces: []
-            - Range: 0xcdf6dc..0xcdf6dd
+            - Range: 0xcdf7fc..0xcdf7fd
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xcdf6dd..0xcdf6ec
+            - Range: 0xcdf7fd..0xcdf80c
               Pieces: []
           Role: Return
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdf6a6..0xcdf6ec
+            - Range: 0xcdf7c6..0xcdf80c
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
-    - ID: 129
+    - ID: 130
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0xcdf700..0xcdf7a6]
+      OutOfLinePCRanges: [0xcdf820..0xcdf8c6]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 253 ArrayType [0]int
-          Locations: [{Range: 0xcdf700..0xcdf7a6, Pieces: []}]
+          Locations: [{Range: 0xcdf820..0xcdf8c6, Pieces: []}]
           Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdf700..0xcdf745
+            - Range: 0xcdf820..0xcdf865
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdf745..0xcdf767
+            - Range: 0xcdf865..0xcdf887
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xcdf767..0xcdf77a
+            - Range: 0xcdf887..0xcdf89a
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xcdf77a..0xcdf7a6
+            - Range: 0xcdf89a..0xcdf8c6
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdf700..0xcdf78c
+            - Range: 0xcdf820..0xcdf8ac
               Pieces: []
-            - Range: 0xcdf78c..0xcdf78d
+            - Range: 0xcdf8ac..0xcdf8ad
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdf78d..0xcdf7a6
+            - Range: 0xcdf8ad..0xcdf8c6
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 253 ArrayType [0]int
           Locations:
-            - Range: 0xcdf700..0xcdf78c
+            - Range: 0xcdf820..0xcdf8ac
               Pieces: []
-            - Range: 0xcdf78c..0xcdf78d
+            - Range: 0xcdf8ac..0xcdf8ad
               Pieces: []
-            - Range: 0xcdf78d..0xcdf7a6
+            - Range: 0xcdf8ad..0xcdf8c6
               Pieces: []
           Role: Return
-    - ID: 130
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0xcdfc80..0xcdfc81]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 257 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xcdfc80..0xcdfc81
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
     - ID: 131
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0xcdfca0..0xcdfca1]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 257 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xcdfca0..0xcdfca1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-    - ID: 132
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0xcdfcc0..0xcdfcc1]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 258 GoSliceHeaderType [][]uint
-          Locations:
-            - Range: 0xcdfcc0..0xcdfcc1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-    - ID: 133
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0xcdfce0..0xcdfce1]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 260 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xcdfce0..0xcdfce1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcdfce0..0xcdfce1
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          Role: Parameter
-    - ID: 134
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0xcdfd00..0xcdfd01]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 260 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xcdfd00..0xcdfd01
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcdfd00..0xcdfd01
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          Role: Parameter
-    - ID: 135
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0xcdfd20..0xcdfd21]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 260 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xcdfd20..0xcdfd21
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcdfd20..0xcdfd21
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          Role: Parameter
-    - ID: 136
-      Name: main.testStringSlice
-      OutOfLinePCRanges: [0xcdfd40..0xcdfd41]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 263 GoSliceHeaderType []string
-          Locations:
-            - Range: 0xcdfd40..0xcdfd41
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-    - ID: 137
-      Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0xcdfd60..0xcdfd61]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 16 BaseType int8
-          Locations:
-            - Range: 0xcdfd60..0xcdfd61
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-        - Name: s
-          Type: 264 GoSliceHeaderType []bool
-          Locations:
-            - Range: 0xcdfd60..0xcdfd61
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-          Role: Parameter
-        - Name: x
-          Type: 17 BaseType uint
-          Locations:
-            - Range: 0xcdfd60..0xcdfd61
-              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-          Role: Parameter
-    - ID: 138
-      Name: main.testNilSlice
-      OutOfLinePCRanges: [0xcdfd80..0xcdfd81]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 265 GoSliceHeaderType []uint16
-          Locations:
-            - Range: 0xcdfd80..0xcdfd81
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-    - ID: 139
-      Name: main.testVeryLargeSlice
+      Name: main.testUintSlice
       OutOfLinePCRanges: [0xcdfda0..0xcdfda1]
       InlinePCRanges: []
       Variables:
-        - Name: xs
+        - Name: u
           Type: 257 GoSliceHeaderType []uint
           Locations:
             - Range: 0xcdfda0..0xcdfda1
@@ -7570,13 +7469,13 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 140
-      Name: main.testSliceEmptyStructs
+    - ID: 132
+      Name: main.testEmptySlice
       OutOfLinePCRanges: [0xcdfdc0..0xcdfdc1]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 266 GoSliceHeaderType []struct {}
+        - Name: u
+          Type: 257 GoSliceHeaderType []uint
           Locations:
             - Range: 0xcdfdc0..0xcdfdc1
               Pieces:
@@ -7587,15 +7486,198 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 141
-      Name: main.testSubslices
+    - ID: 133
+      Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0xcdfde0..0xcdfde1]
+      InlinePCRanges: []
+      Variables:
+        - Name: u
+          Type: 258 GoSliceHeaderType [][]uint
+          Locations:
+            - Range: 0xcdfde0..0xcdfde1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+    - ID: 134
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0xcdfe00..0xcdfe01]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 260 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xcdfe00..0xcdfe01
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdfe00..0xcdfe01
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          Role: Parameter
+    - ID: 135
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0xcdfe20..0xcdfe21]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 260 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xcdfe20..0xcdfe21
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdfe20..0xcdfe21
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          Role: Parameter
+    - ID: 136
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0xcdfe40..0xcdfe41]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 260 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xcdfe40..0xcdfe41
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdfe40..0xcdfe41
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          Role: Parameter
+    - ID: 137
+      Name: main.testStringSlice
+      OutOfLinePCRanges: [0xcdfe60..0xcdfe61]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 263 GoSliceHeaderType []string
+          Locations:
+            - Range: 0xcdfe60..0xcdfe61
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+    - ID: 138
+      Name: main.testNilSliceWithOtherParams
+      OutOfLinePCRanges: [0xcdfe80..0xcdfe81]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 16 BaseType int8
+          Locations:
+            - Range: 0xcdfe80..0xcdfe81
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+        - Name: s
+          Type: 264 GoSliceHeaderType []bool
+          Locations:
+            - Range: 0xcdfe80..0xcdfe81
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+          Role: Parameter
+        - Name: x
+          Type: 17 BaseType uint
+          Locations:
+            - Range: 0xcdfe80..0xcdfe81
+              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
+          Role: Parameter
+    - ID: 139
+      Name: main.testNilSlice
+      OutOfLinePCRanges: [0xcdfea0..0xcdfea1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 265 GoSliceHeaderType []uint16
+          Locations:
+            - Range: 0xcdfea0..0xcdfea1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+    - ID: 140
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0xcdfec0..0xcdfec1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 257 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0xcdfec0..0xcdfec1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+    - ID: 141
+      Name: main.testSliceEmptyStructs
+      OutOfLinePCRanges: [0xcdfee0..0xcdfee1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 266 GoSliceHeaderType []struct {}
+          Locations:
+            - Range: 0xcdfee0..0xcdfee1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+    - ID: 142
+      Name: main.testSubslices
+      OutOfLinePCRanges: [0xcdff00..0xcdff01]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcdfde0..0xcdfde1
+            - Range: 0xcdff00..0xcdff01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7607,7 +7689,7 @@ Subprograms:
         - Name: bs
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcdfde0..0xcdfde1
+            - Range: 0xcdff00..0xcdff01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -7619,7 +7701,7 @@ Subprograms:
         - Name: cs
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcdfde0..0xcdfde1
+            - Range: 0xcdff00..0xcdff01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
@@ -7628,49 +7710,49 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
           Role: Parameter
-    - ID: 142
+    - ID: 143
       Name: main.stackC
-      OutOfLinePCRanges: [0xce0180..0xce01d2]
+      OutOfLinePCRanges: [0xce02a0..0xce02f2]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce0180..0xce01c5
+            - Range: 0xce02a0..0xce02e5
               Pieces: []
-            - Range: 0xce01c5..0xce01c6
+            - Range: 0xce02e5..0xce02e6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce01c6..0xce01d2
+            - Range: 0xce02e6..0xce02f2
               Pieces: []
           Role: Return
-    - ID: 143
+    - ID: 144
       Name: main.testSingleString
-      OutOfLinePCRanges: [0xce01e0..0xce01e1]
+      OutOfLinePCRanges: [0xce0300..0xce0301]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce01e0..0xce01e1
+            - Range: 0xce0300..0xce0301
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
-    - ID: 144
+    - ID: 145
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0xce0200..0xce0201]
+      OutOfLinePCRanges: [0xce0320..0xce0321]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce0200..0xce0201
+            - Range: 0xce0320..0xce0321
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7680,7 +7762,7 @@ Subprograms:
         - Name: y
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce0200..0xce0201
+            - Range: 0xce0320..0xce0321
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -7690,22 +7772,22 @@ Subprograms:
         - Name: z
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce0200..0xce0201
+            - Range: 0xce0320..0xce0321
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 145
+    - ID: 146
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0xce0220..0xce023f]
+      OutOfLinePCRanges: [0xce0340..0xce035f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 268 StructureType main.threeStringStruct
           Locations:
-            - Range: 0xce0220..0xce023f
+            - Range: 0xce0340..0xce035f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7720,52 +7802,37 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 146
+    - ID: 147
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0xce0240..0xce0241]
+      OutOfLinePCRanges: [0xce0360..0xce0361]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 269 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0xce0240..0xce0241
+            - Range: 0xce0360..0xce0361
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 147
+    - ID: 148
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0xce0260..0xce0261]
+      OutOfLinePCRanges: [0xce0380..0xce0381]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 270 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0xce0260..0xce0261
+            - Range: 0xce0380..0xce0381
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 148
-      Name: main.testMassiveString
-      OutOfLinePCRanges: [0xce0280..0xce0281]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xce0280..0xce0281
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          Role: Parameter
     - ID: 149
-      Name: main.testUnitializedString
-      OutOfLinePCRanges: [0xce02a0..0xce02a1]
+      Name: main.testMassiveString
+      OutOfLinePCRanges: [0xce03a0..0xce03a1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce02a0..0xce02a1
+            - Range: 0xce03a0..0xce03a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7773,14 +7840,14 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
     - ID: 150
-      Name: main.testEmptyString
-      OutOfLinePCRanges: [0xce02c0..0xce02c1]
+      Name: main.testUnitializedString
+      OutOfLinePCRanges: [0xce03c0..0xce03c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce02c0..0xce02c1
+            - Range: 0xce03c0..0xce03c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7788,14 +7855,29 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
     - ID: 151
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0xce03e0..0xce03e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xce03e0..0xce03e1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Parameter
+    - ID: 152
       Name: main.testSubstrings
-      OutOfLinePCRanges: [0xce02e0..0xce02e1]
+      OutOfLinePCRanges: [0xce0400..0xce0401]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce02e0..0xce02e1
+            - Range: 0xce0400..0xce0401
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7805,7 +7887,7 @@ Subprograms:
         - Name: b
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce02e0..0xce02e1
+            - Range: 0xce0400..0xce0401
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -7815,33 +7897,33 @@ Subprograms:
         - Name: c
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce02e0..0xce02e1
+            - Range: 0xce0400..0xce0401
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 152
+    - ID: 153
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0xce0460..0xce0461]
+      OutOfLinePCRanges: [0xce0580..0xce0581]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 272 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0xce0460..0xce0461
+            - Range: 0xce0580..0xce0581
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
-    - ID: 153
+    - ID: 154
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0xce0480..0xce049f]
+      OutOfLinePCRanges: [0xce05a0..0xce05bf]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 285 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0xce0480..0xce049f
+            - Range: 0xce05a0..0xce05bf
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7856,15 +7938,15 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 154
+    - ID: 155
       Name: main.testStruct
-      OutOfLinePCRanges: [0xce05c0..0xce05e3]
+      OutOfLinePCRanges: [0xce06e0..0xce0703]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 316 StructureType main.aStruct
           Locations:
-            - Range: 0xce05c0..0xce05e3
+            - Range: 0xce06e0..0xce0703
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -7881,128 +7963,128 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
           Role: Parameter
-    - ID: 155
+    - ID: 156
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0xce06c0..0xce06c1]
+      OutOfLinePCRanges: [0xce07e0..0xce07e1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 317 PointerType *main.anotherStruct
           Locations:
-            - Range: 0xce06c0..0xce06c1
+            - Range: 0xce07e0..0xce07e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 156
+    - ID: 157
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xce0740..0xce0741]
+      OutOfLinePCRanges: [0xce0860..0xce0861]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 319 StructureType main.emptyStruct
-          Locations: [{Range: 0xce0740..0xce0741, Pieces: []}]
+          Locations: [{Range: 0xce0860..0xce0861, Pieces: []}]
           Role: Parameter
-    - ID: 157
+    - ID: 158
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0xce0760..0xce0761]
+      OutOfLinePCRanges: [0xce0880..0xce0881]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 320 PointerType *main.emptyStruct
           Locations:
-            - Range: 0xce0760..0xce0761
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-    - ID: 158
-      Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0xcda200..0xcda262]
-      InlinePCRanges:
-        - Ranges: [0xcda291..0xcda2cd]
-          RootRanges: [0xcda280..0xcda2f1]
-        - Ranges: [0xcda3d2..0xcda40e]
-          RootRanges: [0xcda3a0..0xcda428]
-        - Ranges: [0xcda45c..0xcda498]
-          RootRanges: [0xcda440..0xcda505]
-        - Ranges: [0xcda52f..0xcda56b]
-          RootRanges: [0xcda520..0xcda582]
-      Variables:
-        - Name: x
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcda200..0xcda219
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcda291..0xcda29c
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcda3d2..0xcda3dd
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcda456..0xcda467
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcda467..0xcda505
-              Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xcda520..0xcda53a
+            - Range: 0xce0880..0xce0881
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 159
-      Name: main.testInlinedBBB
-      OutOfLinePCRanges: []
+      Name: main.testInlinedPrint
+      OutOfLinePCRanges: [0xcda320..0xcda382]
       InlinePCRanges:
-        - Ranges: [0xcda4a6..0xcda4de]
-          RootRanges: [0xcda440..0xcda505]
-      Variables: []
-    - ID: 160
-      Name: main.testInlinedBCA
-      OutOfLinePCRanges: []
-      InlinePCRanges:
-        - Ranges: [0xcda5b3..0xcda5f1]
-          RootRanges: [0xcda5a0..0xcda6a5]
-      Variables: []
-    - ID: 161
-      Name: main.testInlinedBCB
-      OutOfLinePCRanges: []
-      InlinePCRanges:
-        - Ranges: [0xcda65b..0xcda693]
-          RootRanges: [0xcda5a0..0xcda6a5]
-      Variables: []
-    - ID: 162
-      Name: main.testInlinedSq
-      OutOfLinePCRanges: []
-      InlinePCRanges:
-        - Ranges: [0xcda6c1..0xcda6c5]
-          RootRanges: [0xcda6c0..0xcda6c6]
+        - Ranges: [0xcda3b1..0xcda3ed]
+          RootRanges: [0xcda3a0..0xcda411]
+        - Ranges: [0xcda4f2..0xcda52e]
+          RootRanges: [0xcda4c0..0xcda548]
+        - Ranges: [0xcda57c..0xcda5b8]
+          RootRanges: [0xcda560..0xcda625]
+        - Ranges: [0xcda64f..0xcda68b]
+          RootRanges: [0xcda640..0xcda6a2]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda6c0..0xcda6c5
+            - Range: 0xcda320..0xcda339
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcda3b1..0xcda3bc
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcda4f2..0xcda4fd
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcda576..0xcda587
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcda587..0xcda625
+              Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
+            - Range: 0xcda640..0xcda65a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
+    - ID: 160
+      Name: main.testInlinedBBB
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0xcda5c6..0xcda5fe]
+          RootRanges: [0xcda560..0xcda625]
+      Variables: []
+    - ID: 161
+      Name: main.testInlinedBCA
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0xcda6d3..0xcda711]
+          RootRanges: [0xcda6c0..0xcda7c5]
+      Variables: []
+    - ID: 162
+      Name: main.testInlinedBCB
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0xcda77b..0xcda7b3]
+          RootRanges: [0xcda6c0..0xcda7c5]
+      Variables: []
     - ID: 163
+      Name: main.testInlinedSq
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0xcda7e1..0xcda7e5]
+          RootRanges: [0xcda7e0..0xcda7e6]
+      Variables:
+        - Name: x
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcda7e0..0xcda7e5
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+    - ID: 164
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcda705..0xcda71d]
-          RootRanges: [0xcda6e0..0xcda723]
-        - Ranges: [0xcda7a5..0xcda7c3]
-          RootRanges: [0xcda740..0xcda8c5]
+        - Ranges: [0xcda825..0xcda83d]
+          RootRanges: [0xcda800..0xcda843]
+        - Ranges: [0xcda8c5..0xcda8e3]
+          RootRanges: [0xcda860..0xcda9e5]
       Variables:
         - Name: a
           Type: 161 ArrayType [5]int
           Locations:
-            - Range: 0xcda6ed..0xcda723
+            - Range: 0xcda80d..0xcda843
               Pieces: [{Size: 40, Op: {CfaOffset: -56}}]
-            - Range: 0xcda78c..0xcda8c5
+            - Range: 0xcda8ac..0xcda9e5
               Pieces: [{Size: 40, Op: {CfaOffset: -128}}]
           Role: Parameter
-    - ID: 164
+    - ID: 165
       Name: main.firstBehavior.DoSomething
-      OutOfLinePCRanges: [0xcda8e0..0xcda946]
+      OutOfLinePCRanges: [0xcdaa00..0xcdaa66]
       InlinePCRanges:
-        - Ranges: [0xce1b03..0xce1b31]
-          RootRanges: [0xce1ae0..0xce1b5f]
+        - Ranges: [0xce1c23..0xce1c51]
+          RootRanges: [0xce1c00..0xce1c7f]
       Variables:
         - Name: b
           Type: 321 StructureType main.firstBehavior
           Locations:
-            - Range: 0xcda8e0..0xcda8fe
+            - Range: 0xcdaa00..0xcdaa1e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8012,23 +8094,23 @@ Subprograms:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcda8e0..0xcda925
+            - Range: 0xcdaa00..0xcdaa45
               Pieces: []
-            - Range: 0xcda925..0xcda926
+            - Range: 0xcdaa45..0xcdaa46
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcda926..0xcda946
+            - Range: 0xcdaa46..0xcdaa66
               Pieces: []
           Role: Return
-    - ID: 165
+    - ID: 166
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcdb02b..0xcdb032]
-          RootRanges: [0xcdaee0..0xcdb06e]
+        - Ranges: [0xcdb14b..0xcdb152]
+          RootRanges: [0xcdb000..0xcdb18e]
         - Ranges: [0xcd8541..0xcd8549]
           RootRanges: [0xcd8540..0xcd854a]
       Variables: []
@@ -11357,10 +11439,10 @@ Types:
       GoKind: 22
       Pointee: 824 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1570
+      ID: 1571
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
     - __kind: EventRootType
-      ID: 1568
+      ID: 1569
       Name: Probe[main.firstBehavior.DoSomething]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11372,11 +11454,11 @@ Types:
             Type: 321 StructureType main.firstBehavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 0, name: b}
+                  Variable: {subprogram: 165, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1569
+      ID: 1570
       Name: Probe[main.firstBehavior.DoSomething]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11388,14 +11470,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 1, name: ~r0}
+                  Variable: {subprogram: 165, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1526
+      ID: 1527
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1527
+      ID: 1528
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11407,11 +11489,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: ~r0}
+                  Variable: {subprogram: 143, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1393
+      ID: 1394
       Name: Probe[main.testAnyPtr]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11423,7 +11505,7 @@ Types:
             Type: 163 PointerType *interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: a}
+                  Variable: {subprogram: 59, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -11433,11 +11515,11 @@ Types:
             Type: 163 PointerType *interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: a}
+                  Variable: {subprogram: 59, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1394
+      ID: 1395
       Name: Probe[main.testAnyPtr]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11449,11 +11531,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 1, name: ~r0}
+                  Variable: {subprogram: 59, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1390
+      ID: 1391
       Name: Probe[main.testAny]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11465,7 +11547,7 @@ Types:
             Type: 157 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: a}
+                  Variable: {subprogram: 57, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -11475,11 +11557,11 @@ Types:
             Type: 157 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: a}
+                  Variable: {subprogram: 57, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1391
+      ID: 1392
       Name: Probe[main.testAny]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11491,11 +11573,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 1, name: ~r0}
+                  Variable: {subprogram: 57, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1497
+      ID: 1498
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11507,7 +11589,7 @@ Types:
             Type: 251 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: arg}
+                  Variable: {subprogram: 123, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
         - Name: arg
@@ -11517,11 +11599,11 @@ Types:
             Type: 251 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: arg}
+                  Variable: {subprogram: 123, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1498
+      ID: 1499
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11533,7 +11615,7 @@ Types:
             Type: 251 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 1, name: ~r0}
+                  Variable: {subprogram: 123, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -11615,7 +11697,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1402
+      ID: 1403
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11627,7 +11709,7 @@ Types:
             Type: 191 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: m}
+                  Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
         - Name: m
@@ -11637,7 +11719,7 @@ Types:
             Type: 191 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: m}
+                  Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -11693,7 +11775,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1424
+      ID: 1425
       Name: Probe[main.testAtomicAdd]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11705,7 +11787,7 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: x}
+                  Variable: {subprogram: 87, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -11715,11 +11797,11 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: x}
+                  Variable: {subprogram: 87, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1425
+      ID: 1426
       Name: Probe[main.testAtomicAdd]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11731,7 +11813,7 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 1, name: ~r0}
+                  Variable: {subprogram: 87, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -11816,7 +11898,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1426
+      ID: 1427
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11828,7 +11910,7 @@ Types:
             Type: 243 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: c}
+                  Variable: {subprogram: 88, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
         - Name: c
@@ -11838,11 +11920,11 @@ Types:
             Type: 243 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: c}
+                  Variable: {subprogram: 88, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1420
+      ID: 1421
       Name: Probe[main.testCombinedByte]
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -11854,7 +11936,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: w}
+                  Variable: {subprogram: 84, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: w
@@ -11864,7 +11946,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: w}
+                  Variable: {subprogram: 84, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: x
@@ -11874,7 +11956,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 1, name: x}
+                  Variable: {subprogram: 84, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: x
@@ -11884,7 +11966,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 1, name: x}
+                  Variable: {subprogram: 84, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: y
@@ -11894,7 +11976,7 @@ Types:
             Type: 18 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 2, name: y}
+                  Variable: {subprogram: 84, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
         - Name: y
@@ -11904,11 +11986,11 @@ Types:
             Type: 18 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 2, name: y}
+                  Variable: {subprogram: 84, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1421
+      ID: 1422
       Name: Probe[main.testCombinedString]
       ByteSize: 18
       PresenceBitsetSize: 1
@@ -11920,7 +12002,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 1, name: x}
+                  Variable: {subprogram: 85, index: 1, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: w_val
@@ -11930,11 +12012,11 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: w}
+                  Variable: {subprogram: 85, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1422
+      ID: 1423
       Name: Probe[main.testCombinedString]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -11946,7 +12028,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 1, name: x}
+                  Variable: {subprogram: 85, index: 1, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x_val
@@ -11956,7 +12038,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 1, name: x}
+                  Variable: {subprogram: 85, index: 1, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: w_val
@@ -11966,11 +12048,11 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: w}
+                  Variable: {subprogram: 85, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1434
+      ID: 1435
       Name: Probe[main.testCycle]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11982,7 +12064,7 @@ Types:
             Type: 248 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: t}
+                  Variable: {subprogram: 96, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
         - Name: t
@@ -11992,11 +12074,11 @@ Types:
             Type: 248 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: t}
+                  Variable: {subprogram: 96, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1365
+      ID: 1366
       Name: Probe[main.testDeepMap1]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12008,7 +12090,7 @@ Types:
             Type: 143 StructureType main.deepMap1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: a}
+                  Variable: {subprogram: 43, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12018,11 +12100,11 @@ Types:
             Type: 143 StructureType main.deepMap1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: a}
+                  Variable: {subprogram: 43, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1366
+      ID: 1367
       Name: Probe[main.testDeepMap7]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12034,7 +12116,7 @@ Types:
             Type: 149 PointerType *main.deepMap7
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 0, name: a}
+                  Variable: {subprogram: 44, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12044,11 +12126,11 @@ Types:
             Type: 149 PointerType *main.deepMap7
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 0, name: a}
+                  Variable: {subprogram: 44, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1361
+      ID: 1362
       Name: Probe[main.testDeepPtr1]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12060,7 +12142,7 @@ Types:
             Type: 132 StructureType main.deepPtr1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: a}
+                  Variable: {subprogram: 39, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12070,11 +12152,11 @@ Types:
             Type: 132 StructureType main.deepPtr1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: a}
+                  Variable: {subprogram: 39, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1362
+      ID: 1363
       Name: Probe[main.testDeepPtr7]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12086,7 +12168,7 @@ Types:
             Type: 135 PointerType *main.deepPtr7
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: a}
+                  Variable: {subprogram: 40, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12096,11 +12178,11 @@ Types:
             Type: 135 PointerType *main.deepPtr7
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: a}
+                  Variable: {subprogram: 40, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1363
+      ID: 1364
       Name: Probe[main.testDeepSlice1]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12112,7 +12194,7 @@ Types:
             Type: 137 StructureType main.deepSlice1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: a}
+                  Variable: {subprogram: 41, index: 0, name: a}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -12122,11 +12204,11 @@ Types:
             Type: 137 StructureType main.deepSlice1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: a}
+                  Variable: {subprogram: 41, index: 0, name: a}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1364
+      ID: 1365
       Name: Probe[main.testDeepSlice7]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12138,7 +12220,7 @@ Types:
             Type: 141 PointerType *main.deepSlice7
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: a}
+                  Variable: {subprogram: 42, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12148,11 +12230,11 @@ Types:
             Type: 141 PointerType *main.deepSlice7
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: a}
+                  Variable: {subprogram: 42, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1517
+      ID: 1518
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -12164,7 +12246,7 @@ Types:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: xs}
+                  Variable: {subprogram: 135, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -12174,7 +12256,7 @@ Types:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: xs}
+                  Variable: {subprogram: 135, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -12184,7 +12266,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 1, name: a}
+                  Variable: {subprogram: 135, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12194,11 +12276,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 1, name: a}
+                  Variable: {subprogram: 135, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1514
+      ID: 1515
       Name: Probe[main.testEmptySlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12210,7 +12292,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: u}
+                  Variable: {subprogram: 132, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -12220,11 +12302,11 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: u}
+                  Variable: {subprogram: 132, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1540
+      ID: 1541
       Name: Probe[main.testEmptyString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12236,7 +12318,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: x}
+                  Variable: {subprogram: 151, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -12246,11 +12328,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: x}
+                  Variable: {subprogram: 151, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1554
+      ID: 1555
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12262,7 +12344,7 @@ Types:
             Type: 320 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: e}
+                  Variable: {subprogram: 158, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -12272,11 +12354,11 @@ Types:
             Type: 320 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: e}
+                  Variable: {subprogram: 158, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1553
+      ID: 1554
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -12288,7 +12370,7 @@ Types:
             Type: 319 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: e}
+                  Variable: {subprogram: 157, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
         - Name: e
@@ -12298,11 +12380,67 @@ Types:
             Type: 319 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: e}
+                  Variable: {subprogram: 157, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1392
+      ID: 1361
+      Name: Probe[main.testErrorAtLine]Line
+      ByteSize: 57
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 2, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 2, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: err
+          Offset: 25
+          Kind: local
+          Expression:
+            Type: 13 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 3, name: err}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: err
+          Offset: 41
+          Kind: template_segment
+          Expression:
+            Type: 13 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 3, name: err}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1393
       Name: Probe[main.testError]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12314,7 +12452,7 @@ Types:
             Type: 13 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: e}
+                  Variable: {subprogram: 58, index: 0, name: e}
                   Offset: 0
                   ByteSize: 16
         - Name: e
@@ -12324,11 +12462,11 @@ Types:
             Type: 13 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: e}
+                  Variable: {subprogram: 58, index: 0, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1374
+      ID: 1375
       Name: Probe[main.testEsotericHeap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12340,7 +12478,7 @@ Types:
             Type: 159 PointerType *main.esotericHeap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 48, index: 0, name: e}
+                  Variable: {subprogram: 49, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -12350,14 +12488,14 @@ Types:
             Type: 159 PointerType *main.esotericHeap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 48, index: 0, name: e}
+                  Variable: {subprogram: 49, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1375
+      ID: 1376
       Name: Probe[main.testEsotericHeap]Return
     - __kind: EventRootType
-      ID: 1372
+      ID: 1373
       Name: Probe[main.testEsotericStack]
       ByteSize: 129
       PresenceBitsetSize: 1
@@ -12369,7 +12507,7 @@ Types:
             Type: 155 StructureType main.esotericStack
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 0, name: e}
+                  Variable: {subprogram: 48, index: 0, name: e}
                   Offset: 0
                   ByteSize: 64
         - Name: e
@@ -12379,14 +12517,14 @@ Types:
             Type: 155 StructureType main.esotericStack
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 0, name: e}
+                  Variable: {subprogram: 48, index: 0, name: e}
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1373
+      ID: 1374
       Name: Probe[main.testEsotericStack]Return
     - __kind: EventRootType
-      ID: 1386
+      ID: 1387
       Name: Probe[main.testFramelessArray]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12398,7 +12536,7 @@ Types:
             Type: 161 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: a}
+                  Variable: {subprogram: 55, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: a
@@ -12408,11 +12546,11 @@ Types:
             Type: 161 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: a}
+                  Variable: {subprogram: 55, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1388
+      ID: 1389
       Name: Probe[main.testFramelessArray]Line
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -12424,7 +12562,7 @@ Types:
             Type: 161 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: a}
+                  Variable: {subprogram: 55, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: a
@@ -12434,7 +12572,7 @@ Types:
             Type: 161 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: a}
+                  Variable: {subprogram: 55, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: ~r0
@@ -12444,11 +12582,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 1, name: ~r0}
+                  Variable: {subprogram: 55, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1387
+      ID: 1388
       Name: Probe[main.testFramelessArray]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12460,11 +12598,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 1, name: ~r0}
+                  Variable: {subprogram: 55, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1384
+      ID: 1385
       Name: Probe[main.testFrameless]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12476,7 +12614,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: x}
+                  Variable: {subprogram: 54, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12486,11 +12624,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: x}
+                  Variable: {subprogram: 54, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1385
+      ID: 1386
       Name: Probe[main.testFrameless]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12502,11 +12640,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 1, name: ~r0}
+                  Variable: {subprogram: 54, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1376
+      ID: 1377
       Name: Probe[main.testInlinedBA]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12518,7 +12656,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: x}
+                  Variable: {subprogram: 50, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12528,14 +12666,14 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: x}
+                  Variable: {subprogram: 50, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1377
+      ID: 1378
       Name: Probe[main.testInlinedBA]Return
     - __kind: EventRootType
-      ID: 1380
+      ID: 1381
       Name: Probe[main.testInlinedBBA]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12547,7 +12685,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: x}
+                  Variable: {subprogram: 52, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12557,17 +12695,17 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: x}
+                  Variable: {subprogram: 52, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1381
+      ID: 1382
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1560
+      ID: 1561
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 1378
+      ID: 1379
       Name: Probe[main.testInlinedBB]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12579,7 +12717,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: x}
+                  Variable: {subprogram: 51, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12589,7 +12727,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: x}
+                  Variable: {subprogram: 51, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: y
@@ -12599,7 +12737,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 1, name: y}
+                  Variable: {subprogram: 51, index: 1, name: y}
                   Offset: 0
                   ByteSize: 8
         - Name: y
@@ -12609,32 +12747,32 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 1, name: y}
+                  Variable: {subprogram: 51, index: 1, name: y}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1379
+      ID: 1380
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1561
+      ID: 1562
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1562
+      ID: 1563
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1563
+      ID: 1564
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1564
+      ID: 1565
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
-      ID: 1382
+      ID: 1383
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 1383
+      ID: 1384
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1557
+      ID: 1558
       Name: Probe[main.testInlinedPrint]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12646,7 +12784,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12656,11 +12794,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1555
+      ID: 1556
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12672,11 +12810,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1556
+      ID: 1557
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12688,7 +12826,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x_val
@@ -12698,11 +12836,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1559
+      ID: 1560
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12714,7 +12852,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12724,14 +12862,14 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1558
+      ID: 1559
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1565
+      ID: 1566
       Name: Probe[main.testInlinedSq]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12743,7 +12881,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12753,11 +12891,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1566
+      ID: 1567
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12769,7 +12907,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12779,11 +12917,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1567
+      ID: 1568
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12795,7 +12933,7 @@ Types:
             Type: 161 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: a}
+                  Variable: {subprogram: 164, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: a
@@ -12805,7 +12943,7 @@ Types:
             Type: 161 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: a}
+                  Variable: {subprogram: 164, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
@@ -12939,7 +13077,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1389
+      ID: 1390
       Name: Probe[main.testInterface]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12951,7 +13089,7 @@ Types:
             Type: 162 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: b}
+                  Variable: {subprogram: 56, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -12961,11 +13099,11 @@ Types:
             Type: 162 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: b}
+                  Variable: {subprogram: 56, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1495
+      ID: 1496
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 161
       PresenceBitsetSize: 1
@@ -12977,7 +13115,7 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: arg}
+                  Variable: {subprogram: 122, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
         - Name: arg
@@ -12987,11 +13125,11 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: arg}
+                  Variable: {subprogram: 122, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1496
+      ID: 1497
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13003,11 +13141,11 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 1, name: ~r0}
+                  Variable: {subprogram: 122, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1428
+      ID: 1429
       Name: Probe[main.testLinkedList]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13019,7 +13157,7 @@ Types:
             Type: 246 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: a}
+                  Variable: {subprogram: 90, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -13029,38 +13167,12 @@ Types:
             Type: 246 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: a}
+                  Variable: {subprogram: 90, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1369
-      Name: Probe[main.testLongFunctionWithChangingState]Line
-    - __kind: EventRootType
       ID: 1370
       Name: Probe[main.testLongFunctionWithChangingState]Line
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: aPerArch
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 1, name: aPerArch}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: b
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 2, name: b}
-                  Offset: 0
-                  ByteSize: 8
     - __kind: EventRootType
       ID: 1371
       Name: Probe[main.testLongFunctionWithChangingState]Line
@@ -13074,7 +13186,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 1, name: aPerArch}
+                  Variable: {subprogram: 47, index: 1, name: aPerArch}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13084,11 +13196,37 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 2, name: b}
+                  Variable: {subprogram: 47, index: 2, name: b}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1501
+      ID: 1372
+      Name: Probe[main.testLongFunctionWithChangingState]Line
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: aPerArch
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 47, index: 1, name: aPerArch}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 47, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1502
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 147
       PresenceBitsetSize: 3
@@ -13100,7 +13238,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: a}
+                  Variable: {subprogram: 125, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -13110,7 +13248,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: a}
+                  Variable: {subprogram: 125, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13120,7 +13258,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 1, name: b}
+                  Variable: {subprogram: 125, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13130,7 +13268,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 1, name: b}
+                  Variable: {subprogram: 125, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13140,7 +13278,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 2, name: c}
+                  Variable: {subprogram: 125, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13150,7 +13288,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 2, name: c}
+                  Variable: {subprogram: 125, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13160,7 +13298,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 3, name: d}
+                  Variable: {subprogram: 125, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13170,7 +13308,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 3, name: d}
+                  Variable: {subprogram: 125, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13180,7 +13318,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 4, name: e}
+                  Variable: {subprogram: 125, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13190,7 +13328,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 4, name: e}
+                  Variable: {subprogram: 125, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13200,7 +13338,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 5, name: f}
+                  Variable: {subprogram: 125, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13210,7 +13348,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 5, name: f}
+                  Variable: {subprogram: 125, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13220,7 +13358,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 6, name: g}
+                  Variable: {subprogram: 125, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13230,7 +13368,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 6, name: g}
+                  Variable: {subprogram: 125, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13240,7 +13378,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 7, name: h}
+                  Variable: {subprogram: 125, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13250,7 +13388,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 7, name: h}
+                  Variable: {subprogram: 125, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13260,7 +13398,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 8, name: i}
+                  Variable: {subprogram: 125, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13270,11 +13408,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 8, name: i}
+                  Variable: {subprogram: 125, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1502
+      ID: 1503
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13286,11 +13424,11 @@ Types:
             Type: 113 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 9, name: ~r0}
+                  Variable: {subprogram: 125, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1400
+      ID: 1401
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13302,7 +13440,7 @@ Types:
             Type: 186 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13312,11 +13450,11 @@ Types:
             Type: 186 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1407
+      ID: 1408
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13328,7 +13466,7 @@ Types:
             Type: 193 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: m}
+                  Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13338,11 +13476,11 @@ Types:
             Type: 193 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: m}
+                  Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1419
+      ID: 1420
       Name: Probe[main.testMapEmptyKeyAndValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13354,7 +13492,7 @@ Types:
             Type: 238 GoMapType map[struct {}]struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: m}
+                  Variable: {subprogram: 83, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13364,11 +13502,11 @@ Types:
             Type: 238 GoMapType map[struct {}]struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: m}
+                  Variable: {subprogram: 83, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1417
+      ID: 1418
       Name: Probe[main.testMapEmptyKey]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13380,7 +13518,7 @@ Types:
             Type: 228 GoMapType map[struct {}]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: m}
+                  Variable: {subprogram: 81, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13390,11 +13528,11 @@ Types:
             Type: 228 GoMapType map[struct {}]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: m}
+                  Variable: {subprogram: 81, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1418
+      ID: 1419
       Name: Probe[main.testMapEmptyValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13406,7 +13544,7 @@ Types:
             Type: 233 GoMapType map[int]struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: m}
+                  Variable: {subprogram: 82, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13416,11 +13554,11 @@ Types:
             Type: 233 GoMapType map[int]struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: m}
+                  Variable: {subprogram: 82, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1404
+      ID: 1405
       Name: Probe[main.testMapIntToInt]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13432,7 +13570,7 @@ Types:
             Type: 166 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
+                  Variable: {subprogram: 69, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13442,11 +13580,11 @@ Types:
             Type: 166 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
+                  Variable: {subprogram: 69, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1416
+      ID: 1417
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13458,7 +13596,7 @@ Types:
             Type: 223 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: m}
+                  Variable: {subprogram: 80, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13468,11 +13606,11 @@ Types:
             Type: 223 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: m}
+                  Variable: {subprogram: 80, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1415
+      ID: 1416
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13484,7 +13622,7 @@ Types:
             Type: 218 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: m}
+                  Variable: {subprogram: 79, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13494,33 +13632,7 @@ Types:
             Type: 218 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1405
-      Name: Probe[main.testMapMassive]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: redactMyEntries
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 193 GoMapType map[string][]main.structWithMap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: redactMyEntries
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 193 GoMapType map[string][]main.structWithMap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 79, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -13536,7 +13648,7 @@ Types:
             Type: 193 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 70, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
         - Name: redactMyEntries
@@ -13546,11 +13658,37 @@ Types:
             Type: 193 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 70, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1414
+      ID: 1407
+      Name: Probe[main.testMapMassive]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: redactMyEntries
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 193 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 70, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: redactMyEntries
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 193 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 70, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1415
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13562,7 +13700,7 @@ Types:
             Type: 213 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: m}
+                  Variable: {subprogram: 78, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13572,11 +13710,11 @@ Types:
             Type: 213 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: m}
+                  Variable: {subprogram: 78, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1413
+      ID: 1414
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13588,6 +13726,136 @@ Types:
             Type: 208 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
+                  Variable: {subprogram: 77, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 208 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 77, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1399
+      Name: Probe[main.testMapStringToInt]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 176 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 63, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 176 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 63, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1400
+      Name: Probe[main.testMapStringToSlice]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 181 GoMapType map[string][]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 64, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 181 GoMapType map[string][]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 64, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1398
+      Name: Probe[main.testMapStringToStruct]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 171 GoMapType map[string]main.nestedStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 62, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 171 GoMapType map[string]main.nestedStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 62, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1409
+      Name: Probe[main.testMapWithLinkedList]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 198 GoMapType map[bool]main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 72, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 198 GoMapType map[bool]main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 72, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1413
+      Name: Probe[main.testMapWithSmallKeyAndValueMassive]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 208 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
                   Variable: {subprogram: 76, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
@@ -13602,112 +13870,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1398
-      Name: Probe[main.testMapStringToInt]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 176 GoMapType map[string]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: m
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 176 GoMapType map[string]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1399
-      Name: Probe[main.testMapStringToSlice]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 181 GoMapType map[string][]string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: m
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 181 GoMapType map[string][]string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1397
-      Name: Probe[main.testMapStringToStruct]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 171 GoMapType map[string]main.nestedStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: m
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 171 GoMapType map[string]main.nestedStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1408
-      Name: Probe[main.testMapWithLinkedList]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 198 GoMapType map[bool]main.node
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: m
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 198 GoMapType map[bool]main.node
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
       ID: 1412
-      Name: Probe[main.testMapWithSmallKeyAndValueMassive]
+      Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
@@ -13733,32 +13897,6 @@ Types:
                   ByteSize: 8
     - __kind: EventRootType
       ID: 1411
-      Name: Probe[main.testMapWithSmallKeyAndValue]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 208 GoMapType map[uint8]uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: m
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 208 GoMapType map[uint8]uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1410
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13770,7 +13908,7 @@ Types:
             Type: 203 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 74, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
         - Name: redactMyEntries
@@ -13780,11 +13918,11 @@ Types:
             Type: 203 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 74, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1409
+      ID: 1410
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13796,7 +13934,7 @@ Types:
             Type: 203 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: m}
+                  Variable: {subprogram: 73, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13806,35 +13944,9 @@ Types:
             Type: 203 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: m}
+                  Variable: {subprogram: 73, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
-    - __kind: EventRootType
-      ID: 1537
-      Name: Probe[main.testMassiveString]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: x
-          Offset: 17
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
     - __kind: EventRootType
       ID: 1538
       Name: Probe[main.testMassiveString]
@@ -13848,7 +13960,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
+                  Variable: {subprogram: 149, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -13858,11 +13970,37 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
+                  Variable: {subprogram: 149, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1503
+      ID: 1539
+      Name: Probe[main.testMassiveString]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 149, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 149, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1504
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 163
       PresenceBitsetSize: 3
@@ -13874,7 +14012,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: a}
+                  Variable: {subprogram: 126, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -13884,7 +14022,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: a}
+                  Variable: {subprogram: 126, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13894,7 +14032,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: b}
+                  Variable: {subprogram: 126, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13904,7 +14042,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: b}
+                  Variable: {subprogram: 126, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13914,7 +14052,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: c}
+                  Variable: {subprogram: 126, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13924,7 +14062,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: c}
+                  Variable: {subprogram: 126, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13934,7 +14072,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 3, name: d}
+                  Variable: {subprogram: 126, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13944,7 +14082,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 3, name: d}
+                  Variable: {subprogram: 126, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13954,7 +14092,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 4, name: e}
+                  Variable: {subprogram: 126, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13964,7 +14102,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 4, name: e}
+                  Variable: {subprogram: 126, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13974,7 +14112,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 5, name: f}
+                  Variable: {subprogram: 126, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13984,7 +14122,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 5, name: f}
+                  Variable: {subprogram: 126, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13994,7 +14132,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 6, name: g}
+                  Variable: {subprogram: 126, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -14004,7 +14142,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 6, name: g}
+                  Variable: {subprogram: 126, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -14014,7 +14152,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 7, name: h}
+                  Variable: {subprogram: 126, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -14024,7 +14162,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 7, name: h}
+                  Variable: {subprogram: 126, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: s
@@ -14034,7 +14172,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 8, name: s}
+                  Variable: {subprogram: 126, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
         - Name: s
@@ -14044,11 +14182,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 8, name: s}
+                  Variable: {subprogram: 126, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1504
+      ID: 1505
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -14060,11 +14198,11 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 9, name: ~r0}
+                  Variable: {subprogram: 126, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1507
+      ID: 1508
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -14076,7 +14214,7 @@ Types:
             Type: 113 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -14086,7 +14224,7 @@ Types:
             Type: 113 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -14096,7 +14234,7 @@ Types:
             Type: 251 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: b}
+                  Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
         - Name: b
@@ -14106,11 +14244,11 @@ Types:
             Type: 251 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: b}
+                  Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1508
+      ID: 1509
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -14122,7 +14260,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 2, name: ~r0}
+                  Variable: {subprogram: 128, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -14132,11 +14270,11 @@ Types:
             Type: 113 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 3, name: ~r1}
+                  Variable: {subprogram: 128, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1499
+      ID: 1500
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 321
       PresenceBitsetSize: 1
@@ -14148,7 +14286,7 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: s1}
+                  Variable: {subprogram: 124, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
         - Name: s1
@@ -14158,7 +14296,7 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: s1}
+                  Variable: {subprogram: 124, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
         - Name: s2
@@ -14168,7 +14306,7 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: s2}
+                  Variable: {subprogram: 124, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
         - Name: s2
@@ -14178,11 +14316,11 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: s2}
+                  Variable: {subprogram: 124, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1500
+      ID: 1501
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -14194,11 +14332,11 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 2, name: ~r0}
+                  Variable: {subprogram: 124, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1453
+      ID: 1454
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14210,7 +14348,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14220,11 +14358,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1455
+      ID: 1456
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14236,7 +14374,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14246,7 +14384,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14256,7 +14394,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14266,11 +14404,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1457
+      ID: 1458
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14282,11 +14420,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1459
+      ID: 1460
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14298,11 +14436,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1461
+      ID: 1462
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14314,11 +14452,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1454
+      ID: 1455
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14330,7 +14468,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14340,11 +14478,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1456
+      ID: 1457
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -14356,7 +14494,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14366,7 +14504,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14376,7 +14514,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14386,7 +14524,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14396,7 +14534,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14406,11 +14544,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1458
+      ID: 1459
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14422,7 +14560,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14432,11 +14570,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1460
+      ID: 1461
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14448,7 +14586,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14458,11 +14596,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1462
+      ID: 1463
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14474,7 +14612,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14484,11 +14622,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1423
+      ID: 1424
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 62
       PresenceBitsetSize: 2
@@ -14500,7 +14638,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: a}
+                  Variable: {subprogram: 86, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: a
@@ -14510,7 +14648,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: a}
+                  Variable: {subprogram: 86, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -14520,7 +14658,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 1, name: b}
+                  Variable: {subprogram: 86, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -14530,7 +14668,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 1, name: b}
+                  Variable: {subprogram: 86, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: c
@@ -14540,7 +14678,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 2, name: c}
+                  Variable: {subprogram: 86, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: c
@@ -14550,7 +14688,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 2, name: c}
+                  Variable: {subprogram: 86, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: d
@@ -14560,7 +14698,7 @@ Types:
             Type: 17 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 3, name: d}
+                  Variable: {subprogram: 86, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -14570,7 +14708,7 @@ Types:
             Type: 17 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 3, name: d}
+                  Variable: {subprogram: 86, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -14580,7 +14718,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 4, name: e}
+                  Variable: {subprogram: 86, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
         - Name: e
@@ -14590,11 +14728,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 4, name: e}
+                  Variable: {subprogram: 86, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1449
+      ID: 1450
       Name: Probe[main.testNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14606,7 +14744,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14616,37 +14754,37 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1452
+      Name: Probe[main.testNamedReturn]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
       ID: 1451
-      Name: Probe[main.testNamedReturn]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1450
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14658,11 +14796,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1452
+      ID: 1453
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14674,7 +14812,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14684,11 +14822,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1549
+      ID: 1550
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14700,7 +14838,7 @@ Types:
             Type: 317 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: x}
+                  Variable: {subprogram: 156, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -14710,11 +14848,11 @@ Types:
             Type: 317 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: x}
+                  Variable: {subprogram: 156, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1550
+      ID: 1551
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14726,7 +14864,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: x}
+                  Variable: {subprogram: 156, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -14736,10 +14874,10 @@ Types:
                   Bias: 8
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1551
+      ID: 1552
       Name: Probe[main.testNestedPointer]
     - __kind: EventRootType
-      ID: 1552
+      ID: 1553
       Name: Probe[main.testNestedPointer]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -14751,7 +14889,7 @@ Types:
             Type: 123 StructureType main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: x}
+                  Variable: {subprogram: 156, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -14761,7 +14899,7 @@ Types:
                   Bias: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1433
+      ID: 1434
       Name: Probe[main.testNilPointer]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14773,7 +14911,7 @@ Types:
             Type: 11 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: z}
+                  Variable: {subprogram: 95, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: z
@@ -14783,7 +14921,7 @@ Types:
             Type: 11 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: z}
+                  Variable: {subprogram: 95, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14793,7 +14931,7 @@ Types:
             Type: 17 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 1, name: a}
+                  Variable: {subprogram: 95, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14803,11 +14941,11 @@ Types:
             Type: 17 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 1, name: a}
+                  Variable: {subprogram: 95, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1518
+      ID: 1519
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -14819,7 +14957,7 @@ Types:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: xs}
+                  Variable: {subprogram: 136, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -14829,7 +14967,7 @@ Types:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: xs}
+                  Variable: {subprogram: 136, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -14839,7 +14977,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 1, name: a}
+                  Variable: {subprogram: 136, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14849,11 +14987,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 1, name: a}
+                  Variable: {subprogram: 136, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1520
+      ID: 1521
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 67
       PresenceBitsetSize: 1
@@ -14865,7 +15003,7 @@ Types:
             Type: 16 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: a}
+                  Variable: {subprogram: 138, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: a
@@ -14875,7 +15013,7 @@ Types:
             Type: 16 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: a}
+                  Variable: {subprogram: 138, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
@@ -14885,7 +15023,7 @@ Types:
             Type: 264 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 1, name: s}
+                  Variable: {subprogram: 138, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: s
@@ -14895,7 +15033,7 @@ Types:
             Type: 264 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 1, name: s}
+                  Variable: {subprogram: 138, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -14905,7 +15043,7 @@ Types:
             Type: 17 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 2, name: x}
+                  Variable: {subprogram: 138, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -14915,11 +15053,11 @@ Types:
             Type: 17 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 2, name: x}
+                  Variable: {subprogram: 138, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1521
+      ID: 1522
       Name: Probe[main.testNilSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -14931,7 +15069,7 @@ Types:
             Type: 265 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -14941,11 +15079,11 @@ Types:
             Type: 265 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1536
+      ID: 1537
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14957,7 +15095,7 @@ Types:
             Type: 270 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14967,11 +15105,11 @@ Types:
             Type: 270 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1429
+      ID: 1430
       Name: Probe[main.testPointerLoop]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14983,7 +15121,7 @@ Types:
             Type: 247 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: a}
+                  Variable: {subprogram: 91, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14993,11 +15131,11 @@ Types:
             Type: 247 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: a}
+                  Variable: {subprogram: 91, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1403
+      ID: 1404
       Name: Probe[main.testPointerToMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15009,7 +15147,7 @@ Types:
             Type: 192 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: m}
+                  Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -15019,11 +15157,11 @@ Types:
             Type: 192 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: m}
+                  Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1427
+      ID: 1428
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15035,7 +15173,7 @@ Types:
             Type: 244 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: a}
+                  Variable: {subprogram: 89, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -15045,11 +15183,11 @@ Types:
             Type: 244 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: a}
+                  Variable: {subprogram: 89, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1443
+      ID: 1444
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 35
       PresenceBitsetSize: 1
@@ -15061,7 +15199,7 @@ Types:
             Type: 157 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: v}
+                  Variable: {subprogram: 101, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: v
@@ -15071,7 +15209,7 @@ Types:
             Type: 157 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: v}
+                  Variable: {subprogram: 101, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: failed
@@ -15081,7 +15219,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 1, name: failed}
+                  Variable: {subprogram: 101, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
         - Name: failed
@@ -15091,11 +15229,11 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 1, name: failed}
+                  Variable: {subprogram: 101, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1444
+      ID: 1445
       Name: Probe[main.testReturnsAnyAndError]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15107,7 +15245,7 @@ Types:
             Type: 157 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 2, name: ~r0}
+                  Variable: {subprogram: 101, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
         - Name: ~r1
@@ -15117,11 +15255,11 @@ Types:
             Type: 13 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 3, name: ~r1}
+                  Variable: {subprogram: 101, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1445
+      ID: 1446
       Name: Probe[main.testReturnsAny]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15133,7 +15271,7 @@ Types:
             Type: 157 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: v}
+                  Variable: {subprogram: 102, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: v
@@ -15143,11 +15281,11 @@ Types:
             Type: 157 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: v}
+                  Variable: {subprogram: 102, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1446
+      ID: 1447
       Name: Probe[main.testReturnsAny]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15159,14 +15297,14 @@ Types:
             Type: 157 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 1, name: ~r0}
+                  Variable: {subprogram: 102, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1475
+      ID: 1476
       Name: Probe[main.testReturnsArrayOne]
     - __kind: EventRootType
-      ID: 1476
+      ID: 1477
       Name: Probe[main.testReturnsArrayOne]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15178,14 +15316,14 @@ Types:
             Type: 252 ArrayType [1]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 0, name: ~r0}
+                  Variable: {subprogram: 112, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1477
+      ID: 1478
       Name: Probe[main.testReturnsArrayZero]
     - __kind: EventRootType
-      ID: 1478
+      ID: 1479
       Name: Probe[main.testReturnsArrayZero]Return
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -15197,14 +15335,14 @@ Types:
             Type: 253 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 0, name: ~r0}
+                  Variable: {subprogram: 113, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1473
+      ID: 1474
       Name: Probe[main.testReturnsArray]
     - __kind: EventRootType
-      ID: 1474
+      ID: 1475
       Name: Probe[main.testReturnsArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15216,14 +15354,14 @@ Types:
             Type: 251 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 0, name: ~r0}
+                  Variable: {subprogram: 111, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1481
+      ID: 1482
       Name: Probe[main.testReturnsBacktrackInt]
     - __kind: EventRootType
-      ID: 1482
+      ID: 1483
       Name: Probe[main.testReturnsBacktrackInt]Return
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -15235,7 +15373,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: ~r0}
+                  Variable: {subprogram: 115, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15245,7 +15383,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 1, name: ~r1}
+                  Variable: {subprogram: 115, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15255,7 +15393,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 2, name: ~r2}
+                  Variable: {subprogram: 115, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -15265,7 +15403,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 3, name: ~r3}
+                  Variable: {subprogram: 115, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15275,7 +15413,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 4, name: ~r4}
+                  Variable: {subprogram: 115, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r5
@@ -15285,7 +15423,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 5, name: ~r5}
+                  Variable: {subprogram: 115, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r6
@@ -15295,7 +15433,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 6, name: ~r6}
+                  Variable: {subprogram: 115, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r7
@@ -15305,7 +15443,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 7, name: ~r7}
+                  Variable: {subprogram: 115, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r8
@@ -15315,14 +15453,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 8, name: ~r8}
+                  Variable: {subprogram: 115, index: 8, name: ~r8}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1493
+      ID: 1494
       Name: Probe[main.testReturnsBoolAndUintptr]
     - __kind: EventRootType
-      ID: 1494
+      ID: 1495
       Name: Probe[main.testReturnsBoolAndUintptr]Return
       ByteSize: 10
       PresenceBitsetSize: 1
@@ -15334,7 +15472,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: ~r0}
+                  Variable: {subprogram: 121, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r1
@@ -15344,14 +15482,14 @@ Types:
             Type: 1 BaseType uintptr
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 1, name: ~r1}
+                  Variable: {subprogram: 121, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1469
+      ID: 1470
       Name: Probe[main.testReturnsComplex]
     - __kind: EventRootType
-      ID: 1470
+      ID: 1471
       Name: Probe[main.testReturnsComplex]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15363,7 +15501,7 @@ Types:
             Type: 96 BaseType complex64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: ~r0}
+                  Variable: {subprogram: 109, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15373,11 +15511,11 @@ Types:
             Type: 97 BaseType complex128
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: ~r1}
+                  Variable: {subprogram: 109, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1441
+      ID: 1442
       Name: Probe[main.testReturnsError]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -15389,7 +15527,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: failed}
+                  Variable: {subprogram: 100, index: 0, name: failed}
                   Offset: 0
                   ByteSize: 1
         - Name: failed
@@ -15399,11 +15537,11 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: failed}
+                  Variable: {subprogram: 100, index: 0, name: failed}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1442
+      ID: 1443
       Name: Probe[main.testReturnsError]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15415,11 +15553,11 @@ Types:
             Type: 13 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 1, name: ~r0}
+                  Variable: {subprogram: 100, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1439
+      ID: 1440
       Name: Probe[main.testReturnsIntAndFloat]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15431,7 +15569,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: i}
+                  Variable: {subprogram: 99, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -15441,11 +15579,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: i}
+                  Variable: {subprogram: 99, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1440
+      ID: 1441
       Name: Probe[main.testReturnsIntAndFloat]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15457,7 +15595,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 1, name: ~r0}
+                  Variable: {subprogram: 99, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15467,11 +15605,11 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 2, name: ~r1}
+                  Variable: {subprogram: 99, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1437
+      ID: 1438
       Name: Probe[main.testReturnsIntPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15483,7 +15621,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: i}
+                  Variable: {subprogram: 98, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -15493,11 +15631,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: i}
+                  Variable: {subprogram: 98, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1438
+      ID: 1439
       Name: Probe[main.testReturnsIntPointer]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15509,11 +15647,11 @@ Types:
             Type: 99 PointerType *int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 1, name: ~r0}
+                  Variable: {subprogram: 98, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1435
+      ID: 1436
       Name: Probe[main.testReturnsInt]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15525,7 +15663,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: i}
+                  Variable: {subprogram: 97, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -15535,11 +15673,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: i}
+                  Variable: {subprogram: 97, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1436
+      ID: 1437
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15551,11 +15689,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 1, name: ~r0}
+                  Variable: {subprogram: 97, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1447
+      ID: 1448
       Name: Probe[main.testReturnsInterface]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15567,7 +15705,7 @@ Types:
             Type: 157 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: v}
+                  Variable: {subprogram: 103, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: v
@@ -15577,11 +15715,11 @@ Types:
             Type: 157 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: v}
+                  Variable: {subprogram: 103, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1448
+      ID: 1449
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15593,14 +15731,14 @@ Types:
             Type: 162 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: ~r0}
+                  Variable: {subprogram: 103, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1471
+      ID: 1472
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1472
+      ID: 1473
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -15612,14 +15750,14 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: ~r0}
+                  Variable: {subprogram: 110, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1467
+      ID: 1468
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1468
+      ID: 1469
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 139
       PresenceBitsetSize: 3
@@ -15631,7 +15769,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: ~r0}
+                  Variable: {subprogram: 108, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15641,7 +15779,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 1, name: ~r1}
+                  Variable: {subprogram: 108, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15651,7 +15789,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 2, name: ~r2}
+                  Variable: {subprogram: 108, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -15661,7 +15799,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 3, name: ~r3}
+                  Variable: {subprogram: 108, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15671,7 +15809,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 4, name: ~r4}
+                  Variable: {subprogram: 108, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r5
@@ -15681,7 +15819,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 5, name: ~r5}
+                  Variable: {subprogram: 108, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r6
@@ -15691,7 +15829,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 6, name: ~r6}
+                  Variable: {subprogram: 108, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r7
@@ -15701,7 +15839,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 7, name: ~r7}
+                  Variable: {subprogram: 108, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r8
@@ -15711,7 +15849,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 8, name: ~r8}
+                  Variable: {subprogram: 108, index: 8, name: ~r8}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r9
@@ -15721,7 +15859,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 9, name: ~r9}
+                  Variable: {subprogram: 108, index: 9, name: ~r9}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r10
@@ -15731,7 +15869,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 10, name: ~r10}
+                  Variable: {subprogram: 108, index: 10, name: ~r10}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r11
@@ -15741,7 +15879,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 11, name: ~r11}
+                  Variable: {subprogram: 108, index: 11, name: ~r11}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r12
@@ -15751,7 +15889,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 12, name: ~r12}
+                  Variable: {subprogram: 108, index: 12, name: ~r12}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r13
@@ -15761,7 +15899,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 13, name: ~r13}
+                  Variable: {subprogram: 108, index: 13, name: ~r13}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r14
@@ -15771,7 +15909,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 14, name: ~r14}
+                  Variable: {subprogram: 108, index: 14, name: ~r14}
                   Offset: 0
                   ByteSize: 8
         - Name: onlyOnAmd64_16
@@ -15781,7 +15919,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 15, name: onlyOnAmd64_16}
+                  Variable: {subprogram: 108, index: 15, name: onlyOnAmd64_16}
                   Offset: 0
                   ByteSize: 8
         - Name: bothArmAndAmd64
@@ -15791,14 +15929,14 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 16, name: bothArmAndAmd64}
+                  Variable: {subprogram: 108, index: 16, name: bothArmAndAmd64}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1479
+      ID: 1480
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1480
+      ID: 1481
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15810,14 +15948,14 @@ Types:
             Type: 254 StructureType main.mixedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: ~r0}
+                  Variable: {subprogram: 114, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1485
+      ID: 1486
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1486
+      ID: 1487
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -15829,7 +15967,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 0, name: ~r0}
+                  Variable: {subprogram: 117, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15839,7 +15977,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 1, name: ~r1}
+                  Variable: {subprogram: 117, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15849,7 +15987,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 2, name: ~r2}
+                  Variable: {subprogram: 117, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -15859,7 +15997,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 3, name: ~r3}
+                  Variable: {subprogram: 117, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15869,14 +16007,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 4, name: ~r4}
+                  Variable: {subprogram: 117, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1491
+      ID: 1492
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1492
+      ID: 1493
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -15888,7 +16026,7 @@ Types:
             Type: 18 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: ~r0}
+                  Variable: {subprogram: 120, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r1
@@ -15898,14 +16036,14 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 1, name: ~r1}
+                  Variable: {subprogram: 120, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1489
+      ID: 1490
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1490
+      ID: 1491
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15917,14 +16055,14 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 0, name: ~r0}
+                  Variable: {subprogram: 119, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1465
+      ID: 1466
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1466
+      ID: 1467
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -15936,7 +16074,7 @@ Types:
             Type: 16 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 0, name: ~r0}
+                  Variable: {subprogram: 107, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r1
@@ -15946,7 +16084,7 @@ Types:
             Type: 104 BaseType int16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 1, name: ~r1}
+                  Variable: {subprogram: 107, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 2
         - Name: ~r2
@@ -15956,7 +16094,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 2, name: ~r2}
+                  Variable: {subprogram: 107, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r3
@@ -15966,7 +16104,7 @@ Types:
             Type: 12 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 3, name: ~r3}
+                  Variable: {subprogram: 107, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15976,7 +16114,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 4, name: ~r4}
+                  Variable: {subprogram: 107, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r5
@@ -15986,7 +16124,7 @@ Types:
             Type: 6 BaseType uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 5, name: ~r5}
+                  Variable: {subprogram: 107, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 2
         - Name: ~r6
@@ -15996,7 +16134,7 @@ Types:
             Type: 2 BaseType uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 6, name: ~r6}
+                  Variable: {subprogram: 107, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r7
@@ -16006,14 +16144,14 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 7, name: ~r7}
+                  Variable: {subprogram: 107, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1487
+      ID: 1488
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1488
+      ID: 1489
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16025,14 +16163,14 @@ Types:
             Type: 256 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 0, name: ~r0}
+                  Variable: {subprogram: 118, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1483
+      ID: 1484
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1484
+      ID: 1485
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -16044,7 +16182,7 @@ Types:
             Type: 255 StructureType main.wideStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 0, name: ~r0}
+                  Variable: {subprogram: 116, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 88
     - __kind: EventRootType
@@ -16354,7 +16492,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1528
+      ID: 1529
       Name: Probe[main.testSingleString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16366,7 +16504,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: x}
+                  Variable: {subprogram: 144, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -16376,7 +16514,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: x}
+                  Variable: {subprogram: 144, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -16510,7 +16648,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1524
+      ID: 1525
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16522,7 +16660,7 @@ Types:
             Type: 266 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: xs}
+                  Variable: {subprogram: 141, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -16532,11 +16670,11 @@ Types:
             Type: 266 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: xs}
+                  Variable: {subprogram: 141, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1515
+      ID: 1516
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16548,7 +16686,7 @@ Types:
             Type: 258 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: u}
+                  Variable: {subprogram: 133, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -16558,11 +16696,11 @@ Types:
             Type: 258 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: u}
+                  Variable: {subprogram: 133, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1401
+      ID: 1402
       Name: Probe[main.testSmallMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16574,7 +16712,7 @@ Types:
             Type: 176 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -16584,11 +16722,11 @@ Types:
             Type: 176 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1463
+      ID: 1464
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16600,7 +16738,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: i}
+                  Variable: {subprogram: 106, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -16610,11 +16748,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: i}
+                  Variable: {subprogram: 106, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1464
+      ID: 1465
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16626,7 +16764,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 1, name: ~r0}
+                  Variable: {subprogram: 106, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -16636,7 +16774,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 2, name: result2}
+                  Variable: {subprogram: 106, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -16646,11 +16784,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 3, name: ~r2}
+                  Variable: {subprogram: 106, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1505
+      ID: 1506
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -16662,7 +16800,7 @@ Types:
             Type: 161 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: arg}
+                  Variable: {subprogram: 127, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
         - Name: arg
@@ -16672,11 +16810,11 @@ Types:
             Type: 161 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: arg}
+                  Variable: {subprogram: 127, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1506
+      ID: 1507
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16688,7 +16826,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: ~r0}
+                  Variable: {subprogram: 127, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -16698,7 +16836,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: ~r1}
+                  Variable: {subprogram: 127, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -16708,7 +16846,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 3, name: ~r2}
+                  Variable: {subprogram: 127, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -16738,7 +16876,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1432
+      ID: 1433
       Name: Probe[main.testStringPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16750,7 +16888,7 @@ Types:
             Type: 95 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: z}
+                  Variable: {subprogram: 94, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: z
@@ -16760,11 +16898,11 @@ Types:
             Type: 95 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: z}
+                  Variable: {subprogram: 94, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1519
+      ID: 1520
       Name: Probe[main.testStringSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16776,7 +16914,7 @@ Types:
             Type: 263 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: s}
+                  Variable: {subprogram: 137, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: s
@@ -16786,11 +16924,11 @@ Types:
             Type: 263 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: s}
+                  Variable: {subprogram: 137, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1367
+      ID: 1368
       Name: Probe[main.testStringType1]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16802,7 +16940,7 @@ Types:
             Type: 151 PointerType *main.stringType1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 0, name: a}
+                  Variable: {subprogram: 45, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -16812,11 +16950,11 @@ Types:
             Type: 151 PointerType *main.stringType1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 0, name: a}
+                  Variable: {subprogram: 45, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1368
+      ID: 1369
       Name: Probe[main.testStringType2]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16828,7 +16966,7 @@ Types:
             Type: 153 PointerType **main.stringType2
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: a}
+                  Variable: {subprogram: 46, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -16838,11 +16976,11 @@ Types:
             Type: 153 PointerType **main.stringType2
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: a}
+                  Variable: {subprogram: 46, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1516
+      ID: 1517
       Name: Probe[main.testStructSlice]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -16854,7 +16992,7 @@ Types:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Variable: {subprogram: 134, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -16864,7 +17002,7 @@ Types:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Variable: {subprogram: 134, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -16874,7 +17012,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 1, name: a}
+                  Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -16884,11 +17022,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 1, name: a}
+                  Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1395
+      ID: 1396
       Name: Probe[main.testStructWithAny]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16900,7 +17038,7 @@ Types:
             Type: 164 StructureType main.structWithAny
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: s}
+                  Variable: {subprogram: 60, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
         - Name: s
@@ -16910,11 +17048,11 @@ Types:
             Type: 164 StructureType main.structWithAny
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: s}
+                  Variable: {subprogram: 60, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1509
+      ID: 1510
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16926,7 +17064,7 @@ Types:
             Type: 256 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: arg}
+                  Variable: {subprogram: 129, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
         - Name: arg
@@ -16936,11 +17074,11 @@ Types:
             Type: 256 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: arg}
+                  Variable: {subprogram: 129, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1510
+      ID: 1511
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16952,7 +17090,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 1, name: ~r0}
+                  Variable: {subprogram: 129, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -16962,11 +17100,11 @@ Types:
             Type: 256 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 2, name: ~r1}
+                  Variable: {subprogram: 129, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1543
+      ID: 1544
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16978,7 +17116,7 @@ Types:
             Type: 285 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: a}
+                  Variable: {subprogram: 154, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
         - Name: a
@@ -16988,14 +17126,14 @@ Types:
             Type: 285 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: a}
+                  Variable: {subprogram: 154, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1544
+      ID: 1545
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1542
+      ID: 1543
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 289
       PresenceBitsetSize: 1
@@ -17007,7 +17145,7 @@ Types:
             Type: 272 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: a}
+                  Variable: {subprogram: 153, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
         - Name: a
@@ -17017,11 +17155,11 @@ Types:
             Type: 272 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: a}
+                  Variable: {subprogram: 153, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
     - __kind: EventRootType
-      ID: 1396
+      ID: 1397
       Name: Probe[main.testStructWithMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17033,7 +17171,7 @@ Types:
             Type: 165 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: s}
+                  Variable: {subprogram: 61, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
         - Name: s
@@ -17043,11 +17181,11 @@ Types:
             Type: 165 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: s}
+                  Variable: {subprogram: 61, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1545
+      ID: 1546
       Name: Probe[main.testStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17059,11 +17197,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 8
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1547
+      ID: 1548
       Name: Probe[main.testStruct]
       ByteSize: 113
       PresenceBitsetSize: 1
@@ -17075,7 +17213,7 @@ Types:
             Type: 316 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
         - Name: x
@@ -17085,17 +17223,17 @@ Types:
             Type: 316 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1546
+      ID: 1547
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1548
+      ID: 1549
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1525
+      ID: 1526
       Name: Probe[main.testSubslices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -17107,7 +17245,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: as}
+                  Variable: {subprogram: 142, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
         - Name: as
@@ -17117,7 +17255,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: as}
+                  Variable: {subprogram: 142, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
         - Name: bs
@@ -17127,7 +17265,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 1, name: bs}
+                  Variable: {subprogram: 142, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
         - Name: bs
@@ -17137,7 +17275,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 1, name: bs}
+                  Variable: {subprogram: 142, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
         - Name: cs
@@ -17147,7 +17285,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 2, name: cs}
+                  Variable: {subprogram: 142, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
         - Name: cs
@@ -17157,11 +17295,11 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 2, name: cs}
+                  Variable: {subprogram: 142, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1541
+      ID: 1542
       Name: Probe[main.testSubstrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17173,7 +17311,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: a}
+                  Variable: {subprogram: 152, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -17183,7 +17321,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: a}
+                  Variable: {subprogram: 152, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -17193,7 +17331,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 1, name: b}
+                  Variable: {subprogram: 152, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -17203,7 +17341,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 1, name: b}
+                  Variable: {subprogram: 152, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: c
@@ -17213,7 +17351,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 2, name: c}
+                  Variable: {subprogram: 152, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
         - Name: c
@@ -17223,11 +17361,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 2, name: c}
+                  Variable: {subprogram: 152, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1534
+      ID: 1535
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17239,7 +17377,7 @@ Types:
             Type: 269 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -17249,11 +17387,11 @@ Types:
             Type: 269 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1535
+      ID: 1536
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17265,7 +17403,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -17278,7 +17416,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -17291,14 +17429,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
                   Bias: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1530
+      ID: 1531
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17310,7 +17448,7 @@ Types:
             Type: 268 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
         - Name: a
@@ -17320,11 +17458,11 @@ Types:
             Type: 268 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1532
+      ID: 1533
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17336,7 +17474,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: t.b
@@ -17346,7 +17484,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 16
                   ByteSize: 16
         - Name: t.c
@@ -17356,17 +17494,17 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1531
+      ID: 1532
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1533
+      ID: 1534
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1529
+      ID: 1530
       Name: Probe[main.testThreeStrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17378,7 +17516,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: x}
+                  Variable: {subprogram: 145, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -17388,7 +17526,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: x}
+                  Variable: {subprogram: 145, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -17398,7 +17536,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 1, name: y}
+                  Variable: {subprogram: 145, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -17408,7 +17546,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 1, name: y}
+                  Variable: {subprogram: 145, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -17418,7 +17556,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 2, name: z}
+                  Variable: {subprogram: 145, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -17428,7 +17566,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 2, name: z}
+                  Variable: {subprogram: 145, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -17588,7 +17726,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1431
+      ID: 1432
       Name: Probe[main.testUintPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17600,7 +17738,7 @@ Types:
             Type: 107 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: x}
+                  Variable: {subprogram: 93, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -17610,11 +17748,11 @@ Types:
             Type: 107 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: x}
+                  Variable: {subprogram: 93, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1513
+      ID: 1514
       Name: Probe[main.testUintSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17626,7 +17764,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: u}
+                  Variable: {subprogram: 131, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -17636,11 +17774,11 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: u}
+                  Variable: {subprogram: 131, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1539
+      ID: 1540
       Name: Probe[main.testUnitializedString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17652,7 +17790,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: x}
+                  Variable: {subprogram: 150, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -17662,11 +17800,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: x}
+                  Variable: {subprogram: 150, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1430
+      ID: 1431
       Name: Probe[main.testUnsafePointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17678,7 +17816,7 @@ Types:
             Type: 14 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: x}
+                  Variable: {subprogram: 92, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -17688,7 +17826,7 @@ Types:
             Type: 14 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: x}
+                  Variable: {subprogram: 92, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -17718,32 +17856,6 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1522
-      Name: Probe[main.testVeryLargeSlice]
-      ByteSize: 49
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: xs
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 257 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: xs
-          Offset: 25
-          Kind: template_segment
-          Expression:
-            Type: 257 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
       ID: 1523
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
@@ -17756,7 +17868,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: xs}
+                  Variable: {subprogram: 140, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -17766,11 +17878,37 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: xs}
+                  Variable: {subprogram: 140, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1511
+      ID: 1524
+      Name: Probe[main.testVeryLargeSlice]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 257 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 140, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: xs
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 257 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 140, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1512
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17782,7 +17920,7 @@ Types:
             Type: 253 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: a}
+                  Variable: {subprogram: 130, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
         - Name: a
@@ -17792,7 +17930,7 @@ Types:
             Type: 253 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: a}
+                  Variable: {subprogram: 130, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
         - Name: b
@@ -17802,7 +17940,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 1, name: b}
+                  Variable: {subprogram: 130, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -17812,11 +17950,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 1, name: b}
+                  Variable: {subprogram: 130, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1512
+      ID: 1513
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -17828,7 +17966,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 2, name: ~r0}
+                  Variable: {subprogram: 130, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -17838,7 +17976,7 @@ Types:
             Type: 253 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 3, name: ~r1}
+                  Variable: {subprogram: 130, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 0
     - __kind: ArrayType
@@ -26506,7 +26644,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 994944
       GoKind: 5
-MaxTypeID: 1570
+MaxTypeID: 1571
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x1805520", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.26rc1.yaml
@@ -8,15 +8,15 @@ Probes:
       template: stackC
       segments: [stackC]
       captureSnapshot: true
-      subprogram: {subprogram: 142}
+      subprogram: {subprogram: 143}
       events:
         - Kind: Entry
-          Type: 1526 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0xcec4ca", Frameless: false}]
+          Type: 1527 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0xcec60a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1527 EventRootType Probe[main.stackC]Return
-          InjectionPoints: [{PC: "0xcec505", Frameless: false}]
+          Type: 1528 EventRootType Probe[main.stackC]Return
+          InjectionPoints: [{PC: "0xcec645", Frameless: false}]
           Condition: null
       probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -27,15 +27,15 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 56}
+      subprogram: {subprogram: 57}
       events:
         - Kind: Entry
-          Type: 1390 EventRootType Probe[main.testAny]
-          InjectionPoints: [{PC: "0xce6d4a", Frameless: false}]
+          Type: 1391 EventRootType Probe[main.testAny]
+          InjectionPoints: [{PC: "0xce6e8a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1391 EventRootType Probe[main.testAny]Return
-          InjectionPoints: [{PC: "0xce6d85", Frameless: false}]
+          Type: 1392 EventRootType Probe[main.testAny]Return
+          InjectionPoints: [{PC: "0xce6ec5", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -52,15 +52,15 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 58}
+      subprogram: {subprogram: 59}
       events:
         - Kind: Entry
-          Type: 1393 EventRootType Probe[main.testAnyPtr]
-          InjectionPoints: [{PC: "0xce6dea", Frameless: false}]
+          Type: 1394 EventRootType Probe[main.testAnyPtr]
+          InjectionPoints: [{PC: "0xce6f2a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1394 EventRootType Probe[main.testAnyPtr]Return
-          InjectionPoints: [{PC: "0xce6e1d", Frameless: false}]
+          Type: 1395 EventRootType Probe[main.testAnyPtr]Return
+          InjectionPoints: [{PC: "0xce6f5d", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -76,15 +76,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 122}
+      subprogram: {subprogram: 123}
       events:
         - Kind: Entry
-          Type: 1497 EventRootType Probe[main.testArrayArgAndReturn]
-          InjectionPoints: [{PC: "0xceaeee", Frameless: false}]
+          Type: 1498 EventRootType Probe[main.testArrayArgAndReturn]
+          InjectionPoints: [{PC: "0xceb02e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1498 EventRootType Probe[main.testArrayArgAndReturn]Return
-          InjectionPoints: [{PC: "0xceafaa", Frameless: false}]
+          Type: 1499 EventRootType Probe[main.testArrayArgAndReturn]Return
+          InjectionPoints: [{PC: "0xceb0ea", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -164,11 +164,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 66}
+      subprogram: {subprogram: 67}
       events:
         - Kind: Entry
-          Type: 1402 EventRootType Probe[main.testArrayOfMaps]
-          InjectionPoints: [{PC: "0xce7560", Frameless: true}]
+          Type: 1403 EventRootType Probe[main.testArrayOfMaps]
+          InjectionPoints: [{PC: "0xce76a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -226,15 +226,15 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 87}
       events:
         - Kind: Entry
-          Type: 1424 EventRootType Probe[main.testAtomicAdd]
-          InjectionPoints: [{PC: "0xce9380", Frameless: true}]
+          Type: 1425 EventRootType Probe[main.testAtomicAdd]
+          InjectionPoints: [{PC: "0xce94c0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1425 EventRootType Probe[main.testAtomicAdd]Return
-          InjectionPoints: [{PC: "0xce9392", Frameless: true}]
+          Type: 1426 EventRootType Probe[main.testAtomicAdd]Return
+          InjectionPoints: [{PC: "0xce94d2", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -319,11 +319,11 @@ Probes:
           expr:
             dsl: x.aString
             json: {getmember: [{ref: x}, aString]}
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1542 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0xcec900", Frameless: true}]
+          Type: 1543 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0xceca40", Frameless: true}]
           Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -337,20 +337,20 @@ Probes:
       segments: []
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1550 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1551 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
-            - PC: "0xce656e"
+            - PC: "0xce66ae"
               Frameless: false
-            - PC: "0xce65f1"
+            - PC: "0xce6731"
               Frameless: false
-            - PC: "0xce6732"
+            - PC: "0xce6872"
               Frameless: false
-            - PC: "0xce67bc"
+            - PC: "0xce68fc"
               Frameless: false
-            - PC: "0xce688f"
+            - PC: "0xce69cf"
               Frameless: false
           Condition: null
     - id: testCaptureExprLineWithTemplate
@@ -365,20 +365,20 @@ Probes:
       segments: [x=, {json: {ref: x}, dsl: x}]
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1551 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1552 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
-            - PC: "0xce656e"
+            - PC: "0xce66ae"
               Frameless: false
-            - PC: "0xce65f1"
+            - PC: "0xce6731"
               Frameless: false
-            - PC: "0xce6732"
+            - PC: "0xce6872"
               Frameless: false
-            - PC: "0xce67bc"
+            - PC: "0xce68fc"
               Frameless: false
-            - PC: "0xce688f"
+            - PC: "0xce69cf"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -401,11 +401,11 @@ Probes:
           expr: {dsl: x, json: {ref: x}}
         - name: w_val
           expr: {dsl: w, json: {ref: w}}
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 85}
       events:
         - Kind: Entry
-          Type: 1421 EventRootType Probe[main.testCombinedString]
-          InjectionPoints: [{PC: "0xce8fe0", Frameless: true}]
+          Type: 1422 EventRootType Probe[main.testCombinedString]
+          InjectionPoints: [{PC: "0xce9120", Frameless: true}]
           Condition: null
     - id: testCaptureExprWithTemplate
       version: 0
@@ -419,11 +419,11 @@ Probes:
           expr: {dsl: x, json: {ref: x}}
         - name: w_val
           expr: {dsl: w, json: {ref: w}}
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 85}
       events:
         - Kind: Entry
-          Type: 1422 EventRootType Probe[main.testCombinedString]
-          InjectionPoints: [{PC: "0xce8fe0", Frameless: true}]
+          Type: 1423 EventRootType Probe[main.testCombinedString]
+          InjectionPoints: [{PC: "0xce9120", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: x={x}
@@ -441,11 +441,11 @@ Probes:
       template: '{c}'
       segments: [{json: {ref: c}, dsl: c}]
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 88}
       events:
         - Kind: Entry
-          Type: 1426 EventRootType Probe[main.testChannel]
-          InjectionPoints: [{PC: "0xce93a0", Frameless: true}]
+          Type: 1427 EventRootType Probe[main.testChannel]
+          InjectionPoints: [{PC: "0xce94e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{c}'
@@ -470,11 +470,11 @@ Probes:
         - json: {ref: y}
           dsl: y
       captureSnapshot: true
-      subprogram: {subprogram: 83}
+      subprogram: {subprogram: 84}
       events:
         - Kind: Entry
-          Type: 1420 EventRootType Probe[main.testCombinedByte]
-          InjectionPoints: [{PC: "0xce8fa0", Frameless: true}]
+          Type: 1421 EventRootType Probe[main.testCombinedByte]
+          InjectionPoints: [{PC: "0xce90e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{w}, {x}, {y}'
@@ -501,11 +501,11 @@ Probes:
       template: '{t}'
       segments: [{json: {ref: t}, dsl: t}]
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 96}
       events:
         - Kind: Entry
-          Type: 1434 EventRootType Probe[main.testCycle]
-          InjectionPoints: [{PC: "0xce9760", Frameless: true}]
+          Type: 1435 EventRootType Probe[main.testCycle]
+          InjectionPoints: [{PC: "0xce98a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{t}'
@@ -522,11 +522,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 42}
+      subprogram: {subprogram: 43}
       events:
         - Kind: Entry
-          Type: 1365 EventRootType Probe[main.testDeepMap1]
-          InjectionPoints: [{PC: "0xce5ae0", Frameless: true}]
+          Type: 1366 EventRootType Probe[main.testDeepMap1]
+          InjectionPoints: [{PC: "0xce5c00", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -543,11 +543,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 43}
+      subprogram: {subprogram: 44}
       events:
         - Kind: Entry
-          Type: 1366 EventRootType Probe[main.testDeepMap7]
-          InjectionPoints: [{PC: "0xce5b00", Frameless: true}]
+          Type: 1367 EventRootType Probe[main.testDeepMap7]
+          InjectionPoints: [{PC: "0xce5c20", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -564,11 +564,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 38}
+      subprogram: {subprogram: 39}
       events:
         - Kind: Entry
-          Type: 1361 EventRootType Probe[main.testDeepPtr1]
-          InjectionPoints: [{PC: "0xce57e0", Frameless: true}]
+          Type: 1362 EventRootType Probe[main.testDeepPtr1]
+          InjectionPoints: [{PC: "0xce5900", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -585,11 +585,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 39}
+      subprogram: {subprogram: 40}
       events:
         - Kind: Entry
-          Type: 1362 EventRootType Probe[main.testDeepPtr7]
-          InjectionPoints: [{PC: "0xce5800", Frameless: true}]
+          Type: 1363 EventRootType Probe[main.testDeepPtr7]
+          InjectionPoints: [{PC: "0xce5920", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -606,11 +606,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 40}
+      subprogram: {subprogram: 41}
       events:
         - Kind: Entry
-          Type: 1363 EventRootType Probe[main.testDeepSlice1]
-          InjectionPoints: [{PC: "0xce5960", Frameless: true}]
+          Type: 1364 EventRootType Probe[main.testDeepSlice1]
+          InjectionPoints: [{PC: "0xce5a80", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -627,11 +627,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 41}
+      subprogram: {subprogram: 42}
       events:
         - Kind: Entry
-          Type: 1364 EventRootType Probe[main.testDeepSlice7]
-          InjectionPoints: [{PC: "0xce5980", Frameless: true}]
+          Type: 1365 EventRootType Probe[main.testDeepSlice7]
+          InjectionPoints: [{PC: "0xce5aa0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -648,11 +648,11 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 131}
+      subprogram: {subprogram: 132}
       events:
         - Kind: Entry
-          Type: 1514 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0xcec020", Frameless: true}]
+          Type: 1515 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0xcec160", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{u}'
@@ -674,11 +674,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 134}
+      subprogram: {subprogram: 135}
       events:
         - Kind: Entry
-          Type: 1517 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0xcec080", Frameless: true}]
+          Type: 1518 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0xcec1c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}, {a}'
@@ -701,11 +701,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 150}
+      subprogram: {subprogram: 151}
       events:
         - Kind: Entry
-          Type: 1538 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0xcec600", Frameless: true}]
+          Type: 1539 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0xcec740", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -722,11 +722,11 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 156}
+      subprogram: {subprogram: 157}
       events:
         - Kind: Entry
-          Type: 1548 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0xceca40", Frameless: true}]
+          Type: 1549 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0xcecb80", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -742,11 +742,11 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 157}
+      subprogram: {subprogram: 158}
       events:
         - Kind: Entry
-          Type: 1549 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0xceca60", Frameless: true}]
+          Type: 1550 EventRootType Probe[main.testEmptyStructPointer]
+          InjectionPoints: [{PC: "0xcecba0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -763,11 +763,11 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 57}
+      subprogram: {subprogram: 58}
       events:
         - Kind: Entry
-          Type: 1392 EventRootType Probe[main.testError]
-          InjectionPoints: [{PC: "0xce6dc0", Frameless: true}]
+          Type: 1393 EventRootType Probe[main.testError]
+          InjectionPoints: [{PC: "0xce6f00", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -776,6 +776,45 @@ Probes:
               DSL: e
               EventKind: Entry
               EventExpressionIndex: 1
+    - id: testErrorAtLine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testErrorAtLine
+        sourceFile: complex.go
+        lines: ["108"]
+      tags:
+        - config_diff:arch=amd64,toolchain=go1.26rc1
+        - skip_integration:arch=arm64,toolchain=go1.25.0
+      sampling: {snapshotsPerSecond: 100}
+      template: x={x}, err={err}
+      segments:
+        - x=
+        - json: {ref: x}
+          dsl: x
+        - ', err='
+        - json: {ref: err}
+          dsl: err
+      captureSnapshot: true
+      subprogram: {subprogram: 38}
+      events:
+        - Kind: Line
+          Type: 1361 EventRootType Probe[main.testErrorAtLine]Line
+          InjectionPoints: [{PC: "0xce57d4", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: x={x}, err={err}
+        Segments:
+            - x=
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Line
+              EventExpressionIndex: 2
+            - ', err='
+            - JSON: {Ref: err}
+              DSL: err
+              EventKind: Line
+              EventExpressionIndex: 4
     - id: testEsotericHeap
       version: 0
       type: LOG_PROBE
@@ -784,15 +823,15 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 48}
+      subprogram: {subprogram: 49}
       events:
         - Kind: Entry
-          Type: 1374 EventRootType Probe[main.testEsotericHeap]
-          InjectionPoints: [{PC: "0xce62aa", Frameless: false}]
+          Type: 1375 EventRootType Probe[main.testEsotericHeap]
+          InjectionPoints: [{PC: "0xce63ea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1375 EventRootType Probe[main.testEsotericHeap]Return
-          InjectionPoints: [{PC: "0xce62ec", Frameless: false}]
+          Type: 1376 EventRootType Probe[main.testEsotericHeap]Return
+          InjectionPoints: [{PC: "0xce642c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -809,15 +848,15 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 47}
+      subprogram: {subprogram: 48}
       events:
         - Kind: Entry
-          Type: 1372 EventRootType Probe[main.testEsotericStack]
-          InjectionPoints: [{PC: "0xce618e", Frameless: false}]
+          Type: 1373 EventRootType Probe[main.testEsotericStack]
+          InjectionPoints: [{PC: "0xce62ce", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1373 EventRootType Probe[main.testEsotericStack]Return
-          InjectionPoints: [{PC: "0xce621b", Frameless: false}]
+          Type: 1374 EventRootType Probe[main.testEsotericStack]Return
+          InjectionPoints: [{PC: "0xce635b", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -834,15 +873,15 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 53}
+      subprogram: {subprogram: 54}
       events:
         - Kind: Entry
-          Type: 1384 EventRootType Probe[main.testFrameless]
-          InjectionPoints: [{PC: "0xce6a20", Frameless: true}]
+          Type: 1385 EventRootType Probe[main.testFrameless]
+          InjectionPoints: [{PC: "0xce6b60", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1385 EventRootType Probe[main.testFrameless]Return
-          InjectionPoints: [{PC: "0xce6a25", Frameless: true}]
+          Type: 1386 EventRootType Probe[main.testFrameless]Return
+          InjectionPoints: [{PC: "0xce6b65", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -859,15 +898,15 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 54}
+      subprogram: {subprogram: 55}
       events:
         - Kind: Entry
-          Type: 1386 EventRootType Probe[main.testFramelessArray]
-          InjectionPoints: [{PC: "0xce6a44", Frameless: false}]
+          Type: 1387 EventRootType Probe[main.testFramelessArray]
+          InjectionPoints: [{PC: "0xce6b84", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1387 EventRootType Probe[main.testFramelessArray]Return
-          InjectionPoints: [{PC: "0xce6a85", Frameless: false}]
+          Type: 1388 EventRootType Probe[main.testFramelessArray]Return
+          InjectionPoints: [{PC: "0xce6bc5", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -887,11 +926,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 54}
+      subprogram: {subprogram: 55}
       events:
         - Kind: Line
-          Type: 1388 EventRootType Probe[main.testFramelessArray]Line
-          InjectionPoints: [{PC: "0xce6a48", Frameless: false}]
+          Type: 1389 EventRootType Probe[main.testFramelessArray]Line
+          InjectionPoints: [{PC: "0xce6b88", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -908,15 +947,15 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 49}
+      subprogram: {subprogram: 50}
       events:
         - Kind: Entry
-          Type: 1376 EventRootType Probe[main.testInlinedBA]
-          InjectionPoints: [{PC: "0xce670a", Frameless: false}]
+          Type: 1377 EventRootType Probe[main.testInlinedBA]
+          InjectionPoints: [{PC: "0xce684a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1377 EventRootType Probe[main.testInlinedBA]Return
-          InjectionPoints: [{PC: "0xce676e", Frameless: false}]
+          Type: 1378 EventRootType Probe[main.testInlinedBA]Return
+          InjectionPoints: [{PC: "0xce68ae", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -938,15 +977,15 @@ Probes:
         - json: {ref: y}
           dsl: y
       captureSnapshot: true
-      subprogram: {subprogram: 50}
+      subprogram: {subprogram: 51}
       events:
         - Kind: Entry
-          Type: 1378 EventRootType Probe[main.testInlinedBB]
-          InjectionPoints: [{PC: "0xce67ae", Frameless: false}]
+          Type: 1379 EventRootType Probe[main.testInlinedBB]
+          InjectionPoints: [{PC: "0xce68ee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1379 EventRootType Probe[main.testInlinedBB]Return
-          InjectionPoints: [{PC: "0xce683e", Frameless: false}]
+          Type: 1380 EventRootType Probe[main.testInlinedBB]Return
+          InjectionPoints: [{PC: "0xce697e", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}, {y}'
@@ -968,15 +1007,15 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 51}
+      subprogram: {subprogram: 52}
       events:
         - Kind: Entry
-          Type: 1380 EventRootType Probe[main.testInlinedBBA]
-          InjectionPoints: [{PC: "0xce688a", Frameless: false}]
+          Type: 1381 EventRootType Probe[main.testInlinedBBA]
+          InjectionPoints: [{PC: "0xce69ca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1381 EventRootType Probe[main.testInlinedBBA]Return
-          InjectionPoints: [{PC: "0xce68cb", Frameless: false}]
+          Type: 1382 EventRootType Probe[main.testInlinedBBA]Return
+          InjectionPoints: [{PC: "0xce6a0b", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -993,11 +1032,11 @@ Probes:
       template: testInlinedBBB
       segments: [testInlinedBBB]
       captureSnapshot: true
-      subprogram: {subprogram: 159}
+      subprogram: {subprogram: 160}
       events:
         - Kind: Entry
-          Type: 1555 EventRootType Probe[main.testInlinedBBB]
-          InjectionPoints: [{PC: "0xce6806", Frameless: false}]
+          Type: 1556 EventRootType Probe[main.testInlinedBBB]
+          InjectionPoints: [{PC: "0xce6946", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBBB
@@ -1010,15 +1049,15 @@ Probes:
       template: testInlinedBC
       segments: [testInlinedBC]
       captureSnapshot: true
-      subprogram: {subprogram: 52}
+      subprogram: {subprogram: 53}
       events:
         - Kind: Entry
-          Type: 1382 EventRootType Probe[main.testInlinedBC]
-          InjectionPoints: [{PC: "0xce690e", Frameless: false}]
+          Type: 1383 EventRootType Probe[main.testInlinedBC]
+          InjectionPoints: [{PC: "0xce6a4e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1383 EventRootType Probe[main.testInlinedBC]Return
-          InjectionPoints: [{PC: "0xce69f3", Frameless: false}]
+          Type: 1384 EventRootType Probe[main.testInlinedBC]Return
+          InjectionPoints: [{PC: "0xce6b33", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBC
@@ -1031,11 +1070,11 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Entry
-          Type: 1556 EventRootType Probe[main.testInlinedBCA]
-          InjectionPoints: [{PC: "0xce6913", Frameless: false}]
+          Type: 1557 EventRootType Probe[main.testInlinedBCA]
+          InjectionPoints: [{PC: "0xce6a53", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBCA
@@ -1051,11 +1090,11 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Line
-          Type: 1557 EventRootType Probe[main.testInlinedBCA]Line
-          InjectionPoints: [{PC: "0xce6913", Frameless: false}]
+          Type: 1558 EventRootType Probe[main.testInlinedBCA]Line
+          InjectionPoints: [{PC: "0xce6a53", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBCA
@@ -1068,11 +1107,11 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Entry
-          Type: 1558 EventRootType Probe[main.testInlinedBCB]
-          InjectionPoints: [{PC: "0xce69bb", Frameless: false}]
+          Type: 1559 EventRootType Probe[main.testInlinedBCB]
+          InjectionPoints: [{PC: "0xce6afb", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBCB
@@ -1088,11 +1127,11 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Line
-          Type: 1559 EventRootType Probe[main.testInlinedBCB]Line
-          InjectionPoints: [{PC: "0xce69bb", Frameless: false}]
+          Type: 1560 EventRootType Probe[main.testInlinedBCB]Line
+          InjectionPoints: [{PC: "0xce6afb", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBCB
@@ -1105,14 +1144,14 @@ Probes:
       template: testInlinedFuncFromOtherPackage
       segments: [testInlinedFuncFromOtherPackage]
       captureSnapshot: true
-      subprogram: {subprogram: 165}
+      subprogram: {subprogram: 166}
       events:
         - Kind: Entry
-          Type: 1565 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
+          Type: 1566 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
           InjectionPoints:
             - PC: "0xce4881"
               Frameless: true
-            - PC: "0xce73ee"
+            - PC: "0xce752e"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -1127,25 +1166,25 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Entry
-          Type: 1552 EventRootType Probe[main.testInlinedPrint]
+          Type: 1553 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
-            - PC: "0xce656a"
+            - PC: "0xce66aa"
               Frameless: false
-            - PC: "0xce65f1"
+            - PC: "0xce6731"
               Frameless: false
-            - PC: "0xce6732"
+            - PC: "0xce6872"
               Frameless: false
-            - PC: "0xce67bc"
+            - PC: "0xce68fc"
               Frameless: false
-            - PC: "0xce688f"
+            - PC: "0xce69cf"
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1553 EventRootType Probe[main.testInlinedPrint]Return
-          InjectionPoints: [{PC: "0xce65aa", Frameless: false}]
+          Type: 1554 EventRootType Probe[main.testInlinedPrint]Return
+          InjectionPoints: [{PC: "0xce66ea", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1165,20 +1204,20 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1554 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1555 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
-            - PC: "0xce656e"
+            - PC: "0xce66ae"
               Frameless: false
-            - PC: "0xce65f1"
+            - PC: "0xce6731"
               Frameless: false
-            - PC: "0xce6732"
+            - PC: "0xce6872"
               Frameless: false
-            - PC: "0xce67bc"
+            - PC: "0xce68fc"
               Frameless: false
-            - PC: "0xce688f"
+            - PC: "0xce69cf"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -1196,11 +1235,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 162}
+      subprogram: {subprogram: 163}
       events:
         - Kind: Entry
-          Type: 1560 EventRootType Probe[main.testInlinedSq]
-          InjectionPoints: [{PC: "0xce6a21", Frameless: true}]
+          Type: 1561 EventRootType Probe[main.testInlinedSq]
+          InjectionPoints: [{PC: "0xce6b61", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1220,11 +1259,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 162}
+      subprogram: {subprogram: 163}
       events:
         - Kind: Line
-          Type: 1561 EventRootType Probe[main.testInlinedSq]Line
-          InjectionPoints: [{PC: "0xce6a21", Frameless: true}]
+          Type: 1562 EventRootType Probe[main.testInlinedSq]Line
+          InjectionPoints: [{PC: "0xce6b61", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1242,14 +1281,14 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 163}
+      subprogram: {subprogram: 164}
       events:
         - Kind: Entry
-          Type: 1562 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1563 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
-            - PC: "0xce6a6d"
+            - PC: "0xce6bad"
               Frameless: false
-            - PC: "0xce6b03"
+            - PC: "0xce6c43"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -1372,11 +1411,11 @@ Probes:
       template: '{b}'
       segments: [{json: {ref: b}, dsl: b}]
       captureSnapshot: true
-      subprogram: {subprogram: 55}
+      subprogram: {subprogram: 56}
       events:
         - Kind: Entry
-          Type: 1389 EventRootType Probe[main.testInterface]
-          InjectionPoints: [{PC: "0xce6d20", Frameless: true}]
+          Type: 1390 EventRootType Probe[main.testInterface]
+          InjectionPoints: [{PC: "0xce6e60", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{b}'
@@ -1392,15 +1431,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 121}
+      subprogram: {subprogram: 122}
       events:
         - Kind: Entry
-          Type: 1495 EventRootType Probe[main.testLargeArgAndReturn]
-          InjectionPoints: [{PC: "0xcead6e", Frameless: false}]
+          Type: 1496 EventRootType Probe[main.testLargeArgAndReturn]
+          InjectionPoints: [{PC: "0xceaeae", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1496 EventRootType Probe[main.testLargeArgAndReturn]Return
-          InjectionPoints: [{PC: "0xceaecd", Frameless: false}]
+          Type: 1497 EventRootType Probe[main.testLargeArgAndReturn]Return
+          InjectionPoints: [{PC: "0xceb00d", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -1417,11 +1456,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 90}
       events:
         - Kind: Entry
-          Type: 1428 EventRootType Probe[main.testLinkedList]
-          InjectionPoints: [{PC: "0xce9580", Frameless: true}]
+          Type: 1429 EventRootType Probe[main.testLinkedList]
+          InjectionPoints: [{PC: "0xce96c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -1436,16 +1475,16 @@ Probes:
       where:
         methodName: main.testLongFunctionWithChangingState
         sourceFile: complex.go
-        lines: ["211"]
+        lines: ["230"]
       sampling: {snapshotsPerSecond: 100}
       template: testLongFunctionWithChangingState
       segments: [testLongFunctionWithChangingState]
       captureSnapshot: true
-      subprogram: {subprogram: 46}
+      subprogram: {subprogram: 47}
       events:
         - Kind: Line
-          Type: 1369 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-          InjectionPoints: [{PC: "0xce5b7a", Frameless: false}]
+          Type: 1370 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          InjectionPoints: [{PC: "0xce5c9a", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testLongFunctionWithChangingState
@@ -1456,17 +1495,17 @@ Probes:
       where:
         methodName: main.testLongFunctionWithChangingState
         sourceFile: complex.go
-        lines: ["218"]
+        lines: ["237"]
       tags: ['version_diff:go1.26rc1']
       sampling: {snapshotsPerSecond: 100}
       template: testLongFunctionWithChangingState
       segments: [testLongFunctionWithChangingState]
       captureSnapshot: true
-      subprogram: {subprogram: 46}
+      subprogram: {subprogram: 47}
       events:
         - Kind: Line
-          Type: 1370 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-          InjectionPoints: [{PC: "0xce5c3f", Frameless: false}]
+          Type: 1371 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          InjectionPoints: [{PC: "0xce5d5f", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testLongFunctionWithChangingState
@@ -1477,17 +1516,17 @@ Probes:
       where:
         methodName: main.testLongFunctionWithChangingState
         sourceFile: complex.go
-        lines: ["223"]
+        lines: ["242"]
       tags: ['version_diff:go1.26rc1']
       sampling: {snapshotsPerSecond: 100}
       template: testLongFunctionWithChangingState
       segments: [testLongFunctionWithChangingState]
       captureSnapshot: true
-      subprogram: {subprogram: 46}
+      subprogram: {subprogram: 47}
       events:
         - Kind: Line
-          Type: 1371 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-          InjectionPoints: [{PC: "0xce5d05", Frameless: false}]
+          Type: 1372 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          InjectionPoints: [{PC: "0xce5e25", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testLongFunctionWithChangingState
@@ -1525,15 +1564,15 @@ Probes:
         - json: {ref: i}
           dsl: i
       captureSnapshot: true
-      subprogram: {subprogram: 124}
+      subprogram: {subprogram: 125}
       events:
         - Kind: Entry
-          Type: 1501 EventRootType Probe[main.testManyArgsArrayReturn]
-          InjectionPoints: [{PC: "0xceb213", Frameless: false}]
+          Type: 1502 EventRootType Probe[main.testManyArgsArrayReturn]
+          InjectionPoints: [{PC: "0xceb353", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1502 EventRootType Probe[main.testManyArgsArrayReturn]Return
-          InjectionPoints: [{PC: "0xceb442", Frameless: false}]
+          Type: 1503 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          InjectionPoints: [{PC: "0xceb582", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -1590,11 +1629,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 64}
+      subprogram: {subprogram: 65}
       events:
         - Kind: Entry
-          Type: 1400 EventRootType Probe[main.testMapArrayToArray]
-          InjectionPoints: [{PC: "0xce7520", Frameless: true}]
+          Type: 1401 EventRootType Probe[main.testMapArrayToArray]
+          InjectionPoints: [{PC: "0xce7660", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1611,11 +1650,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 70}
+      subprogram: {subprogram: 71}
       events:
         - Kind: Entry
-          Type: 1407 EventRootType Probe[main.testMapEmbeddedMaps]
-          InjectionPoints: [{PC: "0xce75e0", Frameless: true}]
+          Type: 1408 EventRootType Probe[main.testMapEmbeddedMaps]
+          InjectionPoints: [{PC: "0xce7720", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1632,11 +1671,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 80}
+      subprogram: {subprogram: 81}
       events:
         - Kind: Entry
-          Type: 1417 EventRootType Probe[main.testMapEmptyKey]
-          InjectionPoints: [{PC: "0xce7720", Frameless: true}]
+          Type: 1418 EventRootType Probe[main.testMapEmptyKey]
+          InjectionPoints: [{PC: "0xce7860", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1653,11 +1692,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 82}
+      subprogram: {subprogram: 83}
       events:
         - Kind: Entry
-          Type: 1419 EventRootType Probe[main.testMapEmptyKeyAndValue]
-          InjectionPoints: [{PC: "0xce7760", Frameless: true}]
+          Type: 1420 EventRootType Probe[main.testMapEmptyKeyAndValue]
+          InjectionPoints: [{PC: "0xce78a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1674,11 +1713,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 81}
+      subprogram: {subprogram: 82}
       events:
         - Kind: Entry
-          Type: 1418 EventRootType Probe[main.testMapEmptyValue]
-          InjectionPoints: [{PC: "0xce7740", Frameless: true}]
+          Type: 1419 EventRootType Probe[main.testMapEmptyValue]
+          InjectionPoints: [{PC: "0xce7880", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1695,11 +1734,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 68}
+      subprogram: {subprogram: 69}
       events:
         - Kind: Entry
-          Type: 1404 EventRootType Probe[main.testMapIntToInt]
-          InjectionPoints: [{PC: "0xce75a0", Frameless: true}]
+          Type: 1405 EventRootType Probe[main.testMapIntToInt]
+          InjectionPoints: [{PC: "0xce76e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1716,11 +1755,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 79}
+      subprogram: {subprogram: 80}
       events:
         - Kind: Entry
-          Type: 1416 EventRootType Probe[main.testMapLargeKeyLargeValue]
-          InjectionPoints: [{PC: "0xce7700", Frameless: true}]
+          Type: 1417 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          InjectionPoints: [{PC: "0xce7840", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1737,11 +1776,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 78}
+      subprogram: {subprogram: 79}
       events:
         - Kind: Entry
-          Type: 1415 EventRootType Probe[main.testMapLargeKeySmallValue]
-          InjectionPoints: [{PC: "0xce76e0", Frameless: true}]
+          Type: 1416 EventRootType Probe[main.testMapLargeKeySmallValue]
+          InjectionPoints: [{PC: "0xce7820", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1760,11 +1799,11 @@ Probes:
         - json: {ref: redactMyEntries}
           dsl: redactMyEntries
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 70}
       events:
         - Kind: Entry
-          Type: 1405 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0xce75c0", Frameless: true}]
+          Type: 1406 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0xce7700", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{redactMyEntries}'
@@ -1783,11 +1822,11 @@ Probes:
         - json: {ref: redactMyEntries}
           dsl: redactMyEntries
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 70}
       events:
         - Kind: Entry
-          Type: 1406 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0xce75c0", Frameless: true}]
+          Type: 1407 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0xce7700", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{redactMyEntries}'
@@ -1804,11 +1843,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 77}
+      subprogram: {subprogram: 78}
       events:
         - Kind: Entry
-          Type: 1414 EventRootType Probe[main.testMapSmallKeyLargeValue]
-          InjectionPoints: [{PC: "0xce76c0", Frameless: true}]
+          Type: 1415 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          InjectionPoints: [{PC: "0xce7800", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1825,11 +1864,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 76}
+      subprogram: {subprogram: 77}
       events:
         - Kind: Entry
-          Type: 1413 EventRootType Probe[main.testMapSmallKeySmallValue]
-          InjectionPoints: [{PC: "0xce76a0", Frameless: true}]
+          Type: 1414 EventRootType Probe[main.testMapSmallKeySmallValue]
+          InjectionPoints: [{PC: "0xce77e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1846,11 +1885,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 62}
+      subprogram: {subprogram: 63}
       events:
         - Kind: Entry
-          Type: 1398 EventRootType Probe[main.testMapStringToInt]
-          InjectionPoints: [{PC: "0xce74e0", Frameless: true}]
+          Type: 1399 EventRootType Probe[main.testMapStringToInt]
+          InjectionPoints: [{PC: "0xce7620", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1867,11 +1906,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 63}
+      subprogram: {subprogram: 64}
       events:
         - Kind: Entry
-          Type: 1399 EventRootType Probe[main.testMapStringToSlice]
-          InjectionPoints: [{PC: "0xce7500", Frameless: true}]
+          Type: 1400 EventRootType Probe[main.testMapStringToSlice]
+          InjectionPoints: [{PC: "0xce7640", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1888,11 +1927,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 61}
+      subprogram: {subprogram: 62}
       events:
         - Kind: Entry
-          Type: 1397 EventRootType Probe[main.testMapStringToStruct]
-          InjectionPoints: [{PC: "0xce74c0", Frameless: true}]
+          Type: 1398 EventRootType Probe[main.testMapStringToStruct]
+          InjectionPoints: [{PC: "0xce7600", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1909,11 +1948,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 71}
+      subprogram: {subprogram: 72}
       events:
         - Kind: Entry
-          Type: 1408 EventRootType Probe[main.testMapWithLinkedList]
-          InjectionPoints: [{PC: "0xce7600", Frameless: true}]
+          Type: 1409 EventRootType Probe[main.testMapWithLinkedList]
+          InjectionPoints: [{PC: "0xce7740", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1930,11 +1969,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 74}
+      subprogram: {subprogram: 75}
       events:
         - Kind: Entry
-          Type: 1411 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-          InjectionPoints: [{PC: "0xce7660", Frameless: true}]
+          Type: 1412 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          InjectionPoints: [{PC: "0xce77a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1951,11 +1990,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 75}
+      subprogram: {subprogram: 76}
       events:
         - Kind: Entry
-          Type: 1412 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-          InjectionPoints: [{PC: "0xce7680", Frameless: true}]
+          Type: 1413 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          InjectionPoints: [{PC: "0xce77c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1972,11 +2011,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 72}
+      subprogram: {subprogram: 73}
       events:
         - Kind: Entry
-          Type: 1409 EventRootType Probe[main.testMapWithSmallValue]
-          InjectionPoints: [{PC: "0xce7620", Frameless: true}]
+          Type: 1410 EventRootType Probe[main.testMapWithSmallValue]
+          InjectionPoints: [{PC: "0xce7760", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1995,11 +2034,11 @@ Probes:
         - json: {ref: redactMyEntries}
           dsl: redactMyEntries
       captureSnapshot: true
-      subprogram: {subprogram: 73}
+      subprogram: {subprogram: 74}
       events:
         - Kind: Entry
-          Type: 1410 EventRootType Probe[main.testMapWithSmallValueMassive]
-          InjectionPoints: [{PC: "0xce7640", Frameless: true}]
+          Type: 1411 EventRootType Probe[main.testMapWithSmallValueMassive]
+          InjectionPoints: [{PC: "0xce7780", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{redactMyEntries}'
@@ -2016,11 +2055,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 148}
+      subprogram: {subprogram: 149}
       events:
         - Kind: Entry
-          Type: 1535 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0xcec5c0", Frameless: true}]
+          Type: 1536 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0xcec700", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -2038,11 +2077,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 148}
+      subprogram: {subprogram: 149}
       events:
         - Kind: Entry
-          Type: 1536 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0xcec5c0", Frameless: true}]
+          Type: 1537 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0xcec700", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -2084,15 +2123,15 @@ Probes:
         - json: {ref: s}
           dsl: s
       captureSnapshot: true
-      subprogram: {subprogram: 125}
+      subprogram: {subprogram: 126}
       events:
         - Kind: Entry
-          Type: 1503 EventRootType Probe[main.testMixedArgsStackReturn]
-          InjectionPoints: [{PC: "0xceb4d3", Frameless: false}]
+          Type: 1504 EventRootType Probe[main.testMixedArgsStackReturn]
+          InjectionPoints: [{PC: "0xceb613", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1504 EventRootType Probe[main.testMixedArgsStackReturn]Return
-          InjectionPoints: [{PC: "0xceb702", Frameless: false}]
+          Type: 1505 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          InjectionPoints: [{PC: "0xceb842", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -2153,15 +2192,15 @@ Probes:
         - json: {ref: b}
           dsl: b
       captureSnapshot: true
-      subprogram: {subprogram: 127}
+      subprogram: {subprogram: 128}
       events:
         - Kind: Entry
-          Type: 1507 EventRootType Probe[main.testMultipleArrayArgs]
-          InjectionPoints: [{PC: "0xceb84e", Frameless: false}]
+          Type: 1508 EventRootType Probe[main.testMultipleArrayArgs]
+          InjectionPoints: [{PC: "0xceb98e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1508 EventRootType Probe[main.testMultipleArrayArgs]Return
-          InjectionPoints: [{PC: "0xceb91d", Frameless: false}]
+          Type: 1509 EventRootType Probe[main.testMultipleArrayArgs]Return
+          InjectionPoints: [{PC: "0xceba5d", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}'
@@ -2187,15 +2226,15 @@ Probes:
         - json: {ref: s2}
           dsl: s2
       captureSnapshot: true
-      subprogram: {subprogram: 123}
+      subprogram: {subprogram: 124}
       events:
         - Kind: Entry
-          Type: 1499 EventRootType Probe[main.testMultipleLargeArgs]
-          InjectionPoints: [{PC: "0xceafce", Frameless: false}]
+          Type: 1500 EventRootType Probe[main.testMultipleLargeArgs]
+          InjectionPoints: [{PC: "0xceb10e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1500 EventRootType Probe[main.testMultipleLargeArgs]Return
-          InjectionPoints: [{PC: "0xceb1eb", Frameless: false}]
+          Type: 1501 EventRootType Probe[main.testMultipleLargeArgs]Return
+          InjectionPoints: [{PC: "0xceb32b", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{s1}, {s2}'
@@ -2216,15 +2255,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1453 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0xcea36e", Frameless: false}]
+          Type: 1454 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xcea4ae", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1454 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0xcea40f", Frameless: false}]
+          Type: 1455 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xcea54f", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2255,11 +2294,11 @@ Probes:
         - json: {ref: e}
           dsl: e
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 86}
       events:
         - Kind: Entry
-          Type: 1423 EventRootType Probe[main.testMultipleSimpleParams]
-          InjectionPoints: [{PC: "0xce9160", Frameless: true}]
+          Type: 1424 EventRootType Probe[main.testMultipleSimpleParams]
+          InjectionPoints: [{PC: "0xce92a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}, {d}, {e}'
@@ -2295,15 +2334,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1449 EventRootType Probe[main.testNamedReturn]
-          InjectionPoints: [{PC: "0xcea2ca", Frameless: false}]
+          Type: 1450 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0xcea40a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1450 EventRootType Probe[main.testNamedReturn]Return
-          InjectionPoints: [{PC: "0xcea33b", Frameless: false}]
+          Type: 1451 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0xcea47b", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2325,15 +2364,15 @@ Probes:
         - json: {ref: result}
           dsl: result
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1451 EventRootType Probe[main.testNamedReturn]
-          InjectionPoints: [{PC: "0xcea2ca", Frameless: false}]
+          Type: 1452 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0xcea40a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1452 EventRootType Probe[main.testNamedReturn]Return
-          InjectionPoints: [{PC: "0xcea33b", Frameless: false}]
+          Type: 1453 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0xcea47b", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: Parameter {i} * 2 = result {result}
@@ -2356,11 +2395,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 155}
+      subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1544 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0xcec9c0", Frameless: true}]
+          Type: 1545 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0xcecb00", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -2380,11 +2419,11 @@ Probes:
             getmember: [{getmember: [{ref: x}, nested]}, anotherString]
           dsl: x.nested.anotherString
       captureSnapshot: false
-      subprogram: {subprogram: 155}
+      subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1545 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0xcec9c0", Frameless: true}]
+          Type: 1546 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0xcecb00", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x.nested.anotherString}'
@@ -2410,11 +2449,11 @@ Probes:
         - json: {getmember: [{ref: x}, notAMember]}
           dsl: x.notAMember
       captureSnapshot: false
-      subprogram: {subprogram: 155}
+      subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1546 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0xcec9c0", Frameless: true}]
+          Type: 1547 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0xcecb00", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -2434,11 +2473,11 @@ Probes:
         - json: {getmember: [{ref: x}, nested]}
           dsl: x.nested
       captureSnapshot: false
-      subprogram: {subprogram: 155}
+      subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1547 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0xcec9c0", Frameless: true}]
+          Type: 1548 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0xcecb00", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x.nested}'
@@ -2460,11 +2499,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 95}
       events:
         - Kind: Entry
-          Type: 1433 EventRootType Probe[main.testNilPointer]
-          InjectionPoints: [{PC: "0xce9720", Frameless: true}]
+          Type: 1434 EventRootType Probe[main.testNilPointer]
+          InjectionPoints: [{PC: "0xce9860", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{z}, {a}'
@@ -2486,11 +2525,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 138}
+      subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1521 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0xcec100", Frameless: true}]
+          Type: 1522 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0xcec240", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -2512,11 +2551,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 135}
+      subprogram: {subprogram: 136}
       events:
         - Kind: Entry
-          Type: 1518 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0xcec0a0", Frameless: true}]
+          Type: 1519 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0xcec1e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}, {a}'
@@ -2546,11 +2585,11 @@ Probes:
         - json: {ref: x}
           dsl: x
       captureSnapshot: true
-      subprogram: {subprogram: 137}
+      subprogram: {subprogram: 138}
       events:
         - Kind: Entry
-          Type: 1520 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0xcec0e0", Frameless: true}]
+          Type: 1521 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0xcec220", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {s}, {x}'
@@ -2577,11 +2616,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 147}
+      subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1534 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0xcec5a0", Frameless: true}]
+          Type: 1535 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0xcec6e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -2598,11 +2637,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 91}
       events:
         - Kind: Entry
-          Type: 1429 EventRootType Probe[main.testPointerLoop]
-          InjectionPoints: [{PC: "0xce95a0", Frameless: true}]
+          Type: 1430 EventRootType Probe[main.testPointerLoop]
+          InjectionPoints: [{PC: "0xce96e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -2619,11 +2658,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 67}
+      subprogram: {subprogram: 68}
       events:
         - Kind: Entry
-          Type: 1403 EventRootType Probe[main.testPointerToMap]
-          InjectionPoints: [{PC: "0xce7580", Frameless: true}]
+          Type: 1404 EventRootType Probe[main.testPointerToMap]
+          InjectionPoints: [{PC: "0xce76c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -2640,11 +2679,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 89}
       events:
         - Kind: Entry
-          Type: 1427 EventRootType Probe[main.testPointerToSimpleStruct]
-          InjectionPoints: [{PC: "0xce9560", Frameless: true}]
+          Type: 1428 EventRootType Probe[main.testPointerToSimpleStruct]
+          InjectionPoints: [{PC: "0xce96a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -2661,22 +2700,22 @@ Probes:
       template: '{v}'
       segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
         - Kind: Entry
-          Type: 1445 EventRootType Probe[main.testReturnsAny]
-          InjectionPoints: [{PC: "0xce9f6e", Frameless: false}]
+          Type: 1446 EventRootType Probe[main.testReturnsAny]
+          InjectionPoints: [{PC: "0xcea0ae", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1446 EventRootType Probe[main.testReturnsAny]Return
+          Type: 1447 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints:
-            - PC: "0xcea015"
+            - PC: "0xcea155"
               Frameless: false
-            - PC: "0xcea064"
+            - PC: "0xcea1a4"
               Frameless: false
-            - PC: "0xcea12f"
+            - PC: "0xcea26f"
               Frameless: false
-            - PC: "0xcea139"
+            - PC: "0xcea279"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2699,22 +2738,22 @@ Probes:
         - json: {ref: failed}
           dsl: failed
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 101}
       events:
         - Kind: Entry
-          Type: 1443 EventRootType Probe[main.testReturnsAnyAndError]
-          InjectionPoints: [{PC: "0xce9e0e", Frameless: false}]
+          Type: 1444 EventRootType Probe[main.testReturnsAnyAndError]
+          InjectionPoints: [{PC: "0xce9f4e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1444 EventRootType Probe[main.testReturnsAnyAndError]Return
+          Type: 1445 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
-            - PC: "0xce9e64"
+            - PC: "0xce9fa4"
               Frameless: false
-            - PC: "0xce9eb3"
+            - PC: "0xce9ff3"
               Frameless: false
-            - PC: "0xce9ef3"
+            - PC: "0xcea033"
               Frameless: false
-            - PC: "0xce9f2f"
+            - PC: "0xcea06f"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2736,15 +2775,15 @@ Probes:
       template: testReturnsArray
       segments: [testReturnsArray]
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 111}
       events:
         - Kind: Entry
-          Type: 1473 EventRootType Probe[main.testReturnsArray]
-          InjectionPoints: [{PC: "0xcea7ea", Frameless: false}]
+          Type: 1474 EventRootType Probe[main.testReturnsArray]
+          InjectionPoints: [{PC: "0xcea92a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1474 EventRootType Probe[main.testReturnsArray]Return
-          InjectionPoints: [{PC: "0xcea84f", Frameless: false}]
+          Type: 1475 EventRootType Probe[main.testReturnsArray]Return
+          InjectionPoints: [{PC: "0xcea98f", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsArray
@@ -2756,15 +2795,15 @@ Probes:
       template: testReturnsArrayOne
       segments: [testReturnsArrayOne]
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 112}
       events:
         - Kind: Entry
-          Type: 1475 EventRootType Probe[main.testReturnsArrayOne]
-          InjectionPoints: [{PC: "0xcea86a", Frameless: false}]
+          Type: 1476 EventRootType Probe[main.testReturnsArrayOne]
+          InjectionPoints: [{PC: "0xcea9aa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1476 EventRootType Probe[main.testReturnsArrayOne]Return
-          InjectionPoints: [{PC: "0xcea8ab", Frameless: false}]
+          Type: 1477 EventRootType Probe[main.testReturnsArrayOne]Return
+          InjectionPoints: [{PC: "0xcea9eb", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsArrayOne
@@ -2776,15 +2815,15 @@ Probes:
       template: testReturnsArrayZero
       segments: [testReturnsArrayZero]
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 113}
       events:
         - Kind: Entry
-          Type: 1477 EventRootType Probe[main.testReturnsArrayZero]
-          InjectionPoints: [{PC: "0xcea8ca", Frameless: false}]
+          Type: 1478 EventRootType Probe[main.testReturnsArrayZero]
+          InjectionPoints: [{PC: "0xceaa0a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1478 EventRootType Probe[main.testReturnsArrayZero]Return
-          InjectionPoints: [{PC: "0xcea906", Frameless: false}]
+          Type: 1479 EventRootType Probe[main.testReturnsArrayZero]Return
+          InjectionPoints: [{PC: "0xceaa46", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsArrayZero
@@ -2796,15 +2835,15 @@ Probes:
       template: testReturnsBacktrackInt
       segments: [testReturnsBacktrackInt]
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 115}
       events:
         - Kind: Entry
-          Type: 1481 EventRootType Probe[main.testReturnsBacktrackInt]
-          InjectionPoints: [{PC: "0xcea9ae", Frameless: false}]
+          Type: 1482 EventRootType Probe[main.testReturnsBacktrackInt]
+          InjectionPoints: [{PC: "0xceaaee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1482 EventRootType Probe[main.testReturnsBacktrackInt]Return
-          InjectionPoints: [{PC: "0xceaa2a", Frameless: false}]
+          Type: 1483 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          InjectionPoints: [{PC: "0xceab6a", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsBacktrackInt
@@ -2816,15 +2855,15 @@ Probes:
       template: testReturnsBoolAndUintptr
       segments: [testReturnsBoolAndUintptr]
       captureSnapshot: true
-      subprogram: {subprogram: 120}
+      subprogram: {subprogram: 121}
       events:
         - Kind: Entry
-          Type: 1493 EventRootType Probe[main.testReturnsBoolAndUintptr]
-          InjectionPoints: [{PC: "0xcead0a", Frameless: false}]
+          Type: 1494 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          InjectionPoints: [{PC: "0xceae4a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1494 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-          InjectionPoints: [{PC: "0xcead50", Frameless: false}]
+          Type: 1495 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          InjectionPoints: [{PC: "0xceae90", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsBoolAndUintptr
@@ -2836,15 +2875,15 @@ Probes:
       template: testReturnsComplex
       segments: [testReturnsComplex]
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 109}
       events:
         - Kind: Entry
-          Type: 1469 EventRootType Probe[main.testReturnsComplex]
-          InjectionPoints: [{PC: "0xcea6aa", Frameless: false}]
+          Type: 1470 EventRootType Probe[main.testReturnsComplex]
+          InjectionPoints: [{PC: "0xcea7ea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1470 EventRootType Probe[main.testReturnsComplex]Return
-          InjectionPoints: [{PC: "0xcea706", Frameless: false}]
+          Type: 1471 EventRootType Probe[main.testReturnsComplex]Return
+          InjectionPoints: [{PC: "0xcea846", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsComplex
@@ -2857,18 +2896,18 @@ Probes:
       template: '{failed}'
       segments: [{json: {ref: failed}, dsl: failed}]
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 100}
       events:
         - Kind: Entry
-          Type: 1441 EventRootType Probe[main.testReturnsError]
-          InjectionPoints: [{PC: "0xce9d8a", Frameless: false}]
+          Type: 1442 EventRootType Probe[main.testReturnsError]
+          InjectionPoints: [{PC: "0xce9eca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1442 EventRootType Probe[main.testReturnsError]Return
+          Type: 1443 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
-            - PC: "0xce9dc4"
+            - PC: "0xce9f04"
               Frameless: false
-            - PC: "0xce9dce"
+            - PC: "0xce9f0e"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2885,15 +2924,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 97}
       events:
         - Kind: Entry
-          Type: 1435 EventRootType Probe[main.testReturnsInt]
-          InjectionPoints: [{PC: "0xce9b8a", Frameless: false}]
+          Type: 1436 EventRootType Probe[main.testReturnsInt]
+          InjectionPoints: [{PC: "0xce9cca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1436 EventRootType Probe[main.testReturnsInt]Return
-          InjectionPoints: [{PC: "0xce9bdb", Frameless: false}]
+          Type: 1437 EventRootType Probe[main.testReturnsInt]Return
+          InjectionPoints: [{PC: "0xce9d1b", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2909,15 +2948,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 99}
       events:
         - Kind: Entry
-          Type: 1439 EventRootType Probe[main.testReturnsIntAndFloat]
-          InjectionPoints: [{PC: "0xce9cae", Frameless: false}]
+          Type: 1440 EventRootType Probe[main.testReturnsIntAndFloat]
+          InjectionPoints: [{PC: "0xce9dee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1440 EventRootType Probe[main.testReturnsIntAndFloat]Return
-          InjectionPoints: [{PC: "0xce9d65", Frameless: false}]
+          Type: 1441 EventRootType Probe[main.testReturnsIntAndFloat]Return
+          InjectionPoints: [{PC: "0xce9ea5", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2933,15 +2972,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 98}
       events:
         - Kind: Entry
-          Type: 1437 EventRootType Probe[main.testReturnsIntPointer]
-          InjectionPoints: [{PC: "0xce9c0a", Frameless: false}]
+          Type: 1438 EventRootType Probe[main.testReturnsIntPointer]
+          InjectionPoints: [{PC: "0xce9d4a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1438 EventRootType Probe[main.testReturnsIntPointer]Return
-          InjectionPoints: [{PC: "0xce9c74", Frameless: false}]
+          Type: 1439 EventRootType Probe[main.testReturnsIntPointer]Return
+          InjectionPoints: [{PC: "0xce9db4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2958,18 +2997,18 @@ Probes:
       template: '{v}'
       segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1447 EventRootType Probe[main.testReturnsInterface]
-          InjectionPoints: [{PC: "0xcea16e", Frameless: false}]
+          Type: 1448 EventRootType Probe[main.testReturnsInterface]
+          InjectionPoints: [{PC: "0xcea2ae", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1448 EventRootType Probe[main.testReturnsInterface]Return
+          Type: 1449 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
-            - PC: "0xcea23d"
+            - PC: "0xcea37d"
               Frameless: false
-            - PC: "0xcea247"
+            - PC: "0xcea387"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2986,15 +3025,15 @@ Probes:
       template: testReturnsLargeStruct
       segments: [testReturnsLargeStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 110}
       events:
         - Kind: Entry
-          Type: 1471 EventRootType Probe[main.testReturnsLargeStruct]
-          InjectionPoints: [{PC: "0xcea72e", Frameless: false}]
+          Type: 1472 EventRootType Probe[main.testReturnsLargeStruct]
+          InjectionPoints: [{PC: "0xcea86e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1472 EventRootType Probe[main.testReturnsLargeStruct]Return
-          InjectionPoints: [{PC: "0xcea7c3", Frameless: false}]
+          Type: 1473 EventRootType Probe[main.testReturnsLargeStruct]Return
+          InjectionPoints: [{PC: "0xcea903", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsLargeStruct
@@ -3006,15 +3045,15 @@ Probes:
       template: testReturnsManyFloats
       segments: [testReturnsManyFloats]
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 108}
       events:
         - Kind: Entry
-          Type: 1467 EventRootType Probe[main.testReturnsManyFloats]
-          InjectionPoints: [{PC: "0xcea5ae", Frameless: false}]
+          Type: 1468 EventRootType Probe[main.testReturnsManyFloats]
+          InjectionPoints: [{PC: "0xcea6ee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1468 EventRootType Probe[main.testReturnsManyFloats]Return
-          InjectionPoints: [{PC: "0xcea687", Frameless: false}]
+          Type: 1469 EventRootType Probe[main.testReturnsManyFloats]Return
+          InjectionPoints: [{PC: "0xcea7c7", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsManyFloats
@@ -3026,15 +3065,15 @@ Probes:
       template: testReturnsMixed
       segments: [testReturnsMixed]
       captureSnapshot: true
-      subprogram: {subprogram: 116}
+      subprogram: {subprogram: 117}
       events:
         - Kind: Entry
-          Type: 1485 EventRootType Probe[main.testReturnsMixed]
-          InjectionPoints: [{PC: "0xceab2a", Frameless: false}]
+          Type: 1486 EventRootType Probe[main.testReturnsMixed]
+          InjectionPoints: [{PC: "0xceac6a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1486 EventRootType Probe[main.testReturnsMixed]Return
-          InjectionPoints: [{PC: "0xceab8c", Frameless: false}]
+          Type: 1487 EventRootType Probe[main.testReturnsMixed]Return
+          InjectionPoints: [{PC: "0xceaccc", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsMixed
@@ -3046,15 +3085,15 @@ Probes:
       template: testReturnsMixedStruct
       segments: [testReturnsMixedStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 114}
       events:
         - Kind: Entry
-          Type: 1479 EventRootType Probe[main.testReturnsMixedStruct]
-          InjectionPoints: [{PC: "0xcea92a", Frameless: false}]
+          Type: 1480 EventRootType Probe[main.testReturnsMixedStruct]
+          InjectionPoints: [{PC: "0xceaa6a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1480 EventRootType Probe[main.testReturnsMixedStruct]Return
-          InjectionPoints: [{PC: "0xcea978", Frameless: false}]
+          Type: 1481 EventRootType Probe[main.testReturnsMixedStruct]Return
+          InjectionPoints: [{PC: "0xceaab8", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsMixedStruct
@@ -3066,15 +3105,15 @@ Probes:
       template: testReturnsMultipleFloats
       segments: [testReturnsMultipleFloats]
       captureSnapshot: true
-      subprogram: {subprogram: 119}
+      subprogram: {subprogram: 120}
       events:
         - Kind: Entry
-          Type: 1491 EventRootType Probe[main.testReturnsMultipleFloats]
-          InjectionPoints: [{PC: "0xceac8a", Frameless: false}]
+          Type: 1492 EventRootType Probe[main.testReturnsMultipleFloats]
+          InjectionPoints: [{PC: "0xceadca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1492 EventRootType Probe[main.testReturnsMultipleFloats]Return
-          InjectionPoints: [{PC: "0xceacd6", Frameless: false}]
+          Type: 1493 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          InjectionPoints: [{PC: "0xceae16", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsMultipleFloats
@@ -3086,15 +3125,15 @@ Probes:
       template: testReturnsOnlyFloat
       segments: [testReturnsOnlyFloat]
       captureSnapshot: true
-      subprogram: {subprogram: 118}
+      subprogram: {subprogram: 119}
       events:
         - Kind: Entry
-          Type: 1489 EventRootType Probe[main.testReturnsOnlyFloat]
-          InjectionPoints: [{PC: "0xceac2a", Frameless: false}]
+          Type: 1490 EventRootType Probe[main.testReturnsOnlyFloat]
+          InjectionPoints: [{PC: "0xcead6a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1490 EventRootType Probe[main.testReturnsOnlyFloat]Return
-          InjectionPoints: [{PC: "0xceac6e", Frameless: false}]
+          Type: 1491 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          InjectionPoints: [{PC: "0xceadae", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsOnlyFloat
@@ -3106,15 +3145,15 @@ Probes:
       template: testReturnsPrimitives
       segments: [testReturnsPrimitives]
       captureSnapshot: true
-      subprogram: {subprogram: 106}
+      subprogram: {subprogram: 107}
       events:
         - Kind: Entry
-          Type: 1465 EventRootType Probe[main.testReturnsPrimitives]
-          InjectionPoints: [{PC: "0xcea52a", Frameless: false}]
+          Type: 1466 EventRootType Probe[main.testReturnsPrimitives]
+          InjectionPoints: [{PC: "0xcea66a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1466 EventRootType Probe[main.testReturnsPrimitives]Return
-          InjectionPoints: [{PC: "0xcea591", Frameless: false}]
+          Type: 1467 EventRootType Probe[main.testReturnsPrimitives]Return
+          InjectionPoints: [{PC: "0xcea6d1", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsPrimitives
@@ -3126,15 +3165,15 @@ Probes:
       template: testReturnsStructWithArray
       segments: [testReturnsStructWithArray]
       captureSnapshot: true
-      subprogram: {subprogram: 117}
+      subprogram: {subprogram: 118}
       events:
         - Kind: Entry
-          Type: 1487 EventRootType Probe[main.testReturnsStructWithArray]
-          InjectionPoints: [{PC: "0xceabaa", Frameless: false}]
+          Type: 1488 EventRootType Probe[main.testReturnsStructWithArray]
+          InjectionPoints: [{PC: "0xceacea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1488 EventRootType Probe[main.testReturnsStructWithArray]Return
-          InjectionPoints: [{PC: "0xceac0f", Frameless: false}]
+          Type: 1489 EventRootType Probe[main.testReturnsStructWithArray]Return
+          InjectionPoints: [{PC: "0xcead4f", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsStructWithArray
@@ -3146,15 +3185,15 @@ Probes:
       template: testReturnsWideStruct
       segments: [testReturnsWideStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 115}
+      subprogram: {subprogram: 116}
       events:
         - Kind: Entry
-          Type: 1483 EventRootType Probe[main.testReturnsWideStruct]
-          InjectionPoints: [{PC: "0xceaa4e", Frameless: false}]
+          Type: 1484 EventRootType Probe[main.testReturnsWideStruct]
+          InjectionPoints: [{PC: "0xceab8e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1484 EventRootType Probe[main.testReturnsWideStruct]Return
-          InjectionPoints: [{PC: "0xceaaf2", Frameless: false}]
+          Type: 1485 EventRootType Probe[main.testReturnsWideStruct]Return
+          InjectionPoints: [{PC: "0xceac32", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsWideStruct
@@ -3201,15 +3240,15 @@ Probes:
         - json: {ref: result}
           dsl: result
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1455 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0xcea36e", Frameless: false}]
+          Type: 1456 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xcea4ae", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1456 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0xcea40f", Frameless: false}]
+          Type: 1457 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xcea54f", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -3477,11 +3516,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 143}
+      subprogram: {subprogram: 144}
       events:
         - Kind: Entry
-          Type: 1528 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0xcec520", Frameless: true}]
+          Type: 1529 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0xcec660", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -3603,11 +3642,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 140}
+      subprogram: {subprogram: 141}
       events:
         - Kind: Entry
-          Type: 1524 EventRootType Probe[main.testSliceEmptyStructs]
-          InjectionPoints: [{PC: "0xcec140", Frameless: true}]
+          Type: 1525 EventRootType Probe[main.testSliceEmptyStructs]
+          InjectionPoints: [{PC: "0xcec280", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -3624,11 +3663,11 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 132}
+      subprogram: {subprogram: 133}
       events:
         - Kind: Entry
-          Type: 1515 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0xcec040", Frameless: true}]
+          Type: 1516 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0xcec180", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{u}'
@@ -3645,11 +3684,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 65}
+      subprogram: {subprogram: 66}
       events:
         - Kind: Entry
-          Type: 1401 EventRootType Probe[main.testSmallMap]
-          InjectionPoints: [{PC: "0xce7540", Frameless: true}]
+          Type: 1402 EventRootType Probe[main.testSmallMap]
+          InjectionPoints: [{PC: "0xce7680", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -3665,15 +3704,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 105}
+      subprogram: {subprogram: 106}
       events:
         - Kind: Entry
-          Type: 1463 EventRootType Probe[main.testSomeNamedReturn]
-          InjectionPoints: [{PC: "0xcea44e", Frameless: false}]
+          Type: 1464 EventRootType Probe[main.testSomeNamedReturn]
+          InjectionPoints: [{PC: "0xcea58e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1464 EventRootType Probe[main.testSomeNamedReturn]Return
-          InjectionPoints: [{PC: "0xcea4ed", Frameless: false}]
+          Type: 1465 EventRootType Probe[main.testSomeNamedReturn]Return
+          InjectionPoints: [{PC: "0xcea62d", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -3689,15 +3728,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 126}
+      subprogram: {subprogram: 127}
       events:
         - Kind: Entry
-          Type: 1505 EventRootType Probe[main.testStackArgRegReturns]
-          InjectionPoints: [{PC: "0xceb7aa", Frameless: false}]
+          Type: 1506 EventRootType Probe[main.testStackArgRegReturns]
+          InjectionPoints: [{PC: "0xceb8ea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1506 EventRootType Probe[main.testStackArgRegReturns]Return
-          InjectionPoints: [{PC: "0xceb81e", Frameless: false}]
+          Type: 1507 EventRootType Probe[main.testStackArgRegReturns]Return
+          InjectionPoints: [{PC: "0xceb95e", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -3735,11 +3774,11 @@ Probes:
       template: '{z}'
       segments: [{json: {ref: z}, dsl: z}]
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 94}
       events:
         - Kind: Entry
-          Type: 1432 EventRootType Probe[main.testStringPointer]
-          InjectionPoints: [{PC: "0xce96e0", Frameless: true}]
+          Type: 1433 EventRootType Probe[main.testStringPointer]
+          InjectionPoints: [{PC: "0xce9820", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{z}'
@@ -3756,11 +3795,11 @@ Probes:
       template: '{s}'
       segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
-      subprogram: {subprogram: 136}
+      subprogram: {subprogram: 137}
       events:
         - Kind: Entry
-          Type: 1519 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0xcec0c0", Frameless: true}]
+          Type: 1520 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0xcec200", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{s}'
@@ -3777,11 +3816,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 44}
+      subprogram: {subprogram: 45}
       events:
         - Kind: Entry
-          Type: 1367 EventRootType Probe[main.testStringType1]
-          InjectionPoints: [{PC: "0xce5b20", Frameless: true}]
+          Type: 1368 EventRootType Probe[main.testStringType1]
+          InjectionPoints: [{PC: "0xce5c40", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3798,11 +3837,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 45}
+      subprogram: {subprogram: 46}
       events:
         - Kind: Entry
-          Type: 1368 EventRootType Probe[main.testStringType2]
-          InjectionPoints: [{PC: "0xce5b40", Frameless: true}]
+          Type: 1369 EventRootType Probe[main.testStringType2]
+          InjectionPoints: [{PC: "0xce5c60", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3819,11 +3858,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1543 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0xcec900", Frameless: true}]
+          Type: 1544 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0xceca40", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -3845,11 +3884,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 133}
+      subprogram: {subprogram: 134}
       events:
         - Kind: Entry
-          Type: 1516 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0xcec060", Frameless: true}]
+          Type: 1517 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0xcec1a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}, {a}'
@@ -3871,11 +3910,11 @@ Probes:
       template: '{s}'
       segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
-      subprogram: {subprogram: 59}
+      subprogram: {subprogram: 60}
       events:
         - Kind: Entry
-          Type: 1395 EventRootType Probe[main.testStructWithAny]
-          InjectionPoints: [{PC: "0xce6e40", Frameless: true}]
+          Type: 1396 EventRootType Probe[main.testStructWithAny]
+          InjectionPoints: [{PC: "0xce6f80", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{s}'
@@ -3891,15 +3930,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 128}
+      subprogram: {subprogram: 129}
       events:
         - Kind: Entry
-          Type: 1509 EventRootType Probe[main.testStructWithArrayArg]
-          InjectionPoints: [{PC: "0xceb94e", Frameless: false}]
+          Type: 1510 EventRootType Probe[main.testStructWithArrayArg]
+          InjectionPoints: [{PC: "0xceba8e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1510 EventRootType Probe[main.testStructWithArrayArg]Return
-          InjectionPoints: [{PC: "0xceba04", Frameless: false}]
+          Type: 1511 EventRootType Probe[main.testStructWithArrayArg]Return
+          InjectionPoints: [{PC: "0xcebb44", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -3916,11 +3955,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 153}
+      subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1541 EventRootType Probe[main.testStructWithCyclicMaps]
-          InjectionPoints: [{PC: "0xcec7c0", Frameless: true}]
+          Type: 1542 EventRootType Probe[main.testStructWithCyclicMaps]
+          InjectionPoints: [{PC: "0xcec900", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3936,11 +3975,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 152}
+      subprogram: {subprogram: 153}
       events:
         - Kind: Entry
-          Type: 1540 EventRootType Probe[main.testStructWithCyclicSlices]
-          InjectionPoints: [{PC: "0xcec7a0", Frameless: true}]
+          Type: 1541 EventRootType Probe[main.testStructWithCyclicSlices]
+          InjectionPoints: [{PC: "0xcec8e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3962,11 +4001,11 @@ Probes:
         - json: {ref: '@duration'}
           dsl: '@duration'
       captureSnapshot: true
-      subprogram: {subprogram: 60}
+      subprogram: {subprogram: 61}
       events:
         - Kind: Entry
-          Type: 1396 EventRootType Probe[main.testStructWithMap]
-          InjectionPoints: [{PC: "0xce74a0", Frameless: true}]
+          Type: 1397 EventRootType Probe[main.testStructWithMap]
+          InjectionPoints: [{PC: "0xce75e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{s} {@duration}'
@@ -3993,11 +4032,11 @@ Probes:
         - json: {ref: cs}
           dsl: cs
       captureSnapshot: true
-      subprogram: {subprogram: 141}
+      subprogram: {subprogram: 142}
       events:
         - Kind: Entry
-          Type: 1525 EventRootType Probe[main.testSubslices]
-          InjectionPoints: [{PC: "0xcec160", Frameless: true}]
+          Type: 1526 EventRootType Probe[main.testSubslices]
+          InjectionPoints: [{PC: "0xcec2a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{as}, {bs}, {cs}'
@@ -4032,11 +4071,11 @@ Probes:
         - json: {ref: c}
           dsl: c
       captureSnapshot: true
-      subprogram: {subprogram: 151}
+      subprogram: {subprogram: 152}
       events:
         - Kind: Entry
-          Type: 1539 EventRootType Probe[main.testSubstrings]
-          InjectionPoints: [{PC: "0xcec620", Frameless: true}]
+          Type: 1540 EventRootType Probe[main.testSubstrings]
+          InjectionPoints: [{PC: "0xcec760", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}'
@@ -4064,15 +4103,15 @@ Probes:
         - json: {ref: nonexistentVariable}
           dsl: nonexistentVariable
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1457 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0xcea36e", Frameless: false}]
+          Type: 1458 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xcea4ae", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1458 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0xcea40f", Frameless: false}]
+          Type: 1459 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xcea54f", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{nonexistentVariable}'
@@ -4088,15 +4127,15 @@ Probes:
         - json: {foobar: unsupportedExpression}
           dsl: unsupportedExpression
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1459 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0xcea36e", Frameless: false}]
+          Type: 1460 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xcea4ae", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1460 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0xcea40f", Frameless: false}]
+          Type: 1461 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xcea54f", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{unsupportedExpression}'
@@ -4114,15 +4153,15 @@ Probes:
           dsl: '@duration'
         - ms
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1461 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0xcea36e", Frameless: false}]
+          Type: 1462 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xcea4ae", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1462 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0xcea40f", Frameless: false}]
+          Type: 1463 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xcea54f", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -4146,11 +4185,11 @@ Probes:
         - json: {ref: z}
           dsl: z
       captureSnapshot: true
-      subprogram: {subprogram: 144}
+      subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1529 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0xcec540", Frameless: true}]
+          Type: 1530 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0xcec680", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}, {y}, {z}'
@@ -4177,11 +4216,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 145}
+      subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1530 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0xcec560", Frameless: true}]
+          Type: 1531 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0xcec6a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -4206,11 +4245,11 @@ Probes:
         - json: {getmember: [{ref: a}, c]}
           dsl: t.c
       captureSnapshot: false
-      subprogram: {subprogram: 145}
+      subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1531 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0xcec560", Frameless: true}]
+          Type: 1532 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0xcec6a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a.a} {a.b} {a.c}'
@@ -4237,11 +4276,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 146}
+      subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1532 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0xcec580", Frameless: true}]
+          Type: 1533 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0xcec6c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -4266,11 +4305,11 @@ Probes:
         - json: {getmember: [{ref: a}, c]}
           dsl: a.c
       captureSnapshot: false
-      subprogram: {subprogram: 146}
+      subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1533 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0xcec580", Frameless: true}]
+          Type: 1534 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0xcec6c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a.a} {a.b} {a.c}'
@@ -4423,11 +4462,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 93}
       events:
         - Kind: Entry
-          Type: 1431 EventRootType Probe[main.testUintPointer]
-          InjectionPoints: [{PC: "0xce9600", Frameless: true}]
+          Type: 1432 EventRootType Probe[main.testUintPointer]
+          InjectionPoints: [{PC: "0xce9740", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4444,11 +4483,11 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 130}
+      subprogram: {subprogram: 131}
       events:
         - Kind: Entry
-          Type: 1513 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0xcec000", Frameless: true}]
+          Type: 1514 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0xcec140", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{u}'
@@ -4465,11 +4504,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 149}
+      subprogram: {subprogram: 150}
       events:
         - Kind: Entry
-          Type: 1537 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0xcec5e0", Frameless: true}]
+          Type: 1538 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0xcec720", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4486,11 +4525,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 92}
       events:
         - Kind: Entry
-          Type: 1430 EventRootType Probe[main.testUnsafePointer]
-          InjectionPoints: [{PC: "0xce95c0", Frameless: true}]
+          Type: 1431 EventRootType Probe[main.testUnsafePointer]
+          InjectionPoints: [{PC: "0xce9700", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4528,11 +4567,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 139}
+      subprogram: {subprogram: 140}
       events:
         - Kind: Entry
-          Type: 1522 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0xcec120", Frameless: true}]
+          Type: 1523 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0xcec260", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -4549,11 +4588,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 139}
+      subprogram: {subprogram: 140}
       events:
         - Kind: Entry
-          Type: 1523 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0xcec120", Frameless: true}]
+          Type: 1524 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0xcec260", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -4569,19 +4608,19 @@ Probes:
       template: testWhollyInlinedSubroutine
       segments: [testWhollyInlinedSubroutine]
       captureSnapshot: true
-      subprogram: {subprogram: 164}
+      subprogram: {subprogram: 165}
       events:
         - Kind: Entry
-          Type: 1563 EventRootType Probe[main.firstBehavior.DoSomething]
+          Type: 1564 EventRootType Probe[main.firstBehavior.DoSomething]
           InjectionPoints:
-            - PC: "0xce6c4a"
+            - PC: "0xce6d8a"
               Frameless: false
-            - PC: "0xcedcba"
+            - PC: "0xceddfa"
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1564 EventRootType Probe[main.firstBehavior.DoSomething]Return
-          InjectionPoints: [{PC: "0xce6c85", Frameless: false}]
+          Type: 1565 EventRootType Probe[main.firstBehavior.DoSomething]Return
+          InjectionPoints: [{PC: "0xce6dc5", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testWhollyInlinedSubroutine
@@ -4598,15 +4637,15 @@ Probes:
         - json: {ref: b}
           dsl: b
       captureSnapshot: true
-      subprogram: {subprogram: 129}
+      subprogram: {subprogram: 130}
       events:
         - Kind: Entry
-          Type: 1511 EventRootType Probe[main.testZeroSizeArgAndReturn]
-          InjectionPoints: [{PC: "0xceba2e", Frameless: false}]
+          Type: 1512 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          InjectionPoints: [{PC: "0xcebb6e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1512 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-          InjectionPoints: [{PC: "0xcebaac", Frameless: false}]
+          Type: 1513 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          InjectionPoints: [{PC: "0xcebbec", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}'
@@ -5041,36 +5080,79 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
     - ID: 38
+      Name: main.testErrorAtLine
+      OutOfLinePCRanges: [0xce5780..0xce5885]
+      InlinePCRanges: []
+      Variables:
+        - Name: shouldErr
+          Type: 4 BaseType bool
+          Locations:
+            - Range: 0xce5780..0xce5798
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+        - Name: ~r0
+          Type: 7 BaseType int
+          Locations: [{Range: 0xce5780..0xce5885, Pieces: []}]
+          Role: Return
+        - Name: x
+          Type: 7 BaseType int
+          Locations: [{Range: 0xce5780..0xce5885, Pieces: []}]
+          Role: Local
+        - Name: err
+          Type: 15 GoInterfaceType error
+          Locations:
+            - Range: 0xce57b3..0xce57cf
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+            - Range: 0xce57cf..0xce583d
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xce583d..0xce5840
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: -72}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xce5840..0xce5885
+              Pieces: [{Size: 8, Op: {CfaOffset: -72}}, {Size: 8, Op: null}]
+          Role: Local
+    - ID: 39
       Name: main.testDeepPtr1
-      OutOfLinePCRanges: [0xce57e0..0xce57e1]
+      OutOfLinePCRanges: [0xce5900..0xce5901]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 138 StructureType main.deepPtr1
           Locations:
-            - Range: 0xce57e0..0xce57e1
+            - Range: 0xce5900..0xce5901
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 39
+    - ID: 40
       Name: main.testDeepPtr7
-      OutOfLinePCRanges: [0xce5800..0xce5801]
+      OutOfLinePCRanges: [0xce5920..0xce5921]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 141 PointerType *main.deepPtr7
           Locations:
-            - Range: 0xce5800..0xce5801
+            - Range: 0xce5920..0xce5921
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 40
+    - ID: 41
       Name: main.testDeepSlice1
-      OutOfLinePCRanges: [0xce5960..0xce5961]
+      OutOfLinePCRanges: [0xce5a80..0xce5a81]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 143 StructureType main.deepSlice1
           Locations:
-            - Range: 0xce5960..0xce5961
+            - Range: 0xce5a80..0xce5a81
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -5079,119 +5161,119 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 41
+    - ID: 42
       Name: main.testDeepSlice7
-      OutOfLinePCRanges: [0xce5980..0xce5981]
+      OutOfLinePCRanges: [0xce5aa0..0xce5aa1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 147 PointerType *main.deepSlice7
           Locations:
-            - Range: 0xce5980..0xce5981
+            - Range: 0xce5aa0..0xce5aa1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 42
+    - ID: 43
       Name: main.testDeepMap1
-      OutOfLinePCRanges: [0xce5ae0..0xce5ae1]
+      OutOfLinePCRanges: [0xce5c00..0xce5c01]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 149 StructureType main.deepMap1
           Locations:
-            - Range: 0xce5ae0..0xce5ae1
+            - Range: 0xce5c00..0xce5c01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 43
+    - ID: 44
       Name: main.testDeepMap7
-      OutOfLinePCRanges: [0xce5b00..0xce5b01]
+      OutOfLinePCRanges: [0xce5c20..0xce5c21]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 155 PointerType *main.deepMap7
           Locations:
-            - Range: 0xce5b00..0xce5b01
+            - Range: 0xce5c20..0xce5c21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 44
+    - ID: 45
       Name: main.testStringType1
-      OutOfLinePCRanges: [0xce5b20..0xce5b21]
+      OutOfLinePCRanges: [0xce5c40..0xce5c41]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 157 PointerType *main.stringType1
           Locations:
-            - Range: 0xce5b20..0xce5b21
+            - Range: 0xce5c40..0xce5c41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 45
+    - ID: 46
       Name: main.testStringType2
-      OutOfLinePCRanges: [0xce5b40..0xce5b41]
+      OutOfLinePCRanges: [0xce5c60..0xce5c61]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 159 PointerType **main.stringType2
           Locations:
-            - Range: 0xce5b40..0xce5b41
+            - Range: 0xce5c60..0xce5c61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 46
+    - ID: 47
       Name: main.testLongFunctionWithChangingState
-      OutOfLinePCRanges: [0xce5b60..0xce5d98]
+      OutOfLinePCRanges: [0xce5c80..0xce5eb8]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce5c3f..0xce5c57
+            - Range: 0xce5d5f..0xce5d77
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce5d05..0xce5d1d
+            - Range: 0xce5e25..0xce5e3d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
         - Name: aPerArch
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce5c28..0xce5c2b
+            - Range: 0xce5d48..0xce5d4b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce5c2b..0xce5c3f
+            - Range: 0xce5d4b..0xce5d5f
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce5c3f..0xce5c57
+            - Range: 0xce5d5f..0xce5d77
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0xce5c57..0xce5cf8
+            - Range: 0xce5d77..0xce5e18
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0xce5cf8..0xce5d05
+            - Range: 0xce5e18..0xce5e25
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0xce5d05..0xce5d98
+            - Range: 0xce5e25..0xce5eb8
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
           Role: Local
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce5c22..0xce5c2b
+            - Range: 0xce5d42..0xce5d4b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce5c2b..0xce5c2b
+            - Range: 0xce5d4b..0xce5d4b
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce5c2b..0xce5c3f
+            - Range: 0xce5d4b..0xce5d5f
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce5c3f..0xce5cf8
+            - Range: 0xce5d5f..0xce5e18
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0xce5cf8..0xce5cfd
+            - Range: 0xce5e18..0xce5e1d
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0xce5cfd..0xce5d05
+            - Range: 0xce5e1d..0xce5e25
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
-            - Range: 0xce5d05..0xce5d0a
+            - Range: 0xce5e25..0xce5e2a
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
-            - Range: 0xce5d0a..0xce5d98
+            - Range: 0xce5e2a..0xce5eb8
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
           Role: Local
-    - ID: 47
+    - ID: 48
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0xce6180..0xce6285]
+      OutOfLinePCRanges: [0xce62c0..0xce63c5]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 161 StructureType main.esotericStack
           Locations:
-            - Range: 0xce6180..0xce61d3
+            - Range: 0xce62c0..0xce6313
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -5211,7 +5293,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
-            - Range: 0xce61d3..0xce61d8
+            - Range: 0xce6313..0xce6318
               Pieces:
                 - Size: 4
                   Op: null
@@ -5231,7 +5313,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
-            - Range: 0xce61d8..0xce61dd
+            - Range: 0xce6318..0xce631d
               Pieces:
                 - Size: 4
                   Op: null
@@ -5252,159 +5334,159 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
           Role: Parameter
-    - ID: 48
+    - ID: 49
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0xce62a0..0xce6303]
+      OutOfLinePCRanges: [0xce63e0..0xce6443]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 165 PointerType *main.esotericHeap
           Locations:
-            - Range: 0xce62a0..0xce62cd
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-    - ID: 49
-      Name: main.testInlinedBA
-      OutOfLinePCRanges: [0xce6700..0xce6788]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xce6700..0xce6715
+            - Range: 0xce63e0..0xce640d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 50
-      Name: main.testInlinedBB
-      OutOfLinePCRanges: [0xce67a0..0xce6865]
+      Name: main.testInlinedBA
+      OutOfLinePCRanges: [0xce6840..0xce68c8]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce67a0..0xce67b6
+            - Range: 0xce6840..0xce6855
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+    - ID: 51
+      Name: main.testInlinedBB
+      OutOfLinePCRanges: [0xce68e0..0xce69a5]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xce68e0..0xce68f6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: y
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce67a0..0xce67c7
+            - Range: 0xce68e0..0xce6907
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
         - Name: z
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce67b6..0xce67c7
+            - Range: 0xce68f6..0xce6907
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce67c7..0xce6865
+            - Range: 0xce6907..0xce69a5
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Local
-    - ID: 51
+    - ID: 52
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0xce6880..0xce68e2]
+      OutOfLinePCRanges: [0xce69c0..0xce6a22]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce6880..0xce689a
+            - Range: 0xce69c0..0xce69da
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 52
+    - ID: 53
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0xce6900..0xce6a05]
+      OutOfLinePCRanges: [0xce6a40..0xce6b45]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce695b..0xce6965
+            - Range: 0xce6a9b..0xce6aa5
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xce6965..0xce6975
+            - Range: 0xce6aa5..0xce6ab5
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xce6975..0xce6989
+            - Range: 0xce6ab5..0xce6ac9
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce6956..0xce6960
+            - Range: 0xce6a96..0xce6aa0
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xce6960..0xce6975
+            - Range: 0xce6aa0..0xce6ab5
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xce6975..0xce6984
+            - Range: 0xce6ab5..0xce6ac4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 53
+    - ID: 54
       Name: main.testFrameless
-      OutOfLinePCRanges: [0xce6a20..0xce6a26]
+      OutOfLinePCRanges: [0xce6b60..0xce6b66]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce6a20..0xce6a25
+            - Range: 0xce6b60..0xce6b65
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce6a20..0xce6a25
+            - Range: 0xce6b60..0xce6b65
               Pieces: []
-            - Range: 0xce6a25..0xce6a26
+            - Range: 0xce6b65..0xce6b66
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
-    - ID: 54
+    - ID: 55
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0xce6a40..0xce6a8b]
+      OutOfLinePCRanges: [0xce6b80..0xce6bcb]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 167 ArrayType [5]int
           Locations:
-            - Range: 0xce6a40..0xce6a8b
+            - Range: 0xce6b80..0xce6bcb
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce6a40..0xce6a85
+            - Range: 0xce6b80..0xce6bc5
               Pieces: []
-            - Range: 0xce6a85..0xce6a86
+            - Range: 0xce6bc5..0xce6bc6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce6a86..0xce6a8b
+            - Range: 0xce6bc6..0xce6bcb
               Pieces: []
           Role: Return
-    - ID: 55
+    - ID: 56
       Name: main.testInterface
-      OutOfLinePCRanges: [0xce6d20..0xce6d21]
+      OutOfLinePCRanges: [0xce6e60..0xce6e61]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 168 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xce6d20..0xce6d21
+            - Range: 0xce6e60..0xce6e61
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
-    - ID: 56
+    - ID: 57
       Name: main.testAny
-      OutOfLinePCRanges: [0xce6d40..0xce6da6]
+      OutOfLinePCRanges: [0xce6e80..0xce6ee6]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 163 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xce6d40..0xce6d69
+            - Range: 0xce6e80..0xce6ea9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce6d69..0xce6d6e
+            - Range: 0xce6ea9..0xce6eae
               Pieces:
                 - Size: 8
                   Op: null
@@ -5414,363 +5496,363 @@ Subprograms:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce6d40..0xce6d85
+            - Range: 0xce6e80..0xce6ec5
               Pieces: []
-            - Range: 0xce6d85..0xce6d86
+            - Range: 0xce6ec5..0xce6ec6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce6d86..0xce6da6
+            - Range: 0xce6ec6..0xce6ee6
               Pieces: []
           Role: Return
-    - ID: 57
+    - ID: 58
       Name: main.testError
-      OutOfLinePCRanges: [0xce6dc0..0xce6dc1]
+      OutOfLinePCRanges: [0xce6f00..0xce6f01]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 15 GoInterfaceType error
           Locations:
-            - Range: 0xce6dc0..0xce6dc1
+            - Range: 0xce6f00..0xce6f01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
-    - ID: 58
+    - ID: 59
       Name: main.testAnyPtr
-      OutOfLinePCRanges: [0xce6de0..0xce6e34]
+      OutOfLinePCRanges: [0xce6f20..0xce6f74]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 169 PointerType *interface {}
           Locations:
-            - Range: 0xce6de0..0xce6e06
+            - Range: 0xce6f20..0xce6f46
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce6de0..0xce6e1d
+            - Range: 0xce6f20..0xce6f5d
               Pieces: []
-            - Range: 0xce6e1d..0xce6e1e
+            - Range: 0xce6f5d..0xce6f5e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce6e1e..0xce6e34
+            - Range: 0xce6f5e..0xce6f74
               Pieces: []
           Role: Return
-    - ID: 59
+    - ID: 60
       Name: main.testStructWithAny
-      OutOfLinePCRanges: [0xce6e40..0xce6e41]
+      OutOfLinePCRanges: [0xce6f80..0xce6f81]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 170 StructureType main.structWithAny
           Locations:
-            - Range: 0xce6e40..0xce6e41
+            - Range: 0xce6f80..0xce6f81
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
-    - ID: 60
+    - ID: 61
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0xce74a0..0xce74a1]
+      OutOfLinePCRanges: [0xce75e0..0xce75e1]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 171 StructureType main.structWithMap
           Locations:
-            - Range: 0xce74a0..0xce74a1
+            - Range: 0xce75e0..0xce75e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 61
+    - ID: 62
       Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0xce74c0..0xce74c1]
+      OutOfLinePCRanges: [0xce7600..0xce7601]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 177 GoMapType map[string]main.nestedStruct
           Locations:
-            - Range: 0xce74c0..0xce74c1
+            - Range: 0xce7600..0xce7601
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 62
+    - ID: 63
       Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0xce74e0..0xce74e1]
+      OutOfLinePCRanges: [0xce7620..0xce7621]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 182 GoMapType map[string]int
           Locations:
-            - Range: 0xce74e0..0xce74e1
+            - Range: 0xce7620..0xce7621
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 63
+    - ID: 64
       Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0xce7500..0xce7501]
+      OutOfLinePCRanges: [0xce7640..0xce7641]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 187 GoMapType map[string][]string
           Locations:
-            - Range: 0xce7500..0xce7501
+            - Range: 0xce7640..0xce7641
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 64
+    - ID: 65
       Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0xce7520..0xce7521]
+      OutOfLinePCRanges: [0xce7660..0xce7661]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 192 GoMapType map[[4]string][2]int
           Locations:
-            - Range: 0xce7520..0xce7521
+            - Range: 0xce7660..0xce7661
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 65
+    - ID: 66
       Name: main.testSmallMap
-      OutOfLinePCRanges: [0xce7540..0xce7541]
+      OutOfLinePCRanges: [0xce7680..0xce7681]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 182 GoMapType map[string]int
           Locations:
-            - Range: 0xce7540..0xce7541
+            - Range: 0xce7680..0xce7681
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 66
+    - ID: 67
       Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0xce7560..0xce7561]
+      OutOfLinePCRanges: [0xce76a0..0xce76a1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 197 ArrayType [2]map[string]int
           Locations:
-            - Range: 0xce7560..0xce7561
+            - Range: 0xce76a0..0xce76a1
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
-    - ID: 67
+    - ID: 68
       Name: main.testPointerToMap
-      OutOfLinePCRanges: [0xce7580..0xce7581]
+      OutOfLinePCRanges: [0xce76c0..0xce76c1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 198 PointerType *map[string]int
           Locations:
-            - Range: 0xce7580..0xce7581
+            - Range: 0xce76c0..0xce76c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 68
+    - ID: 69
       Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0xce75a0..0xce75a1]
+      OutOfLinePCRanges: [0xce76e0..0xce76e1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 172 GoMapType map[int]int
           Locations:
-            - Range: 0xce75a0..0xce75a1
+            - Range: 0xce76e0..0xce76e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 69
+    - ID: 70
       Name: main.testMapMassive
-      OutOfLinePCRanges: [0xce75c0..0xce75c1]
+      OutOfLinePCRanges: [0xce7700..0xce7701]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 199 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0xce75c0..0xce75c1
+            - Range: 0xce7700..0xce7701
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 70
+    - ID: 71
       Name: main.testMapEmbeddedMaps
-      OutOfLinePCRanges: [0xce75e0..0xce75e1]
+      OutOfLinePCRanges: [0xce7720..0xce7721]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 199 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0xce75e0..0xce75e1
+            - Range: 0xce7720..0xce7721
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 71
+    - ID: 72
       Name: main.testMapWithLinkedList
-      OutOfLinePCRanges: [0xce7600..0xce7601]
+      OutOfLinePCRanges: [0xce7740..0xce7741]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 204 GoMapType map[bool]main.node
           Locations:
-            - Range: 0xce7600..0xce7601
+            - Range: 0xce7740..0xce7741
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 72
+    - ID: 73
       Name: main.testMapWithSmallValue
-      OutOfLinePCRanges: [0xce7620..0xce7621]
+      OutOfLinePCRanges: [0xce7760..0xce7761]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 209 GoMapType map[int]uint8
           Locations:
-            - Range: 0xce7620..0xce7621
+            - Range: 0xce7760..0xce7761
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 73
+    - ID: 74
       Name: main.testMapWithSmallValueMassive
-      OutOfLinePCRanges: [0xce7640..0xce7641]
+      OutOfLinePCRanges: [0xce7780..0xce7781]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 209 GoMapType map[int]uint8
           Locations:
-            - Range: 0xce7640..0xce7641
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-    - ID: 74
-      Name: main.testMapWithSmallKeyAndValue
-      OutOfLinePCRanges: [0xce7660..0xce7661]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 214 GoMapType map[uint8]uint8
-          Locations:
-            - Range: 0xce7660..0xce7661
+            - Range: 0xce7780..0xce7781
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 75
-      Name: main.testMapWithSmallKeyAndValueMassive
-      OutOfLinePCRanges: [0xce7680..0xce7681]
+      Name: main.testMapWithSmallKeyAndValue
+      OutOfLinePCRanges: [0xce77a0..0xce77a1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 214 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0xce7680..0xce7681
+            - Range: 0xce77a0..0xce77a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 76
-      Name: main.testMapSmallKeySmallValue
-      OutOfLinePCRanges: [0xce76a0..0xce76a1]
+      Name: main.testMapWithSmallKeyAndValueMassive
+      OutOfLinePCRanges: [0xce77c0..0xce77c1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 214 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0xce76a0..0xce76a1
+            - Range: 0xce77c0..0xce77c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 77
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0xce77e0..0xce77e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 214 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xce77e0..0xce77e1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+    - ID: 78
       Name: main.testMapSmallKeyLargeValue
-      OutOfLinePCRanges: [0xce76c0..0xce76c1]
+      OutOfLinePCRanges: [0xce7800..0xce7801]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 219 GoMapType map[uint8][4]int
           Locations:
-            - Range: 0xce76c0..0xce76c1
+            - Range: 0xce7800..0xce7801
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 78
+    - ID: 79
       Name: main.testMapLargeKeySmallValue
-      OutOfLinePCRanges: [0xce76e0..0xce76e1]
+      OutOfLinePCRanges: [0xce7820..0xce7821]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 224 GoMapType map[[4]int]uint8
           Locations:
-            - Range: 0xce76e0..0xce76e1
+            - Range: 0xce7820..0xce7821
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 79
+    - ID: 80
       Name: main.testMapLargeKeyLargeValue
-      OutOfLinePCRanges: [0xce7700..0xce7701]
+      OutOfLinePCRanges: [0xce7840..0xce7841]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 229 GoMapType map[[4]int][4]int
           Locations:
-            - Range: 0xce7700..0xce7701
+            - Range: 0xce7840..0xce7841
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 80
+    - ID: 81
       Name: main.testMapEmptyKey
-      OutOfLinePCRanges: [0xce7720..0xce7721]
+      OutOfLinePCRanges: [0xce7860..0xce7861]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 234 GoMapType map[struct {}]int
           Locations:
-            - Range: 0xce7720..0xce7721
+            - Range: 0xce7860..0xce7861
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 81
+    - ID: 82
       Name: main.testMapEmptyValue
-      OutOfLinePCRanges: [0xce7740..0xce7741]
+      OutOfLinePCRanges: [0xce7880..0xce7881]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 239 GoMapType map[int]struct {}
           Locations:
-            - Range: 0xce7740..0xce7741
+            - Range: 0xce7880..0xce7881
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 82
+    - ID: 83
       Name: main.testMapEmptyKeyAndValue
-      OutOfLinePCRanges: [0xce7760..0xce7761]
+      OutOfLinePCRanges: [0xce78a0..0xce78a1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 244 GoMapType map[struct {}]struct {}
           Locations:
-            - Range: 0xce7760..0xce7761
+            - Range: 0xce78a0..0xce78a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 83
+    - ID: 84
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0xce8fa0..0xce8fa1]
+      OutOfLinePCRanges: [0xce90e0..0xce90e1]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xce8fa0..0xce8fa1
+            - Range: 0xce90e0..0xce90e1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xce8fa0..0xce8fa1
+            - Range: 0xce90e0..0xce90e1
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
         - Name: y
           Type: 17 BaseType float32
           Locations:
-            - Range: 0xce8fa0..0xce8fa1
+            - Range: 0xce90e0..0xce90e1
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
-    - ID: 84
+    - ID: 85
       Name: main.testCombinedString
-      OutOfLinePCRanges: [0xce8fe0..0xce8fe1]
+      OutOfLinePCRanges: [0xce9120..0xce9121]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xce8fe0..0xce8fe1
+            - Range: 0xce9120..0xce9121
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce8fe0..0xce8fe1
+            - Range: 0xce9120..0xce9121
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -5780,343 +5862,343 @@ Subprograms:
         - Name: y
           Type: 17 BaseType float32
           Locations:
-            - Range: 0xce8fe0..0xce8fe1
+            - Range: 0xce9120..0xce9121
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
-    - ID: 85
+    - ID: 86
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0xce9160..0xce9161]
+      OutOfLinePCRanges: [0xce92a0..0xce92a1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xce9160..0xce9161
+            - Range: 0xce92a0..0xce92a1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: b
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xce9160..0xce9161
+            - Range: 0xce92a0..0xce92a1
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
         - Name: c
           Type: 10 BaseType int32
           Locations:
-            - Range: 0xce9160..0xce9161
+            - Range: 0xce92a0..0xce92a1
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
         - Name: d
           Type: 14 BaseType uint
           Locations:
-            - Range: 0xce9160..0xce9161
+            - Range: 0xce92a0..0xce92a1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
         - Name: e
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce9160..0xce9161
+            - Range: 0xce92a0..0xce92a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 86
+    - ID: 87
       Name: main.testAtomicAdd
-      OutOfLinePCRanges: [0xce9380..0xce9393]
+      OutOfLinePCRanges: [0xce94c0..0xce94d3]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0xce9380..0xce9392
+            - Range: 0xce94c0..0xce94d2
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0xce9380..0xce9392
+            - Range: 0xce94c0..0xce94d2
               Pieces: []
-            - Range: 0xce9392..0xce9393
+            - Range: 0xce94d2..0xce94d3
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
-    - ID: 87
+    - ID: 88
       Name: main.testChannel
-      OutOfLinePCRanges: [0xce93a0..0xce93a1]
+      OutOfLinePCRanges: [0xce94e0..0xce94e1]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 249 GoChannelType chan bool
           Locations:
-            - Range: 0xce93a0..0xce93a1
+            - Range: 0xce94e0..0xce94e1
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 88
+    - ID: 89
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0xce9560..0xce9561]
+      OutOfLinePCRanges: [0xce96a0..0xce96a1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 250 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0xce9560..0xce9561
+            - Range: 0xce96a0..0xce96a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 89
+    - ID: 90
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0xce9580..0xce9581]
+      OutOfLinePCRanges: [0xce96c0..0xce96c1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 252 StructureType main.node
           Locations:
-            - Range: 0xce9580..0xce9581
+            - Range: 0xce96c0..0xce96c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
-    - ID: 90
+    - ID: 91
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0xce95a0..0xce95a1]
+      OutOfLinePCRanges: [0xce96e0..0xce96e1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 253 PointerType *main.node
           Locations:
-            - Range: 0xce95a0..0xce95a1
+            - Range: 0xce96e0..0xce96e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 91
+    - ID: 92
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0xce95c0..0xce95c1]
+      OutOfLinePCRanges: [0xce9700..0xce9701]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 16 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0xce95c0..0xce95c1
+            - Range: 0xce9700..0xce9701
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 92
+    - ID: 93
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0xce9600..0xce9601]
+      OutOfLinePCRanges: [0xce9740..0xce9741]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 112 PointerType *uint
           Locations:
-            - Range: 0xce9600..0xce9601
+            - Range: 0xce9740..0xce9741
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 93
+    - ID: 94
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0xce96e0..0xce96e1]
+      OutOfLinePCRanges: [0xce9820..0xce9821]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 101 PointerType *string
           Locations:
-            - Range: 0xce96e0..0xce96e1
+            - Range: 0xce9820..0xce9821
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 94
+    - ID: 95
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0xce9720..0xce9721]
+      OutOfLinePCRanges: [0xce9860..0xce9861]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 11 PointerType *bool
           Locations:
-            - Range: 0xce9720..0xce9721
+            - Range: 0xce9860..0xce9861
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: a
           Type: 14 BaseType uint
           Locations:
-            - Range: 0xce9720..0xce9721
+            - Range: 0xce9860..0xce9861
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
-    - ID: 95
+    - ID: 96
       Name: main.testCycle
-      OutOfLinePCRanges: [0xce9760..0xce9761]
+      OutOfLinePCRanges: [0xce98a0..0xce98a1]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 254 PointerType *main.t
           Locations:
-            - Range: 0xce9760..0xce9761
+            - Range: 0xce98a0..0xce98a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 96
+    - ID: 97
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0xce9b80..0xce9bf2]
+      OutOfLinePCRanges: [0xce9cc0..0xce9d32]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce9b80..0xce9b92
+            - Range: 0xce9cc0..0xce9cd2
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce9b80..0xce9bdb
+            - Range: 0xce9cc0..0xce9d1b
               Pieces: []
-            - Range: 0xce9bdb..0xce9bdc
+            - Range: 0xce9d1b..0xce9d1c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce9bdc..0xce9bf2
+            - Range: 0xce9d1c..0xce9d32
               Pieces: []
           Role: Return
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce9b92..0xce9ba5
+            - Range: 0xce9cd2..0xce9ce5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce9ba5..0xce9bf2
+            - Range: 0xce9ce5..0xce9d32
               Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
           Role: Local
-    - ID: 97
+    - ID: 98
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0xce9c00..0xce9c8f]
+      OutOfLinePCRanges: [0xce9d40..0xce9dcf]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce9c00..0xce9c1a
+            - Range: 0xce9d40..0xce9d5a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce9c1a..0xce9c8f
+            - Range: 0xce9d5a..0xce9dcf
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 104 PointerType *int
           Locations:
-            - Range: 0xce9c00..0xce9c74
+            - Range: 0xce9d40..0xce9db4
               Pieces: []
-            - Range: 0xce9c74..0xce9c75
+            - Range: 0xce9db4..0xce9db5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce9c75..0xce9c8f
+            - Range: 0xce9db5..0xce9dcf
               Pieces: []
           Role: Return
         - Name: '&result'
           Type: 104 PointerType *int
           Locations:
-            - Range: 0xce9c1f..0xce9c39
+            - Range: 0xce9d5f..0xce9d79
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce9c39..0xce9c8f
+            - Range: 0xce9d79..0xce9dcf
               Pieces: [{Size: 8, Op: {CfaOffset: -24}}]
           Role: Local
-    - ID: 98
+    - ID: 99
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0xce9ca0..0xce9d7f]
+      OutOfLinePCRanges: [0xce9de0..0xce9ebf]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce9ca0..0xce9d03
+            - Range: 0xce9de0..0xce9e43
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce9ca0..0xce9d65
+            - Range: 0xce9de0..0xce9ea5
               Pieces: []
-            - Range: 0xce9d65..0xce9d66
+            - Range: 0xce9ea5..0xce9ea6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce9d66..0xce9d7f
+            - Range: 0xce9ea6..0xce9ebf
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 13 BaseType float64
-          Locations: [{Range: 0xce9ca0..0xce9d7f, Pieces: []}]
+          Locations: [{Range: 0xce9de0..0xce9ebf, Pieces: []}]
           Role: Return
         - Name: resultInt
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce9cb6..0xce9d08
+            - Range: 0xce9df6..0xce9e48
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xce9d08..0xce9d7f
+            - Range: 0xce9e48..0xce9ebf
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
           Role: Local
         - Name: resultFloat
           Type: 13 BaseType float64
           Locations:
-            - Range: 0xce9ccf..0xce9d08
+            - Range: 0xce9e0f..0xce9e48
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
-            - Range: 0xce9d08..0xce9d7f
+            - Range: 0xce9e48..0xce9ebf
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
-    - ID: 99
+    - ID: 100
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0xce9d80..0xce9de4]
+      OutOfLinePCRanges: [0xce9ec0..0xce9f24]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xce9d80..0xce9d97
+            - Range: 0xce9ec0..0xce9ed7
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 15 GoInterfaceType error
           Locations:
-            - Range: 0xce9d80..0xce9dc4
+            - Range: 0xce9ec0..0xce9f04
               Pieces: []
-            - Range: 0xce9dc4..0xce9dc5
+            - Range: 0xce9f04..0xce9f05
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce9dc5..0xce9dce
+            - Range: 0xce9f05..0xce9f0e
               Pieces: []
-            - Range: 0xce9dce..0xce9dcf
+            - Range: 0xce9f0e..0xce9f0f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce9dcf..0xce9de4
+            - Range: 0xce9f0f..0xce9f24
               Pieces: []
           Role: Return
-    - ID: 100
+    - ID: 101
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0xce9e00..0xce9f5c]
+      OutOfLinePCRanges: [0xce9f40..0xcea09c]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 163 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xce9e00..0xce9e4b
+            - Range: 0xce9f40..0xce9f8b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce9e4b..0xce9e56
+            - Range: 0xce9f8b..0xce9f96
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce9e87..0xce9e8a
+            - Range: 0xce9fc7..0xce9fca
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce9ebe..0xce9ec5
+            - Range: 0xce9ffe..0xcea005
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce9efe..0xce9f05
+            - Range: 0xcea03e..0xcea045
               Pieces:
                 - Size: 8
                   Op: null
@@ -6126,112 +6208,112 @@ Subprograms:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xce9e00..0xce9e56
+            - Range: 0xce9f40..0xce9f96
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 163 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xce9e00..0xce9e64
+            - Range: 0xce9f40..0xce9fa4
               Pieces: []
-            - Range: 0xce9e64..0xce9e65
+            - Range: 0xce9fa4..0xce9fa5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce9e65..0xce9eb3
+            - Range: 0xce9fa5..0xce9ff3
               Pieces: []
-            - Range: 0xce9eb3..0xce9eb4
+            - Range: 0xce9ff3..0xce9ff4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce9eb4..0xce9ef3
+            - Range: 0xce9ff4..0xcea033
               Pieces: []
-            - Range: 0xce9ef3..0xce9ef4
+            - Range: 0xcea033..0xcea034
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce9ef4..0xce9f2f
+            - Range: 0xcea034..0xcea06f
               Pieces: []
-            - Range: 0xce9f2f..0xce9f30
+            - Range: 0xcea06f..0xcea070
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce9f30..0xce9f5c
+            - Range: 0xcea070..0xcea09c
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 15 GoInterfaceType error
           Locations:
-            - Range: 0xce9e00..0xce9e64
+            - Range: 0xce9f40..0xce9fa4
               Pieces: []
-            - Range: 0xce9e64..0xce9e65
+            - Range: 0xce9fa4..0xce9fa5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce9e65..0xce9eb3
+            - Range: 0xce9fa5..0xce9ff3
               Pieces: []
-            - Range: 0xce9eb3..0xce9eb4
+            - Range: 0xce9ff3..0xce9ff4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce9eb4..0xce9ef3
+            - Range: 0xce9ff4..0xcea033
               Pieces: []
-            - Range: 0xce9ef3..0xce9ef4
+            - Range: 0xcea033..0xcea034
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce9ef4..0xce9f2f
+            - Range: 0xcea034..0xcea06f
               Pieces: []
-            - Range: 0xce9f2f..0xce9f30
+            - Range: 0xcea06f..0xcea070
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce9f30..0xce9f5c
+            - Range: 0xcea070..0xcea09c
               Pieces: []
           Role: Return
         - Name: val
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce9e4b..0xce9e51
+            - Range: 0xce9f8b..0xce9f91
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 101
+    - ID: 102
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0xce9f60..0xcea15d]
+      OutOfLinePCRanges: [0xcea0a0..0xcea29d]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 163 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xce9f60..0xce9fab
+            - Range: 0xcea0a0..0xcea0eb
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce9fab..0xce9fb2
+            - Range: 0xcea0eb..0xcea0f2
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xce9fb2..0xcea15d
+            - Range: 0xcea0f2..0xcea29d
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -6241,941 +6323,941 @@ Subprograms:
         - Name: ~r0
           Type: 163 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xce9f60..0xcea015
+            - Range: 0xcea0a0..0xcea155
               Pieces: []
-            - Range: 0xcea015..0xcea016
+            - Range: 0xcea155..0xcea156
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcea016..0xcea064
+            - Range: 0xcea156..0xcea1a4
               Pieces: []
-            - Range: 0xcea064..0xcea065
+            - Range: 0xcea1a4..0xcea1a5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcea065..0xcea12f
+            - Range: 0xcea1a5..0xcea26f
               Pieces: []
-            - Range: 0xcea12f..0xcea130
+            - Range: 0xcea26f..0xcea270
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcea130..0xcea139
+            - Range: 0xcea270..0xcea279
               Pieces: []
-            - Range: 0xcea139..0xcea13a
+            - Range: 0xcea279..0xcea27a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcea13a..0xcea15d
+            - Range: 0xcea27a..0xcea29d
               Pieces: []
           Role: Return
         - Name: val
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcea000..0xcea006
+            - Range: 0xcea140..0xcea146
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
         - Name: '&result'
           Type: 104 PointerType *int
           Locations:
-            - Range: 0xcea045..0xcea064
+            - Range: 0xcea185..0xcea1a4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 102
+    - ID: 103
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0xcea160..0xcea2b4]
+      OutOfLinePCRanges: [0xcea2a0..0xcea3f4]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 163 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcea160..0xcea1a0
+            - Range: 0xcea2a0..0xcea2e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcea1a0..0xcea1f0
+            - Range: 0xcea2e0..0xcea330
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcea1f0..0xcea24d
+            - Range: 0xcea330..0xcea38d
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcea24d..0xcea271
+            - Range: 0xcea38d..0xcea3b1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcea271..0xcea278
+            - Range: 0xcea3b1..0xcea3b8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcea278..0xcea2b4
+            - Range: 0xcea3b8..0xcea3f4
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 168 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xcea160..0xcea23d
+            - Range: 0xcea2a0..0xcea37d
               Pieces: []
-            - Range: 0xcea23d..0xcea23e
+            - Range: 0xcea37d..0xcea37e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcea23e..0xcea247
+            - Range: 0xcea37e..0xcea387
               Pieces: []
-            - Range: 0xcea247..0xcea248
+            - Range: 0xcea387..0xcea388
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcea248..0xcea2b4
+            - Range: 0xcea388..0xcea3f4
               Pieces: []
           Role: Return
         - Name: b
           Type: 168 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xcea160..0xcea1a0
+            - Range: 0xcea2a0..0xcea2e0
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcea1a0..0xcea1f0
+            - Range: 0xcea2e0..0xcea330
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcea1f0..0xcea1f7
+            - Range: 0xcea330..0xcea337
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcea1f7..0xcea243
+            - Range: 0xcea337..0xcea383
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcea243..0xcea245
+            - Range: 0xcea383..0xcea385
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcea245..0xcea247
+            - Range: 0xcea385..0xcea387
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcea247..0xcea2b4
+            - Range: 0xcea387..0xcea3f4
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           Role: Local
-    - ID: 103
+    - ID: 104
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0xcea2c0..0xcea355]
+      OutOfLinePCRanges: [0xcea400..0xcea495]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcea2c0..0xcea2d1
+            - Range: 0xcea400..0xcea411
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcea2c0..0xcea33b
+            - Range: 0xcea400..0xcea47b
               Pieces: []
-            - Range: 0xcea33b..0xcea33c
+            - Range: 0xcea47b..0xcea47c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcea33c..0xcea355
+            - Range: 0xcea47c..0xcea495
               Pieces: []
           Role: Return
-    - ID: 104
+    - ID: 105
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0xcea360..0xcea429]
+      OutOfLinePCRanges: [0xcea4a0..0xcea569]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcea360..0xcea3b2
+            - Range: 0xcea4a0..0xcea4f2
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcea360..0xcea40f
+            - Range: 0xcea4a0..0xcea54f
               Pieces: []
-            - Range: 0xcea40f..0xcea410
+            - Range: 0xcea54f..0xcea550
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcea410..0xcea429
+            - Range: 0xcea550..0xcea569
               Pieces: []
           Role: Return
         - Name: result2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcea360..0xcea40f
+            - Range: 0xcea4a0..0xcea54f
               Pieces: []
-            - Range: 0xcea40f..0xcea410
+            - Range: 0xcea54f..0xcea550
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcea410..0xcea429
+            - Range: 0xcea550..0xcea569
               Pieces: []
           Role: Return
-    - ID: 105
+    - ID: 106
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0xcea440..0xcea507]
+      OutOfLinePCRanges: [0xcea580..0xcea647]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcea440..0xcea485
+            - Range: 0xcea580..0xcea5c5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcea485..0xcea507
+            - Range: 0xcea5c5..0xcea647
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcea440..0xcea4ed
+            - Range: 0xcea580..0xcea62d
               Pieces: []
-            - Range: 0xcea4ed..0xcea4ee
+            - Range: 0xcea62d..0xcea62e
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcea4ee..0xcea507
+            - Range: 0xcea62e..0xcea647
               Pieces: []
           Role: Return
         - Name: result2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcea440..0xcea4ed
+            - Range: 0xcea580..0xcea62d
               Pieces: []
-            - Range: 0xcea4ed..0xcea4ee
+            - Range: 0xcea62d..0xcea62e
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcea4ee..0xcea507
+            - Range: 0xcea62e..0xcea647
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcea440..0xcea4ed
+            - Range: 0xcea580..0xcea62d
               Pieces: []
-            - Range: 0xcea4ed..0xcea4ee
+            - Range: 0xcea62d..0xcea62e
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcea4ee..0xcea507
+            - Range: 0xcea62e..0xcea647
               Pieces: []
           Role: Return
-    - ID: 106
+    - ID: 107
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0xcea520..0xcea59e]
+      OutOfLinePCRanges: [0xcea660..0xcea6de]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 20 BaseType int8
           Locations:
-            - Range: 0xcea520..0xcea591
+            - Range: 0xcea660..0xcea6d1
               Pieces: []
-            - Range: 0xcea591..0xcea592
+            - Range: 0xcea6d1..0xcea6d2
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcea592..0xcea59e
+            - Range: 0xcea6d2..0xcea6de
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 109 BaseType int16
           Locations:
-            - Range: 0xcea520..0xcea591
+            - Range: 0xcea660..0xcea6d1
               Pieces: []
-            - Range: 0xcea591..0xcea592
+            - Range: 0xcea6d1..0xcea6d2
               Pieces: [{Size: 2, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcea592..0xcea59e
+            - Range: 0xcea6d2..0xcea6de
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 10 BaseType int32
           Locations:
-            - Range: 0xcea520..0xcea591
+            - Range: 0xcea660..0xcea6d1
               Pieces: []
-            - Range: 0xcea591..0xcea592
+            - Range: 0xcea6d1..0xcea6d2
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcea592..0xcea59e
+            - Range: 0xcea6d2..0xcea6de
               Pieces: []
           Role: Return
         - Name: ~r3
           Type: 12 BaseType int64
           Locations:
-            - Range: 0xcea520..0xcea591
+            - Range: 0xcea660..0xcea6d1
               Pieces: []
-            - Range: 0xcea591..0xcea592
+            - Range: 0xcea6d1..0xcea6d2
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xcea592..0xcea59e
+            - Range: 0xcea6d2..0xcea6de
               Pieces: []
           Role: Return
         - Name: ~r4
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcea520..0xcea591
+            - Range: 0xcea660..0xcea6d1
               Pieces: []
-            - Range: 0xcea591..0xcea592
+            - Range: 0xcea6d1..0xcea6d2
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcea592..0xcea59e
+            - Range: 0xcea6d2..0xcea6de
               Pieces: []
           Role: Return
         - Name: ~r5
           Type: 6 BaseType uint16
           Locations:
-            - Range: 0xcea520..0xcea591
+            - Range: 0xcea660..0xcea6d1
               Pieces: []
-            - Range: 0xcea591..0xcea592
+            - Range: 0xcea6d1..0xcea6d2
               Pieces: [{Size: 2, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xcea592..0xcea59e
+            - Range: 0xcea6d2..0xcea6de
               Pieces: []
           Role: Return
         - Name: ~r6
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0xcea520..0xcea591
+            - Range: 0xcea660..0xcea6d1
               Pieces: []
-            - Range: 0xcea591..0xcea592
+            - Range: 0xcea6d1..0xcea6d2
               Pieces: [{Size: 4, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xcea592..0xcea59e
+            - Range: 0xcea6d2..0xcea6de
               Pieces: []
           Role: Return
         - Name: ~r7
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0xcea520..0xcea591
+            - Range: 0xcea660..0xcea6d1
               Pieces: []
-            - Range: 0xcea591..0xcea592
+            - Range: 0xcea6d1..0xcea6d2
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xcea592..0xcea59e
+            - Range: 0xcea6d2..0xcea6de
               Pieces: []
           Role: Return
-    - ID: 107
+    - ID: 108
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0xcea5a0..0xcea697]
+      OutOfLinePCRanges: [0xcea6e0..0xcea7d7]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 13 BaseType float64
-          Locations: [{Range: 0xcea5a0..0xcea697, Pieces: []}]
+          Locations: [{Range: 0xcea6e0..0xcea7d7, Pieces: []}]
           Role: Return
         - Name: ~r1
           Type: 13 BaseType float64
-          Locations: [{Range: 0xcea5a0..0xcea697, Pieces: []}]
+          Locations: [{Range: 0xcea6e0..0xcea7d7, Pieces: []}]
           Role: Return
         - Name: ~r2
           Type: 13 BaseType float64
-          Locations: [{Range: 0xcea5a0..0xcea697, Pieces: []}]
+          Locations: [{Range: 0xcea6e0..0xcea7d7, Pieces: []}]
           Role: Return
         - Name: ~r3
           Type: 13 BaseType float64
-          Locations: [{Range: 0xcea5a0..0xcea697, Pieces: []}]
+          Locations: [{Range: 0xcea6e0..0xcea7d7, Pieces: []}]
           Role: Return
         - Name: ~r4
           Type: 13 BaseType float64
-          Locations: [{Range: 0xcea5a0..0xcea697, Pieces: []}]
+          Locations: [{Range: 0xcea6e0..0xcea7d7, Pieces: []}]
           Role: Return
         - Name: ~r5
           Type: 13 BaseType float64
-          Locations: [{Range: 0xcea5a0..0xcea697, Pieces: []}]
+          Locations: [{Range: 0xcea6e0..0xcea7d7, Pieces: []}]
           Role: Return
         - Name: ~r6
           Type: 13 BaseType float64
-          Locations: [{Range: 0xcea5a0..0xcea697, Pieces: []}]
+          Locations: [{Range: 0xcea6e0..0xcea7d7, Pieces: []}]
           Role: Return
         - Name: ~r7
           Type: 13 BaseType float64
-          Locations: [{Range: 0xcea5a0..0xcea697, Pieces: []}]
+          Locations: [{Range: 0xcea6e0..0xcea7d7, Pieces: []}]
           Role: Return
         - Name: ~r8
           Type: 13 BaseType float64
-          Locations: [{Range: 0xcea5a0..0xcea697, Pieces: []}]
+          Locations: [{Range: 0xcea6e0..0xcea7d7, Pieces: []}]
           Role: Return
         - Name: ~r9
           Type: 13 BaseType float64
-          Locations: [{Range: 0xcea5a0..0xcea697, Pieces: []}]
+          Locations: [{Range: 0xcea6e0..0xcea7d7, Pieces: []}]
           Role: Return
         - Name: ~r10
           Type: 13 BaseType float64
-          Locations: [{Range: 0xcea5a0..0xcea697, Pieces: []}]
+          Locations: [{Range: 0xcea6e0..0xcea7d7, Pieces: []}]
           Role: Return
         - Name: ~r11
           Type: 13 BaseType float64
-          Locations: [{Range: 0xcea5a0..0xcea697, Pieces: []}]
+          Locations: [{Range: 0xcea6e0..0xcea7d7, Pieces: []}]
           Role: Return
         - Name: ~r12
           Type: 13 BaseType float64
-          Locations: [{Range: 0xcea5a0..0xcea697, Pieces: []}]
+          Locations: [{Range: 0xcea6e0..0xcea7d7, Pieces: []}]
           Role: Return
         - Name: ~r13
           Type: 13 BaseType float64
-          Locations: [{Range: 0xcea5a0..0xcea697, Pieces: []}]
+          Locations: [{Range: 0xcea6e0..0xcea7d7, Pieces: []}]
           Role: Return
         - Name: ~r14
           Type: 13 BaseType float64
-          Locations: [{Range: 0xcea5a0..0xcea697, Pieces: []}]
+          Locations: [{Range: 0xcea6e0..0xcea7d7, Pieces: []}]
           Role: Return
         - Name: onlyOnAmd64_16
           Type: 13 BaseType float64
           Locations:
-            - Range: 0xcea5a0..0xcea687
+            - Range: 0xcea6e0..0xcea7c7
               Pieces: []
-            - Range: 0xcea687..0xcea688
+            - Range: 0xcea7c7..0xcea7c8
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xcea688..0xcea697
+            - Range: 0xcea7c8..0xcea7d7
               Pieces: []
           Role: Return
         - Name: bothArmAndAmd64
           Type: 13 BaseType float64
           Locations:
-            - Range: 0xcea5a0..0xcea687
+            - Range: 0xcea6e0..0xcea7c7
               Pieces: []
-            - Range: 0xcea687..0xcea688
+            - Range: 0xcea7c7..0xcea7c8
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcea688..0xcea697
+            - Range: 0xcea7c8..0xcea7d7
               Pieces: []
           Role: Return
-    - ID: 108
+    - ID: 109
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0xcea6a0..0xcea713]
+      OutOfLinePCRanges: [0xcea7e0..0xcea853]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 102 BaseType complex64
-          Locations: [{Range: 0xcea6a0..0xcea713, Pieces: []}]
+          Locations: [{Range: 0xcea7e0..0xcea853, Pieces: []}]
           Role: Return
         - Name: ~r1
           Type: 18 BaseType complex128
-          Locations: [{Range: 0xcea6a0..0xcea713, Pieces: []}]
+          Locations: [{Range: 0xcea7e0..0xcea853, Pieces: []}]
           Role: Return
-    - ID: 109
+    - ID: 110
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0xcea720..0xcea7d3]
+      OutOfLinePCRanges: [0xcea860..0xcea913]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0xcea720..0xcea7c3
+            - Range: 0xcea860..0xcea903
               Pieces: []
-            - Range: 0xcea7c3..0xcea7c4
+            - Range: 0xcea903..0xcea904
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
-            - Range: 0xcea7c4..0xcea7d3
+            - Range: 0xcea904..0xcea913
               Pieces: []
           Role: Return
-    - ID: 110
+    - ID: 111
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0xcea7e0..0xcea85c]
+      OutOfLinePCRanges: [0xcea920..0xcea99c]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 257 ArrayType [3]int
           Locations:
-            - Range: 0xcea7e0..0xcea84f
+            - Range: 0xcea920..0xcea98f
               Pieces: []
-            - Range: 0xcea84f..0xcea850
+            - Range: 0xcea98f..0xcea990
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xcea850..0xcea85c
+            - Range: 0xcea990..0xcea99c
               Pieces: []
           Role: Return
-    - ID: 111
+    - ID: 112
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0xcea860..0xcea8b8]
+      OutOfLinePCRanges: [0xcea9a0..0xcea9f8]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 258 ArrayType [1]int
           Locations:
-            - Range: 0xcea860..0xcea8ab
+            - Range: 0xcea9a0..0xcea9eb
               Pieces: []
-            - Range: 0xcea8ab..0xcea8ac
+            - Range: 0xcea9eb..0xcea9ec
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcea8ac..0xcea8b8
+            - Range: 0xcea9ec..0xcea9f8
               Pieces: []
           Role: Return
-    - ID: 112
+    - ID: 113
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0xcea8c0..0xcea913]
+      OutOfLinePCRanges: [0xceaa00..0xceaa53]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 259 ArrayType [0]int
           Locations:
-            - Range: 0xcea8c0..0xcea906
+            - Range: 0xceaa00..0xceaa46
               Pieces: []
-            - Range: 0xcea906..0xcea907
+            - Range: 0xceaa46..0xceaa47
               Pieces: []
-            - Range: 0xcea907..0xcea913
+            - Range: 0xceaa47..0xceaa53
               Pieces: []
           Role: Return
-    - ID: 113
+    - ID: 114
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0xcea920..0xcea987]
+      OutOfLinePCRanges: [0xceaa60..0xceaac7]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 260 StructureType main.mixedStruct
-          Locations: [{Range: 0xcea920..0xcea987, Pieces: []}]
+          Locations: [{Range: 0xceaa60..0xceaac7, Pieces: []}]
           Role: Return
-    - ID: 114
+    - ID: 115
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0xcea9a0..0xceaa3a]
+      OutOfLinePCRanges: [0xceaae0..0xceab7a]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcea9a0..0xceaa2a
+            - Range: 0xceaae0..0xceab6a
               Pieces: []
-            - Range: 0xceaa2a..0xceaa2b
+            - Range: 0xceab6a..0xceab6b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xceaa2b..0xceaa3a
+            - Range: 0xceab6b..0xceab7a
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcea9a0..0xceaa2a
+            - Range: 0xceaae0..0xceab6a
               Pieces: []
-            - Range: 0xceaa2a..0xceaa2b
+            - Range: 0xceab6a..0xceab6b
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xceaa2b..0xceaa3a
+            - Range: 0xceab6b..0xceab7a
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcea9a0..0xceaa2a
+            - Range: 0xceaae0..0xceab6a
               Pieces: []
-            - Range: 0xceaa2a..0xceaa2b
+            - Range: 0xceab6a..0xceab6b
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xceaa2b..0xceaa3a
+            - Range: 0xceab6b..0xceab7a
               Pieces: []
           Role: Return
         - Name: ~r3
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcea9a0..0xceaa2a
+            - Range: 0xceaae0..0xceab6a
               Pieces: []
-            - Range: 0xceaa2a..0xceaa2b
+            - Range: 0xceab6a..0xceab6b
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xceaa2b..0xceaa3a
+            - Range: 0xceab6b..0xceab7a
               Pieces: []
           Role: Return
         - Name: ~r4
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcea9a0..0xceaa2a
+            - Range: 0xceaae0..0xceab6a
               Pieces: []
-            - Range: 0xceaa2a..0xceaa2b
+            - Range: 0xceab6a..0xceab6b
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xceaa2b..0xceaa3a
+            - Range: 0xceab6b..0xceab7a
               Pieces: []
           Role: Return
         - Name: ~r5
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcea9a0..0xceaa2a
+            - Range: 0xceaae0..0xceab6a
               Pieces: []
-            - Range: 0xceaa2a..0xceaa2b
+            - Range: 0xceab6a..0xceab6b
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xceaa2b..0xceaa3a
+            - Range: 0xceab6b..0xceab7a
               Pieces: []
           Role: Return
         - Name: ~r6
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcea9a0..0xceaa2a
+            - Range: 0xceaae0..0xceab6a
               Pieces: []
-            - Range: 0xceaa2a..0xceaa2b
+            - Range: 0xceab6a..0xceab6b
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xceaa2b..0xceaa3a
+            - Range: 0xceab6b..0xceab7a
               Pieces: []
           Role: Return
         - Name: ~r7
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcea9a0..0xceaa2a
+            - Range: 0xceaae0..0xceab6a
               Pieces: []
-            - Range: 0xceaa2a..0xceaa2b
+            - Range: 0xceab6a..0xceab6b
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xceaa2b..0xceaa3a
+            - Range: 0xceab6b..0xceab7a
               Pieces: []
           Role: Return
         - Name: ~r8
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcea9a0..0xceaa2a
+            - Range: 0xceaae0..0xceab6a
               Pieces: []
-            - Range: 0xceaa2a..0xceaa2b
+            - Range: 0xceab6a..0xceab6b
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xceaa2b..0xceaa3a
+            - Range: 0xceab6b..0xceab7a
               Pieces: []
           Role: Return
-    - ID: 115
+    - ID: 116
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0xceaa40..0xceab05]
+      OutOfLinePCRanges: [0xceab80..0xceac45]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 261 StructureType main.wideStruct
           Locations:
-            - Range: 0xceaa40..0xceaaf2
+            - Range: 0xceab80..0xceac32
               Pieces: []
-            - Range: 0xceaaf2..0xceaaf3
+            - Range: 0xceac32..0xceac33
               Pieces: [{Size: 88, Op: {CfaOffset: 0}}]
-            - Range: 0xceaaf3..0xceab05
+            - Range: 0xceac33..0xceac45
               Pieces: []
           Role: Return
-    - ID: 116
+    - ID: 117
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0xceab20..0xceab99]
+      OutOfLinePCRanges: [0xceac60..0xceacd9]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceab20..0xceab8c
+            - Range: 0xceac60..0xceaccc
               Pieces: []
-            - Range: 0xceab8c..0xceab8d
+            - Range: 0xceaccc..0xceaccd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xceab8d..0xceab99
+            - Range: 0xceaccd..0xceacd9
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 13 BaseType float64
-          Locations: [{Range: 0xceab20..0xceab99, Pieces: []}]
+          Locations: [{Range: 0xceac60..0xceacd9, Pieces: []}]
           Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceab20..0xceab8c
+            - Range: 0xceac60..0xceaccc
               Pieces: []
-            - Range: 0xceab8c..0xceab8d
+            - Range: 0xceaccc..0xceaccd
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xceab8d..0xceab99
+            - Range: 0xceaccd..0xceacd9
               Pieces: []
           Role: Return
         - Name: ~r3
           Type: 13 BaseType float64
-          Locations: [{Range: 0xceab20..0xceab99, Pieces: []}]
+          Locations: [{Range: 0xceac60..0xceacd9, Pieces: []}]
           Role: Return
         - Name: ~r4
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xceab20..0xceab8c
+            - Range: 0xceac60..0xceaccc
               Pieces: []
-            - Range: 0xceab8c..0xceab8d
+            - Range: 0xceaccc..0xceaccd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xceab8d..0xceab99
+            - Range: 0xceaccd..0xceacd9
               Pieces: []
           Role: Return
-    - ID: 117
+    - ID: 118
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0xceaba0..0xceac1c]
+      OutOfLinePCRanges: [0xceace0..0xcead5c]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 262 StructureType main.structWithArray
           Locations:
-            - Range: 0xceaba0..0xceac0f
+            - Range: 0xceace0..0xcead4f
               Pieces: []
-            - Range: 0xceac0f..0xceac10
+            - Range: 0xcead4f..0xcead50
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xceac10..0xceac1c
+            - Range: 0xcead50..0xcead5c
               Pieces: []
           Role: Return
-    - ID: 118
+    - ID: 119
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0xceac20..0xceac7b]
+      OutOfLinePCRanges: [0xcead60..0xceadbb]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 13 BaseType float64
-          Locations: [{Range: 0xceac20..0xceac7b, Pieces: []}]
+          Locations: [{Range: 0xcead60..0xceadbb, Pieces: []}]
           Role: Return
-    - ID: 119
+    - ID: 120
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0xceac80..0xceace7]
+      OutOfLinePCRanges: [0xceadc0..0xceae27]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType float32
-          Locations: [{Range: 0xceac80..0xceace7, Pieces: []}]
+          Locations: [{Range: 0xceadc0..0xceae27, Pieces: []}]
           Role: Return
         - Name: ~r1
           Type: 13 BaseType float64
-          Locations: [{Range: 0xceac80..0xceace7, Pieces: []}]
+          Locations: [{Range: 0xceadc0..0xceae27, Pieces: []}]
           Role: Return
-    - ID: 120
+    - ID: 121
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0xcead00..0xcead5d]
+      OutOfLinePCRanges: [0xceae40..0xceae9d]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcead00..0xcead50
+            - Range: 0xceae40..0xceae90
               Pieces: []
-            - Range: 0xcead50..0xcead51
+            - Range: 0xceae90..0xceae91
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcead51..0xcead5d
+            - Range: 0xceae91..0xceae9d
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 1 BaseType uintptr
           Locations:
-            - Range: 0xcead00..0xcead50
+            - Range: 0xceae40..0xceae90
               Pieces: []
-            - Range: 0xcead50..0xcead51
+            - Range: 0xceae90..0xceae91
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcead51..0xcead5d
+            - Range: 0xceae91..0xceae9d
               Pieces: []
           Role: Return
-    - ID: 121
+    - ID: 122
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0xcead60..0xceaedd]
+      OutOfLinePCRanges: [0xceaea0..0xceb01d]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0xcead60..0xceaedd
+            - Range: 0xceaea0..0xceb01d
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0xcead60..0xceaecd
+            - Range: 0xceaea0..0xceb00d
               Pieces: []
-            - Range: 0xceaecd..0xceaece
+            - Range: 0xceb00d..0xceb00e
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
-            - Range: 0xceaece..0xceaedd
+            - Range: 0xceb00e..0xceb01d
               Pieces: []
           Role: Return
-    - ID: 122
+    - ID: 123
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0xceaee0..0xceafba]
+      OutOfLinePCRanges: [0xceb020..0xceb0fa]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 257 ArrayType [3]int
           Locations:
-            - Range: 0xceaee0..0xceafba
+            - Range: 0xceb020..0xceb0fa
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 257 ArrayType [3]int
           Locations:
-            - Range: 0xceaee0..0xceafaa
+            - Range: 0xceb020..0xceb0ea
               Pieces: []
-            - Range: 0xceafaa..0xceafab
+            - Range: 0xceb0ea..0xceb0eb
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xceafab..0xceafba
+            - Range: 0xceb0eb..0xceb0fa
               Pieces: []
           Role: Return
-    - ID: 123
+    - ID: 124
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0xceafc0..0xceb1fb]
+      OutOfLinePCRanges: [0xceb100..0xceb33b]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0xceafc0..0xceb1fb
+            - Range: 0xceb100..0xceb33b
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: s2
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0xceafc0..0xceb1fb
+            - Range: 0xceb100..0xceb33b
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
           Role: Parameter
         - Name: ~r0
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0xceafc0..0xceb1eb
+            - Range: 0xceb100..0xceb32b
               Pieces: []
-            - Range: 0xceb1eb..0xceb1ec
+            - Range: 0xceb32b..0xceb32c
               Pieces: [{Size: 80, Op: {CfaOffset: 160}}]
-            - Range: 0xceb1ec..0xceb1fb
+            - Range: 0xceb32c..0xceb33b
               Pieces: []
           Role: Return
-    - ID: 124
+    - ID: 125
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0xceb200..0xceb4af]
+      OutOfLinePCRanges: [0xceb340..0xceb5ef]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceb200..0xceb2c7
+            - Range: 0xceb340..0xceb407
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xceb2c7..0xceb4af
+            - Range: 0xceb407..0xceb5ef
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceb200..0xceb2c7
+            - Range: 0xceb340..0xceb407
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xceb2c7..0xceb4af
+            - Range: 0xceb407..0xceb5ef
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceb200..0xceb26a
+            - Range: 0xceb340..0xceb3aa
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xceb26a..0xceb4af
+            - Range: 0xceb3aa..0xceb5ef
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceb200..0xceb2c7
+            - Range: 0xceb340..0xceb407
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xceb2c7..0xceb4af
+            - Range: 0xceb407..0xceb5ef
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceb200..0xceb2c7
+            - Range: 0xceb340..0xceb407
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xceb2c7..0xceb4af
+            - Range: 0xceb407..0xceb5ef
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceb200..0xceb2c7
+            - Range: 0xceb340..0xceb407
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xceb2c7..0xceb4af
+            - Range: 0xceb407..0xceb5ef
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceb200..0xceb2c7
+            - Range: 0xceb340..0xceb407
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xceb2c7..0xceb4af
+            - Range: 0xceb407..0xceb5ef
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceb200..0xceb2c7
+            - Range: 0xceb340..0xceb407
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xceb2c7..0xceb4af
+            - Range: 0xceb407..0xceb5ef
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceb200..0xceb2c7
+            - Range: 0xceb340..0xceb407
               Pieces: [{Size: 8, Op: {RegNo: 11, Shift: 0}}]
-            - Range: 0xceb2c7..0xceb4af
+            - Range: 0xceb407..0xceb5ef
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
         - Name: ~r0
           Type: 119 ArrayType [2]int
           Locations:
-            - Range: 0xceb200..0xceb442
+            - Range: 0xceb340..0xceb582
               Pieces: []
-            - Range: 0xceb442..0xceb443
+            - Range: 0xceb582..0xceb583
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xceb443..0xceb4af
+            - Range: 0xceb583..0xceb5ef
               Pieces: []
           Role: Return
-    - ID: 125
+    - ID: 126
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0xceb4c0..0xceb785]
+      OutOfLinePCRanges: [0xceb600..0xceb8c5]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceb4c0..0xceb56a
+            - Range: 0xceb600..0xceb6aa
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xceb56a..0xceb785
+            - Range: 0xceb6aa..0xceb8c5
               Pieces: [{Size: 8, Op: {CfaOffset: 96}}]
           Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceb4c0..0xceb56a
+            - Range: 0xceb600..0xceb6aa
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xceb56a..0xceb785
+            - Range: 0xceb6aa..0xceb8c5
               Pieces: [{Size: 8, Op: {CfaOffset: 104}}]
           Role: Parameter
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceb4c0..0xceb522
+            - Range: 0xceb600..0xceb662
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xceb522..0xceb785
+            - Range: 0xceb662..0xceb8c5
               Pieces: [{Size: 8, Op: {CfaOffset: 112}}]
           Role: Parameter
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceb4c0..0xceb56a
+            - Range: 0xceb600..0xceb6aa
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xceb56a..0xceb785
+            - Range: 0xceb6aa..0xceb8c5
               Pieces: [{Size: 8, Op: {CfaOffset: 120}}]
           Role: Parameter
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceb4c0..0xceb56a
+            - Range: 0xceb600..0xceb6aa
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xceb56a..0xceb785
+            - Range: 0xceb6aa..0xceb8c5
               Pieces: [{Size: 8, Op: {CfaOffset: 128}}]
           Role: Parameter
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceb4c0..0xceb56a
+            - Range: 0xceb600..0xceb6aa
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xceb56a..0xceb785
+            - Range: 0xceb6aa..0xceb8c5
               Pieces: [{Size: 8, Op: {CfaOffset: 136}}]
           Role: Parameter
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceb4c0..0xceb56a
+            - Range: 0xceb600..0xceb6aa
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xceb56a..0xceb785
+            - Range: 0xceb6aa..0xceb8c5
               Pieces: [{Size: 8, Op: {CfaOffset: 144}}]
           Role: Parameter
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceb4c0..0xceb56a
+            - Range: 0xceb600..0xceb6aa
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xceb56a..0xceb785
+            - Range: 0xceb6aa..0xceb8c5
               Pieces: [{Size: 8, Op: {CfaOffset: 152}}]
           Role: Parameter
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xceb4c0..0xceb785
+            - Range: 0xceb600..0xceb8c5
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -7185,376 +7267,176 @@ Subprograms:
         - Name: ~r0
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0xceb4c0..0xceb702
+            - Range: 0xceb600..0xceb842
               Pieces: []
-            - Range: 0xceb702..0xceb703
+            - Range: 0xceb842..0xceb843
               Pieces: [{Size: 80, Op: {CfaOffset: 16}}]
-            - Range: 0xceb703..0xceb785
+            - Range: 0xceb843..0xceb8c5
               Pieces: []
           Role: Return
-    - ID: 126
+    - ID: 127
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0xceb7a0..0xceb82e]
+      OutOfLinePCRanges: [0xceb8e0..0xceb96e]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 167 ArrayType [5]int
           Locations:
-            - Range: 0xceb7a0..0xceb82e
+            - Range: 0xceb8e0..0xceb96e
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceb7a0..0xceb81e
+            - Range: 0xceb8e0..0xceb95e
               Pieces: []
-            - Range: 0xceb81e..0xceb81f
+            - Range: 0xceb95e..0xceb95f
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xceb81f..0xceb82e
+            - Range: 0xceb95f..0xceb96e
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceb7a0..0xceb81e
+            - Range: 0xceb8e0..0xceb95e
               Pieces: []
-            - Range: 0xceb81e..0xceb81f
+            - Range: 0xceb95e..0xceb95f
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xceb81f..0xceb82e
+            - Range: 0xceb95f..0xceb96e
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceb7a0..0xceb81e
+            - Range: 0xceb8e0..0xceb95e
               Pieces: []
-            - Range: 0xceb81e..0xceb81f
+            - Range: 0xceb95e..0xceb95f
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xceb81f..0xceb82e
+            - Range: 0xceb95f..0xceb96e
               Pieces: []
           Role: Return
-    - ID: 127
+    - ID: 128
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0xceb840..0xceb92d]
+      OutOfLinePCRanges: [0xceb980..0xceba6d]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 119 ArrayType [2]int
           Locations:
-            - Range: 0xceb840..0xceb92d
+            - Range: 0xceb980..0xceba6d
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: b
           Type: 257 ArrayType [3]int
           Locations:
-            - Range: 0xceb840..0xceb92d
+            - Range: 0xceb980..0xceba6d
               Pieces: [{Size: 24, Op: {CfaOffset: 16}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceb840..0xceb91d
+            - Range: 0xceb980..0xceba5d
               Pieces: []
-            - Range: 0xceb91d..0xceb91e
+            - Range: 0xceba5d..0xceba5e
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xceb91e..0xceb92d
+            - Range: 0xceba5e..0xceba6d
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 119 ArrayType [2]int
           Locations:
-            - Range: 0xceb840..0xceb91d
+            - Range: 0xceb980..0xceba5d
               Pieces: []
-            - Range: 0xceb91d..0xceb91e
+            - Range: 0xceba5d..0xceba5e
               Pieces: [{Size: 16, Op: {CfaOffset: 40}}]
-            - Range: 0xceb91e..0xceb92d
+            - Range: 0xceba5e..0xceba6d
               Pieces: []
           Role: Return
-    - ID: 128
+    - ID: 129
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0xceb940..0xceba14]
+      OutOfLinePCRanges: [0xceba80..0xcebb54]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 262 StructureType main.structWithArray
           Locations:
-            - Range: 0xceb940..0xceba14
+            - Range: 0xceba80..0xcebb54
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceb940..0xceba04
+            - Range: 0xceba80..0xcebb44
               Pieces: []
-            - Range: 0xceba04..0xceba05
+            - Range: 0xcebb44..0xcebb45
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xceba05..0xceba14
+            - Range: 0xcebb45..0xcebb54
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 262 StructureType main.structWithArray
           Locations:
-            - Range: 0xceb940..0xceba04
+            - Range: 0xceba80..0xcebb44
               Pieces: []
-            - Range: 0xceba04..0xceba05
+            - Range: 0xcebb44..0xcebb45
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xceba05..0xceba14
+            - Range: 0xcebb45..0xcebb54
               Pieces: []
           Role: Return
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceb9ce..0xceba14
+            - Range: 0xcebb0e..0xcebb54
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
-    - ID: 129
+    - ID: 130
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0xceba20..0xcebac6]
+      OutOfLinePCRanges: [0xcebb60..0xcebc06]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 259 ArrayType [0]int
-          Locations: [{Range: 0xceba20..0xcebac6, Pieces: []}]
+          Locations: [{Range: 0xcebb60..0xcebc06, Pieces: []}]
           Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceba20..0xceba65
+            - Range: 0xcebb60..0xcebba5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xceba65..0xceba87
+            - Range: 0xcebba5..0xcebbc7
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xceba87..0xceba9a
+            - Range: 0xcebbc7..0xcebbda
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xceba9a..0xcebac6
+            - Range: 0xcebbda..0xcebc06
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceba20..0xcebaac
+            - Range: 0xcebb60..0xcebbec
               Pieces: []
-            - Range: 0xcebaac..0xcebaad
+            - Range: 0xcebbec..0xcebbed
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcebaad..0xcebac6
+            - Range: 0xcebbed..0xcebc06
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 259 ArrayType [0]int
           Locations:
-            - Range: 0xceba20..0xcebaac
+            - Range: 0xcebb60..0xcebbec
               Pieces: []
-            - Range: 0xcebaac..0xcebaad
+            - Range: 0xcebbec..0xcebbed
               Pieces: []
-            - Range: 0xcebaad..0xcebac6
+            - Range: 0xcebbed..0xcebc06
               Pieces: []
           Role: Return
-    - ID: 130
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0xcec000..0xcec001]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 263 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xcec000..0xcec001
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
     - ID: 131
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0xcec020..0xcec021]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 263 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xcec020..0xcec021
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-    - ID: 132
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0xcec040..0xcec041]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 264 GoSliceHeaderType [][]uint
-          Locations:
-            - Range: 0xcec040..0xcec041
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-    - ID: 133
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0xcec060..0xcec061]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 266 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xcec060..0xcec061
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcec060..0xcec061
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          Role: Parameter
-    - ID: 134
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0xcec080..0xcec081]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 266 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xcec080..0xcec081
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcec080..0xcec081
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          Role: Parameter
-    - ID: 135
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0xcec0a0..0xcec0a1]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 266 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xcec0a0..0xcec0a1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcec0a0..0xcec0a1
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          Role: Parameter
-    - ID: 136
-      Name: main.testStringSlice
-      OutOfLinePCRanges: [0xcec0c0..0xcec0c1]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 269 GoSliceHeaderType []string
-          Locations:
-            - Range: 0xcec0c0..0xcec0c1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-    - ID: 137
-      Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0xcec0e0..0xcec0e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 20 BaseType int8
-          Locations:
-            - Range: 0xcec0e0..0xcec0e1
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-        - Name: s
-          Type: 270 GoSliceHeaderType []bool
-          Locations:
-            - Range: 0xcec0e0..0xcec0e1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-          Role: Parameter
-        - Name: x
-          Type: 14 BaseType uint
-          Locations:
-            - Range: 0xcec0e0..0xcec0e1
-              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-          Role: Parameter
-    - ID: 138
-      Name: main.testNilSlice
-      OutOfLinePCRanges: [0xcec100..0xcec101]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 271 GoSliceHeaderType []uint16
-          Locations:
-            - Range: 0xcec100..0xcec101
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-    - ID: 139
-      Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0xcec120..0xcec121]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 263 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xcec120..0xcec121
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-    - ID: 140
-      Name: main.testSliceEmptyStructs
+      Name: main.testUintSlice
       OutOfLinePCRanges: [0xcec140..0xcec141]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 272 GoSliceHeaderType []struct {}
+        - Name: u
+          Type: 263 GoSliceHeaderType []uint
           Locations:
             - Range: 0xcec140..0xcec141
               Pieces:
@@ -7565,15 +7447,215 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 141
-      Name: main.testSubslices
+    - ID: 132
+      Name: main.testEmptySlice
       OutOfLinePCRanges: [0xcec160..0xcec161]
+      InlinePCRanges: []
+      Variables:
+        - Name: u
+          Type: 263 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0xcec160..0xcec161
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+    - ID: 133
+      Name: main.testSliceOfSlices
+      OutOfLinePCRanges: [0xcec180..0xcec181]
+      InlinePCRanges: []
+      Variables:
+        - Name: u
+          Type: 264 GoSliceHeaderType [][]uint
+          Locations:
+            - Range: 0xcec180..0xcec181
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+    - ID: 134
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0xcec1a0..0xcec1a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 266 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xcec1a0..0xcec1a1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcec1a0..0xcec1a1
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          Role: Parameter
+    - ID: 135
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0xcec1c0..0xcec1c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 266 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xcec1c0..0xcec1c1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcec1c0..0xcec1c1
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          Role: Parameter
+    - ID: 136
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0xcec1e0..0xcec1e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 266 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xcec1e0..0xcec1e1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcec1e0..0xcec1e1
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          Role: Parameter
+    - ID: 137
+      Name: main.testStringSlice
+      OutOfLinePCRanges: [0xcec200..0xcec201]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 269 GoSliceHeaderType []string
+          Locations:
+            - Range: 0xcec200..0xcec201
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+    - ID: 138
+      Name: main.testNilSliceWithOtherParams
+      OutOfLinePCRanges: [0xcec220..0xcec221]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 20 BaseType int8
+          Locations:
+            - Range: 0xcec220..0xcec221
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+        - Name: s
+          Type: 270 GoSliceHeaderType []bool
+          Locations:
+            - Range: 0xcec220..0xcec221
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+          Role: Parameter
+        - Name: x
+          Type: 14 BaseType uint
+          Locations:
+            - Range: 0xcec220..0xcec221
+              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
+          Role: Parameter
+    - ID: 139
+      Name: main.testNilSlice
+      OutOfLinePCRanges: [0xcec240..0xcec241]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 271 GoSliceHeaderType []uint16
+          Locations:
+            - Range: 0xcec240..0xcec241
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+    - ID: 140
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0xcec260..0xcec261]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 263 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0xcec260..0xcec261
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+    - ID: 141
+      Name: main.testSliceEmptyStructs
+      OutOfLinePCRanges: [0xcec280..0xcec281]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 272 GoSliceHeaderType []struct {}
+          Locations:
+            - Range: 0xcec280..0xcec281
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+    - ID: 142
+      Name: main.testSubslices
+      OutOfLinePCRanges: [0xcec2a0..0xcec2a1]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 263 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcec160..0xcec161
+            - Range: 0xcec2a0..0xcec2a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7585,7 +7667,7 @@ Subprograms:
         - Name: bs
           Type: 263 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcec160..0xcec161
+            - Range: 0xcec2a0..0xcec2a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -7597,7 +7679,7 @@ Subprograms:
         - Name: cs
           Type: 263 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcec160..0xcec161
+            - Range: 0xcec2a0..0xcec2a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
@@ -7606,49 +7688,49 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
           Role: Parameter
-    - ID: 142
+    - ID: 143
       Name: main.stackC
-      OutOfLinePCRanges: [0xcec4c0..0xcec512]
+      OutOfLinePCRanges: [0xcec600..0xcec652]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcec4c0..0xcec505
+            - Range: 0xcec600..0xcec645
               Pieces: []
-            - Range: 0xcec505..0xcec506
+            - Range: 0xcec645..0xcec646
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcec506..0xcec512
+            - Range: 0xcec646..0xcec652
               Pieces: []
           Role: Return
-    - ID: 143
+    - ID: 144
       Name: main.testSingleString
-      OutOfLinePCRanges: [0xcec520..0xcec521]
+      OutOfLinePCRanges: [0xcec660..0xcec661]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcec520..0xcec521
+            - Range: 0xcec660..0xcec661
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
-    - ID: 144
+    - ID: 145
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0xcec540..0xcec541]
+      OutOfLinePCRanges: [0xcec680..0xcec681]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcec540..0xcec541
+            - Range: 0xcec680..0xcec681
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7658,7 +7740,7 @@ Subprograms:
         - Name: y
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcec540..0xcec541
+            - Range: 0xcec680..0xcec681
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -7668,22 +7750,22 @@ Subprograms:
         - Name: z
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcec540..0xcec541
+            - Range: 0xcec680..0xcec681
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 145
+    - ID: 146
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0xcec560..0xcec561]
+      OutOfLinePCRanges: [0xcec6a0..0xcec6a1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 274 StructureType main.threeStringStruct
           Locations:
-            - Range: 0xcec560..0xcec561
+            - Range: 0xcec6a0..0xcec6a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7698,52 +7780,37 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 146
+    - ID: 147
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0xcec580..0xcec581]
+      OutOfLinePCRanges: [0xcec6c0..0xcec6c1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 275 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0xcec580..0xcec581
+            - Range: 0xcec6c0..0xcec6c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 147
+    - ID: 148
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0xcec5a0..0xcec5a1]
+      OutOfLinePCRanges: [0xcec6e0..0xcec6e1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 276 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0xcec5a0..0xcec5a1
+            - Range: 0xcec6e0..0xcec6e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 148
-      Name: main.testMassiveString
-      OutOfLinePCRanges: [0xcec5c0..0xcec5c1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xcec5c0..0xcec5c1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          Role: Parameter
     - ID: 149
-      Name: main.testUnitializedString
-      OutOfLinePCRanges: [0xcec5e0..0xcec5e1]
+      Name: main.testMassiveString
+      OutOfLinePCRanges: [0xcec700..0xcec701]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcec5e0..0xcec5e1
+            - Range: 0xcec700..0xcec701
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7751,14 +7818,14 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
     - ID: 150
-      Name: main.testEmptyString
-      OutOfLinePCRanges: [0xcec600..0xcec601]
+      Name: main.testUnitializedString
+      OutOfLinePCRanges: [0xcec720..0xcec721]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcec600..0xcec601
+            - Range: 0xcec720..0xcec721
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7766,14 +7833,29 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
     - ID: 151
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0xcec740..0xcec741]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xcec740..0xcec741
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Parameter
+    - ID: 152
       Name: main.testSubstrings
-      OutOfLinePCRanges: [0xcec620..0xcec621]
+      OutOfLinePCRanges: [0xcec760..0xcec761]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcec620..0xcec621
+            - Range: 0xcec760..0xcec761
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7783,7 +7865,7 @@ Subprograms:
         - Name: b
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcec620..0xcec621
+            - Range: 0xcec760..0xcec761
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -7793,33 +7875,33 @@ Subprograms:
         - Name: c
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcec620..0xcec621
+            - Range: 0xcec760..0xcec761
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 152
+    - ID: 153
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0xcec7a0..0xcec7a1]
+      OutOfLinePCRanges: [0xcec8e0..0xcec8e1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 278 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0xcec7a0..0xcec7a1
+            - Range: 0xcec8e0..0xcec8e1
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
-    - ID: 153
+    - ID: 154
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0xcec7c0..0xcec7c1]
+      OutOfLinePCRanges: [0xcec900..0xcec901]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 291 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0xcec7c0..0xcec7c1
+            - Range: 0xcec900..0xcec901
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7834,15 +7916,15 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 154
+    - ID: 155
       Name: main.testStruct
-      OutOfLinePCRanges: [0xcec900..0xcec901]
+      OutOfLinePCRanges: [0xceca40..0xceca41]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 322 StructureType main.aStruct
           Locations:
-            - Range: 0xcec900..0xcec901
+            - Range: 0xceca40..0xceca41
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -7859,128 +7941,128 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
           Role: Parameter
-    - ID: 155
+    - ID: 156
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0xcec9c0..0xcec9c1]
+      OutOfLinePCRanges: [0xcecb00..0xcecb01]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 323 PointerType *main.anotherStruct
           Locations:
-            - Range: 0xcec9c0..0xcec9c1
+            - Range: 0xcecb00..0xcecb01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 156
+    - ID: 157
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xceca40..0xceca41]
+      OutOfLinePCRanges: [0xcecb80..0xcecb81]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 325 StructureType main.emptyStruct
-          Locations: [{Range: 0xceca40..0xceca41, Pieces: []}]
+          Locations: [{Range: 0xcecb80..0xcecb81, Pieces: []}]
           Role: Parameter
-    - ID: 157
+    - ID: 158
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0xceca60..0xceca61]
+      OutOfLinePCRanges: [0xcecba0..0xcecba1]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 326 PointerType *main.emptyStruct
           Locations:
-            - Range: 0xceca60..0xceca61
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-    - ID: 158
-      Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0xce6560..0xce65c2]
-      InlinePCRanges:
-        - Ranges: [0xce65f1..0xce662d]
-          RootRanges: [0xce65e0..0xce6651]
-        - Ranges: [0xce6732..0xce676e]
-          RootRanges: [0xce6700..0xce6788]
-        - Ranges: [0xce67bc..0xce67f8]
-          RootRanges: [0xce67a0..0xce6865]
-        - Ranges: [0xce688f..0xce68cb]
-          RootRanges: [0xce6880..0xce68e2]
-      Variables:
-        - Name: x
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xce6560..0xce6579
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce65f1..0xce65fc
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce6732..0xce673d
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce67b6..0xce67c7
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce67c7..0xce6865
-              Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xce6880..0xce689a
+            - Range: 0xcecba0..0xcecba1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 159
-      Name: main.testInlinedBBB
-      OutOfLinePCRanges: []
+      Name: main.testInlinedPrint
+      OutOfLinePCRanges: [0xce66a0..0xce6702]
       InlinePCRanges:
-        - Ranges: [0xce6806..0xce683e]
-          RootRanges: [0xce67a0..0xce6865]
-      Variables: []
-    - ID: 160
-      Name: main.testInlinedBCA
-      OutOfLinePCRanges: []
-      InlinePCRanges:
-        - Ranges: [0xce6913..0xce6951]
-          RootRanges: [0xce6900..0xce6a05]
-      Variables: []
-    - ID: 161
-      Name: main.testInlinedBCB
-      OutOfLinePCRanges: []
-      InlinePCRanges:
-        - Ranges: [0xce69bb..0xce69f3]
-          RootRanges: [0xce6900..0xce6a05]
-      Variables: []
-    - ID: 162
-      Name: main.testInlinedSq
-      OutOfLinePCRanges: []
-      InlinePCRanges:
-        - Ranges: [0xce6a21..0xce6a25]
-          RootRanges: [0xce6a20..0xce6a26]
+        - Ranges: [0xce6731..0xce676d]
+          RootRanges: [0xce6720..0xce6791]
+        - Ranges: [0xce6872..0xce68ae]
+          RootRanges: [0xce6840..0xce68c8]
+        - Ranges: [0xce68fc..0xce6938]
+          RootRanges: [0xce68e0..0xce69a5]
+        - Ranges: [0xce69cf..0xce6a0b]
+          RootRanges: [0xce69c0..0xce6a22]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce6a20..0xce6a25
+            - Range: 0xce66a0..0xce66b9
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xce6731..0xce673c
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xce6872..0xce687d
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xce68f6..0xce6907
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xce6907..0xce69a5
+              Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
+            - Range: 0xce69c0..0xce69da
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
+    - ID: 160
+      Name: main.testInlinedBBB
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0xce6946..0xce697e]
+          RootRanges: [0xce68e0..0xce69a5]
+      Variables: []
+    - ID: 161
+      Name: main.testInlinedBCA
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0xce6a53..0xce6a91]
+          RootRanges: [0xce6a40..0xce6b45]
+      Variables: []
+    - ID: 162
+      Name: main.testInlinedBCB
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0xce6afb..0xce6b33]
+          RootRanges: [0xce6a40..0xce6b45]
+      Variables: []
     - ID: 163
+      Name: main.testInlinedSq
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0xce6b61..0xce6b65]
+          RootRanges: [0xce6b60..0xce6b66]
+      Variables:
+        - Name: x
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xce6b60..0xce6b65
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+    - ID: 164
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xce6a6d..0xce6a85]
-          RootRanges: [0xce6a40..0xce6a8b]
-        - Ranges: [0xce6b03..0xce6b21]
-          RootRanges: [0xce6aa0..0xce6c25]
+        - Ranges: [0xce6bad..0xce6bc5]
+          RootRanges: [0xce6b80..0xce6bcb]
+        - Ranges: [0xce6c43..0xce6c61]
+          RootRanges: [0xce6be0..0xce6d65]
       Variables:
         - Name: a
           Type: 167 ArrayType [5]int
           Locations:
-            - Range: 0xce6a4c..0xce6a8b
+            - Range: 0xce6b8c..0xce6bcb
               Pieces: [{Size: 40, Op: {CfaOffset: -56}}]
-            - Range: 0xce6ae7..0xce6c25
+            - Range: 0xce6c27..0xce6d65
               Pieces: [{Size: 40, Op: {CfaOffset: -128}}]
           Role: Parameter
-    - ID: 164
+    - ID: 165
       Name: main.firstBehavior.DoSomething
-      OutOfLinePCRanges: [0xce6c40..0xce6ca6]
+      OutOfLinePCRanges: [0xce6d80..0xce6de6]
       InlinePCRanges:
-        - Ranges: [0xcedcba..0xcedce8]
-          RootRanges: [0xcedca0..0xcedd05]
+        - Ranges: [0xceddfa..0xcede28]
+          RootRanges: [0xcedde0..0xcede45]
       Variables:
         - Name: b
           Type: 327 StructureType main.firstBehavior
           Locations:
-            - Range: 0xce6c40..0xce6c5e
+            - Range: 0xce6d80..0xce6d9e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7990,23 +8072,23 @@ Subprograms:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce6c40..0xce6c85
+            - Range: 0xce6d80..0xce6dc5
               Pieces: []
-            - Range: 0xce6c85..0xce6c86
+            - Range: 0xce6dc5..0xce6dc6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce6c86..0xce6ca6
+            - Range: 0xce6dc6..0xce6de6
               Pieces: []
           Role: Return
-    - ID: 165
+    - ID: 166
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xce73ee..0xce73f5]
-          RootRanges: [0xce72a0..0xce742e]
+        - Ranges: [0xce752e..0xce7535]
+          RootRanges: [0xce73e0..0xce756e]
         - Ranges: [0xce4881..0xce4889]
           RootRanges: [0xce4880..0xce488a]
       Variables: []
@@ -11344,10 +11426,10 @@ Types:
       GoKind: 22
       Pointee: 826 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1565
+      ID: 1566
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
     - __kind: EventRootType
-      ID: 1563
+      ID: 1564
       Name: Probe[main.firstBehavior.DoSomething]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11359,11 +11441,11 @@ Types:
             Type: 327 StructureType main.firstBehavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 0, name: b}
+                  Variable: {subprogram: 165, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1564
+      ID: 1565
       Name: Probe[main.firstBehavior.DoSomething]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11375,14 +11457,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 1, name: ~r0}
+                  Variable: {subprogram: 165, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1526
+      ID: 1527
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1527
+      ID: 1528
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11394,11 +11476,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: ~r0}
+                  Variable: {subprogram: 143, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1393
+      ID: 1394
       Name: Probe[main.testAnyPtr]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11410,7 +11492,7 @@ Types:
             Type: 169 PointerType *interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: a}
+                  Variable: {subprogram: 59, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -11420,11 +11502,11 @@ Types:
             Type: 169 PointerType *interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: a}
+                  Variable: {subprogram: 59, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1394
+      ID: 1395
       Name: Probe[main.testAnyPtr]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11436,11 +11518,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 1, name: ~r0}
+                  Variable: {subprogram: 59, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1390
+      ID: 1391
       Name: Probe[main.testAny]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11452,7 +11534,7 @@ Types:
             Type: 163 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: a}
+                  Variable: {subprogram: 57, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -11462,11 +11544,11 @@ Types:
             Type: 163 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: a}
+                  Variable: {subprogram: 57, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1391
+      ID: 1392
       Name: Probe[main.testAny]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11478,11 +11560,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 1, name: ~r0}
+                  Variable: {subprogram: 57, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1497
+      ID: 1498
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11494,7 +11576,7 @@ Types:
             Type: 257 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: arg}
+                  Variable: {subprogram: 123, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
         - Name: arg
@@ -11504,11 +11586,11 @@ Types:
             Type: 257 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: arg}
+                  Variable: {subprogram: 123, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1498
+      ID: 1499
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11520,7 +11602,7 @@ Types:
             Type: 257 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 1, name: ~r0}
+                  Variable: {subprogram: 123, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -11602,7 +11684,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1402
+      ID: 1403
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11614,7 +11696,7 @@ Types:
             Type: 197 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: m}
+                  Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
         - Name: m
@@ -11624,7 +11706,7 @@ Types:
             Type: 197 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: m}
+                  Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -11680,7 +11762,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1424
+      ID: 1425
       Name: Probe[main.testAtomicAdd]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11692,7 +11774,7 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: x}
+                  Variable: {subprogram: 87, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -11702,11 +11784,11 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: x}
+                  Variable: {subprogram: 87, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1425
+      ID: 1426
       Name: Probe[main.testAtomicAdd]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11718,7 +11800,7 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 1, name: ~r0}
+                  Variable: {subprogram: 87, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -11800,7 +11882,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1426
+      ID: 1427
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11812,7 +11894,7 @@ Types:
             Type: 249 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: c}
+                  Variable: {subprogram: 88, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
         - Name: c
@@ -11822,11 +11904,11 @@ Types:
             Type: 249 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: c}
+                  Variable: {subprogram: 88, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1420
+      ID: 1421
       Name: Probe[main.testCombinedByte]
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -11838,7 +11920,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: w}
+                  Variable: {subprogram: 84, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: w
@@ -11848,7 +11930,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: w}
+                  Variable: {subprogram: 84, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: x
@@ -11858,7 +11940,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 1, name: x}
+                  Variable: {subprogram: 84, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: x
@@ -11868,7 +11950,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 1, name: x}
+                  Variable: {subprogram: 84, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: y
@@ -11878,7 +11960,7 @@ Types:
             Type: 17 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 2, name: y}
+                  Variable: {subprogram: 84, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
         - Name: y
@@ -11888,11 +11970,11 @@ Types:
             Type: 17 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 2, name: y}
+                  Variable: {subprogram: 84, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1421
+      ID: 1422
       Name: Probe[main.testCombinedString]
       ByteSize: 18
       PresenceBitsetSize: 1
@@ -11904,7 +11986,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 1, name: x}
+                  Variable: {subprogram: 85, index: 1, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: w_val
@@ -11914,11 +11996,11 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: w}
+                  Variable: {subprogram: 85, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1422
+      ID: 1423
       Name: Probe[main.testCombinedString]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -11930,7 +12012,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 1, name: x}
+                  Variable: {subprogram: 85, index: 1, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x_val
@@ -11940,7 +12022,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 1, name: x}
+                  Variable: {subprogram: 85, index: 1, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: w_val
@@ -11950,11 +12032,11 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: w}
+                  Variable: {subprogram: 85, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1434
+      ID: 1435
       Name: Probe[main.testCycle]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11966,7 +12048,7 @@ Types:
             Type: 254 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: t}
+                  Variable: {subprogram: 96, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
         - Name: t
@@ -11976,11 +12058,11 @@ Types:
             Type: 254 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: t}
+                  Variable: {subprogram: 96, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1365
+      ID: 1366
       Name: Probe[main.testDeepMap1]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11992,7 +12074,7 @@ Types:
             Type: 149 StructureType main.deepMap1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: a}
+                  Variable: {subprogram: 43, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12002,11 +12084,11 @@ Types:
             Type: 149 StructureType main.deepMap1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: a}
+                  Variable: {subprogram: 43, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1366
+      ID: 1367
       Name: Probe[main.testDeepMap7]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12018,7 +12100,7 @@ Types:
             Type: 155 PointerType *main.deepMap7
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 0, name: a}
+                  Variable: {subprogram: 44, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12028,11 +12110,11 @@ Types:
             Type: 155 PointerType *main.deepMap7
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 0, name: a}
+                  Variable: {subprogram: 44, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1361
+      ID: 1362
       Name: Probe[main.testDeepPtr1]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12044,7 +12126,7 @@ Types:
             Type: 138 StructureType main.deepPtr1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: a}
+                  Variable: {subprogram: 39, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12054,11 +12136,11 @@ Types:
             Type: 138 StructureType main.deepPtr1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: a}
+                  Variable: {subprogram: 39, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1362
+      ID: 1363
       Name: Probe[main.testDeepPtr7]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12070,7 +12152,7 @@ Types:
             Type: 141 PointerType *main.deepPtr7
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: a}
+                  Variable: {subprogram: 40, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12080,11 +12162,11 @@ Types:
             Type: 141 PointerType *main.deepPtr7
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: a}
+                  Variable: {subprogram: 40, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1363
+      ID: 1364
       Name: Probe[main.testDeepSlice1]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12096,7 +12178,7 @@ Types:
             Type: 143 StructureType main.deepSlice1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: a}
+                  Variable: {subprogram: 41, index: 0, name: a}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -12106,11 +12188,11 @@ Types:
             Type: 143 StructureType main.deepSlice1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: a}
+                  Variable: {subprogram: 41, index: 0, name: a}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1364
+      ID: 1365
       Name: Probe[main.testDeepSlice7]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12122,7 +12204,7 @@ Types:
             Type: 147 PointerType *main.deepSlice7
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: a}
+                  Variable: {subprogram: 42, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12132,11 +12214,11 @@ Types:
             Type: 147 PointerType *main.deepSlice7
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: a}
+                  Variable: {subprogram: 42, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1517
+      ID: 1518
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -12148,7 +12230,7 @@ Types:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: xs}
+                  Variable: {subprogram: 135, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -12158,7 +12240,7 @@ Types:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: xs}
+                  Variable: {subprogram: 135, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -12168,7 +12250,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 1, name: a}
+                  Variable: {subprogram: 135, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12178,11 +12260,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 1, name: a}
+                  Variable: {subprogram: 135, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1514
+      ID: 1515
       Name: Probe[main.testEmptySlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12194,7 +12276,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: u}
+                  Variable: {subprogram: 132, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -12204,11 +12286,11 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: u}
+                  Variable: {subprogram: 132, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1538
+      ID: 1539
       Name: Probe[main.testEmptyString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12220,7 +12302,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: x}
+                  Variable: {subprogram: 151, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -12230,11 +12312,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: x}
+                  Variable: {subprogram: 151, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1549
+      ID: 1550
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12246,7 +12328,7 @@ Types:
             Type: 326 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: e}
+                  Variable: {subprogram: 158, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -12256,11 +12338,11 @@ Types:
             Type: 326 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: e}
+                  Variable: {subprogram: 158, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1548
+      ID: 1549
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -12272,7 +12354,7 @@ Types:
             Type: 325 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: e}
+                  Variable: {subprogram: 157, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
         - Name: e
@@ -12282,11 +12364,67 @@ Types:
             Type: 325 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: e}
+                  Variable: {subprogram: 157, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1392
+      ID: 1361
+      Name: Probe[main.testErrorAtLine]Line
+      ByteSize: 57
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 2, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 2, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: err
+          Offset: 25
+          Kind: local
+          Expression:
+            Type: 15 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 3, name: err}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: err
+          Offset: 41
+          Kind: template_segment
+          Expression:
+            Type: 15 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 3, name: err}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1393
       Name: Probe[main.testError]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12298,7 +12436,7 @@ Types:
             Type: 15 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: e}
+                  Variable: {subprogram: 58, index: 0, name: e}
                   Offset: 0
                   ByteSize: 16
         - Name: e
@@ -12308,11 +12446,11 @@ Types:
             Type: 15 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: e}
+                  Variable: {subprogram: 58, index: 0, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1374
+      ID: 1375
       Name: Probe[main.testEsotericHeap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12324,7 +12462,7 @@ Types:
             Type: 165 PointerType *main.esotericHeap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 48, index: 0, name: e}
+                  Variable: {subprogram: 49, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -12334,14 +12472,14 @@ Types:
             Type: 165 PointerType *main.esotericHeap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 48, index: 0, name: e}
+                  Variable: {subprogram: 49, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1375
+      ID: 1376
       Name: Probe[main.testEsotericHeap]Return
     - __kind: EventRootType
-      ID: 1372
+      ID: 1373
       Name: Probe[main.testEsotericStack]
       ByteSize: 129
       PresenceBitsetSize: 1
@@ -12353,7 +12491,7 @@ Types:
             Type: 161 StructureType main.esotericStack
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 0, name: e}
+                  Variable: {subprogram: 48, index: 0, name: e}
                   Offset: 0
                   ByteSize: 64
         - Name: e
@@ -12363,14 +12501,14 @@ Types:
             Type: 161 StructureType main.esotericStack
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 0, name: e}
+                  Variable: {subprogram: 48, index: 0, name: e}
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1373
+      ID: 1374
       Name: Probe[main.testEsotericStack]Return
     - __kind: EventRootType
-      ID: 1386
+      ID: 1387
       Name: Probe[main.testFramelessArray]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12382,7 +12520,7 @@ Types:
             Type: 167 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: a}
+                  Variable: {subprogram: 55, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: a
@@ -12392,11 +12530,11 @@ Types:
             Type: 167 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: a}
+                  Variable: {subprogram: 55, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1388
+      ID: 1389
       Name: Probe[main.testFramelessArray]Line
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -12408,7 +12546,7 @@ Types:
             Type: 167 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: a}
+                  Variable: {subprogram: 55, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: a
@@ -12418,7 +12556,7 @@ Types:
             Type: 167 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: a}
+                  Variable: {subprogram: 55, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: ~r0
@@ -12428,11 +12566,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 1, name: ~r0}
+                  Variable: {subprogram: 55, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1387
+      ID: 1388
       Name: Probe[main.testFramelessArray]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12444,11 +12582,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 1, name: ~r0}
+                  Variable: {subprogram: 55, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1384
+      ID: 1385
       Name: Probe[main.testFrameless]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12460,7 +12598,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: x}
+                  Variable: {subprogram: 54, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12470,11 +12608,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: x}
+                  Variable: {subprogram: 54, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1385
+      ID: 1386
       Name: Probe[main.testFrameless]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12486,11 +12624,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 1, name: ~r0}
+                  Variable: {subprogram: 54, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1376
+      ID: 1377
       Name: Probe[main.testInlinedBA]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12502,7 +12640,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: x}
+                  Variable: {subprogram: 50, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12512,14 +12650,14 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: x}
+                  Variable: {subprogram: 50, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1377
+      ID: 1378
       Name: Probe[main.testInlinedBA]Return
     - __kind: EventRootType
-      ID: 1380
+      ID: 1381
       Name: Probe[main.testInlinedBBA]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12531,7 +12669,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: x}
+                  Variable: {subprogram: 52, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12541,17 +12679,17 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: x}
+                  Variable: {subprogram: 52, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1381
+      ID: 1382
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1555
+      ID: 1556
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 1378
+      ID: 1379
       Name: Probe[main.testInlinedBB]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12563,7 +12701,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: x}
+                  Variable: {subprogram: 51, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12573,7 +12711,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: x}
+                  Variable: {subprogram: 51, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: y
@@ -12583,7 +12721,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 1, name: y}
+                  Variable: {subprogram: 51, index: 1, name: y}
                   Offset: 0
                   ByteSize: 8
         - Name: y
@@ -12593,32 +12731,32 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 1, name: y}
+                  Variable: {subprogram: 51, index: 1, name: y}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1379
+      ID: 1380
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1556
+      ID: 1557
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1557
+      ID: 1558
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1558
+      ID: 1559
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1559
+      ID: 1560
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
-      ID: 1382
+      ID: 1383
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 1383
+      ID: 1384
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1552
+      ID: 1553
       Name: Probe[main.testInlinedPrint]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12630,7 +12768,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12640,11 +12778,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1550
+      ID: 1551
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12656,11 +12794,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1551
+      ID: 1552
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12672,7 +12810,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x_val
@@ -12682,11 +12820,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1554
+      ID: 1555
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12698,7 +12836,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12708,14 +12846,14 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1553
+      ID: 1554
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1560
+      ID: 1561
       Name: Probe[main.testInlinedSq]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12727,7 +12865,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12737,11 +12875,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1561
+      ID: 1562
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12753,7 +12891,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12763,11 +12901,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1562
+      ID: 1563
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12779,7 +12917,7 @@ Types:
             Type: 167 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: a}
+                  Variable: {subprogram: 164, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: a
@@ -12789,7 +12927,7 @@ Types:
             Type: 167 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: a}
+                  Variable: {subprogram: 164, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
@@ -12923,7 +13061,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1389
+      ID: 1390
       Name: Probe[main.testInterface]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12935,7 +13073,7 @@ Types:
             Type: 168 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: b}
+                  Variable: {subprogram: 56, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -12945,11 +13083,11 @@ Types:
             Type: 168 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: b}
+                  Variable: {subprogram: 56, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1495
+      ID: 1496
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 161
       PresenceBitsetSize: 1
@@ -12961,7 +13099,7 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: arg}
+                  Variable: {subprogram: 122, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
         - Name: arg
@@ -12971,11 +13109,11 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: arg}
+                  Variable: {subprogram: 122, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1496
+      ID: 1497
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12987,11 +13125,11 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 1, name: ~r0}
+                  Variable: {subprogram: 122, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1428
+      ID: 1429
       Name: Probe[main.testLinkedList]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13003,7 +13141,7 @@ Types:
             Type: 252 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: a}
+                  Variable: {subprogram: 90, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -13013,48 +13151,12 @@ Types:
             Type: 252 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: a}
+                  Variable: {subprogram: 90, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1369
-      Name: Probe[main.testLongFunctionWithChangingState]Line
-    - __kind: EventRootType
       ID: 1370
       Name: Probe[main.testLongFunctionWithChangingState]Line
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: aPerArch
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 1, name: aPerArch}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: b
-          Offset: 17
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 2, name: b}
-                  Offset: 0
-                  ByteSize: 8
     - __kind: EventRootType
       ID: 1371
       Name: Probe[main.testLongFunctionWithChangingState]Line
@@ -13068,7 +13170,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 0, name: s}
+                  Variable: {subprogram: 47, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
         - Name: aPerArch
@@ -13078,7 +13180,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 1, name: aPerArch}
+                  Variable: {subprogram: 47, index: 1, name: aPerArch}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13088,11 +13190,47 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 2, name: b}
+                  Variable: {subprogram: 47, index: 2, name: b}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1501
+      ID: 1372
+      Name: Probe[main.testLongFunctionWithChangingState]Line
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 47, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: aPerArch
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 47, index: 1, name: aPerArch}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 17
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 47, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1502
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 147
       PresenceBitsetSize: 3
@@ -13104,7 +13242,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: a}
+                  Variable: {subprogram: 125, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -13114,7 +13252,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: a}
+                  Variable: {subprogram: 125, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13124,7 +13262,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 1, name: b}
+                  Variable: {subprogram: 125, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13134,7 +13272,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 1, name: b}
+                  Variable: {subprogram: 125, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13144,7 +13282,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 2, name: c}
+                  Variable: {subprogram: 125, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13154,7 +13292,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 2, name: c}
+                  Variable: {subprogram: 125, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13164,7 +13302,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 3, name: d}
+                  Variable: {subprogram: 125, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13174,7 +13312,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 3, name: d}
+                  Variable: {subprogram: 125, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13184,7 +13322,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 4, name: e}
+                  Variable: {subprogram: 125, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13194,7 +13332,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 4, name: e}
+                  Variable: {subprogram: 125, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13204,7 +13342,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 5, name: f}
+                  Variable: {subprogram: 125, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13214,7 +13352,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 5, name: f}
+                  Variable: {subprogram: 125, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13224,7 +13362,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 6, name: g}
+                  Variable: {subprogram: 125, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13234,7 +13372,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 6, name: g}
+                  Variable: {subprogram: 125, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13244,7 +13382,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 7, name: h}
+                  Variable: {subprogram: 125, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13254,7 +13392,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 7, name: h}
+                  Variable: {subprogram: 125, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13264,7 +13402,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 8, name: i}
+                  Variable: {subprogram: 125, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13274,11 +13412,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 8, name: i}
+                  Variable: {subprogram: 125, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1502
+      ID: 1503
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13290,11 +13428,11 @@ Types:
             Type: 119 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 9, name: ~r0}
+                  Variable: {subprogram: 125, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1400
+      ID: 1401
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13306,7 +13444,7 @@ Types:
             Type: 192 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13316,11 +13454,11 @@ Types:
             Type: 192 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1407
+      ID: 1408
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13332,7 +13470,7 @@ Types:
             Type: 199 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: m}
+                  Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13342,11 +13480,11 @@ Types:
             Type: 199 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: m}
+                  Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1419
+      ID: 1420
       Name: Probe[main.testMapEmptyKeyAndValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13358,7 +13496,7 @@ Types:
             Type: 244 GoMapType map[struct {}]struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: m}
+                  Variable: {subprogram: 83, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13368,11 +13506,11 @@ Types:
             Type: 244 GoMapType map[struct {}]struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: m}
+                  Variable: {subprogram: 83, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1417
+      ID: 1418
       Name: Probe[main.testMapEmptyKey]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13384,7 +13522,7 @@ Types:
             Type: 234 GoMapType map[struct {}]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: m}
+                  Variable: {subprogram: 81, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13394,11 +13532,11 @@ Types:
             Type: 234 GoMapType map[struct {}]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: m}
+                  Variable: {subprogram: 81, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1418
+      ID: 1419
       Name: Probe[main.testMapEmptyValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13410,7 +13548,7 @@ Types:
             Type: 239 GoMapType map[int]struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: m}
+                  Variable: {subprogram: 82, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13420,11 +13558,11 @@ Types:
             Type: 239 GoMapType map[int]struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: m}
+                  Variable: {subprogram: 82, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1404
+      ID: 1405
       Name: Probe[main.testMapIntToInt]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13436,7 +13574,7 @@ Types:
             Type: 172 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
+                  Variable: {subprogram: 69, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13446,11 +13584,11 @@ Types:
             Type: 172 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
+                  Variable: {subprogram: 69, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1416
+      ID: 1417
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13462,7 +13600,7 @@ Types:
             Type: 229 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: m}
+                  Variable: {subprogram: 80, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13472,11 +13610,11 @@ Types:
             Type: 229 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: m}
+                  Variable: {subprogram: 80, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1415
+      ID: 1416
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13488,7 +13626,7 @@ Types:
             Type: 224 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: m}
+                  Variable: {subprogram: 79, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13498,33 +13636,7 @@ Types:
             Type: 224 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1405
-      Name: Probe[main.testMapMassive]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: redactMyEntries
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 199 GoMapType map[string][]main.structWithMap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: redactMyEntries
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 199 GoMapType map[string][]main.structWithMap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 79, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -13540,7 +13652,7 @@ Types:
             Type: 199 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 70, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
         - Name: redactMyEntries
@@ -13550,11 +13662,37 @@ Types:
             Type: 199 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 70, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1414
+      ID: 1407
+      Name: Probe[main.testMapMassive]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: redactMyEntries
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 199 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 70, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: redactMyEntries
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 199 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 70, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1415
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13566,7 +13704,7 @@ Types:
             Type: 219 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: m}
+                  Variable: {subprogram: 78, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13576,11 +13714,11 @@ Types:
             Type: 219 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: m}
+                  Variable: {subprogram: 78, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1413
+      ID: 1414
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13592,6 +13730,136 @@ Types:
             Type: 214 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
+                  Variable: {subprogram: 77, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 214 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 77, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1399
+      Name: Probe[main.testMapStringToInt]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 182 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 63, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 182 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 63, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1400
+      Name: Probe[main.testMapStringToSlice]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 187 GoMapType map[string][]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 64, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 187 GoMapType map[string][]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 64, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1398
+      Name: Probe[main.testMapStringToStruct]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 177 GoMapType map[string]main.nestedStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 62, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 177 GoMapType map[string]main.nestedStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 62, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1409
+      Name: Probe[main.testMapWithLinkedList]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 204 GoMapType map[bool]main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 72, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 204 GoMapType map[bool]main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 72, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1413
+      Name: Probe[main.testMapWithSmallKeyAndValueMassive]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 214 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
                   Variable: {subprogram: 76, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
@@ -13606,112 +13874,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1398
-      Name: Probe[main.testMapStringToInt]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 182 GoMapType map[string]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: m
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 182 GoMapType map[string]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1399
-      Name: Probe[main.testMapStringToSlice]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 187 GoMapType map[string][]string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: m
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 187 GoMapType map[string][]string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1397
-      Name: Probe[main.testMapStringToStruct]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 177 GoMapType map[string]main.nestedStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: m
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 177 GoMapType map[string]main.nestedStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1408
-      Name: Probe[main.testMapWithLinkedList]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 204 GoMapType map[bool]main.node
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: m
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 204 GoMapType map[bool]main.node
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
       ID: 1412
-      Name: Probe[main.testMapWithSmallKeyAndValueMassive]
+      Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
@@ -13737,32 +13901,6 @@ Types:
                   ByteSize: 8
     - __kind: EventRootType
       ID: 1411
-      Name: Probe[main.testMapWithSmallKeyAndValue]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 214 GoMapType map[uint8]uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: m
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 214 GoMapType map[uint8]uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1410
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13774,7 +13912,7 @@ Types:
             Type: 209 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 74, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
         - Name: redactMyEntries
@@ -13784,11 +13922,11 @@ Types:
             Type: 209 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 74, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1409
+      ID: 1410
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13800,7 +13938,7 @@ Types:
             Type: 209 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: m}
+                  Variable: {subprogram: 73, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13810,35 +13948,9 @@ Types:
             Type: 209 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: m}
+                  Variable: {subprogram: 73, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
-    - __kind: EventRootType
-      ID: 1535
-      Name: Probe[main.testMassiveString]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: x
-          Offset: 17
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
     - __kind: EventRootType
       ID: 1536
       Name: Probe[main.testMassiveString]
@@ -13852,7 +13964,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
+                  Variable: {subprogram: 149, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -13862,11 +13974,37 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
+                  Variable: {subprogram: 149, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1503
+      ID: 1537
+      Name: Probe[main.testMassiveString]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 149, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 149, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1504
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 163
       PresenceBitsetSize: 3
@@ -13878,7 +14016,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: a}
+                  Variable: {subprogram: 126, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -13888,7 +14026,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: a}
+                  Variable: {subprogram: 126, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13898,7 +14036,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: b}
+                  Variable: {subprogram: 126, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13908,7 +14046,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: b}
+                  Variable: {subprogram: 126, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13918,7 +14056,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: c}
+                  Variable: {subprogram: 126, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13928,7 +14066,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: c}
+                  Variable: {subprogram: 126, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13938,7 +14076,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 3, name: d}
+                  Variable: {subprogram: 126, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13948,7 +14086,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 3, name: d}
+                  Variable: {subprogram: 126, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13958,7 +14096,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 4, name: e}
+                  Variable: {subprogram: 126, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13968,7 +14106,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 4, name: e}
+                  Variable: {subprogram: 126, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13978,7 +14116,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 5, name: f}
+                  Variable: {subprogram: 126, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13988,7 +14126,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 5, name: f}
+                  Variable: {subprogram: 126, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13998,7 +14136,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 6, name: g}
+                  Variable: {subprogram: 126, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -14008,7 +14146,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 6, name: g}
+                  Variable: {subprogram: 126, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -14018,7 +14156,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 7, name: h}
+                  Variable: {subprogram: 126, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -14028,7 +14166,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 7, name: h}
+                  Variable: {subprogram: 126, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: s
@@ -14038,7 +14176,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 8, name: s}
+                  Variable: {subprogram: 126, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
         - Name: s
@@ -14048,11 +14186,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 8, name: s}
+                  Variable: {subprogram: 126, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1504
+      ID: 1505
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -14064,11 +14202,11 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 9, name: ~r0}
+                  Variable: {subprogram: 126, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1507
+      ID: 1508
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -14080,7 +14218,7 @@ Types:
             Type: 119 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -14090,7 +14228,7 @@ Types:
             Type: 119 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -14100,7 +14238,7 @@ Types:
             Type: 257 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: b}
+                  Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
         - Name: b
@@ -14110,11 +14248,11 @@ Types:
             Type: 257 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: b}
+                  Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1508
+      ID: 1509
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -14126,7 +14264,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 2, name: ~r0}
+                  Variable: {subprogram: 128, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -14136,11 +14274,11 @@ Types:
             Type: 119 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 3, name: ~r1}
+                  Variable: {subprogram: 128, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1499
+      ID: 1500
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 321
       PresenceBitsetSize: 1
@@ -14152,7 +14290,7 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: s1}
+                  Variable: {subprogram: 124, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
         - Name: s1
@@ -14162,7 +14300,7 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: s1}
+                  Variable: {subprogram: 124, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
         - Name: s2
@@ -14172,7 +14310,7 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: s2}
+                  Variable: {subprogram: 124, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
         - Name: s2
@@ -14182,11 +14320,11 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: s2}
+                  Variable: {subprogram: 124, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1500
+      ID: 1501
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -14198,11 +14336,11 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 2, name: ~r0}
+                  Variable: {subprogram: 124, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1453
+      ID: 1454
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14214,7 +14352,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14224,11 +14362,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1455
+      ID: 1456
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14240,7 +14378,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14250,7 +14388,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14260,7 +14398,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14270,11 +14408,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1457
+      ID: 1458
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14286,11 +14424,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1459
+      ID: 1460
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14302,11 +14440,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1461
+      ID: 1462
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14318,11 +14456,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1454
+      ID: 1455
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14334,7 +14472,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14344,11 +14482,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1456
+      ID: 1457
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -14360,7 +14498,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14370,7 +14508,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14380,7 +14518,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14390,7 +14528,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14400,7 +14538,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14410,11 +14548,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1458
+      ID: 1459
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14426,7 +14564,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14436,11 +14574,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1460
+      ID: 1461
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14452,7 +14590,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14462,11 +14600,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1462
+      ID: 1463
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14478,7 +14616,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14488,11 +14626,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1423
+      ID: 1424
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 62
       PresenceBitsetSize: 2
@@ -14504,7 +14642,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: a}
+                  Variable: {subprogram: 86, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: a
@@ -14514,7 +14652,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: a}
+                  Variable: {subprogram: 86, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -14524,7 +14662,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 1, name: b}
+                  Variable: {subprogram: 86, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -14534,7 +14672,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 1, name: b}
+                  Variable: {subprogram: 86, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: c
@@ -14544,7 +14682,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 2, name: c}
+                  Variable: {subprogram: 86, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: c
@@ -14554,7 +14692,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 2, name: c}
+                  Variable: {subprogram: 86, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: d
@@ -14564,7 +14702,7 @@ Types:
             Type: 14 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 3, name: d}
+                  Variable: {subprogram: 86, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -14574,7 +14712,7 @@ Types:
             Type: 14 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 3, name: d}
+                  Variable: {subprogram: 86, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -14584,7 +14722,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 4, name: e}
+                  Variable: {subprogram: 86, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
         - Name: e
@@ -14594,11 +14732,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 4, name: e}
+                  Variable: {subprogram: 86, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1449
+      ID: 1450
       Name: Probe[main.testNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14610,7 +14748,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14620,37 +14758,37 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1452
+      Name: Probe[main.testNamedReturn]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
       ID: 1451
-      Name: Probe[main.testNamedReturn]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1450
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14662,11 +14800,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1452
+      ID: 1453
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14678,7 +14816,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14688,11 +14826,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1544
+      ID: 1545
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14704,7 +14842,7 @@ Types:
             Type: 323 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: x}
+                  Variable: {subprogram: 156, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -14714,11 +14852,11 @@ Types:
             Type: 323 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: x}
+                  Variable: {subprogram: 156, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1545
+      ID: 1546
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14730,7 +14868,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: x}
+                  Variable: {subprogram: 156, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -14740,10 +14878,10 @@ Types:
                   Bias: 8
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1546
+      ID: 1547
       Name: Probe[main.testNestedPointer]
     - __kind: EventRootType
-      ID: 1547
+      ID: 1548
       Name: Probe[main.testNestedPointer]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -14755,7 +14893,7 @@ Types:
             Type: 129 StructureType main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: x}
+                  Variable: {subprogram: 156, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -14765,7 +14903,7 @@ Types:
                   Bias: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1433
+      ID: 1434
       Name: Probe[main.testNilPointer]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14777,7 +14915,7 @@ Types:
             Type: 11 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: z}
+                  Variable: {subprogram: 95, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: z
@@ -14787,7 +14925,7 @@ Types:
             Type: 11 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: z}
+                  Variable: {subprogram: 95, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14797,7 +14935,7 @@ Types:
             Type: 14 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 1, name: a}
+                  Variable: {subprogram: 95, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14807,11 +14945,11 @@ Types:
             Type: 14 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 1, name: a}
+                  Variable: {subprogram: 95, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1518
+      ID: 1519
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -14823,7 +14961,7 @@ Types:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: xs}
+                  Variable: {subprogram: 136, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -14833,7 +14971,7 @@ Types:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: xs}
+                  Variable: {subprogram: 136, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -14843,7 +14981,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 1, name: a}
+                  Variable: {subprogram: 136, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14853,11 +14991,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 1, name: a}
+                  Variable: {subprogram: 136, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1520
+      ID: 1521
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 67
       PresenceBitsetSize: 1
@@ -14869,7 +15007,7 @@ Types:
             Type: 20 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: a}
+                  Variable: {subprogram: 138, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: a
@@ -14879,7 +15017,7 @@ Types:
             Type: 20 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: a}
+                  Variable: {subprogram: 138, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
@@ -14889,7 +15027,7 @@ Types:
             Type: 270 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 1, name: s}
+                  Variable: {subprogram: 138, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: s
@@ -14899,7 +15037,7 @@ Types:
             Type: 270 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 1, name: s}
+                  Variable: {subprogram: 138, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -14909,7 +15047,7 @@ Types:
             Type: 14 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 2, name: x}
+                  Variable: {subprogram: 138, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -14919,11 +15057,11 @@ Types:
             Type: 14 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 2, name: x}
+                  Variable: {subprogram: 138, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1521
+      ID: 1522
       Name: Probe[main.testNilSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -14935,7 +15073,7 @@ Types:
             Type: 271 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -14945,11 +15083,11 @@ Types:
             Type: 271 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1534
+      ID: 1535
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14961,7 +15099,7 @@ Types:
             Type: 276 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14971,11 +15109,11 @@ Types:
             Type: 276 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1429
+      ID: 1430
       Name: Probe[main.testPointerLoop]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14987,7 +15125,7 @@ Types:
             Type: 253 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: a}
+                  Variable: {subprogram: 91, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14997,11 +15135,11 @@ Types:
             Type: 253 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: a}
+                  Variable: {subprogram: 91, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1403
+      ID: 1404
       Name: Probe[main.testPointerToMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15013,7 +15151,7 @@ Types:
             Type: 198 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: m}
+                  Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -15023,11 +15161,11 @@ Types:
             Type: 198 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: m}
+                  Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1427
+      ID: 1428
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15039,7 +15177,7 @@ Types:
             Type: 250 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: a}
+                  Variable: {subprogram: 89, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -15049,11 +15187,11 @@ Types:
             Type: 250 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: a}
+                  Variable: {subprogram: 89, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1443
+      ID: 1444
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 35
       PresenceBitsetSize: 1
@@ -15065,7 +15203,7 @@ Types:
             Type: 163 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: v}
+                  Variable: {subprogram: 101, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: v
@@ -15075,7 +15213,7 @@ Types:
             Type: 163 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: v}
+                  Variable: {subprogram: 101, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: failed
@@ -15085,7 +15223,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 1, name: failed}
+                  Variable: {subprogram: 101, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
         - Name: failed
@@ -15095,11 +15233,11 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 1, name: failed}
+                  Variable: {subprogram: 101, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1444
+      ID: 1445
       Name: Probe[main.testReturnsAnyAndError]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15111,7 +15249,7 @@ Types:
             Type: 163 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 2, name: ~r0}
+                  Variable: {subprogram: 101, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
         - Name: ~r1
@@ -15121,11 +15259,11 @@ Types:
             Type: 15 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 3, name: ~r1}
+                  Variable: {subprogram: 101, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1445
+      ID: 1446
       Name: Probe[main.testReturnsAny]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15137,7 +15275,7 @@ Types:
             Type: 163 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: v}
+                  Variable: {subprogram: 102, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: v
@@ -15147,11 +15285,11 @@ Types:
             Type: 163 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: v}
+                  Variable: {subprogram: 102, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1446
+      ID: 1447
       Name: Probe[main.testReturnsAny]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15163,14 +15301,14 @@ Types:
             Type: 163 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 1, name: ~r0}
+                  Variable: {subprogram: 102, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1475
+      ID: 1476
       Name: Probe[main.testReturnsArrayOne]
     - __kind: EventRootType
-      ID: 1476
+      ID: 1477
       Name: Probe[main.testReturnsArrayOne]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15182,14 +15320,14 @@ Types:
             Type: 258 ArrayType [1]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 0, name: ~r0}
+                  Variable: {subprogram: 112, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1477
+      ID: 1478
       Name: Probe[main.testReturnsArrayZero]
     - __kind: EventRootType
-      ID: 1478
+      ID: 1479
       Name: Probe[main.testReturnsArrayZero]Return
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -15201,14 +15339,14 @@ Types:
             Type: 259 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 0, name: ~r0}
+                  Variable: {subprogram: 113, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1473
+      ID: 1474
       Name: Probe[main.testReturnsArray]
     - __kind: EventRootType
-      ID: 1474
+      ID: 1475
       Name: Probe[main.testReturnsArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15220,14 +15358,14 @@ Types:
             Type: 257 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 0, name: ~r0}
+                  Variable: {subprogram: 111, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1481
+      ID: 1482
       Name: Probe[main.testReturnsBacktrackInt]
     - __kind: EventRootType
-      ID: 1482
+      ID: 1483
       Name: Probe[main.testReturnsBacktrackInt]Return
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -15239,7 +15377,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: ~r0}
+                  Variable: {subprogram: 115, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15249,7 +15387,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 1, name: ~r1}
+                  Variable: {subprogram: 115, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15259,7 +15397,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 2, name: ~r2}
+                  Variable: {subprogram: 115, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -15269,7 +15407,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 3, name: ~r3}
+                  Variable: {subprogram: 115, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15279,7 +15417,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 4, name: ~r4}
+                  Variable: {subprogram: 115, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r5
@@ -15289,7 +15427,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 5, name: ~r5}
+                  Variable: {subprogram: 115, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r6
@@ -15299,7 +15437,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 6, name: ~r6}
+                  Variable: {subprogram: 115, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r7
@@ -15309,7 +15447,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 7, name: ~r7}
+                  Variable: {subprogram: 115, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r8
@@ -15319,14 +15457,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 8, name: ~r8}
+                  Variable: {subprogram: 115, index: 8, name: ~r8}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1493
+      ID: 1494
       Name: Probe[main.testReturnsBoolAndUintptr]
     - __kind: EventRootType
-      ID: 1494
+      ID: 1495
       Name: Probe[main.testReturnsBoolAndUintptr]Return
       ByteSize: 10
       PresenceBitsetSize: 1
@@ -15338,7 +15476,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: ~r0}
+                  Variable: {subprogram: 121, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r1
@@ -15348,14 +15486,14 @@ Types:
             Type: 1 BaseType uintptr
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 1, name: ~r1}
+                  Variable: {subprogram: 121, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1469
+      ID: 1470
       Name: Probe[main.testReturnsComplex]
     - __kind: EventRootType
-      ID: 1470
+      ID: 1471
       Name: Probe[main.testReturnsComplex]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15367,7 +15505,7 @@ Types:
             Type: 102 BaseType complex64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: ~r0}
+                  Variable: {subprogram: 109, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15377,11 +15515,11 @@ Types:
             Type: 18 BaseType complex128
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: ~r1}
+                  Variable: {subprogram: 109, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1441
+      ID: 1442
       Name: Probe[main.testReturnsError]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -15393,7 +15531,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: failed}
+                  Variable: {subprogram: 100, index: 0, name: failed}
                   Offset: 0
                   ByteSize: 1
         - Name: failed
@@ -15403,11 +15541,11 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: failed}
+                  Variable: {subprogram: 100, index: 0, name: failed}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1442
+      ID: 1443
       Name: Probe[main.testReturnsError]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15419,11 +15557,11 @@ Types:
             Type: 15 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 1, name: ~r0}
+                  Variable: {subprogram: 100, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1439
+      ID: 1440
       Name: Probe[main.testReturnsIntAndFloat]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15435,7 +15573,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: i}
+                  Variable: {subprogram: 99, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -15445,11 +15583,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: i}
+                  Variable: {subprogram: 99, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1440
+      ID: 1441
       Name: Probe[main.testReturnsIntAndFloat]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15461,7 +15599,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 1, name: ~r0}
+                  Variable: {subprogram: 99, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15471,11 +15609,11 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 2, name: ~r1}
+                  Variable: {subprogram: 99, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1437
+      ID: 1438
       Name: Probe[main.testReturnsIntPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15487,7 +15625,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: i}
+                  Variable: {subprogram: 98, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -15497,11 +15635,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: i}
+                  Variable: {subprogram: 98, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1438
+      ID: 1439
       Name: Probe[main.testReturnsIntPointer]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15513,11 +15651,11 @@ Types:
             Type: 104 PointerType *int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 1, name: ~r0}
+                  Variable: {subprogram: 98, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1435
+      ID: 1436
       Name: Probe[main.testReturnsInt]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15529,7 +15667,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: i}
+                  Variable: {subprogram: 97, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -15539,11 +15677,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: i}
+                  Variable: {subprogram: 97, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1436
+      ID: 1437
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15555,11 +15693,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 1, name: ~r0}
+                  Variable: {subprogram: 97, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1447
+      ID: 1448
       Name: Probe[main.testReturnsInterface]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15571,7 +15709,7 @@ Types:
             Type: 163 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: v}
+                  Variable: {subprogram: 103, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: v
@@ -15581,11 +15719,11 @@ Types:
             Type: 163 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: v}
+                  Variable: {subprogram: 103, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1448
+      ID: 1449
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15597,14 +15735,14 @@ Types:
             Type: 168 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: ~r0}
+                  Variable: {subprogram: 103, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1471
+      ID: 1472
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1472
+      ID: 1473
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -15616,14 +15754,14 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: ~r0}
+                  Variable: {subprogram: 110, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1467
+      ID: 1468
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1468
+      ID: 1469
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 139
       PresenceBitsetSize: 3
@@ -15635,7 +15773,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: ~r0}
+                  Variable: {subprogram: 108, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15645,7 +15783,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 1, name: ~r1}
+                  Variable: {subprogram: 108, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15655,7 +15793,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 2, name: ~r2}
+                  Variable: {subprogram: 108, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -15665,7 +15803,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 3, name: ~r3}
+                  Variable: {subprogram: 108, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15675,7 +15813,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 4, name: ~r4}
+                  Variable: {subprogram: 108, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r5
@@ -15685,7 +15823,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 5, name: ~r5}
+                  Variable: {subprogram: 108, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r6
@@ -15695,7 +15833,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 6, name: ~r6}
+                  Variable: {subprogram: 108, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r7
@@ -15705,7 +15843,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 7, name: ~r7}
+                  Variable: {subprogram: 108, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r8
@@ -15715,7 +15853,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 8, name: ~r8}
+                  Variable: {subprogram: 108, index: 8, name: ~r8}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r9
@@ -15725,7 +15863,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 9, name: ~r9}
+                  Variable: {subprogram: 108, index: 9, name: ~r9}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r10
@@ -15735,7 +15873,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 10, name: ~r10}
+                  Variable: {subprogram: 108, index: 10, name: ~r10}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r11
@@ -15745,7 +15883,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 11, name: ~r11}
+                  Variable: {subprogram: 108, index: 11, name: ~r11}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r12
@@ -15755,7 +15893,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 12, name: ~r12}
+                  Variable: {subprogram: 108, index: 12, name: ~r12}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r13
@@ -15765,7 +15903,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 13, name: ~r13}
+                  Variable: {subprogram: 108, index: 13, name: ~r13}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r14
@@ -15775,7 +15913,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 14, name: ~r14}
+                  Variable: {subprogram: 108, index: 14, name: ~r14}
                   Offset: 0
                   ByteSize: 8
         - Name: onlyOnAmd64_16
@@ -15785,7 +15923,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 15, name: onlyOnAmd64_16}
+                  Variable: {subprogram: 108, index: 15, name: onlyOnAmd64_16}
                   Offset: 0
                   ByteSize: 8
         - Name: bothArmAndAmd64
@@ -15795,14 +15933,14 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 16, name: bothArmAndAmd64}
+                  Variable: {subprogram: 108, index: 16, name: bothArmAndAmd64}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1479
+      ID: 1480
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1480
+      ID: 1481
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15814,14 +15952,14 @@ Types:
             Type: 260 StructureType main.mixedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: ~r0}
+                  Variable: {subprogram: 114, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1485
+      ID: 1486
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1486
+      ID: 1487
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -15833,7 +15971,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 0, name: ~r0}
+                  Variable: {subprogram: 117, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15843,7 +15981,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 1, name: ~r1}
+                  Variable: {subprogram: 117, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15853,7 +15991,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 2, name: ~r2}
+                  Variable: {subprogram: 117, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -15863,7 +16001,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 3, name: ~r3}
+                  Variable: {subprogram: 117, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15873,14 +16011,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 4, name: ~r4}
+                  Variable: {subprogram: 117, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1491
+      ID: 1492
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1492
+      ID: 1493
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -15892,7 +16030,7 @@ Types:
             Type: 17 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: ~r0}
+                  Variable: {subprogram: 120, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r1
@@ -15902,14 +16040,14 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 1, name: ~r1}
+                  Variable: {subprogram: 120, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1489
+      ID: 1490
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1490
+      ID: 1491
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15921,14 +16059,14 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 0, name: ~r0}
+                  Variable: {subprogram: 119, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1465
+      ID: 1466
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1466
+      ID: 1467
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -15940,7 +16078,7 @@ Types:
             Type: 20 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 0, name: ~r0}
+                  Variable: {subprogram: 107, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r1
@@ -15950,7 +16088,7 @@ Types:
             Type: 109 BaseType int16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 1, name: ~r1}
+                  Variable: {subprogram: 107, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 2
         - Name: ~r2
@@ -15960,7 +16098,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 2, name: ~r2}
+                  Variable: {subprogram: 107, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r3
@@ -15970,7 +16108,7 @@ Types:
             Type: 12 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 3, name: ~r3}
+                  Variable: {subprogram: 107, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15980,7 +16118,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 4, name: ~r4}
+                  Variable: {subprogram: 107, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r5
@@ -15990,7 +16128,7 @@ Types:
             Type: 6 BaseType uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 5, name: ~r5}
+                  Variable: {subprogram: 107, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 2
         - Name: ~r6
@@ -16000,7 +16138,7 @@ Types:
             Type: 2 BaseType uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 6, name: ~r6}
+                  Variable: {subprogram: 107, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r7
@@ -16010,14 +16148,14 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 7, name: ~r7}
+                  Variable: {subprogram: 107, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1487
+      ID: 1488
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1488
+      ID: 1489
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16029,14 +16167,14 @@ Types:
             Type: 262 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 0, name: ~r0}
+                  Variable: {subprogram: 118, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1483
+      ID: 1484
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1484
+      ID: 1485
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -16048,7 +16186,7 @@ Types:
             Type: 261 StructureType main.wideStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 0, name: ~r0}
+                  Variable: {subprogram: 116, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 88
     - __kind: EventRootType
@@ -16358,7 +16496,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1528
+      ID: 1529
       Name: Probe[main.testSingleString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16370,7 +16508,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: x}
+                  Variable: {subprogram: 144, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -16380,7 +16518,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: x}
+                  Variable: {subprogram: 144, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -16514,7 +16652,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1524
+      ID: 1525
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16526,7 +16664,7 @@ Types:
             Type: 272 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: xs}
+                  Variable: {subprogram: 141, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -16536,11 +16674,11 @@ Types:
             Type: 272 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: xs}
+                  Variable: {subprogram: 141, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1515
+      ID: 1516
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16552,7 +16690,7 @@ Types:
             Type: 264 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: u}
+                  Variable: {subprogram: 133, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -16562,11 +16700,11 @@ Types:
             Type: 264 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: u}
+                  Variable: {subprogram: 133, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1401
+      ID: 1402
       Name: Probe[main.testSmallMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16578,7 +16716,7 @@ Types:
             Type: 182 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -16588,11 +16726,11 @@ Types:
             Type: 182 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1463
+      ID: 1464
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16604,7 +16742,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: i}
+                  Variable: {subprogram: 106, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -16614,11 +16752,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: i}
+                  Variable: {subprogram: 106, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1464
+      ID: 1465
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16630,7 +16768,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 1, name: ~r0}
+                  Variable: {subprogram: 106, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -16640,7 +16778,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 2, name: result2}
+                  Variable: {subprogram: 106, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -16650,11 +16788,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 3, name: ~r2}
+                  Variable: {subprogram: 106, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1505
+      ID: 1506
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -16666,7 +16804,7 @@ Types:
             Type: 167 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: arg}
+                  Variable: {subprogram: 127, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
         - Name: arg
@@ -16676,11 +16814,11 @@ Types:
             Type: 167 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: arg}
+                  Variable: {subprogram: 127, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1506
+      ID: 1507
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16692,7 +16830,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: ~r0}
+                  Variable: {subprogram: 127, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -16702,7 +16840,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: ~r1}
+                  Variable: {subprogram: 127, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -16712,7 +16850,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 3, name: ~r2}
+                  Variable: {subprogram: 127, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -16742,7 +16880,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1432
+      ID: 1433
       Name: Probe[main.testStringPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16754,7 +16892,7 @@ Types:
             Type: 101 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: z}
+                  Variable: {subprogram: 94, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: z
@@ -16764,11 +16902,11 @@ Types:
             Type: 101 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: z}
+                  Variable: {subprogram: 94, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1519
+      ID: 1520
       Name: Probe[main.testStringSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16780,7 +16918,7 @@ Types:
             Type: 269 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: s}
+                  Variable: {subprogram: 137, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: s
@@ -16790,11 +16928,11 @@ Types:
             Type: 269 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: s}
+                  Variable: {subprogram: 137, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1367
+      ID: 1368
       Name: Probe[main.testStringType1]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16806,7 +16944,7 @@ Types:
             Type: 157 PointerType *main.stringType1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 0, name: a}
+                  Variable: {subprogram: 45, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -16816,11 +16954,11 @@ Types:
             Type: 157 PointerType *main.stringType1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 0, name: a}
+                  Variable: {subprogram: 45, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1368
+      ID: 1369
       Name: Probe[main.testStringType2]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16832,7 +16970,7 @@ Types:
             Type: 159 PointerType **main.stringType2
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: a}
+                  Variable: {subprogram: 46, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -16842,11 +16980,11 @@ Types:
             Type: 159 PointerType **main.stringType2
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: a}
+                  Variable: {subprogram: 46, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1516
+      ID: 1517
       Name: Probe[main.testStructSlice]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -16858,7 +16996,7 @@ Types:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Variable: {subprogram: 134, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -16868,7 +17006,7 @@ Types:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Variable: {subprogram: 134, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -16878,7 +17016,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 1, name: a}
+                  Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -16888,11 +17026,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 1, name: a}
+                  Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1395
+      ID: 1396
       Name: Probe[main.testStructWithAny]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16904,7 +17042,7 @@ Types:
             Type: 170 StructureType main.structWithAny
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: s}
+                  Variable: {subprogram: 60, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
         - Name: s
@@ -16914,11 +17052,11 @@ Types:
             Type: 170 StructureType main.structWithAny
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: s}
+                  Variable: {subprogram: 60, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1509
+      ID: 1510
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16930,7 +17068,7 @@ Types:
             Type: 262 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: arg}
+                  Variable: {subprogram: 129, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
         - Name: arg
@@ -16940,11 +17078,11 @@ Types:
             Type: 262 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: arg}
+                  Variable: {subprogram: 129, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1510
+      ID: 1511
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16956,7 +17094,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 1, name: ~r0}
+                  Variable: {subprogram: 129, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -16966,11 +17104,11 @@ Types:
             Type: 262 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 2, name: ~r1}
+                  Variable: {subprogram: 129, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1541
+      ID: 1542
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16982,7 +17120,7 @@ Types:
             Type: 291 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: a}
+                  Variable: {subprogram: 154, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
         - Name: a
@@ -16992,11 +17130,11 @@ Types:
             Type: 291 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: a}
+                  Variable: {subprogram: 154, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1540
+      ID: 1541
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 289
       PresenceBitsetSize: 1
@@ -17008,7 +17146,7 @@ Types:
             Type: 278 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: a}
+                  Variable: {subprogram: 153, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
         - Name: a
@@ -17018,11 +17156,11 @@ Types:
             Type: 278 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: a}
+                  Variable: {subprogram: 153, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
     - __kind: EventRootType
-      ID: 1396
+      ID: 1397
       Name: Probe[main.testStructWithMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17034,7 +17172,7 @@ Types:
             Type: 171 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: s}
+                  Variable: {subprogram: 61, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
         - Name: s
@@ -17044,11 +17182,11 @@ Types:
             Type: 171 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: s}
+                  Variable: {subprogram: 61, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1542
+      ID: 1543
       Name: Probe[main.testStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17060,11 +17198,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 8
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1543
+      ID: 1544
       Name: Probe[main.testStruct]
       ByteSize: 113
       PresenceBitsetSize: 1
@@ -17076,7 +17214,7 @@ Types:
             Type: 322 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
         - Name: x
@@ -17086,11 +17224,11 @@ Types:
             Type: 322 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1525
+      ID: 1526
       Name: Probe[main.testSubslices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -17102,7 +17240,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: as}
+                  Variable: {subprogram: 142, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
         - Name: as
@@ -17112,7 +17250,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: as}
+                  Variable: {subprogram: 142, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
         - Name: bs
@@ -17122,7 +17260,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 1, name: bs}
+                  Variable: {subprogram: 142, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
         - Name: bs
@@ -17132,7 +17270,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 1, name: bs}
+                  Variable: {subprogram: 142, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
         - Name: cs
@@ -17142,7 +17280,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 2, name: cs}
+                  Variable: {subprogram: 142, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
         - Name: cs
@@ -17152,11 +17290,11 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 2, name: cs}
+                  Variable: {subprogram: 142, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1539
+      ID: 1540
       Name: Probe[main.testSubstrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17168,7 +17306,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: a}
+                  Variable: {subprogram: 152, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -17178,7 +17316,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: a}
+                  Variable: {subprogram: 152, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -17188,7 +17326,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 1, name: b}
+                  Variable: {subprogram: 152, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -17198,7 +17336,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 1, name: b}
+                  Variable: {subprogram: 152, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: c
@@ -17208,7 +17346,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 2, name: c}
+                  Variable: {subprogram: 152, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
         - Name: c
@@ -17218,11 +17356,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 2, name: c}
+                  Variable: {subprogram: 152, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1532
+      ID: 1533
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17234,7 +17372,7 @@ Types:
             Type: 275 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -17244,11 +17382,11 @@ Types:
             Type: 275 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1533
+      ID: 1534
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17260,7 +17398,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -17273,7 +17411,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -17286,14 +17424,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
                   Bias: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1530
+      ID: 1531
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17305,7 +17443,7 @@ Types:
             Type: 274 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
         - Name: a
@@ -17315,11 +17453,11 @@ Types:
             Type: 274 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1531
+      ID: 1532
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17331,7 +17469,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: t.b
@@ -17341,7 +17479,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 16
                   ByteSize: 16
         - Name: t.c
@@ -17351,11 +17489,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1529
+      ID: 1530
       Name: Probe[main.testThreeStrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17367,7 +17505,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: x}
+                  Variable: {subprogram: 145, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -17377,7 +17515,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: x}
+                  Variable: {subprogram: 145, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -17387,7 +17525,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 1, name: y}
+                  Variable: {subprogram: 145, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -17397,7 +17535,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 1, name: y}
+                  Variable: {subprogram: 145, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -17407,7 +17545,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 2, name: z}
+                  Variable: {subprogram: 145, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -17417,7 +17555,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 2, name: z}
+                  Variable: {subprogram: 145, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -17577,7 +17715,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1431
+      ID: 1432
       Name: Probe[main.testUintPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17589,7 +17727,7 @@ Types:
             Type: 112 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: x}
+                  Variable: {subprogram: 93, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -17599,11 +17737,11 @@ Types:
             Type: 112 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: x}
+                  Variable: {subprogram: 93, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1513
+      ID: 1514
       Name: Probe[main.testUintSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17615,7 +17753,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: u}
+                  Variable: {subprogram: 131, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -17625,11 +17763,11 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: u}
+                  Variable: {subprogram: 131, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1537
+      ID: 1538
       Name: Probe[main.testUnitializedString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17641,7 +17779,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: x}
+                  Variable: {subprogram: 150, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -17651,11 +17789,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: x}
+                  Variable: {subprogram: 150, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1430
+      ID: 1431
       Name: Probe[main.testUnsafePointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17667,7 +17805,7 @@ Types:
             Type: 16 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: x}
+                  Variable: {subprogram: 92, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -17677,7 +17815,7 @@ Types:
             Type: 16 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: x}
+                  Variable: {subprogram: 92, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -17707,32 +17845,6 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1522
-      Name: Probe[main.testVeryLargeSlice]
-      ByteSize: 49
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: xs
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 263 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: xs
-          Offset: 25
-          Kind: template_segment
-          Expression:
-            Type: 263 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
       ID: 1523
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
@@ -17745,7 +17857,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: xs}
+                  Variable: {subprogram: 140, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -17755,11 +17867,37 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: xs}
+                  Variable: {subprogram: 140, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1511
+      ID: 1524
+      Name: Probe[main.testVeryLargeSlice]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 263 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 140, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: xs
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 263 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 140, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1512
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17771,7 +17909,7 @@ Types:
             Type: 259 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: a}
+                  Variable: {subprogram: 130, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
         - Name: a
@@ -17781,7 +17919,7 @@ Types:
             Type: 259 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: a}
+                  Variable: {subprogram: 130, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
         - Name: b
@@ -17791,7 +17929,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 1, name: b}
+                  Variable: {subprogram: 130, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -17801,11 +17939,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 1, name: b}
+                  Variable: {subprogram: 130, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1512
+      ID: 1513
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -17817,7 +17955,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 2, name: ~r0}
+                  Variable: {subprogram: 130, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -17827,7 +17965,7 @@ Types:
             Type: 259 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 3, name: ~r1}
+                  Variable: {subprogram: 130, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 0
     - __kind: ArrayType
@@ -26489,7 +26627,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 1.004e+06
       GoKind: 5
-MaxTypeID: 1565
+MaxTypeID: 1566
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x1853d00", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -8,15 +8,15 @@ Probes:
       template: stackC
       segments: [stackC]
       captureSnapshot: true
-      subprogram: {subprogram: 142}
+      subprogram: {subprogram: 143}
       events:
         - Kind: Entry
-          Type: 1332 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0x892908", Frameless: false}]
+          Type: 1333 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0x892a38", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1333 EventRootType Probe[main.stackC]Return
-          InjectionPoints: [{PC: "0x89293c", Frameless: false}]
+          Type: 1334 EventRootType Probe[main.stackC]Return
+          InjectionPoints: [{PC: "0x892a6c", Frameless: false}]
           Condition: null
       probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -27,15 +27,15 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 56}
+      subprogram: {subprogram: 57}
       events:
         - Kind: Entry
-          Type: 1196 EventRootType Probe[main.testAny]
-          InjectionPoints: [{PC: "0x88dd68", Frameless: false}]
+          Type: 1197 EventRootType Probe[main.testAny]
+          InjectionPoints: [{PC: "0x88de98", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1197 EventRootType Probe[main.testAny]Return
-          InjectionPoints: [{PC: "0x88dd94", Frameless: false}]
+          Type: 1198 EventRootType Probe[main.testAny]Return
+          InjectionPoints: [{PC: "0x88dec4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -52,15 +52,15 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 58}
+      subprogram: {subprogram: 59}
       events:
         - Kind: Entry
-          Type: 1199 EventRootType Probe[main.testAnyPtr]
-          InjectionPoints: [{PC: "0x88dde8", Frameless: false}]
+          Type: 1200 EventRootType Probe[main.testAnyPtr]
+          InjectionPoints: [{PC: "0x88df18", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1200 EventRootType Probe[main.testAnyPtr]Return
-          InjectionPoints: [{PC: "0x88de14", Frameless: false}]
+          Type: 1201 EventRootType Probe[main.testAnyPtr]Return
+          InjectionPoints: [{PC: "0x88df44", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -76,15 +76,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 122}
+      subprogram: {subprogram: 123}
       events:
         - Kind: Entry
-          Type: 1303 EventRootType Probe[main.testArrayArgAndReturn]
-          InjectionPoints: [{PC: "0x89166c", Frameless: false}]
+          Type: 1304 EventRootType Probe[main.testArrayArgAndReturn]
+          InjectionPoints: [{PC: "0x89179c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1304 EventRootType Probe[main.testArrayArgAndReturn]Return
-          InjectionPoints: [{PC: "0x891704", Frameless: false}]
+          Type: 1305 EventRootType Probe[main.testArrayArgAndReturn]Return
+          InjectionPoints: [{PC: "0x891834", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -164,11 +164,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 66}
+      subprogram: {subprogram: 67}
       events:
         - Kind: Entry
-          Type: 1208 EventRootType Probe[main.testArrayOfMaps]
-          InjectionPoints: [{PC: "0x88e450", Frameless: true}]
+          Type: 1209 EventRootType Probe[main.testArrayOfMaps]
+          InjectionPoints: [{PC: "0x88e580", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -226,15 +226,15 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 87}
       events:
         - Kind: Entry
-          Type: 1230 EventRootType Probe[main.testAtomicAdd]
-          InjectionPoints: [{PC: "0x88fb40", Frameless: true}]
+          Type: 1231 EventRootType Probe[main.testAtomicAdd]
+          InjectionPoints: [{PC: "0x88fc70", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1231 EventRootType Probe[main.testAtomicAdd]Return
-          InjectionPoints: [{PC: "0x88fb7c", Frameless: true}]
+          Type: 1232 EventRootType Probe[main.testAtomicAdd]Return
+          InjectionPoints: [{PC: "0x88fcac", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -323,15 +323,15 @@ Probes:
           expr:
             dsl: x.aString
             json: {getmember: [{ref: x}, aString]}
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1351 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0x892c60", Frameless: true}]
+          Type: 1352 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0x892d90", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1352 EventRootType Probe[main.testStruct]Return
-          InjectionPoints: [{PC: "0x892c7c", Frameless: true}]
+          Type: 1353 EventRootType Probe[main.testStruct]Return
+          InjectionPoints: [{PC: "0x892dac", Frameless: true}]
           Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -345,20 +345,20 @@ Probes:
       segments: []
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1361 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1362 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
-            - PC: "0x88d608"
+            - PC: "0x88d738"
               Frameless: false
-            - PC: "0x88d67c"
+            - PC: "0x88d7ac"
               Frameless: false
-            - PC: "0x88d7c8"
+            - PC: "0x88d8f8"
               Frameless: false
-            - PC: "0x88d844"
+            - PC: "0x88d974"
               Frameless: false
-            - PC: "0x88d90c"
+            - PC: "0x88da3c"
               Frameless: false
           Condition: null
     - id: testCaptureExprLineWithTemplate
@@ -373,20 +373,20 @@ Probes:
       segments: [x=, {json: {ref: x}, dsl: x}]
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1362 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1363 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
-            - PC: "0x88d608"
+            - PC: "0x88d738"
               Frameless: false
-            - PC: "0x88d67c"
+            - PC: "0x88d7ac"
               Frameless: false
-            - PC: "0x88d7c8"
+            - PC: "0x88d8f8"
               Frameless: false
-            - PC: "0x88d844"
+            - PC: "0x88d974"
               Frameless: false
-            - PC: "0x88d90c"
+            - PC: "0x88da3c"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -409,11 +409,11 @@ Probes:
           expr: {dsl: x, json: {ref: x}}
         - name: w_val
           expr: {dsl: w, json: {ref: w}}
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 85}
       events:
         - Kind: Entry
-          Type: 1227 EventRootType Probe[main.testCombinedString]
-          InjectionPoints: [{PC: "0x88f8e0", Frameless: true}]
+          Type: 1228 EventRootType Probe[main.testCombinedString]
+          InjectionPoints: [{PC: "0x88fa10", Frameless: true}]
           Condition: null
     - id: testCaptureExprWithTemplate
       version: 0
@@ -427,11 +427,11 @@ Probes:
           expr: {dsl: x, json: {ref: x}}
         - name: w_val
           expr: {dsl: w, json: {ref: w}}
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 85}
       events:
         - Kind: Entry
-          Type: 1228 EventRootType Probe[main.testCombinedString]
-          InjectionPoints: [{PC: "0x88f8e0", Frameless: true}]
+          Type: 1229 EventRootType Probe[main.testCombinedString]
+          InjectionPoints: [{PC: "0x88fa10", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: x={x}
@@ -449,11 +449,11 @@ Probes:
       template: '{c}'
       segments: [{json: {ref: c}, dsl: c}]
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 88}
       events:
         - Kind: Entry
-          Type: 1232 EventRootType Probe[main.testChannel]
-          InjectionPoints: [{PC: "0x88fb80", Frameless: true}]
+          Type: 1233 EventRootType Probe[main.testChannel]
+          InjectionPoints: [{PC: "0x88fcb0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{c}'
@@ -478,11 +478,11 @@ Probes:
         - json: {ref: y}
           dsl: y
       captureSnapshot: true
-      subprogram: {subprogram: 83}
+      subprogram: {subprogram: 84}
       events:
         - Kind: Entry
-          Type: 1226 EventRootType Probe[main.testCombinedByte]
-          InjectionPoints: [{PC: "0x88f8c0", Frameless: true}]
+          Type: 1227 EventRootType Probe[main.testCombinedByte]
+          InjectionPoints: [{PC: "0x88f9f0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{w}, {x}, {y}'
@@ -509,11 +509,11 @@ Probes:
       template: '{t}'
       segments: [{json: {ref: t}, dsl: t}]
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 96}
       events:
         - Kind: Entry
-          Type: 1240 EventRootType Probe[main.testCycle]
-          InjectionPoints: [{PC: "0x88fe30", Frameless: true}]
+          Type: 1241 EventRootType Probe[main.testCycle]
+          InjectionPoints: [{PC: "0x88ff60", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{t}'
@@ -530,11 +530,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 42}
+      subprogram: {subprogram: 43}
       events:
         - Kind: Entry
-          Type: 1171 EventRootType Probe[main.testDeepMap1]
-          InjectionPoints: [{PC: "0x88cca0", Frameless: true}]
+          Type: 1172 EventRootType Probe[main.testDeepMap1]
+          InjectionPoints: [{PC: "0x88cdc0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -551,11 +551,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 43}
+      subprogram: {subprogram: 44}
       events:
         - Kind: Entry
-          Type: 1172 EventRootType Probe[main.testDeepMap7]
-          InjectionPoints: [{PC: "0x88ccb0", Frameless: true}]
+          Type: 1173 EventRootType Probe[main.testDeepMap7]
+          InjectionPoints: [{PC: "0x88cdd0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -572,11 +572,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 38}
+      subprogram: {subprogram: 39}
       events:
         - Kind: Entry
-          Type: 1167 EventRootType Probe[main.testDeepPtr1]
-          InjectionPoints: [{PC: "0x88c990", Frameless: true}]
+          Type: 1168 EventRootType Probe[main.testDeepPtr1]
+          InjectionPoints: [{PC: "0x88cab0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -593,11 +593,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 39}
+      subprogram: {subprogram: 40}
       events:
         - Kind: Entry
-          Type: 1168 EventRootType Probe[main.testDeepPtr7]
-          InjectionPoints: [{PC: "0x88c9a0", Frameless: true}]
+          Type: 1169 EventRootType Probe[main.testDeepPtr7]
+          InjectionPoints: [{PC: "0x88cac0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -614,11 +614,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 40}
+      subprogram: {subprogram: 41}
       events:
         - Kind: Entry
-          Type: 1169 EventRootType Probe[main.testDeepSlice1]
-          InjectionPoints: [{PC: "0x88cb40", Frameless: true}]
+          Type: 1170 EventRootType Probe[main.testDeepSlice1]
+          InjectionPoints: [{PC: "0x88cc60", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -635,11 +635,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 41}
+      subprogram: {subprogram: 42}
       events:
         - Kind: Entry
-          Type: 1170 EventRootType Probe[main.testDeepSlice7]
-          InjectionPoints: [{PC: "0x88cb50", Frameless: true}]
+          Type: 1171 EventRootType Probe[main.testDeepSlice7]
+          InjectionPoints: [{PC: "0x88cc70", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -656,11 +656,11 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 131}
+      subprogram: {subprogram: 132}
       events:
         - Kind: Entry
-          Type: 1320 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0x892530", Frameless: true}]
+          Type: 1321 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0x892660", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{u}'
@@ -682,11 +682,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 134}
+      subprogram: {subprogram: 135}
       events:
         - Kind: Entry
-          Type: 1323 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0x892560", Frameless: true}]
+          Type: 1324 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0x892690", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}, {a}'
@@ -709,11 +709,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 150}
+      subprogram: {subprogram: 151}
       events:
         - Kind: Entry
-          Type: 1346 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0x8929e0", Frameless: true}]
+          Type: 1347 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0x892b10", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -730,11 +730,11 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 156}
+      subprogram: {subprogram: 157}
       events:
         - Kind: Entry
-          Type: 1359 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0x892d60", Frameless: true}]
+          Type: 1360 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0x892e90", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -750,11 +750,11 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 157}
+      subprogram: {subprogram: 158}
       events:
         - Kind: Entry
-          Type: 1360 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0x892d70", Frameless: true}]
+          Type: 1361 EventRootType Probe[main.testEmptyStructPointer]
+          InjectionPoints: [{PC: "0x892ea0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -771,11 +771,11 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 57}
+      subprogram: {subprogram: 58}
       events:
         - Kind: Entry
-          Type: 1198 EventRootType Probe[main.testError]
-          InjectionPoints: [{PC: "0x88ddc0", Frameless: true}]
+          Type: 1199 EventRootType Probe[main.testError]
+          InjectionPoints: [{PC: "0x88def0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -784,6 +784,45 @@ Probes:
               DSL: e
               EventKind: Entry
               EventExpressionIndex: 1
+    - id: testErrorAtLine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testErrorAtLine
+        sourceFile: complex.go
+        lines: ["108"]
+      tags:
+        - config_diff:arch=amd64,toolchain=go1.26rc1
+        - skip_integration:arch=arm64,toolchain=go1.25.0
+      sampling: {snapshotsPerSecond: 100}
+      template: x={x}, err={err}
+      segments:
+        - x=
+        - json: {ref: x}
+          dsl: x
+        - ', err='
+        - json: {ref: err}
+          dsl: err
+      captureSnapshot: true
+      subprogram: {subprogram: 38}
+      events:
+        - Kind: Line
+          Type: 1167 EventRootType Probe[main.testErrorAtLine]Line
+          InjectionPoints: [{PC: "0x88c94c", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: x={x}, err={err}
+        Segments:
+            - x=
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Line
+              EventExpressionIndex: 2
+            - ', err='
+            - JSON: {Ref: err}
+              DSL: err
+              EventKind: Line
+              EventExpressionIndex: 4
     - id: testEsotericHeap
       version: 0
       type: LOG_PROBE
@@ -792,15 +831,15 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 48}
+      subprogram: {subprogram: 49}
       events:
         - Kind: Entry
-          Type: 1180 EventRootType Probe[main.testEsotericHeap]
-          InjectionPoints: [{PC: "0x88d368", Frameless: false}]
+          Type: 1181 EventRootType Probe[main.testEsotericHeap]
+          InjectionPoints: [{PC: "0x88d498", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1181 EventRootType Probe[main.testEsotericHeap]Return
-          InjectionPoints: [{PC: "0x88d3a4", Frameless: false}]
+          Type: 1182 EventRootType Probe[main.testEsotericHeap]Return
+          InjectionPoints: [{PC: "0x88d4d4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -817,15 +856,15 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 47}
+      subprogram: {subprogram: 48}
       events:
         - Kind: Entry
-          Type: 1178 EventRootType Probe[main.testEsotericStack]
-          InjectionPoints: [{PC: "0x88d27c", Frameless: false}]
+          Type: 1179 EventRootType Probe[main.testEsotericStack]
+          InjectionPoints: [{PC: "0x88d3ac", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1179 EventRootType Probe[main.testEsotericStack]Return
-          InjectionPoints: [{PC: "0x88d2ec", Frameless: false}]
+          Type: 1180 EventRootType Probe[main.testEsotericStack]Return
+          InjectionPoints: [{PC: "0x88d41c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -842,15 +881,15 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 53}
+      subprogram: {subprogram: 54}
       events:
         - Kind: Entry
-          Type: 1190 EventRootType Probe[main.testFrameless]
-          InjectionPoints: [{PC: "0x88da90", Frameless: true}]
+          Type: 1191 EventRootType Probe[main.testFrameless]
+          InjectionPoints: [{PC: "0x88dbc0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1191 EventRootType Probe[main.testFrameless]Return
-          InjectionPoints: [{PC: "0x88da98", Frameless: true}]
+          Type: 1192 EventRootType Probe[main.testFrameless]Return
+          InjectionPoints: [{PC: "0x88dbc8", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -867,15 +906,15 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 54}
+      subprogram: {subprogram: 55}
       events:
         - Kind: Entry
-          Type: 1192 EventRootType Probe[main.testFramelessArray]
-          InjectionPoints: [{PC: "0x88daac", Frameless: false}]
+          Type: 1193 EventRootType Probe[main.testFramelessArray]
+          InjectionPoints: [{PC: "0x88dbdc", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1193 EventRootType Probe[main.testFramelessArray]Return
-          InjectionPoints: [{PC: "0x88dae8", Frameless: false}]
+          Type: 1194 EventRootType Probe[main.testFramelessArray]Return
+          InjectionPoints: [{PC: "0x88dc18", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -895,11 +934,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 54}
+      subprogram: {subprogram: 55}
       events:
         - Kind: Line
-          Type: 1194 EventRootType Probe[main.testFramelessArray]Line
-          InjectionPoints: [{PC: "0x88daac", Frameless: false}]
+          Type: 1195 EventRootType Probe[main.testFramelessArray]Line
+          InjectionPoints: [{PC: "0x88dbdc", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -916,15 +955,15 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 49}
+      subprogram: {subprogram: 50}
       events:
         - Kind: Entry
-          Type: 1182 EventRootType Probe[main.testInlinedBA]
-          InjectionPoints: [{PC: "0x88d7a8", Frameless: false}]
+          Type: 1183 EventRootType Probe[main.testInlinedBA]
+          InjectionPoints: [{PC: "0x88d8d8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1183 EventRootType Probe[main.testInlinedBA]Return
-          InjectionPoints: [{PC: "0x88d800", Frameless: false}]
+          Type: 1184 EventRootType Probe[main.testInlinedBA]Return
+          InjectionPoints: [{PC: "0x88d930", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -946,15 +985,15 @@ Probes:
         - json: {ref: y}
           dsl: y
       captureSnapshot: true
-      subprogram: {subprogram: 50}
+      subprogram: {subprogram: 51}
       events:
         - Kind: Entry
-          Type: 1184 EventRootType Probe[main.testInlinedBB]
-          InjectionPoints: [{PC: "0x88d838", Frameless: false}]
+          Type: 1185 EventRootType Probe[main.testInlinedBB]
+          InjectionPoints: [{PC: "0x88d968", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1185 EventRootType Probe[main.testInlinedBB]Return
-          InjectionPoints: [{PC: "0x88d8c0", Frameless: false}]
+          Type: 1186 EventRootType Probe[main.testInlinedBB]Return
+          InjectionPoints: [{PC: "0x88d9f0", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}, {y}'
@@ -976,15 +1015,15 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 51}
+      subprogram: {subprogram: 52}
       events:
         - Kind: Entry
-          Type: 1186 EventRootType Probe[main.testInlinedBBA]
-          InjectionPoints: [{PC: "0x88d908", Frameless: false}]
+          Type: 1187 EventRootType Probe[main.testInlinedBBA]
+          InjectionPoints: [{PC: "0x88da38", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1187 EventRootType Probe[main.testInlinedBBA]Return
-          InjectionPoints: [{PC: "0x88d944", Frameless: false}]
+          Type: 1188 EventRootType Probe[main.testInlinedBBA]Return
+          InjectionPoints: [{PC: "0x88da74", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1001,11 +1040,11 @@ Probes:
       template: testInlinedBBB
       segments: [testInlinedBBB]
       captureSnapshot: true
-      subprogram: {subprogram: 159}
+      subprogram: {subprogram: 160}
       events:
         - Kind: Entry
-          Type: 1366 EventRootType Probe[main.testInlinedBBB]
-          InjectionPoints: [{PC: "0x88d888", Frameless: false}]
+          Type: 1367 EventRootType Probe[main.testInlinedBBB]
+          InjectionPoints: [{PC: "0x88d9b8", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBBB
@@ -1018,15 +1057,15 @@ Probes:
       template: testInlinedBC
       segments: [testInlinedBC]
       captureSnapshot: true
-      subprogram: {subprogram: 52}
+      subprogram: {subprogram: 53}
       events:
         - Kind: Entry
-          Type: 1188 EventRootType Probe[main.testInlinedBC]
-          InjectionPoints: [{PC: "0x88d988", Frameless: false}]
+          Type: 1189 EventRootType Probe[main.testInlinedBC]
+          InjectionPoints: [{PC: "0x88dab8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1189 EventRootType Probe[main.testInlinedBC]Return
-          InjectionPoints: [{PC: "0x88da78", Frameless: false}]
+          Type: 1190 EventRootType Probe[main.testInlinedBC]Return
+          InjectionPoints: [{PC: "0x88dba8", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBC
@@ -1039,11 +1078,11 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Entry
-          Type: 1367 EventRootType Probe[main.testInlinedBCA]
-          InjectionPoints: [{PC: "0x88d98c", Frameless: false}]
+          Type: 1368 EventRootType Probe[main.testInlinedBCA]
+          InjectionPoints: [{PC: "0x88dabc", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBCA
@@ -1059,11 +1098,11 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Line
-          Type: 1368 EventRootType Probe[main.testInlinedBCA]Line
-          InjectionPoints: [{PC: "0x88d98c", Frameless: false}]
+          Type: 1369 EventRootType Probe[main.testInlinedBCA]Line
+          InjectionPoints: [{PC: "0x88dabc", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBCA
@@ -1076,11 +1115,11 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Entry
-          Type: 1369 EventRootType Probe[main.testInlinedBCB]
-          InjectionPoints: [{PC: "0x88da40", Frameless: false}]
+          Type: 1370 EventRootType Probe[main.testInlinedBCB]
+          InjectionPoints: [{PC: "0x88db70", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBCB
@@ -1096,11 +1135,11 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Line
-          Type: 1370 EventRootType Probe[main.testInlinedBCB]Line
-          InjectionPoints: [{PC: "0x88da40", Frameless: false}]
+          Type: 1371 EventRootType Probe[main.testInlinedBCB]Line
+          InjectionPoints: [{PC: "0x88db70", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBCB
@@ -1113,14 +1152,14 @@ Probes:
       template: testInlinedFuncFromOtherPackage
       segments: [testInlinedFuncFromOtherPackage]
       captureSnapshot: true
-      subprogram: {subprogram: 165}
+      subprogram: {subprogram: 166}
       events:
         - Kind: Entry
-          Type: 1376 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
+          Type: 1377 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
           InjectionPoints:
             - PC: "0x88bd84"
               Frameless: true
-            - PC: "0x88e328"
+            - PC: "0x88e458"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -1135,25 +1174,25 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Entry
-          Type: 1363 EventRootType Probe[main.testInlinedPrint]
+          Type: 1364 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
-            - PC: "0x88d608"
+            - PC: "0x88d738"
               Frameless: false
-            - PC: "0x88d67c"
+            - PC: "0x88d7ac"
               Frameless: false
-            - PC: "0x88d7c8"
+            - PC: "0x88d8f8"
               Frameless: false
-            - PC: "0x88d844"
+            - PC: "0x88d974"
               Frameless: false
-            - PC: "0x88d90c"
+            - PC: "0x88da3c"
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1364 EventRootType Probe[main.testInlinedPrint]Return
-          InjectionPoints: [{PC: "0x88d640", Frameless: false}]
+          Type: 1365 EventRootType Probe[main.testInlinedPrint]Return
+          InjectionPoints: [{PC: "0x88d770", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1173,20 +1212,20 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1365 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1366 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
-            - PC: "0x88d608"
+            - PC: "0x88d738"
               Frameless: false
-            - PC: "0x88d67c"
+            - PC: "0x88d7ac"
               Frameless: false
-            - PC: "0x88d7c8"
+            - PC: "0x88d8f8"
               Frameless: false
-            - PC: "0x88d844"
+            - PC: "0x88d974"
               Frameless: false
-            - PC: "0x88d90c"
+            - PC: "0x88da3c"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -1204,11 +1243,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 162}
+      subprogram: {subprogram: 163}
       events:
         - Kind: Entry
-          Type: 1371 EventRootType Probe[main.testInlinedSq]
-          InjectionPoints: [{PC: "0x88da94", Frameless: true}]
+          Type: 1372 EventRootType Probe[main.testInlinedSq]
+          InjectionPoints: [{PC: "0x88dbc4", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1228,11 +1267,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 162}
+      subprogram: {subprogram: 163}
       events:
         - Kind: Line
-          Type: 1372 EventRootType Probe[main.testInlinedSq]Line
-          InjectionPoints: [{PC: "0x88da94", Frameless: true}]
+          Type: 1373 EventRootType Probe[main.testInlinedSq]Line
+          InjectionPoints: [{PC: "0x88dbc4", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1250,14 +1289,14 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 163}
+      subprogram: {subprogram: 164}
       events:
         - Kind: Entry
-          Type: 1373 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1374 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
-            - PC: "0x88dac4"
+            - PC: "0x88dbf4"
               Frameless: false
-            - PC: "0x88db5c"
+            - PC: "0x88dc8c"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -1380,11 +1419,11 @@ Probes:
       template: '{b}'
       segments: [{json: {ref: b}, dsl: b}]
       captureSnapshot: true
-      subprogram: {subprogram: 55}
+      subprogram: {subprogram: 56}
       events:
         - Kind: Entry
-          Type: 1195 EventRootType Probe[main.testInterface]
-          InjectionPoints: [{PC: "0x88dd40", Frameless: true}]
+          Type: 1196 EventRootType Probe[main.testInterface]
+          InjectionPoints: [{PC: "0x88de70", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{b}'
@@ -1400,15 +1439,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 121}
+      subprogram: {subprogram: 122}
       events:
         - Kind: Entry
-          Type: 1301 EventRootType Probe[main.testLargeArgAndReturn]
-          InjectionPoints: [{PC: "0x891490", Frameless: false}]
+          Type: 1302 EventRootType Probe[main.testLargeArgAndReturn]
+          InjectionPoints: [{PC: "0x8915c0", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1302 EventRootType Probe[main.testLargeArgAndReturn]Return
-          InjectionPoints: [{PC: "0x8915e8", Frameless: false}]
+          Type: 1303 EventRootType Probe[main.testLargeArgAndReturn]Return
+          InjectionPoints: [{PC: "0x891718", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -1425,11 +1464,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 90}
       events:
         - Kind: Entry
-          Type: 1234 EventRootType Probe[main.testLinkedList]
-          InjectionPoints: [{PC: "0x88fd40", Frameless: true}]
+          Type: 1235 EventRootType Probe[main.testLinkedList]
+          InjectionPoints: [{PC: "0x88fe70", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -1444,16 +1483,16 @@ Probes:
       where:
         methodName: main.testLongFunctionWithChangingState
         sourceFile: complex.go
-        lines: ["211"]
+        lines: ["230"]
       sampling: {snapshotsPerSecond: 100}
       template: testLongFunctionWithChangingState
       segments: [testLongFunctionWithChangingState]
       captureSnapshot: true
-      subprogram: {subprogram: 46}
+      subprogram: {subprogram: 47}
       events:
         - Kind: Line
-          Type: 1175 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-          InjectionPoints: [{PC: "0x88ccfc", Frameless: false}]
+          Type: 1176 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          InjectionPoints: [{PC: "0x88ce1c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testLongFunctionWithChangingState
@@ -1464,17 +1503,17 @@ Probes:
       where:
         methodName: main.testLongFunctionWithChangingState
         sourceFile: complex.go
-        lines: ["218"]
+        lines: ["237"]
       tags: ['version_diff:go1.26rc1']
       sampling: {snapshotsPerSecond: 100}
       template: testLongFunctionWithChangingState
       segments: [testLongFunctionWithChangingState]
       captureSnapshot: true
-      subprogram: {subprogram: 46}
+      subprogram: {subprogram: 47}
       events:
         - Kind: Line
-          Type: 1176 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-          InjectionPoints: [{PC: "0x88cd90", Frameless: false}]
+          Type: 1177 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          InjectionPoints: [{PC: "0x88ceb0", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testLongFunctionWithChangingState
@@ -1485,17 +1524,17 @@ Probes:
       where:
         methodName: main.testLongFunctionWithChangingState
         sourceFile: complex.go
-        lines: ["223"]
+        lines: ["242"]
       tags: ['version_diff:go1.26rc1']
       sampling: {snapshotsPerSecond: 100}
       template: testLongFunctionWithChangingState
       segments: [testLongFunctionWithChangingState]
       captureSnapshot: true
-      subprogram: {subprogram: 46}
+      subprogram: {subprogram: 47}
       events:
         - Kind: Line
-          Type: 1177 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-          InjectionPoints: [{PC: "0x88ce3c", Frameless: false}]
+          Type: 1178 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          InjectionPoints: [{PC: "0x88cf5c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testLongFunctionWithChangingState
@@ -1533,15 +1572,15 @@ Probes:
         - json: {ref: i}
           dsl: i
       captureSnapshot: true
-      subprogram: {subprogram: 124}
+      subprogram: {subprogram: 125}
       events:
         - Kind: Entry
-          Type: 1307 EventRootType Probe[main.testManyArgsArrayReturn]
-          InjectionPoints: [{PC: "0x89199c", Frameless: false}]
+          Type: 1308 EventRootType Probe[main.testManyArgsArrayReturn]
+          InjectionPoints: [{PC: "0x891acc", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1308 EventRootType Probe[main.testManyArgsArrayReturn]Return
-          InjectionPoints: [{PC: "0x891b0c", Frameless: false}]
+          Type: 1309 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          InjectionPoints: [{PC: "0x891c3c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -1598,11 +1637,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 64}
+      subprogram: {subprogram: 65}
       events:
         - Kind: Entry
-          Type: 1206 EventRootType Probe[main.testMapArrayToArray]
-          InjectionPoints: [{PC: "0x88e430", Frameless: true}]
+          Type: 1207 EventRootType Probe[main.testMapArrayToArray]
+          InjectionPoints: [{PC: "0x88e560", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1619,11 +1658,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 70}
+      subprogram: {subprogram: 71}
       events:
         - Kind: Entry
-          Type: 1213 EventRootType Probe[main.testMapEmbeddedMaps]
-          InjectionPoints: [{PC: "0x88e490", Frameless: true}]
+          Type: 1214 EventRootType Probe[main.testMapEmbeddedMaps]
+          InjectionPoints: [{PC: "0x88e5c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1640,11 +1679,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 80}
+      subprogram: {subprogram: 81}
       events:
         - Kind: Entry
-          Type: 1223 EventRootType Probe[main.testMapEmptyKey]
-          InjectionPoints: [{PC: "0x88e530", Frameless: true}]
+          Type: 1224 EventRootType Probe[main.testMapEmptyKey]
+          InjectionPoints: [{PC: "0x88e660", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1661,11 +1700,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 82}
+      subprogram: {subprogram: 83}
       events:
         - Kind: Entry
-          Type: 1225 EventRootType Probe[main.testMapEmptyKeyAndValue]
-          InjectionPoints: [{PC: "0x88e550", Frameless: true}]
+          Type: 1226 EventRootType Probe[main.testMapEmptyKeyAndValue]
+          InjectionPoints: [{PC: "0x88e680", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1682,11 +1721,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 81}
+      subprogram: {subprogram: 82}
       events:
         - Kind: Entry
-          Type: 1224 EventRootType Probe[main.testMapEmptyValue]
-          InjectionPoints: [{PC: "0x88e540", Frameless: true}]
+          Type: 1225 EventRootType Probe[main.testMapEmptyValue]
+          InjectionPoints: [{PC: "0x88e670", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1703,11 +1742,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 68}
+      subprogram: {subprogram: 69}
       events:
         - Kind: Entry
-          Type: 1210 EventRootType Probe[main.testMapIntToInt]
-          InjectionPoints: [{PC: "0x88e470", Frameless: true}]
+          Type: 1211 EventRootType Probe[main.testMapIntToInt]
+          InjectionPoints: [{PC: "0x88e5a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1724,11 +1763,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 79}
+      subprogram: {subprogram: 80}
       events:
         - Kind: Entry
-          Type: 1222 EventRootType Probe[main.testMapLargeKeyLargeValue]
-          InjectionPoints: [{PC: "0x88e520", Frameless: true}]
+          Type: 1223 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          InjectionPoints: [{PC: "0x88e650", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1745,11 +1784,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 78}
+      subprogram: {subprogram: 79}
       events:
         - Kind: Entry
-          Type: 1221 EventRootType Probe[main.testMapLargeKeySmallValue]
-          InjectionPoints: [{PC: "0x88e510", Frameless: true}]
+          Type: 1222 EventRootType Probe[main.testMapLargeKeySmallValue]
+          InjectionPoints: [{PC: "0x88e640", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1768,11 +1807,11 @@ Probes:
         - json: {ref: redactMyEntries}
           dsl: redactMyEntries
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 70}
       events:
         - Kind: Entry
-          Type: 1211 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0x88e480", Frameless: true}]
+          Type: 1212 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0x88e5b0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{redactMyEntries}'
@@ -1791,11 +1830,11 @@ Probes:
         - json: {ref: redactMyEntries}
           dsl: redactMyEntries
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 70}
       events:
         - Kind: Entry
-          Type: 1212 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0x88e480", Frameless: true}]
+          Type: 1213 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0x88e5b0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{redactMyEntries}'
@@ -1812,11 +1851,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 77}
+      subprogram: {subprogram: 78}
       events:
         - Kind: Entry
-          Type: 1220 EventRootType Probe[main.testMapSmallKeyLargeValue]
-          InjectionPoints: [{PC: "0x88e500", Frameless: true}]
+          Type: 1221 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          InjectionPoints: [{PC: "0x88e630", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1833,11 +1872,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 76}
+      subprogram: {subprogram: 77}
       events:
         - Kind: Entry
-          Type: 1219 EventRootType Probe[main.testMapSmallKeySmallValue]
-          InjectionPoints: [{PC: "0x88e4f0", Frameless: true}]
+          Type: 1220 EventRootType Probe[main.testMapSmallKeySmallValue]
+          InjectionPoints: [{PC: "0x88e620", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1854,11 +1893,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 62}
+      subprogram: {subprogram: 63}
       events:
         - Kind: Entry
-          Type: 1204 EventRootType Probe[main.testMapStringToInt]
-          InjectionPoints: [{PC: "0x88e410", Frameless: true}]
+          Type: 1205 EventRootType Probe[main.testMapStringToInt]
+          InjectionPoints: [{PC: "0x88e540", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1875,11 +1914,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 63}
+      subprogram: {subprogram: 64}
       events:
         - Kind: Entry
-          Type: 1205 EventRootType Probe[main.testMapStringToSlice]
-          InjectionPoints: [{PC: "0x88e420", Frameless: true}]
+          Type: 1206 EventRootType Probe[main.testMapStringToSlice]
+          InjectionPoints: [{PC: "0x88e550", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1896,11 +1935,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 61}
+      subprogram: {subprogram: 62}
       events:
         - Kind: Entry
-          Type: 1203 EventRootType Probe[main.testMapStringToStruct]
-          InjectionPoints: [{PC: "0x88e400", Frameless: true}]
+          Type: 1204 EventRootType Probe[main.testMapStringToStruct]
+          InjectionPoints: [{PC: "0x88e530", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1917,11 +1956,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 71}
+      subprogram: {subprogram: 72}
       events:
         - Kind: Entry
-          Type: 1214 EventRootType Probe[main.testMapWithLinkedList]
-          InjectionPoints: [{PC: "0x88e4a0", Frameless: true}]
+          Type: 1215 EventRootType Probe[main.testMapWithLinkedList]
+          InjectionPoints: [{PC: "0x88e5d0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1938,11 +1977,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 74}
+      subprogram: {subprogram: 75}
       events:
         - Kind: Entry
-          Type: 1217 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-          InjectionPoints: [{PC: "0x88e4d0", Frameless: true}]
+          Type: 1218 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          InjectionPoints: [{PC: "0x88e600", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1959,11 +1998,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 75}
+      subprogram: {subprogram: 76}
       events:
         - Kind: Entry
-          Type: 1218 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-          InjectionPoints: [{PC: "0x88e4e0", Frameless: true}]
+          Type: 1219 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          InjectionPoints: [{PC: "0x88e610", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1980,11 +2019,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 72}
+      subprogram: {subprogram: 73}
       events:
         - Kind: Entry
-          Type: 1215 EventRootType Probe[main.testMapWithSmallValue]
-          InjectionPoints: [{PC: "0x88e4b0", Frameless: true}]
+          Type: 1216 EventRootType Probe[main.testMapWithSmallValue]
+          InjectionPoints: [{PC: "0x88e5e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -2003,11 +2042,11 @@ Probes:
         - json: {ref: redactMyEntries}
           dsl: redactMyEntries
       captureSnapshot: true
-      subprogram: {subprogram: 73}
+      subprogram: {subprogram: 74}
       events:
         - Kind: Entry
-          Type: 1216 EventRootType Probe[main.testMapWithSmallValueMassive]
-          InjectionPoints: [{PC: "0x88e4c0", Frameless: true}]
+          Type: 1217 EventRootType Probe[main.testMapWithSmallValueMassive]
+          InjectionPoints: [{PC: "0x88e5f0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{redactMyEntries}'
@@ -2024,11 +2063,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 148}
+      subprogram: {subprogram: 149}
       events:
         - Kind: Entry
-          Type: 1343 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0x8929c0", Frameless: true}]
+          Type: 1344 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0x892af0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -2046,11 +2085,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 148}
+      subprogram: {subprogram: 149}
       events:
         - Kind: Entry
-          Type: 1344 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0x8929c0", Frameless: true}]
+          Type: 1345 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0x892af0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -2092,15 +2131,15 @@ Probes:
         - json: {ref: s}
           dsl: s
       captureSnapshot: true
-      subprogram: {subprogram: 125}
+      subprogram: {subprogram: 126}
       events:
         - Kind: Entry
-          Type: 1309 EventRootType Probe[main.testMixedArgsStackReturn]
-          InjectionPoints: [{PC: "0x891b90", Frameless: false}]
+          Type: 1310 EventRootType Probe[main.testMixedArgsStackReturn]
+          InjectionPoints: [{PC: "0x891cc0", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1310 EventRootType Probe[main.testMixedArgsStackReturn]Return
-          InjectionPoints: [{PC: "0x891d40", Frameless: false}]
+          Type: 1311 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          InjectionPoints: [{PC: "0x891e70", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -2161,15 +2200,15 @@ Probes:
         - json: {ref: b}
           dsl: b
       captureSnapshot: true
-      subprogram: {subprogram: 127}
+      subprogram: {subprogram: 128}
       events:
         - Kind: Entry
-          Type: 1313 EventRootType Probe[main.testMultipleArrayArgs]
-          InjectionPoints: [{PC: "0x891e6c", Frameless: false}]
+          Type: 1314 EventRootType Probe[main.testMultipleArrayArgs]
+          InjectionPoints: [{PC: "0x891f9c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1314 EventRootType Probe[main.testMultipleArrayArgs]Return
-          InjectionPoints: [{PC: "0x891f10", Frameless: false}]
+          Type: 1315 EventRootType Probe[main.testMultipleArrayArgs]Return
+          InjectionPoints: [{PC: "0x892040", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}'
@@ -2195,15 +2234,15 @@ Probes:
         - json: {ref: s2}
           dsl: s2
       captureSnapshot: true
-      subprogram: {subprogram: 123}
+      subprogram: {subprogram: 124}
       events:
         - Kind: Entry
-          Type: 1305 EventRootType Probe[main.testMultipleLargeArgs]
-          InjectionPoints: [{PC: "0x891740", Frameless: false}]
+          Type: 1306 EventRootType Probe[main.testMultipleLargeArgs]
+          InjectionPoints: [{PC: "0x891870", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1306 EventRootType Probe[main.testMultipleLargeArgs]Return
-          InjectionPoints: [{PC: "0x891910", Frameless: false}]
+          Type: 1307 EventRootType Probe[main.testMultipleLargeArgs]Return
+          InjectionPoints: [{PC: "0x891a40", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{s1}, {s2}'
@@ -2224,15 +2263,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1259 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0x890a58", Frameless: false}]
+          Type: 1260 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x890b88", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1260 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0x890ae4", Frameless: false}]
+          Type: 1261 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x890c14", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2263,11 +2302,11 @@ Probes:
         - json: {ref: e}
           dsl: e
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 86}
       events:
         - Kind: Entry
-          Type: 1229 EventRootType Probe[main.testMultipleSimpleParams]
-          InjectionPoints: [{PC: "0x88f9a0", Frameless: true}]
+          Type: 1230 EventRootType Probe[main.testMultipleSimpleParams]
+          InjectionPoints: [{PC: "0x88fad0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}, {d}, {e}'
@@ -2303,15 +2342,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1255 EventRootType Probe[main.testNamedReturn]
-          InjectionPoints: [{PC: "0x8909b8", Frameless: false}]
+          Type: 1256 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0x890ae8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1256 EventRootType Probe[main.testNamedReturn]Return
-          InjectionPoints: [{PC: "0x890a18", Frameless: false}]
+          Type: 1257 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0x890b48", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2333,15 +2372,15 @@ Probes:
         - json: {ref: result}
           dsl: result
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1257 EventRootType Probe[main.testNamedReturn]
-          InjectionPoints: [{PC: "0x8909b8", Frameless: false}]
+          Type: 1258 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0x890ae8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1258 EventRootType Probe[main.testNamedReturn]Return
-          InjectionPoints: [{PC: "0x890a18", Frameless: false}]
+          Type: 1259 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0x890b48", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: Parameter {i} * 2 = result {result}
@@ -2364,11 +2403,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 155}
+      subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1355 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0x892d00", Frameless: true}]
+          Type: 1356 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0x892e30", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -2388,11 +2427,11 @@ Probes:
             getmember: [{getmember: [{ref: x}, nested]}, anotherString]
           dsl: x.nested.anotherString
       captureSnapshot: false
-      subprogram: {subprogram: 155}
+      subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1356 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0x892d00", Frameless: true}]
+          Type: 1357 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0x892e30", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x.nested.anotherString}'
@@ -2418,11 +2457,11 @@ Probes:
         - json: {getmember: [{ref: x}, notAMember]}
           dsl: x.notAMember
       captureSnapshot: false
-      subprogram: {subprogram: 155}
+      subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1357 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0x892d00", Frameless: true}]
+          Type: 1358 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0x892e30", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -2442,11 +2481,11 @@ Probes:
         - json: {getmember: [{ref: x}, nested]}
           dsl: x.nested
       captureSnapshot: false
-      subprogram: {subprogram: 155}
+      subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1358 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0x892d00", Frameless: true}]
+          Type: 1359 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0x892e30", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x.nested}'
@@ -2468,11 +2507,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 95}
       events:
         - Kind: Entry
-          Type: 1239 EventRootType Probe[main.testNilPointer]
-          InjectionPoints: [{PC: "0x88fe10", Frameless: true}]
+          Type: 1240 EventRootType Probe[main.testNilPointer]
+          InjectionPoints: [{PC: "0x88ff40", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{z}, {a}'
@@ -2494,11 +2533,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 138}
+      subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1327 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0x8925a0", Frameless: true}]
+          Type: 1328 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0x8926d0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -2520,11 +2559,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 135}
+      subprogram: {subprogram: 136}
       events:
         - Kind: Entry
-          Type: 1324 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0x892570", Frameless: true}]
+          Type: 1325 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0x8926a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}, {a}'
@@ -2554,11 +2593,11 @@ Probes:
         - json: {ref: x}
           dsl: x
       captureSnapshot: true
-      subprogram: {subprogram: 137}
+      subprogram: {subprogram: 138}
       events:
         - Kind: Entry
-          Type: 1326 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0x892590", Frameless: true}]
+          Type: 1327 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0x8926c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {s}, {x}'
@@ -2585,11 +2624,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 147}
+      subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1342 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0x8929b0", Frameless: true}]
+          Type: 1343 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0x892ae0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -2606,11 +2645,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 91}
       events:
         - Kind: Entry
-          Type: 1235 EventRootType Probe[main.testPointerLoop]
-          InjectionPoints: [{PC: "0x88fd50", Frameless: true}]
+          Type: 1236 EventRootType Probe[main.testPointerLoop]
+          InjectionPoints: [{PC: "0x88fe80", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -2627,11 +2666,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 67}
+      subprogram: {subprogram: 68}
       events:
         - Kind: Entry
-          Type: 1209 EventRootType Probe[main.testPointerToMap]
-          InjectionPoints: [{PC: "0x88e460", Frameless: true}]
+          Type: 1210 EventRootType Probe[main.testPointerToMap]
+          InjectionPoints: [{PC: "0x88e590", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -2648,11 +2687,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 89}
       events:
         - Kind: Entry
-          Type: 1233 EventRootType Probe[main.testPointerToSimpleStruct]
-          InjectionPoints: [{PC: "0x88fd30", Frameless: true}]
+          Type: 1234 EventRootType Probe[main.testPointerToSimpleStruct]
+          InjectionPoints: [{PC: "0x88fe60", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -2669,22 +2708,22 @@ Probes:
       template: '{v}'
       segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
         - Kind: Entry
-          Type: 1251 EventRootType Probe[main.testReturnsAny]
-          InjectionPoints: [{PC: "0x890648", Frameless: false}]
+          Type: 1252 EventRootType Probe[main.testReturnsAny]
+          InjectionPoints: [{PC: "0x890778", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1252 EventRootType Probe[main.testReturnsAny]Return
+          Type: 1253 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints:
-            - PC: "0x8906e8"
+            - PC: "0x890818"
               Frameless: false
-            - PC: "0x890730"
+            - PC: "0x890860"
               Frameless: false
-            - PC: "0x8907f4"
+            - PC: "0x890924"
               Frameless: false
-            - PC: "0x890808"
+            - PC: "0x890938"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2707,22 +2746,22 @@ Probes:
         - json: {ref: failed}
           dsl: failed
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 101}
       events:
         - Kind: Entry
-          Type: 1249 EventRootType Probe[main.testReturnsAnyAndError]
-          InjectionPoints: [{PC: "0x8904c8", Frameless: false}]
+          Type: 1250 EventRootType Probe[main.testReturnsAnyAndError]
+          InjectionPoints: [{PC: "0x8905f8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1250 EventRootType Probe[main.testReturnsAnyAndError]Return
+          Type: 1251 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
-            - PC: "0x890534"
+            - PC: "0x890664"
               Frameless: false
-            - PC: "0x890580"
+            - PC: "0x8906b0"
               Frameless: false
-            - PC: "0x8905c0"
+            - PC: "0x8906f0"
               Frameless: false
-            - PC: "0x890600"
+            - PC: "0x890730"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2744,15 +2783,15 @@ Probes:
       template: testReturnsArray
       segments: [testReturnsArray]
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 111}
       events:
         - Kind: Entry
-          Type: 1279 EventRootType Probe[main.testReturnsArray]
-          InjectionPoints: [{PC: "0x890e9c", Frameless: false}]
+          Type: 1280 EventRootType Probe[main.testReturnsArray]
+          InjectionPoints: [{PC: "0x890fcc", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1280 EventRootType Probe[main.testReturnsArray]Return
-          InjectionPoints: [{PC: "0x890ef0", Frameless: false}]
+          Type: 1281 EventRootType Probe[main.testReturnsArray]Return
+          InjectionPoints: [{PC: "0x891020", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsArray
@@ -2764,15 +2803,15 @@ Probes:
       template: testReturnsArrayOne
       segments: [testReturnsArrayOne]
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 112}
       events:
         - Kind: Entry
-          Type: 1281 EventRootType Probe[main.testReturnsArrayOne]
-          InjectionPoints: [{PC: "0x890f28", Frameless: false}]
+          Type: 1282 EventRootType Probe[main.testReturnsArrayOne]
+          InjectionPoints: [{PC: "0x891058", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1282 EventRootType Probe[main.testReturnsArrayOne]Return
-          InjectionPoints: [{PC: "0x890f64", Frameless: false}]
+          Type: 1283 EventRootType Probe[main.testReturnsArrayOne]Return
+          InjectionPoints: [{PC: "0x891094", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsArrayOne
@@ -2784,15 +2823,15 @@ Probes:
       template: testReturnsArrayZero
       segments: [testReturnsArrayZero]
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 113}
       events:
         - Kind: Entry
-          Type: 1283 EventRootType Probe[main.testReturnsArrayZero]
-          InjectionPoints: [{PC: "0x890f98", Frameless: false}]
+          Type: 1284 EventRootType Probe[main.testReturnsArrayZero]
+          InjectionPoints: [{PC: "0x8910c8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1284 EventRootType Probe[main.testReturnsArrayZero]Return
-          InjectionPoints: [{PC: "0x890fd0", Frameless: false}]
+          Type: 1285 EventRootType Probe[main.testReturnsArrayZero]Return
+          InjectionPoints: [{PC: "0x891100", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsArrayZero
@@ -2804,15 +2843,15 @@ Probes:
       template: testReturnsBacktrackInt
       segments: [testReturnsBacktrackInt]
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 115}
       events:
         - Kind: Entry
-          Type: 1287 EventRootType Probe[main.testReturnsBacktrackInt]
-          InjectionPoints: [{PC: "0x891088", Frameless: false}]
+          Type: 1288 EventRootType Probe[main.testReturnsBacktrackInt]
+          InjectionPoints: [{PC: "0x8911b8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1288 EventRootType Probe[main.testReturnsBacktrackInt]Return
-          InjectionPoints: [{PC: "0x8910ec", Frameless: false}]
+          Type: 1289 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          InjectionPoints: [{PC: "0x89121c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsBacktrackInt
@@ -2824,15 +2863,15 @@ Probes:
       template: testReturnsBoolAndUintptr
       segments: [testReturnsBoolAndUintptr]
       captureSnapshot: true
-      subprogram: {subprogram: 120}
+      subprogram: {subprogram: 121}
       events:
         - Kind: Entry
-          Type: 1299 EventRootType Probe[main.testReturnsBoolAndUintptr]
-          InjectionPoints: [{PC: "0x891418", Frameless: false}]
+          Type: 1300 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          InjectionPoints: [{PC: "0x891548", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1300 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-          InjectionPoints: [{PC: "0x891458", Frameless: false}]
+          Type: 1301 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          InjectionPoints: [{PC: "0x891588", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsBoolAndUintptr
@@ -2844,15 +2883,15 @@ Probes:
       template: testReturnsComplex
       segments: [testReturnsComplex]
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 109}
       events:
         - Kind: Entry
-          Type: 1275 EventRootType Probe[main.testReturnsComplex]
-          InjectionPoints: [{PC: "0x890d48", Frameless: false}]
+          Type: 1276 EventRootType Probe[main.testReturnsComplex]
+          InjectionPoints: [{PC: "0x890e78", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1276 EventRootType Probe[main.testReturnsComplex]Return
-          InjectionPoints: [{PC: "0x890d94", Frameless: false}]
+          Type: 1277 EventRootType Probe[main.testReturnsComplex]Return
+          InjectionPoints: [{PC: "0x890ec4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsComplex
@@ -2865,18 +2904,18 @@ Probes:
       template: '{failed}'
       segments: [{json: {ref: failed}, dsl: failed}]
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 100}
       events:
         - Kind: Entry
-          Type: 1247 EventRootType Probe[main.testReturnsError]
-          InjectionPoints: [{PC: "0x890448", Frameless: false}]
+          Type: 1248 EventRootType Probe[main.testReturnsError]
+          InjectionPoints: [{PC: "0x890578", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1248 EventRootType Probe[main.testReturnsError]Return
+          Type: 1249 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
-            - PC: "0x890478"
+            - PC: "0x8905a8"
               Frameless: false
-            - PC: "0x89048c"
+            - PC: "0x8905bc"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2893,15 +2932,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 97}
       events:
         - Kind: Entry
-          Type: 1241 EventRootType Probe[main.testReturnsInt]
-          InjectionPoints: [{PC: "0x890258", Frameless: false}]
+          Type: 1242 EventRootType Probe[main.testReturnsInt]
+          InjectionPoints: [{PC: "0x890388", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1242 EventRootType Probe[main.testReturnsInt]Return
-          InjectionPoints: [{PC: "0x89029c", Frameless: false}]
+          Type: 1243 EventRootType Probe[main.testReturnsInt]Return
+          InjectionPoints: [{PC: "0x8903cc", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2917,15 +2956,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 99}
       events:
         - Kind: Entry
-          Type: 1245 EventRootType Probe[main.testReturnsIntAndFloat]
-          InjectionPoints: [{PC: "0x890378", Frameless: false}]
+          Type: 1246 EventRootType Probe[main.testReturnsIntAndFloat]
+          InjectionPoints: [{PC: "0x8904a8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1246 EventRootType Probe[main.testReturnsIntAndFloat]Return
-          InjectionPoints: [{PC: "0x890410", Frameless: false}]
+          Type: 1247 EventRootType Probe[main.testReturnsIntAndFloat]Return
+          InjectionPoints: [{PC: "0x890540", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2941,15 +2980,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 98}
       events:
         - Kind: Entry
-          Type: 1243 EventRootType Probe[main.testReturnsIntPointer]
-          InjectionPoints: [{PC: "0x8902d8", Frameless: false}]
+          Type: 1244 EventRootType Probe[main.testReturnsIntPointer]
+          InjectionPoints: [{PC: "0x890408", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1244 EventRootType Probe[main.testReturnsIntPointer]Return
-          InjectionPoints: [{PC: "0x89033c", Frameless: false}]
+          Type: 1245 EventRootType Probe[main.testReturnsIntPointer]Return
+          InjectionPoints: [{PC: "0x89046c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2966,18 +3005,18 @@ Probes:
       template: '{v}'
       segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1253 EventRootType Probe[main.testReturnsInterface]
-          InjectionPoints: [{PC: "0x890848", Frameless: false}]
+          Type: 1254 EventRootType Probe[main.testReturnsInterface]
+          InjectionPoints: [{PC: "0x890978", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1254 EventRootType Probe[main.testReturnsInterface]Return
+          Type: 1255 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
-            - PC: "0x890918"
+            - PC: "0x890a48"
               Frameless: false
-            - PC: "0x89092c"
+            - PC: "0x890a5c"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2994,15 +3033,15 @@ Probes:
       template: testReturnsLargeStruct
       segments: [testReturnsLargeStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 110}
       events:
         - Kind: Entry
-          Type: 1277 EventRootType Probe[main.testReturnsLargeStruct]
-          InjectionPoints: [{PC: "0x890dd0", Frameless: false}]
+          Type: 1278 EventRootType Probe[main.testReturnsLargeStruct]
+          InjectionPoints: [{PC: "0x890f00", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1278 EventRootType Probe[main.testReturnsLargeStruct]Return
-          InjectionPoints: [{PC: "0x890e64", Frameless: false}]
+          Type: 1279 EventRootType Probe[main.testReturnsLargeStruct]Return
+          InjectionPoints: [{PC: "0x890f94", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsLargeStruct
@@ -3014,15 +3053,15 @@ Probes:
       template: testReturnsManyFloats
       segments: [testReturnsManyFloats]
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 108}
       events:
         - Kind: Entry
-          Type: 1273 EventRootType Probe[main.testReturnsManyFloats]
-          InjectionPoints: [{PC: "0x890c88", Frameless: false}]
+          Type: 1274 EventRootType Probe[main.testReturnsManyFloats]
+          InjectionPoints: [{PC: "0x890db8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1274 EventRootType Probe[main.testReturnsManyFloats]Return
-          InjectionPoints: [{PC: "0x890d0c", Frameless: false}]
+          Type: 1275 EventRootType Probe[main.testReturnsManyFloats]Return
+          InjectionPoints: [{PC: "0x890e3c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsManyFloats
@@ -3034,15 +3073,15 @@ Probes:
       template: testReturnsMixed
       segments: [testReturnsMixed]
       captureSnapshot: true
-      subprogram: {subprogram: 116}
+      subprogram: {subprogram: 117}
       events:
         - Kind: Entry
-          Type: 1291 EventRootType Probe[main.testReturnsMixed]
-          InjectionPoints: [{PC: "0x891208", Frameless: false}]
+          Type: 1292 EventRootType Probe[main.testReturnsMixed]
+          InjectionPoints: [{PC: "0x891338", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1292 EventRootType Probe[main.testReturnsMixed]Return
-          InjectionPoints: [{PC: "0x891260", Frameless: false}]
+          Type: 1293 EventRootType Probe[main.testReturnsMixed]Return
+          InjectionPoints: [{PC: "0x891390", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsMixed
@@ -3054,15 +3093,15 @@ Probes:
       template: testReturnsMixedStruct
       segments: [testReturnsMixedStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 114}
       events:
         - Kind: Entry
-          Type: 1285 EventRootType Probe[main.testReturnsMixedStruct]
-          InjectionPoints: [{PC: "0x891008", Frameless: false}]
+          Type: 1286 EventRootType Probe[main.testReturnsMixedStruct]
+          InjectionPoints: [{PC: "0x891138", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1286 EventRootType Probe[main.testReturnsMixedStruct]Return
-          InjectionPoints: [{PC: "0x891050", Frameless: false}]
+          Type: 1287 EventRootType Probe[main.testReturnsMixedStruct]Return
+          InjectionPoints: [{PC: "0x891180", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsMixedStruct
@@ -3074,15 +3113,15 @@ Probes:
       template: testReturnsMultipleFloats
       segments: [testReturnsMultipleFloats]
       captureSnapshot: true
-      subprogram: {subprogram: 119}
+      subprogram: {subprogram: 120}
       events:
         - Kind: Entry
-          Type: 1297 EventRootType Probe[main.testReturnsMultipleFloats]
-          InjectionPoints: [{PC: "0x891398", Frameless: false}]
+          Type: 1298 EventRootType Probe[main.testReturnsMultipleFloats]
+          InjectionPoints: [{PC: "0x8914c8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1298 EventRootType Probe[main.testReturnsMultipleFloats]Return
-          InjectionPoints: [{PC: "0x8913dc", Frameless: false}]
+          Type: 1299 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          InjectionPoints: [{PC: "0x89150c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsMultipleFloats
@@ -3094,15 +3133,15 @@ Probes:
       template: testReturnsOnlyFloat
       segments: [testReturnsOnlyFloat]
       captureSnapshot: true
-      subprogram: {subprogram: 118}
+      subprogram: {subprogram: 119}
       events:
         - Kind: Entry
-          Type: 1295 EventRootType Probe[main.testReturnsOnlyFloat]
-          InjectionPoints: [{PC: "0x891328", Frameless: false}]
+          Type: 1296 EventRootType Probe[main.testReturnsOnlyFloat]
+          InjectionPoints: [{PC: "0x891458", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1296 EventRootType Probe[main.testReturnsOnlyFloat]Return
-          InjectionPoints: [{PC: "0x891368", Frameless: false}]
+          Type: 1297 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          InjectionPoints: [{PC: "0x891498", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsOnlyFloat
@@ -3114,15 +3153,15 @@ Probes:
       template: testReturnsPrimitives
       segments: [testReturnsPrimitives]
       captureSnapshot: true
-      subprogram: {subprogram: 106}
+      subprogram: {subprogram: 107}
       events:
         - Kind: Entry
-          Type: 1271 EventRootType Probe[main.testReturnsPrimitives]
-          InjectionPoints: [{PC: "0x890bf8", Frameless: false}]
+          Type: 1272 EventRootType Probe[main.testReturnsPrimitives]
+          InjectionPoints: [{PC: "0x890d28", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1272 EventRootType Probe[main.testReturnsPrimitives]Return
-          InjectionPoints: [{PC: "0x890c50", Frameless: false}]
+          Type: 1273 EventRootType Probe[main.testReturnsPrimitives]Return
+          InjectionPoints: [{PC: "0x890d80", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsPrimitives
@@ -3134,15 +3173,15 @@ Probes:
       template: testReturnsStructWithArray
       segments: [testReturnsStructWithArray]
       captureSnapshot: true
-      subprogram: {subprogram: 117}
+      subprogram: {subprogram: 118}
       events:
         - Kind: Entry
-          Type: 1293 EventRootType Probe[main.testReturnsStructWithArray]
-          InjectionPoints: [{PC: "0x89129c", Frameless: false}]
+          Type: 1294 EventRootType Probe[main.testReturnsStructWithArray]
+          InjectionPoints: [{PC: "0x8913cc", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1294 EventRootType Probe[main.testReturnsStructWithArray]Return
-          InjectionPoints: [{PC: "0x8912f0", Frameless: false}]
+          Type: 1295 EventRootType Probe[main.testReturnsStructWithArray]Return
+          InjectionPoints: [{PC: "0x891420", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsStructWithArray
@@ -3154,15 +3193,15 @@ Probes:
       template: testReturnsWideStruct
       segments: [testReturnsWideStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 115}
+      subprogram: {subprogram: 116}
       events:
         - Kind: Entry
-          Type: 1289 EventRootType Probe[main.testReturnsWideStruct]
-          InjectionPoints: [{PC: "0x891130", Frameless: false}]
+          Type: 1290 EventRootType Probe[main.testReturnsWideStruct]
+          InjectionPoints: [{PC: "0x891260", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1290 EventRootType Probe[main.testReturnsWideStruct]Return
-          InjectionPoints: [{PC: "0x8911d4", Frameless: false}]
+          Type: 1291 EventRootType Probe[main.testReturnsWideStruct]Return
+          InjectionPoints: [{PC: "0x891304", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsWideStruct
@@ -3209,15 +3248,15 @@ Probes:
         - json: {ref: result}
           dsl: result
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1261 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0x890a58", Frameless: false}]
+          Type: 1262 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x890b88", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1262 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0x890ae4", Frameless: false}]
+          Type: 1263 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x890c14", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -3485,11 +3524,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 143}
+      subprogram: {subprogram: 144}
       events:
         - Kind: Entry
-          Type: 1334 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0x892960", Frameless: true}]
+          Type: 1335 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0x892a90", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -3611,11 +3650,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 140}
+      subprogram: {subprogram: 141}
       events:
         - Kind: Entry
-          Type: 1330 EventRootType Probe[main.testSliceEmptyStructs]
-          InjectionPoints: [{PC: "0x8925c0", Frameless: true}]
+          Type: 1331 EventRootType Probe[main.testSliceEmptyStructs]
+          InjectionPoints: [{PC: "0x8926f0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -3632,11 +3671,11 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 132}
+      subprogram: {subprogram: 133}
       events:
         - Kind: Entry
-          Type: 1321 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0x892540", Frameless: true}]
+          Type: 1322 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0x892670", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{u}'
@@ -3653,11 +3692,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 65}
+      subprogram: {subprogram: 66}
       events:
         - Kind: Entry
-          Type: 1207 EventRootType Probe[main.testSmallMap]
-          InjectionPoints: [{PC: "0x88e440", Frameless: true}]
+          Type: 1208 EventRootType Probe[main.testSmallMap]
+          InjectionPoints: [{PC: "0x88e570", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -3673,15 +3712,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 105}
+      subprogram: {subprogram: 106}
       events:
         - Kind: Entry
-          Type: 1269 EventRootType Probe[main.testSomeNamedReturn]
-          InjectionPoints: [{PC: "0x890b28", Frameless: false}]
+          Type: 1270 EventRootType Probe[main.testSomeNamedReturn]
+          InjectionPoints: [{PC: "0x890c58", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1270 EventRootType Probe[main.testSomeNamedReturn]Return
-          InjectionPoints: [{PC: "0x890bb4", Frameless: false}]
+          Type: 1271 EventRootType Probe[main.testSomeNamedReturn]Return
+          InjectionPoints: [{PC: "0x890ce4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -3697,15 +3736,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 126}
+      subprogram: {subprogram: 127}
       events:
         - Kind: Entry
-          Type: 1311 EventRootType Probe[main.testStackArgRegReturns]
-          InjectionPoints: [{PC: "0x891dc8", Frameless: false}]
+          Type: 1312 EventRootType Probe[main.testStackArgRegReturns]
+          InjectionPoints: [{PC: "0x891ef8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1312 EventRootType Probe[main.testStackArgRegReturns]Return
-          InjectionPoints: [{PC: "0x891e2c", Frameless: false}]
+          Type: 1313 EventRootType Probe[main.testStackArgRegReturns]Return
+          InjectionPoints: [{PC: "0x891f5c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -3743,11 +3782,11 @@ Probes:
       template: '{z}'
       segments: [{json: {ref: z}, dsl: z}]
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 94}
       events:
         - Kind: Entry
-          Type: 1238 EventRootType Probe[main.testStringPointer]
-          InjectionPoints: [{PC: "0x88fdf0", Frameless: true}]
+          Type: 1239 EventRootType Probe[main.testStringPointer]
+          InjectionPoints: [{PC: "0x88ff20", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{z}'
@@ -3764,11 +3803,11 @@ Probes:
       template: '{s}'
       segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
-      subprogram: {subprogram: 136}
+      subprogram: {subprogram: 137}
       events:
         - Kind: Entry
-          Type: 1325 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0x892580", Frameless: true}]
+          Type: 1326 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0x8926b0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{s}'
@@ -3785,11 +3824,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 44}
+      subprogram: {subprogram: 45}
       events:
         - Kind: Entry
-          Type: 1173 EventRootType Probe[main.testStringType1]
-          InjectionPoints: [{PC: "0x88ccc0", Frameless: true}]
+          Type: 1174 EventRootType Probe[main.testStringType1]
+          InjectionPoints: [{PC: "0x88cde0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3806,11 +3845,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 45}
+      subprogram: {subprogram: 46}
       events:
         - Kind: Entry
-          Type: 1174 EventRootType Probe[main.testStringType2]
-          InjectionPoints: [{PC: "0x88ccd0", Frameless: true}]
+          Type: 1175 EventRootType Probe[main.testStringType2]
+          InjectionPoints: [{PC: "0x88cdf0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3827,15 +3866,15 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1353 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0x892c60", Frameless: true}]
+          Type: 1354 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0x892d90", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1354 EventRootType Probe[main.testStruct]Return
-          InjectionPoints: [{PC: "0x892c7c", Frameless: true}]
+          Type: 1355 EventRootType Probe[main.testStruct]Return
+          InjectionPoints: [{PC: "0x892dac", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -3857,11 +3896,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 133}
+      subprogram: {subprogram: 134}
       events:
         - Kind: Entry
-          Type: 1322 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0x892550", Frameless: true}]
+          Type: 1323 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0x892680", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}, {a}'
@@ -3883,11 +3922,11 @@ Probes:
       template: '{s}'
       segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
-      subprogram: {subprogram: 59}
+      subprogram: {subprogram: 60}
       events:
         - Kind: Entry
-          Type: 1201 EventRootType Probe[main.testStructWithAny]
-          InjectionPoints: [{PC: "0x88de40", Frameless: true}]
+          Type: 1202 EventRootType Probe[main.testStructWithAny]
+          InjectionPoints: [{PC: "0x88df70", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{s}'
@@ -3903,15 +3942,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 128}
+      subprogram: {subprogram: 129}
       events:
         - Kind: Entry
-          Type: 1315 EventRootType Probe[main.testStructWithArrayArg]
-          InjectionPoints: [{PC: "0x891f4c", Frameless: false}]
+          Type: 1316 EventRootType Probe[main.testStructWithArrayArg]
+          InjectionPoints: [{PC: "0x89207c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1316 EventRootType Probe[main.testStructWithArrayArg]Return
-          InjectionPoints: [{PC: "0x891fdc", Frameless: false}]
+          Type: 1317 EventRootType Probe[main.testStructWithArrayArg]Return
+          InjectionPoints: [{PC: "0x89210c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -3928,15 +3967,15 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 153}
+      subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1349 EventRootType Probe[main.testStructWithCyclicMaps]
-          InjectionPoints: [{PC: "0x892b70", Frameless: true}]
+          Type: 1350 EventRootType Probe[main.testStructWithCyclicMaps]
+          InjectionPoints: [{PC: "0x892ca0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1350 EventRootType Probe[main.testStructWithCyclicMaps]Return
-          InjectionPoints: [{PC: "0x892b88", Frameless: true}]
+          Type: 1351 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          InjectionPoints: [{PC: "0x892cb8", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3952,11 +3991,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 152}
+      subprogram: {subprogram: 153}
       events:
         - Kind: Entry
-          Type: 1348 EventRootType Probe[main.testStructWithCyclicSlices]
-          InjectionPoints: [{PC: "0x892b60", Frameless: true}]
+          Type: 1349 EventRootType Probe[main.testStructWithCyclicSlices]
+          InjectionPoints: [{PC: "0x892c90", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3978,11 +4017,11 @@ Probes:
         - json: {ref: '@duration'}
           dsl: '@duration'
       captureSnapshot: true
-      subprogram: {subprogram: 60}
+      subprogram: {subprogram: 61}
       events:
         - Kind: Entry
-          Type: 1202 EventRootType Probe[main.testStructWithMap]
-          InjectionPoints: [{PC: "0x88e3f0", Frameless: true}]
+          Type: 1203 EventRootType Probe[main.testStructWithMap]
+          InjectionPoints: [{PC: "0x88e520", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{s} {@duration}'
@@ -4009,11 +4048,11 @@ Probes:
         - json: {ref: cs}
           dsl: cs
       captureSnapshot: true
-      subprogram: {subprogram: 141}
+      subprogram: {subprogram: 142}
       events:
         - Kind: Entry
-          Type: 1331 EventRootType Probe[main.testSubslices]
-          InjectionPoints: [{PC: "0x8925d0", Frameless: true}]
+          Type: 1332 EventRootType Probe[main.testSubslices]
+          InjectionPoints: [{PC: "0x892700", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{as}, {bs}, {cs}'
@@ -4048,11 +4087,11 @@ Probes:
         - json: {ref: c}
           dsl: c
       captureSnapshot: true
-      subprogram: {subprogram: 151}
+      subprogram: {subprogram: 152}
       events:
         - Kind: Entry
-          Type: 1347 EventRootType Probe[main.testSubstrings]
-          InjectionPoints: [{PC: "0x8929f0", Frameless: true}]
+          Type: 1348 EventRootType Probe[main.testSubstrings]
+          InjectionPoints: [{PC: "0x892b20", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}'
@@ -4080,15 +4119,15 @@ Probes:
         - json: {ref: nonexistentVariable}
           dsl: nonexistentVariable
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1263 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0x890a58", Frameless: false}]
+          Type: 1264 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x890b88", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1264 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0x890ae4", Frameless: false}]
+          Type: 1265 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x890c14", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{nonexistentVariable}'
@@ -4104,15 +4143,15 @@ Probes:
         - json: {foobar: unsupportedExpression}
           dsl: unsupportedExpression
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1265 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0x890a58", Frameless: false}]
+          Type: 1266 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x890b88", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1266 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0x890ae4", Frameless: false}]
+          Type: 1267 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x890c14", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{unsupportedExpression}'
@@ -4130,15 +4169,15 @@ Probes:
           dsl: '@duration'
         - ms
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1267 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0x890a58", Frameless: false}]
+          Type: 1268 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x890b88", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1268 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0x890ae4", Frameless: false}]
+          Type: 1269 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x890c14", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -4162,11 +4201,11 @@ Probes:
         - json: {ref: z}
           dsl: z
       captureSnapshot: true
-      subprogram: {subprogram: 144}
+      subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1335 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0x892970", Frameless: true}]
+          Type: 1336 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0x892aa0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}, {y}, {z}'
@@ -4193,15 +4232,15 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 145}
+      subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1336 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0x892980", Frameless: true}]
+          Type: 1337 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0x892ab0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1337 EventRootType Probe[main.testThreeStringsInStruct]Return
-          InjectionPoints: [{PC: "0x892998", Frameless: true}]
+          Type: 1338 EventRootType Probe[main.testThreeStringsInStruct]Return
+          InjectionPoints: [{PC: "0x892ac8", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -4226,15 +4265,15 @@ Probes:
         - json: {getmember: [{ref: a}, c]}
           dsl: t.c
       captureSnapshot: false
-      subprogram: {subprogram: 145}
+      subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1338 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0x892980", Frameless: true}]
+          Type: 1339 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0x892ab0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1339 EventRootType Probe[main.testThreeStringsInStruct]Return
-          InjectionPoints: [{PC: "0x892998", Frameless: true}]
+          Type: 1340 EventRootType Probe[main.testThreeStringsInStruct]Return
+          InjectionPoints: [{PC: "0x892ac8", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a.a} {a.b} {a.c}'
@@ -4261,11 +4300,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 146}
+      subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1340 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0x8929a0", Frameless: true}]
+          Type: 1341 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0x892ad0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -4290,11 +4329,11 @@ Probes:
         - json: {getmember: [{ref: a}, c]}
           dsl: a.c
       captureSnapshot: false
-      subprogram: {subprogram: 146}
+      subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1341 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0x8929a0", Frameless: true}]
+          Type: 1342 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0x892ad0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a.a} {a.b} {a.c}'
@@ -4447,11 +4486,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 93}
       events:
         - Kind: Entry
-          Type: 1237 EventRootType Probe[main.testUintPointer]
-          InjectionPoints: [{PC: "0x88fd80", Frameless: true}]
+          Type: 1238 EventRootType Probe[main.testUintPointer]
+          InjectionPoints: [{PC: "0x88feb0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4468,11 +4507,11 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 130}
+      subprogram: {subprogram: 131}
       events:
         - Kind: Entry
-          Type: 1319 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0x892520", Frameless: true}]
+          Type: 1320 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0x892650", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{u}'
@@ -4489,11 +4528,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 149}
+      subprogram: {subprogram: 150}
       events:
         - Kind: Entry
-          Type: 1345 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0x8929d0", Frameless: true}]
+          Type: 1346 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0x892b00", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4510,11 +4549,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 92}
       events:
         - Kind: Entry
-          Type: 1236 EventRootType Probe[main.testUnsafePointer]
-          InjectionPoints: [{PC: "0x88fd60", Frameless: true}]
+          Type: 1237 EventRootType Probe[main.testUnsafePointer]
+          InjectionPoints: [{PC: "0x88fe90", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4552,11 +4591,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 139}
+      subprogram: {subprogram: 140}
       events:
         - Kind: Entry
-          Type: 1328 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0x8925b0", Frameless: true}]
+          Type: 1329 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0x8926e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -4573,11 +4612,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 139}
+      subprogram: {subprogram: 140}
       events:
         - Kind: Entry
-          Type: 1329 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0x8925b0", Frameless: true}]
+          Type: 1330 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0x8926e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -4593,19 +4632,19 @@ Probes:
       template: testWhollyInlinedSubroutine
       segments: [testWhollyInlinedSubroutine]
       captureSnapshot: true
-      subprogram: {subprogram: 164}
+      subprogram: {subprogram: 165}
       events:
         - Kind: Entry
-          Type: 1374 EventRootType Probe[main.firstBehavior.DoSomething]
+          Type: 1375 EventRootType Probe[main.firstBehavior.DoSomething]
           InjectionPoints:
-            - PC: "0x88dc68"
+            - PC: "0x88dd98"
               Frameless: false
-            - PC: "0x893abc"
+            - PC: "0x893bec"
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1375 EventRootType Probe[main.firstBehavior.DoSomething]Return
-          InjectionPoints: [{PC: "0x88dca0", Frameless: false}]
+          Type: 1376 EventRootType Probe[main.firstBehavior.DoSomething]Return
+          InjectionPoints: [{PC: "0x88ddd0", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testWhollyInlinedSubroutine
@@ -4622,15 +4661,15 @@ Probes:
         - json: {ref: b}
           dsl: b
       captureSnapshot: true
-      subprogram: {subprogram: 129}
+      subprogram: {subprogram: 130}
       events:
         - Kind: Entry
-          Type: 1317 EventRootType Probe[main.testZeroSizeArgAndReturn]
-          InjectionPoints: [{PC: "0x892018", Frameless: false}]
+          Type: 1318 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          InjectionPoints: [{PC: "0x892148", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1318 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-          InjectionPoints: [{PC: "0x892084", Frameless: false}]
+          Type: 1319 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          InjectionPoints: [{PC: "0x8921b4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}'
@@ -5065,36 +5104,83 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
     - ID: 38
+      Name: main.testErrorAtLine
+      OutOfLinePCRanges: [0x88c900..0x88ca20]
+      InlinePCRanges: []
+      Variables:
+        - Name: shouldErr
+          Type: 4 BaseType bool
+          Locations:
+            - Range: 0x88c900..0x88c920
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+        - Name: ~r0
+          Type: 9 BaseType int
+          Locations: [{Range: 0x88c900..0x88ca20, Pieces: []}]
+          Role: Return
+        - Name: x
+          Type: 9 BaseType int
+          Locations: [{Range: 0x88c900..0x88ca20, Pieces: []}]
+          Role: Local
+        - Name: err
+          Type: 18 GoInterfaceType error
+          Locations:
+            - Range: 0x88c938..0x88c958
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+            - Range: 0x88c958..0x88c988
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x88c988..0x88c98c
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: -72}
+                - Size: 8
+                  Op: {CfaOffset: -64}
+            - Range: 0x88c98c..0x88ca20
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: -72}
+                - Size: 8
+                  Op: {CfaOffset: -64}
+          Role: Local
+    - ID: 39
       Name: main.testDeepPtr1
-      OutOfLinePCRanges: [0x88c990..0x88c9a0]
+      OutOfLinePCRanges: [0x88cab0..0x88cac0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 125 StructureType main.deepPtr1
           Locations:
-            - Range: 0x88c990..0x88c9a0
+            - Range: 0x88cab0..0x88cac0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 39
+    - ID: 40
       Name: main.testDeepPtr7
-      OutOfLinePCRanges: [0x88c9a0..0x88c9b0]
+      OutOfLinePCRanges: [0x88cac0..0x88cad0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 128 PointerType *main.deepPtr7
           Locations:
-            - Range: 0x88c9a0..0x88c9b0
+            - Range: 0x88cac0..0x88cad0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 40
+    - ID: 41
       Name: main.testDeepSlice1
-      OutOfLinePCRanges: [0x88cb40..0x88cb50]
+      OutOfLinePCRanges: [0x88cc60..0x88cc70]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 130 StructureType main.deepSlice1
           Locations:
-            - Range: 0x88cb40..0x88cb50
+            - Range: 0x88cc60..0x88cc70
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -5103,117 +5189,117 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 41
+    - ID: 42
       Name: main.testDeepSlice7
-      OutOfLinePCRanges: [0x88cb50..0x88cb60]
+      OutOfLinePCRanges: [0x88cc70..0x88cc80]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 134 PointerType *main.deepSlice7
           Locations:
-            - Range: 0x88cb50..0x88cb60
+            - Range: 0x88cc70..0x88cc80
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 42
+    - ID: 43
       Name: main.testDeepMap1
-      OutOfLinePCRanges: [0x88cca0..0x88ccb0]
+      OutOfLinePCRanges: [0x88cdc0..0x88cdd0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 136 StructureType main.deepMap1
           Locations:
-            - Range: 0x88cca0..0x88ccb0
+            - Range: 0x88cdc0..0x88cdd0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 43
+    - ID: 44
       Name: main.testDeepMap7
-      OutOfLinePCRanges: [0x88ccb0..0x88ccc0]
+      OutOfLinePCRanges: [0x88cdd0..0x88cde0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 144 PointerType *main.deepMap7
           Locations:
-            - Range: 0x88ccb0..0x88ccc0
+            - Range: 0x88cdd0..0x88cde0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 44
+    - ID: 45
       Name: main.testStringType1
-      OutOfLinePCRanges: [0x88ccc0..0x88ccd0]
+      OutOfLinePCRanges: [0x88cde0..0x88cdf0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 146 PointerType *main.stringType1
           Locations:
-            - Range: 0x88ccc0..0x88ccd0
+            - Range: 0x88cde0..0x88cdf0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 45
+    - ID: 46
       Name: main.testStringType2
-      OutOfLinePCRanges: [0x88ccd0..0x88cce0]
+      OutOfLinePCRanges: [0x88cdf0..0x88ce00]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 148 PointerType **main.stringType2
           Locations:
-            - Range: 0x88ccd0..0x88cce0
+            - Range: 0x88cdf0..0x88ce00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 46
+    - ID: 47
       Name: main.testLongFunctionWithChangingState
-      OutOfLinePCRanges: [0x88cce0..0x88cee0]
+      OutOfLinePCRanges: [0x88ce00..0x88d000]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88cda8..0x88cdb8
+            - Range: 0x88cec8..0x88ced8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88ce58..0x88ce68
+            - Range: 0x88cf78..0x88cf88
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
         - Name: aPerArch
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88cd90..0x88cd94
+            - Range: 0x88ceb0..0x88ceb4
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x88cd94..0x88cdb8
+            - Range: 0x88ceb4..0x88ced8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x88cdb8..0x88ce4c
+            - Range: 0x88ced8..0x88cf6c
               Pieces: [{Size: 8, Op: {CfaOffset: -160}}]
-            - Range: 0x88ce4c..0x88ce54
+            - Range: 0x88cf6c..0x88cf74
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0x88ce54..0x88cee0
+            - Range: 0x88cf74..0x88d000
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
           Role: Local
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88cd8c..0x88cd94
+            - Range: 0x88ceac..0x88ceb4
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x88cd94..0x88cd94
+            - Range: 0x88ceb4..0x88ceb4
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x88cd94..0x88cdb8
+            - Range: 0x88ceb4..0x88ced8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x88cdb8..0x88ce4c
+            - Range: 0x88ced8..0x88cf6c
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0x88ce4c..0x88ce50
+            - Range: 0x88cf6c..0x88cf70
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0x88ce50..0x88ce54
+            - Range: 0x88cf70..0x88cf74
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0x88ce54..0x88ce68
+            - Range: 0x88cf74..0x88cf88
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0x88ce68..0x88cee0
+            - Range: 0x88cf88..0x88d000
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
           Role: Local
-    - ID: 47
+    - ID: 48
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0x88d260..0x88d350]
+      OutOfLinePCRanges: [0x88d390..0x88d480]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 150 StructureType main.esotericStack
           Locations:
-            - Range: 0x88d260..0x88d2a8
+            - Range: 0x88d390..0x88d3d8
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -5233,7 +5319,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x88d2a8..0x88d2ac
+            - Range: 0x88d3d8..0x88d3dc
               Pieces:
                 - Size: 4
                   Op: null
@@ -5253,7 +5339,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x88d2ac..0x88d2b0
+            - Range: 0x88d3dc..0x88d3e0
               Pieces:
                 - Size: 4
                   Op: null
@@ -5274,161 +5360,161 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 48
+    - ID: 49
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0x88d350..0x88d3d0]
+      OutOfLinePCRanges: [0x88d480..0x88d500]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 154 PointerType *main.esotericHeap
           Locations:
-            - Range: 0x88d350..0x88d388
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-    - ID: 49
-      Name: main.testInlinedBA
-      OutOfLinePCRanges: [0x88d790..0x88d820]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0x88d790..0x88d7c8
+            - Range: 0x88d480..0x88d4b8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 50
-      Name: main.testInlinedBB
-      OutOfLinePCRanges: [0x88d820..0x88d8f0]
+      Name: main.testInlinedBA
+      OutOfLinePCRanges: [0x88d8c0..0x88d950]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88d820..0x88d83c
+            - Range: 0x88d8c0..0x88d8f8
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+    - ID: 51
+      Name: main.testInlinedBB
+      OutOfLinePCRanges: [0x88d950..0x88da20]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x88d950..0x88d96c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: y
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88d820..0x88d84c
+            - Range: 0x88d950..0x88d97c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
         - Name: z
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88d83c..0x88d84c
+            - Range: 0x88d96c..0x88d97c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88d84c..0x88d8f0
+            - Range: 0x88d97c..0x88da20
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Local
-    - ID: 51
+    - ID: 52
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0x88d8f0..0x88d970]
+      OutOfLinePCRanges: [0x88da20..0x88daa0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88d8f0..0x88d914
+            - Range: 0x88da20..0x88da44
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 52
+    - ID: 53
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0x88d970..0x88da90]
+      OutOfLinePCRanges: [0x88daa0..0x88dbc0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88d9d8..0x88d9e0
+            - Range: 0x88db08..0x88db10
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0x88d9e0..0x88d9f8
+            - Range: 0x88db10..0x88db28
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0x88d9f8..0x88da0c
+            - Range: 0x88db28..0x88db3c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88d9d4..0x88d9dc
+            - Range: 0x88db04..0x88db0c
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
-            - Range: 0x88d9dc..0x88d9f8
+            - Range: 0x88db0c..0x88db28
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
-            - Range: 0x88d9f8..0x88da08
+            - Range: 0x88db28..0x88db38
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 53
+    - ID: 54
       Name: main.testFrameless
-      OutOfLinePCRanges: [0x88da90..0x88daa0]
+      OutOfLinePCRanges: [0x88dbc0..0x88dbd0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88da90..0x88da98
+            - Range: 0x88dbc0..0x88dbc8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88da90..0x88da98
+            - Range: 0x88dbc0..0x88dbc8
               Pieces: []
-            - Range: 0x88da98..0x88da99
+            - Range: 0x88dbc8..0x88dbc9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88da99..0x88daa0
+            - Range: 0x88dbc9..0x88dbd0
               Pieces: []
           Role: Return
-    - ID: 54
+    - ID: 55
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0x88daa0..0x88db00]
+      OutOfLinePCRanges: [0x88dbd0..0x88dc30]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 156 ArrayType [5]int
           Locations:
-            - Range: 0x88daa0..0x88db00
+            - Range: 0x88dbd0..0x88dc30
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88daa0..0x88dae8
+            - Range: 0x88dbd0..0x88dc18
               Pieces: []
-            - Range: 0x88dae8..0x88dae9
+            - Range: 0x88dc18..0x88dc19
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88dae9..0x88db00
+            - Range: 0x88dc19..0x88dc30
               Pieces: []
           Role: Return
-    - ID: 55
+    - ID: 56
       Name: main.testInterface
-      OutOfLinePCRanges: [0x88dd40..0x88dd50]
+      OutOfLinePCRanges: [0x88de70..0x88de80]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 157 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x88dd40..0x88dd50
+            - Range: 0x88de70..0x88de80
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 56
+    - ID: 57
       Name: main.testAny
-      OutOfLinePCRanges: [0x88dd50..0x88ddc0]
+      OutOfLinePCRanges: [0x88de80..0x88def0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x88dd50..0x88dd80
+            - Range: 0x88de80..0x88deb0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x88dd80..0x88dd84
+            - Range: 0x88deb0..0x88deb4
               Pieces:
                 - Size: 8
                   Op: null
@@ -5438,363 +5524,363 @@ Subprograms:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x88dd50..0x88dd94
+            - Range: 0x88de80..0x88dec4
               Pieces: []
-            - Range: 0x88dd94..0x88dd95
+            - Range: 0x88dec4..0x88dec5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x88dd95..0x88ddc0
+            - Range: 0x88dec5..0x88def0
               Pieces: []
           Role: Return
-    - ID: 57
+    - ID: 58
       Name: main.testError
-      OutOfLinePCRanges: [0x88ddc0..0x88ddd0]
+      OutOfLinePCRanges: [0x88def0..0x88df00]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 18 GoInterfaceType error
           Locations:
-            - Range: 0x88ddc0..0x88ddd0
+            - Range: 0x88def0..0x88df00
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 58
+    - ID: 59
       Name: main.testAnyPtr
-      OutOfLinePCRanges: [0x88ddd0..0x88de40]
+      OutOfLinePCRanges: [0x88df00..0x88df70]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 158 PointerType *interface {}
           Locations:
-            - Range: 0x88ddd0..0x88de00
+            - Range: 0x88df00..0x88df30
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x88ddd0..0x88de14
+            - Range: 0x88df00..0x88df44
               Pieces: []
-            - Range: 0x88de14..0x88de15
+            - Range: 0x88df44..0x88df45
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x88de15..0x88de40
+            - Range: 0x88df45..0x88df70
               Pieces: []
           Role: Return
-    - ID: 59
+    - ID: 60
       Name: main.testStructWithAny
-      OutOfLinePCRanges: [0x88de40..0x88de50]
+      OutOfLinePCRanges: [0x88df70..0x88df80]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 159 StructureType main.structWithAny
           Locations:
-            - Range: 0x88de40..0x88de50
+            - Range: 0x88df70..0x88df80
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 60
+    - ID: 61
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0x88e3f0..0x88e400]
+      OutOfLinePCRanges: [0x88e520..0x88e530]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 160 StructureType main.structWithMap
           Locations:
-            - Range: 0x88e3f0..0x88e400
+            - Range: 0x88e520..0x88e530
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 61
+    - ID: 62
       Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0x88e400..0x88e410]
+      OutOfLinePCRanges: [0x88e530..0x88e540]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 166 GoMapType map[string]main.nestedStruct
           Locations:
-            - Range: 0x88e400..0x88e410
+            - Range: 0x88e530..0x88e540
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 62
+    - ID: 63
       Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0x88e410..0x88e420]
+      OutOfLinePCRanges: [0x88e540..0x88e550]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 171 GoMapType map[string]int
           Locations:
-            - Range: 0x88e410..0x88e420
+            - Range: 0x88e540..0x88e550
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 63
+    - ID: 64
       Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0x88e420..0x88e430]
+      OutOfLinePCRanges: [0x88e550..0x88e560]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 176 GoMapType map[string][]string
           Locations:
-            - Range: 0x88e420..0x88e430
+            - Range: 0x88e550..0x88e560
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 64
+    - ID: 65
       Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0x88e430..0x88e440]
+      OutOfLinePCRanges: [0x88e560..0x88e570]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 181 GoMapType map[[4]string][2]int
           Locations:
-            - Range: 0x88e430..0x88e440
+            - Range: 0x88e560..0x88e570
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 65
+    - ID: 66
       Name: main.testSmallMap
-      OutOfLinePCRanges: [0x88e440..0x88e450]
+      OutOfLinePCRanges: [0x88e570..0x88e580]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 171 GoMapType map[string]int
           Locations:
-            - Range: 0x88e440..0x88e450
+            - Range: 0x88e570..0x88e580
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 66
+    - ID: 67
       Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0x88e450..0x88e460]
+      OutOfLinePCRanges: [0x88e580..0x88e590]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 186 ArrayType [2]map[string]int
           Locations:
-            - Range: 0x88e450..0x88e460
+            - Range: 0x88e580..0x88e590
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
-    - ID: 67
+    - ID: 68
       Name: main.testPointerToMap
-      OutOfLinePCRanges: [0x88e460..0x88e470]
+      OutOfLinePCRanges: [0x88e590..0x88e5a0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 187 PointerType *map[string]int
           Locations:
-            - Range: 0x88e460..0x88e470
+            - Range: 0x88e590..0x88e5a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 68
+    - ID: 69
       Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0x88e470..0x88e480]
+      OutOfLinePCRanges: [0x88e5a0..0x88e5b0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 161 GoMapType map[int]int
           Locations:
-            - Range: 0x88e470..0x88e480
+            - Range: 0x88e5a0..0x88e5b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 69
+    - ID: 70
       Name: main.testMapMassive
-      OutOfLinePCRanges: [0x88e480..0x88e490]
+      OutOfLinePCRanges: [0x88e5b0..0x88e5c0]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 188 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0x88e480..0x88e490
+            - Range: 0x88e5b0..0x88e5c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 70
+    - ID: 71
       Name: main.testMapEmbeddedMaps
-      OutOfLinePCRanges: [0x88e490..0x88e4a0]
+      OutOfLinePCRanges: [0x88e5c0..0x88e5d0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 188 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0x88e490..0x88e4a0
+            - Range: 0x88e5c0..0x88e5d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 71
+    - ID: 72
       Name: main.testMapWithLinkedList
-      OutOfLinePCRanges: [0x88e4a0..0x88e4b0]
+      OutOfLinePCRanges: [0x88e5d0..0x88e5e0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 193 GoMapType map[bool]main.node
           Locations:
-            - Range: 0x88e4a0..0x88e4b0
+            - Range: 0x88e5d0..0x88e5e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 72
+    - ID: 73
       Name: main.testMapWithSmallValue
-      OutOfLinePCRanges: [0x88e4b0..0x88e4c0]
+      OutOfLinePCRanges: [0x88e5e0..0x88e5f0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 198 GoMapType map[int]uint8
           Locations:
-            - Range: 0x88e4b0..0x88e4c0
+            - Range: 0x88e5e0..0x88e5f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 73
+    - ID: 74
       Name: main.testMapWithSmallValueMassive
-      OutOfLinePCRanges: [0x88e4c0..0x88e4d0]
+      OutOfLinePCRanges: [0x88e5f0..0x88e600]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 198 GoMapType map[int]uint8
           Locations:
-            - Range: 0x88e4c0..0x88e4d0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-    - ID: 74
-      Name: main.testMapWithSmallKeyAndValue
-      OutOfLinePCRanges: [0x88e4d0..0x88e4e0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 203 GoMapType map[uint8]uint8
-          Locations:
-            - Range: 0x88e4d0..0x88e4e0
+            - Range: 0x88e5f0..0x88e600
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 75
-      Name: main.testMapWithSmallKeyAndValueMassive
-      OutOfLinePCRanges: [0x88e4e0..0x88e4f0]
+      Name: main.testMapWithSmallKeyAndValue
+      OutOfLinePCRanges: [0x88e600..0x88e610]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 203 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0x88e4e0..0x88e4f0
+            - Range: 0x88e600..0x88e610
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 76
-      Name: main.testMapSmallKeySmallValue
-      OutOfLinePCRanges: [0x88e4f0..0x88e500]
+      Name: main.testMapWithSmallKeyAndValueMassive
+      OutOfLinePCRanges: [0x88e610..0x88e620]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 203 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0x88e4f0..0x88e500
+            - Range: 0x88e610..0x88e620
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 77
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0x88e620..0x88e630]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 203 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0x88e620..0x88e630
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+    - ID: 78
       Name: main.testMapSmallKeyLargeValue
-      OutOfLinePCRanges: [0x88e500..0x88e510]
+      OutOfLinePCRanges: [0x88e630..0x88e640]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 208 GoMapType map[uint8][4]int
           Locations:
-            - Range: 0x88e500..0x88e510
+            - Range: 0x88e630..0x88e640
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 78
+    - ID: 79
       Name: main.testMapLargeKeySmallValue
-      OutOfLinePCRanges: [0x88e510..0x88e520]
+      OutOfLinePCRanges: [0x88e640..0x88e650]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 213 GoMapType map[[4]int]uint8
           Locations:
-            - Range: 0x88e510..0x88e520
+            - Range: 0x88e640..0x88e650
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 79
+    - ID: 80
       Name: main.testMapLargeKeyLargeValue
-      OutOfLinePCRanges: [0x88e520..0x88e530]
+      OutOfLinePCRanges: [0x88e650..0x88e660]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 218 GoMapType map[[4]int][4]int
           Locations:
-            - Range: 0x88e520..0x88e530
+            - Range: 0x88e650..0x88e660
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 80
+    - ID: 81
       Name: main.testMapEmptyKey
-      OutOfLinePCRanges: [0x88e530..0x88e540]
+      OutOfLinePCRanges: [0x88e660..0x88e670]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 223 GoMapType map[struct {}]int
           Locations:
-            - Range: 0x88e530..0x88e540
+            - Range: 0x88e660..0x88e670
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 81
+    - ID: 82
       Name: main.testMapEmptyValue
-      OutOfLinePCRanges: [0x88e540..0x88e550]
+      OutOfLinePCRanges: [0x88e670..0x88e680]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 228 GoMapType map[int]struct {}
           Locations:
-            - Range: 0x88e540..0x88e550
+            - Range: 0x88e670..0x88e680
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 82
+    - ID: 83
       Name: main.testMapEmptyKeyAndValue
-      OutOfLinePCRanges: [0x88e550..0x88e560]
+      OutOfLinePCRanges: [0x88e680..0x88e690]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 233 GoMapType map[struct {}]struct {}
           Locations:
-            - Range: 0x88e550..0x88e560
+            - Range: 0x88e680..0x88e690
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 83
+    - ID: 84
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0x88f8c0..0x88f8d0]
+      OutOfLinePCRanges: [0x88f9f0..0x88fa00]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x88f8c0..0x88f8d0
+            - Range: 0x88f9f0..0x88fa00
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x88f8c0..0x88f8d0
+            - Range: 0x88f9f0..0x88fa00
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
         - Name: y
           Type: 16 BaseType float32
           Locations:
-            - Range: 0x88f8c0..0x88f8d0
+            - Range: 0x88f9f0..0x88fa00
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
-    - ID: 84
+    - ID: 85
       Name: main.testCombinedString
-      OutOfLinePCRanges: [0x88f8e0..0x88f8f0]
+      OutOfLinePCRanges: [0x88fa10..0x88fa20]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x88f8e0..0x88f8f0
+            - Range: 0x88fa10..0x88fa20
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x88f8e0..0x88f8f0
+            - Range: 0x88fa10..0x88fa20
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -5804,345 +5890,345 @@ Subprograms:
         - Name: y
           Type: 16 BaseType float32
           Locations:
-            - Range: 0x88f8e0..0x88f8f0
+            - Range: 0x88fa10..0x88fa20
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
-    - ID: 85
+    - ID: 86
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0x88f9a0..0x88f9b0]
+      OutOfLinePCRanges: [0x88fad0..0x88fae0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x88f9a0..0x88f9b0
+            - Range: 0x88fad0..0x88fae0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: b
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x88f9a0..0x88f9b0
+            - Range: 0x88fad0..0x88fae0
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
         - Name: c
           Type: 13 BaseType int32
           Locations:
-            - Range: 0x88f9a0..0x88f9b0
+            - Range: 0x88fad0..0x88fae0
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
         - Name: d
           Type: 12 BaseType uint
           Locations:
-            - Range: 0x88f9a0..0x88f9b0
+            - Range: 0x88fad0..0x88fae0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
         - Name: e
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x88f9a0..0x88f9b0
+            - Range: 0x88fad0..0x88fae0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
-    - ID: 86
+    - ID: 87
       Name: main.testAtomicAdd
-      OutOfLinePCRanges: [0x88fb40..0x88fb80]
+      OutOfLinePCRanges: [0x88fc70..0x88fcb0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0x88fb40..0x88fb7c
+            - Range: 0x88fc70..0x88fcac
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0x88fb40..0x88fb7c
+            - Range: 0x88fc70..0x88fcac
               Pieces: []
-            - Range: 0x88fb7c..0x88fb7d
+            - Range: 0x88fcac..0x88fcad
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88fb7d..0x88fb80
+            - Range: 0x88fcad..0x88fcb0
               Pieces: []
           Role: Return
-    - ID: 87
+    - ID: 88
       Name: main.testChannel
-      OutOfLinePCRanges: [0x88fb80..0x88fb90]
+      OutOfLinePCRanges: [0x88fcb0..0x88fcc0]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 238 GoChannelType chan bool
           Locations:
-            - Range: 0x88fb80..0x88fb90
+            - Range: 0x88fcb0..0x88fcc0
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 88
+    - ID: 89
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0x88fd30..0x88fd40]
+      OutOfLinePCRanges: [0x88fe60..0x88fe70]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 239 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0x88fd30..0x88fd40
+            - Range: 0x88fe60..0x88fe70
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 89
+    - ID: 90
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0x88fd40..0x88fd50]
+      OutOfLinePCRanges: [0x88fe70..0x88fe80]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 241 StructureType main.node
           Locations:
-            - Range: 0x88fd40..0x88fd50
+            - Range: 0x88fe70..0x88fe80
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 90
+    - ID: 91
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0x88fd50..0x88fd60]
+      OutOfLinePCRanges: [0x88fe80..0x88fe90]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 242 PointerType *main.node
           Locations:
-            - Range: 0x88fd50..0x88fd60
+            - Range: 0x88fe80..0x88fe90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 91
+    - ID: 92
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0x88fd60..0x88fd70]
+      OutOfLinePCRanges: [0x88fe90..0x88fea0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 19 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0x88fd60..0x88fd70
+            - Range: 0x88fe90..0x88fea0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 92
+    - ID: 93
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0x88fd80..0x88fd90]
+      OutOfLinePCRanges: [0x88feb0..0x88fec0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 100 PointerType *uint
           Locations:
-            - Range: 0x88fd80..0x88fd90
+            - Range: 0x88feb0..0x88fec0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 93
+    - ID: 94
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0x88fdf0..0x88fe00]
+      OutOfLinePCRanges: [0x88ff20..0x88ff30]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 88 PointerType *string
           Locations:
-            - Range: 0x88fdf0..0x88fe00
+            - Range: 0x88ff20..0x88ff30
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 94
+    - ID: 95
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0x88fe10..0x88fe20]
+      OutOfLinePCRanges: [0x88ff40..0x88ff50]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 5 PointerType *bool
           Locations:
-            - Range: 0x88fe10..0x88fe20
+            - Range: 0x88ff40..0x88ff50
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: a
           Type: 12 BaseType uint
           Locations:
-            - Range: 0x88fe10..0x88fe20
+            - Range: 0x88ff40..0x88ff50
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
-    - ID: 95
+    - ID: 96
       Name: main.testCycle
-      OutOfLinePCRanges: [0x88fe30..0x88fe40]
+      OutOfLinePCRanges: [0x88ff60..0x88ff70]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 243 PointerType *main.t
           Locations:
-            - Range: 0x88fe30..0x88fe40
+            - Range: 0x88ff60..0x88ff70
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 96
+    - ID: 97
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0x890240..0x8902c0]
+      OutOfLinePCRanges: [0x890370..0x8903f0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x890240..0x89025c
+            - Range: 0x890370..0x89038c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x890240..0x89029c
+            - Range: 0x890370..0x8903cc
               Pieces: []
-            - Range: 0x89029c..0x89029d
+            - Range: 0x8903cc..0x8903cd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x89029d..0x8902c0
+            - Range: 0x8903cd..0x8903f0
               Pieces: []
           Role: Return
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0x89025c..0x890268
+            - Range: 0x89038c..0x890398
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x890268..0x8902c0
+            - Range: 0x890398..0x8903f0
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
-    - ID: 97
+    - ID: 98
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0x8902c0..0x890360]
+      OutOfLinePCRanges: [0x8903f0..0x890490]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8902c0..0x8902e4
+            - Range: 0x8903f0..0x890414
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8902e4..0x890360
+            - Range: 0x890414..0x890490
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 94 PointerType *int
           Locations:
-            - Range: 0x8902c0..0x89033c
+            - Range: 0x8903f0..0x89046c
               Pieces: []
-            - Range: 0x89033c..0x89033d
+            - Range: 0x89046c..0x89046d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x89033d..0x890360
+            - Range: 0x89046d..0x890490
               Pieces: []
           Role: Return
         - Name: '&result'
           Type: 94 PointerType *int
           Locations:
-            - Range: 0x8902e8..0x890304
+            - Range: 0x890418..0x890434
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x890304..0x890360
+            - Range: 0x890434..0x890490
               Pieces: [{Size: 8, Op: {CfaOffset: -16}}]
           Role: Local
-    - ID: 98
+    - ID: 99
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0x890360..0x890430]
+      OutOfLinePCRanges: [0x890490..0x890560]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x890360..0x8903b8
+            - Range: 0x890490..0x8904e8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x890360..0x890410
+            - Range: 0x890490..0x890540
               Pieces: []
-            - Range: 0x890410..0x890411
+            - Range: 0x890540..0x890541
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x890411..0x890430
+            - Range: 0x890541..0x890560
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890360..0x890430, Pieces: []}]
+          Locations: [{Range: 0x890490..0x890560, Pieces: []}]
           Role: Return
         - Name: resultInt
           Type: 9 BaseType int
           Locations:
-            - Range: 0x89037c..0x8903bc
+            - Range: 0x8904ac..0x8904ec
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x8903bc..0x890430
+            - Range: 0x8904ec..0x890560
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
         - Name: resultFloat
           Type: 17 BaseType float64
           Locations:
-            - Range: 0x89038c..0x8903bc
+            - Range: 0x8904bc..0x8904ec
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
-            - Range: 0x8903bc..0x890430
+            - Range: 0x8904ec..0x890560
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
           Role: Local
-    - ID: 99
+    - ID: 100
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0x890430..0x8904b0]
+      OutOfLinePCRanges: [0x890560..0x8905e0]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x890430..0x890454
+            - Range: 0x890560..0x890584
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 18 GoInterfaceType error
           Locations:
-            - Range: 0x890430..0x890478
+            - Range: 0x890560..0x8905a8
               Pieces: []
-            - Range: 0x890478..0x890479
+            - Range: 0x8905a8..0x8905a9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x890479..0x89048c
+            - Range: 0x8905a9..0x8905bc
               Pieces: []
-            - Range: 0x89048c..0x89048d
+            - Range: 0x8905bc..0x8905bd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89048d..0x8904b0
+            - Range: 0x8905bd..0x8905e0
               Pieces: []
           Role: Return
-    - ID: 100
+    - ID: 101
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0x8904b0..0x890630]
+      OutOfLinePCRanges: [0x8905e0..0x890760]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x8904b0..0x890508
+            - Range: 0x8905e0..0x890638
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x890508..0x89050c
+            - Range: 0x890638..0x89063c
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x890564..0x890568
+            - Range: 0x890694..0x890698
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: null
-            - Range: 0x890594..0x890598
+            - Range: 0x8906c4..0x8906c8
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8905d4..0x8905d8
+            - Range: 0x890704..0x890708
               Pieces:
                 - Size: 8
                   Op: null
@@ -6152,130 +6238,37 @@ Subprograms:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x8904b0..0x890504
+            - Range: 0x8905e0..0x890634
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x8904b0..0x890534
+            - Range: 0x8905e0..0x890664
               Pieces: []
-            - Range: 0x890534..0x890535
+            - Range: 0x890664..0x890665
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x890535..0x890580
+            - Range: 0x890665..0x8906b0
               Pieces: []
-            - Range: 0x890580..0x890581
+            - Range: 0x8906b0..0x8906b1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x890581..0x8905c0
+            - Range: 0x8906b1..0x8906f0
               Pieces: []
-            - Range: 0x8905c0..0x8905c1
+            - Range: 0x8906f0..0x8906f1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8905c1..0x890600
-              Pieces: []
-            - Range: 0x890600..0x890601
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x890601..0x890630
-              Pieces: []
-          Role: Return
-        - Name: ~r1
-          Type: 18 GoInterfaceType error
-          Locations:
-            - Range: 0x8904b0..0x890534
-              Pieces: []
-            - Range: 0x890534..0x890535
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0x890535..0x890580
-              Pieces: []
-            - Range: 0x890580..0x890581
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0x890581..0x8905c0
-              Pieces: []
-            - Range: 0x8905c0..0x8905c1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8905c1..0x890600
-              Pieces: []
-            - Range: 0x890600..0x890601
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0x890601..0x890630
-              Pieces: []
-          Role: Return
-        - Name: val
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0x890564..0x89056c
-              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          Role: Local
-    - ID: 101
-      Name: main.testReturnsAny
-      OutOfLinePCRanges: [0x890630..0x890830]
-      InlinePCRanges: []
-      Variables:
-        - Name: v
-          Type: 152 GoEmptyInterfaceType interface {}
-          Locations:
-            - Range: 0x890630..0x89068c
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89068c..0x890690
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 8}
-                - Size: 8
-                  Op: {CfaOffset: 16}
-            - Range: 0x890690..0x890830
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 8}
-                - Size: 8
-                  Op: {CfaOffset: 16}
-          Role: Parameter
-        - Name: ~r0
-          Type: 152 GoEmptyInterfaceType interface {}
-          Locations:
-            - Range: 0x890630..0x8906e8
-              Pieces: []
-            - Range: 0x8906e8..0x8906e9
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8906e9..0x890730
+            - Range: 0x8906f1..0x890730
               Pieces: []
             - Range: 0x890730..0x890731
               Pieces:
@@ -6283,413 +6276,506 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x890731..0x8907f4
+            - Range: 0x890731..0x890760
               Pieces: []
-            - Range: 0x8907f4..0x8907f5
+          Role: Return
+        - Name: ~r1
+          Type: 18 GoInterfaceType error
+          Locations:
+            - Range: 0x8905e0..0x890664
+              Pieces: []
+            - Range: 0x890664..0x890665
               Pieces:
                 - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
+                  Op: {RegNo: 2, Shift: 0}
                 - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8907f5..0x890808
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x890665..0x8906b0
               Pieces: []
-            - Range: 0x890808..0x890809
+            - Range: 0x8906b0..0x8906b1
               Pieces:
                 - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
+                  Op: {RegNo: 2, Shift: 0}
                 - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x890809..0x890830
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x8906b1..0x8906f0
+              Pieces: []
+            - Range: 0x8906f0..0x8906f1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x8906f1..0x890730
+              Pieces: []
+            - Range: 0x890730..0x890731
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x890731..0x890760
               Pieces: []
           Role: Return
         - Name: val
           Type: 9 BaseType int
           Locations:
-            - Range: 0x89071c..0x890724
+            - Range: 0x890694..0x89069c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
-        - Name: '&result'
-          Type: 94 PointerType *int
-          Locations:
-            - Range: 0x8906cc..0x8906e8
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Local
     - ID: 102
-      Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0x890830..0x8909a0]
+      Name: main.testReturnsAny
+      OutOfLinePCRanges: [0x890760..0x890960]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x890830..0x89086c
+            - Range: 0x890760..0x8907bc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89086c..0x8908cc
+            - Range: 0x8907bc..0x8907c0
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0x8907c0..0x890960
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+          Role: Parameter
+        - Name: ~r0
+          Type: 152 GoEmptyInterfaceType interface {}
+          Locations:
+            - Range: 0x890760..0x890818
+              Pieces: []
+            - Range: 0x890818..0x890819
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x890819..0x890860
+              Pieces: []
+            - Range: 0x890860..0x890861
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x890861..0x890924
+              Pieces: []
+            - Range: 0x890924..0x890925
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x890925..0x890938
+              Pieces: []
+            - Range: 0x890938..0x890939
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x890939..0x890960
+              Pieces: []
+          Role: Return
+        - Name: val
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x89084c..0x890854
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          Role: Local
+        - Name: '&result'
+          Type: 94 PointerType *int
+          Locations:
+            - Range: 0x8907fc..0x890818
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Local
+    - ID: 103
+      Name: main.testReturnsInterface
+      OutOfLinePCRanges: [0x890960..0x890ad0]
+      InlinePCRanges: []
+      Variables:
+        - Name: v
+          Type: 152 GoEmptyInterfaceType interface {}
+          Locations:
+            - Range: 0x890960..0x89099c
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x89099c..0x8909fc
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x8908cc..0x890938
+            - Range: 0x8909fc..0x890a68
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x890938..0x890960
+            - Range: 0x890a68..0x890a90
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x890960..0x890964
+            - Range: 0x890a90..0x890a94
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x890964..0x8909a0
+            - Range: 0x890a94..0x890ad0
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
         - Name: ~r0
           Type: 157 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x890830..0x890918
+            - Range: 0x890960..0x890a48
               Pieces: []
-            - Range: 0x890918..0x890919
+            - Range: 0x890a48..0x890a49
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x890919..0x89092c
+            - Range: 0x890a49..0x890a5c
               Pieces: []
-            - Range: 0x89092c..0x89092d
+            - Range: 0x890a5c..0x890a5d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89092d..0x8909a0
+            - Range: 0x890a5d..0x890ad0
               Pieces: []
           Role: Return
         - Name: b
           Type: 157 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x890830..0x89086c
+            - Range: 0x890960..0x89099c
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89086c..0x8908bc
+            - Range: 0x89099c..0x8909ec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x8908bc..0x8908cc
+            - Range: 0x8909ec..0x8909fc
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -64}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x8908cc..0x890924
+            - Range: 0x8909fc..0x890a54
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -64}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x890924..0x890928
+            - Range: 0x890a54..0x890a58
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x890928..0x89092c
+            - Range: 0x890a58..0x890a5c
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x89092c..0x8909a0
+            - Range: 0x890a5c..0x890ad0
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Local
-    - ID: 103
+    - ID: 104
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0x8909a0..0x890a40]
+      OutOfLinePCRanges: [0x890ad0..0x890b70]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8909a0..0x8909bc
+            - Range: 0x890ad0..0x890aec
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8909a0..0x890a18
+            - Range: 0x890ad0..0x890b48
               Pieces: []
-            - Range: 0x890a18..0x890a19
+            - Range: 0x890b48..0x890b49
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x890a19..0x890a40
+            - Range: 0x890b49..0x890b70
               Pieces: []
           Role: Return
-    - ID: 104
+    - ID: 105
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0x890a40..0x890b10]
+      OutOfLinePCRanges: [0x890b70..0x890c40]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x890a40..0x890a90
+            - Range: 0x890b70..0x890bc0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0x890a40..0x890ae4
+            - Range: 0x890b70..0x890c14
               Pieces: []
-            - Range: 0x890ae4..0x890ae5
+            - Range: 0x890c14..0x890c15
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x890ae5..0x890b10
+            - Range: 0x890c15..0x890c40
               Pieces: []
           Role: Return
         - Name: result2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x890a40..0x890ae4
+            - Range: 0x890b70..0x890c14
               Pieces: []
-            - Range: 0x890ae4..0x890ae5
+            - Range: 0x890c14..0x890c15
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x890ae5..0x890b10
+            - Range: 0x890c15..0x890c40
               Pieces: []
           Role: Return
-    - ID: 105
+    - ID: 106
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0x890b10..0x890be0]
+      OutOfLinePCRanges: [0x890c40..0x890d10]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x890b10..0x890b50
+            - Range: 0x890c40..0x890c80
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x890b50..0x890be0
+            - Range: 0x890c80..0x890d10
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x890b10..0x890bb4
+            - Range: 0x890c40..0x890ce4
               Pieces: []
-            - Range: 0x890bb4..0x890bb5
+            - Range: 0x890ce4..0x890ce5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x890bb5..0x890be0
+            - Range: 0x890ce5..0x890d10
               Pieces: []
           Role: Return
         - Name: result2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x890b10..0x890bb4
+            - Range: 0x890c40..0x890ce4
               Pieces: []
-            - Range: 0x890bb4..0x890bb5
+            - Range: 0x890ce4..0x890ce5
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x890bb5..0x890be0
+            - Range: 0x890ce5..0x890d10
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x890b10..0x890bb4
+            - Range: 0x890c40..0x890ce4
               Pieces: []
-            - Range: 0x890bb4..0x890bb5
+            - Range: 0x890ce4..0x890ce5
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x890bb5..0x890be0
+            - Range: 0x890ce5..0x890d10
               Pieces: []
           Role: Return
-    - ID: 106
+    - ID: 107
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0x890be0..0x890c70]
+      OutOfLinePCRanges: [0x890d10..0x890da0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 15 BaseType int8
           Locations:
-            - Range: 0x890be0..0x890c50
+            - Range: 0x890d10..0x890d80
               Pieces: []
-            - Range: 0x890c50..0x890c51
+            - Range: 0x890d80..0x890d81
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x890c51..0x890c70
+            - Range: 0x890d81..0x890da0
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 89 BaseType int16
           Locations:
-            - Range: 0x890be0..0x890c50
+            - Range: 0x890d10..0x890d80
               Pieces: []
-            - Range: 0x890c50..0x890c51
+            - Range: 0x890d80..0x890d81
               Pieces: [{Size: 2, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x890c51..0x890c70
+            - Range: 0x890d81..0x890da0
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 13 BaseType int32
           Locations:
-            - Range: 0x890be0..0x890c50
+            - Range: 0x890d10..0x890d80
               Pieces: []
-            - Range: 0x890c50..0x890c51
+            - Range: 0x890d80..0x890d81
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x890c51..0x890c70
+            - Range: 0x890d81..0x890da0
               Pieces: []
           Role: Return
         - Name: ~r3
           Type: 14 BaseType int64
           Locations:
-            - Range: 0x890be0..0x890c50
+            - Range: 0x890d10..0x890d80
               Pieces: []
-            - Range: 0x890c50..0x890c51
+            - Range: 0x890d80..0x890d81
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x890c51..0x890c70
+            - Range: 0x890d81..0x890da0
               Pieces: []
           Role: Return
         - Name: ~r4
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x890be0..0x890c50
+            - Range: 0x890d10..0x890d80
               Pieces: []
-            - Range: 0x890c50..0x890c51
+            - Range: 0x890d80..0x890d81
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x890c51..0x890c70
+            - Range: 0x890d81..0x890da0
               Pieces: []
           Role: Return
         - Name: ~r5
           Type: 7 BaseType uint16
           Locations:
-            - Range: 0x890be0..0x890c50
+            - Range: 0x890d10..0x890d80
               Pieces: []
-            - Range: 0x890c50..0x890c51
+            - Range: 0x890d80..0x890d81
               Pieces: [{Size: 2, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x890c51..0x890c70
+            - Range: 0x890d81..0x890da0
               Pieces: []
           Role: Return
         - Name: ~r6
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0x890be0..0x890c50
+            - Range: 0x890d10..0x890d80
               Pieces: []
-            - Range: 0x890c50..0x890c51
+            - Range: 0x890d80..0x890d81
               Pieces: [{Size: 4, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x890c51..0x890c70
+            - Range: 0x890d81..0x890da0
               Pieces: []
           Role: Return
         - Name: ~r7
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0x890be0..0x890c50
+            - Range: 0x890d10..0x890d80
               Pieces: []
-            - Range: 0x890c50..0x890c51
+            - Range: 0x890d80..0x890d81
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x890c51..0x890c70
+            - Range: 0x890d81..0x890da0
               Pieces: []
           Role: Return
-    - ID: 107
+    - ID: 108
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0x890c70..0x890d30]
+      OutOfLinePCRanges: [0x890da0..0x890e60]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890c70..0x890d30, Pieces: []}]
+          Locations: [{Range: 0x890da0..0x890e60, Pieces: []}]
           Role: Return
         - Name: ~r1
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890c70..0x890d30, Pieces: []}]
+          Locations: [{Range: 0x890da0..0x890e60, Pieces: []}]
           Role: Return
         - Name: ~r2
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890c70..0x890d30, Pieces: []}]
+          Locations: [{Range: 0x890da0..0x890e60, Pieces: []}]
           Role: Return
         - Name: ~r3
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890c70..0x890d30, Pieces: []}]
+          Locations: [{Range: 0x890da0..0x890e60, Pieces: []}]
           Role: Return
         - Name: ~r4
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890c70..0x890d30, Pieces: []}]
+          Locations: [{Range: 0x890da0..0x890e60, Pieces: []}]
           Role: Return
         - Name: ~r5
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890c70..0x890d30, Pieces: []}]
+          Locations: [{Range: 0x890da0..0x890e60, Pieces: []}]
           Role: Return
         - Name: ~r6
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890c70..0x890d30, Pieces: []}]
+          Locations: [{Range: 0x890da0..0x890e60, Pieces: []}]
           Role: Return
         - Name: ~r7
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890c70..0x890d30, Pieces: []}]
+          Locations: [{Range: 0x890da0..0x890e60, Pieces: []}]
           Role: Return
         - Name: ~r8
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890c70..0x890d30, Pieces: []}]
+          Locations: [{Range: 0x890da0..0x890e60, Pieces: []}]
           Role: Return
         - Name: ~r9
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890c70..0x890d30, Pieces: []}]
+          Locations: [{Range: 0x890da0..0x890e60, Pieces: []}]
           Role: Return
         - Name: ~r10
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890c70..0x890d30, Pieces: []}]
+          Locations: [{Range: 0x890da0..0x890e60, Pieces: []}]
           Role: Return
         - Name: ~r11
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890c70..0x890d30, Pieces: []}]
+          Locations: [{Range: 0x890da0..0x890e60, Pieces: []}]
           Role: Return
         - Name: ~r12
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890c70..0x890d30, Pieces: []}]
+          Locations: [{Range: 0x890da0..0x890e60, Pieces: []}]
           Role: Return
         - Name: ~r13
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890c70..0x890d30, Pieces: []}]
+          Locations: [{Range: 0x890da0..0x890e60, Pieces: []}]
           Role: Return
         - Name: ~r14
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890c70..0x890d30, Pieces: []}]
+          Locations: [{Range: 0x890da0..0x890e60, Pieces: []}]
           Role: Return
         - Name: onlyOnAmd64_16
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890c70..0x890d30, Pieces: []}]
+          Locations: [{Range: 0x890da0..0x890e60, Pieces: []}]
           Role: Return
         - Name: bothArmAndAmd64
           Type: 17 BaseType float64
           Locations:
-            - Range: 0x890c70..0x890d0c
+            - Range: 0x890da0..0x890e3c
               Pieces: []
-            - Range: 0x890d0c..0x890d0d
+            - Range: 0x890e3c..0x890e3d
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x890d0d..0x890d30
+            - Range: 0x890e3d..0x890e60
               Pieces: []
           Role: Return
-    - ID: 108
+    - ID: 109
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0x890d30..0x890db0]
+      OutOfLinePCRanges: [0x890e60..0x890ee0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 90 BaseType complex64
-          Locations: [{Range: 0x890d30..0x890db0, Pieces: []}]
+          Locations: [{Range: 0x890e60..0x890ee0, Pieces: []}]
           Role: Return
         - Name: ~r1
           Type: 91 BaseType complex128
-          Locations: [{Range: 0x890d30..0x890db0, Pieces: []}]
+          Locations: [{Range: 0x890e60..0x890ee0, Pieces: []}]
           Role: Return
-    - ID: 109
+    - ID: 110
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0x890db0..0x890e80]
+      OutOfLinePCRanges: [0x890ee0..0x890fb0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0x890db0..0x890e64
+            - Range: 0x890ee0..0x890f94
               Pieces: []
-            - Range: 0x890e64..0x890e65
+            - Range: 0x890f94..0x890f95
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6711,173 +6797,173 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x890e65..0x890e80
+            - Range: 0x890f95..0x890fb0
               Pieces: []
           Role: Return
-    - ID: 110
+    - ID: 111
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0x890e80..0x890f10]
+      OutOfLinePCRanges: [0x890fb0..0x891040]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 246 ArrayType [3]int
           Locations:
-            - Range: 0x890e80..0x890ef0
+            - Range: 0x890fb0..0x891020
               Pieces: []
-            - Range: 0x890ef0..0x890ef1
+            - Range: 0x891020..0x891021
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x890ef1..0x890f10
+            - Range: 0x891021..0x891040
               Pieces: []
           Role: Return
-    - ID: 111
+    - ID: 112
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0x890f10..0x890f80]
+      OutOfLinePCRanges: [0x891040..0x8910b0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 247 ArrayType [1]int
           Locations:
-            - Range: 0x890f10..0x890f64
+            - Range: 0x891040..0x891094
               Pieces: []
-            - Range: 0x890f64..0x890f65
+            - Range: 0x891094..0x891095
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x890f65..0x890f80
+            - Range: 0x891095..0x8910b0
               Pieces: []
           Role: Return
-    - ID: 112
+    - ID: 113
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0x890f80..0x890ff0]
+      OutOfLinePCRanges: [0x8910b0..0x891120]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 248 ArrayType [0]int
           Locations:
-            - Range: 0x890f80..0x890fd0
+            - Range: 0x8910b0..0x891100
               Pieces: []
-            - Range: 0x890fd0..0x890fd1
+            - Range: 0x891100..0x891101
               Pieces: []
-            - Range: 0x890fd1..0x890ff0
+            - Range: 0x891101..0x891120
               Pieces: []
           Role: Return
-    - ID: 113
+    - ID: 114
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0x890ff0..0x891070]
+      OutOfLinePCRanges: [0x891120..0x8911a0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 249 StructureType main.mixedStruct
-          Locations: [{Range: 0x890ff0..0x891070, Pieces: []}]
+          Locations: [{Range: 0x891120..0x8911a0, Pieces: []}]
           Role: Return
-    - ID: 114
+    - ID: 115
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0x891070..0x891110]
+      OutOfLinePCRanges: [0x8911a0..0x891240]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891070..0x8910ec
+            - Range: 0x8911a0..0x89121c
               Pieces: []
-            - Range: 0x8910ec..0x8910ed
+            - Range: 0x89121c..0x89121d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8910ed..0x891110
+            - Range: 0x89121d..0x891240
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891070..0x8910ec
+            - Range: 0x8911a0..0x89121c
               Pieces: []
-            - Range: 0x8910ec..0x8910ed
+            - Range: 0x89121c..0x89121d
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x8910ed..0x891110
+            - Range: 0x89121d..0x891240
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891070..0x8910ec
+            - Range: 0x8911a0..0x89121c
               Pieces: []
-            - Range: 0x8910ec..0x8910ed
+            - Range: 0x89121c..0x89121d
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x8910ed..0x891110
+            - Range: 0x89121d..0x891240
               Pieces: []
           Role: Return
         - Name: ~r3
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891070..0x8910ec
+            - Range: 0x8911a0..0x89121c
               Pieces: []
-            - Range: 0x8910ec..0x8910ed
+            - Range: 0x89121c..0x89121d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x8910ed..0x891110
+            - Range: 0x89121d..0x891240
               Pieces: []
           Role: Return
         - Name: ~r4
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891070..0x8910ec
+            - Range: 0x8911a0..0x89121c
               Pieces: []
-            - Range: 0x8910ec..0x8910ed
+            - Range: 0x89121c..0x89121d
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x8910ed..0x891110
+            - Range: 0x89121d..0x891240
               Pieces: []
           Role: Return
         - Name: ~r5
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891070..0x8910ec
+            - Range: 0x8911a0..0x89121c
               Pieces: []
-            - Range: 0x8910ec..0x8910ed
+            - Range: 0x89121c..0x89121d
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x8910ed..0x891110
+            - Range: 0x89121d..0x891240
               Pieces: []
           Role: Return
         - Name: ~r6
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891070..0x8910ec
+            - Range: 0x8911a0..0x89121c
               Pieces: []
-            - Range: 0x8910ec..0x8910ed
+            - Range: 0x89121c..0x89121d
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x8910ed..0x891110
+            - Range: 0x89121d..0x891240
               Pieces: []
           Role: Return
         - Name: ~r7
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891070..0x8910ec
+            - Range: 0x8911a0..0x89121c
               Pieces: []
-            - Range: 0x8910ec..0x8910ed
+            - Range: 0x89121c..0x89121d
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x8910ed..0x891110
+            - Range: 0x89121d..0x891240
               Pieces: []
           Role: Return
         - Name: ~r8
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x891070..0x8910ec
+            - Range: 0x8911a0..0x89121c
               Pieces: []
-            - Range: 0x8910ec..0x8910ed
+            - Range: 0x89121c..0x89121d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8910ed..0x891110
+            - Range: 0x89121d..0x891240
               Pieces: []
           Role: Return
-    - ID: 115
+    - ID: 116
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0x891110..0x8911f0]
+      OutOfLinePCRanges: [0x891240..0x891320]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 250 StructureType main.wideStruct
           Locations:
-            - Range: 0x891110..0x8911d4
+            - Range: 0x891240..0x891304
               Pieces: []
-            - Range: 0x8911d4..0x8911d5
+            - Range: 0x891304..0x891305
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6901,127 +6987,127 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0x8911d5..0x8911f0
+            - Range: 0x891305..0x891320
               Pieces: []
           Role: Return
-    - ID: 116
+    - ID: 117
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0x8911f0..0x891280]
+      OutOfLinePCRanges: [0x891320..0x8913b0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8911f0..0x891260
+            - Range: 0x891320..0x891390
               Pieces: []
-            - Range: 0x891260..0x891261
+            - Range: 0x891390..0x891391
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x891261..0x891280
+            - Range: 0x891391..0x8913b0
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 17 BaseType float64
-          Locations: [{Range: 0x8911f0..0x891280, Pieces: []}]
+          Locations: [{Range: 0x891320..0x8913b0, Pieces: []}]
           Role: Return
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8911f0..0x891260
+            - Range: 0x891320..0x891390
               Pieces: []
-            - Range: 0x891260..0x891261
+            - Range: 0x891390..0x891391
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x891261..0x891280
+            - Range: 0x891391..0x8913b0
               Pieces: []
           Role: Return
         - Name: ~r3
           Type: 17 BaseType float64
-          Locations: [{Range: 0x8911f0..0x891280, Pieces: []}]
+          Locations: [{Range: 0x891320..0x8913b0, Pieces: []}]
           Role: Return
         - Name: ~r4
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x8911f0..0x891260
+            - Range: 0x891320..0x891390
               Pieces: []
-            - Range: 0x891260..0x891261
+            - Range: 0x891390..0x891391
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x891261..0x891280
+            - Range: 0x891391..0x8913b0
               Pieces: []
           Role: Return
-    - ID: 117
+    - ID: 118
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0x891280..0x891310]
+      OutOfLinePCRanges: [0x8913b0..0x891440]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 251 StructureType main.structWithArray
           Locations:
-            - Range: 0x891280..0x8912f0
+            - Range: 0x8913b0..0x891420
               Pieces: []
-            - Range: 0x8912f0..0x8912f1
+            - Range: 0x891420..0x891421
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x8912f1..0x891310
+            - Range: 0x891421..0x891440
               Pieces: []
           Role: Return
-    - ID: 118
+    - ID: 119
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0x891310..0x891380]
+      OutOfLinePCRanges: [0x891440..0x8914b0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType float64
-          Locations: [{Range: 0x891310..0x891380, Pieces: []}]
+          Locations: [{Range: 0x891440..0x8914b0, Pieces: []}]
           Role: Return
-    - ID: 119
+    - ID: 120
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0x891380..0x891400]
+      OutOfLinePCRanges: [0x8914b0..0x891530]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 16 BaseType float32
-          Locations: [{Range: 0x891380..0x891400, Pieces: []}]
+          Locations: [{Range: 0x8914b0..0x891530, Pieces: []}]
           Role: Return
         - Name: ~r1
           Type: 17 BaseType float64
-          Locations: [{Range: 0x891380..0x891400, Pieces: []}]
+          Locations: [{Range: 0x8914b0..0x891530, Pieces: []}]
           Role: Return
-    - ID: 120
+    - ID: 121
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0x891400..0x891470]
+      OutOfLinePCRanges: [0x891530..0x8915a0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x891400..0x891458
+            - Range: 0x891530..0x891588
               Pieces: []
-            - Range: 0x891458..0x891459
+            - Range: 0x891588..0x891589
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x891459..0x891470
+            - Range: 0x891589..0x8915a0
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 1 BaseType uintptr
           Locations:
-            - Range: 0x891400..0x891458
+            - Range: 0x891530..0x891588
               Pieces: []
-            - Range: 0x891458..0x891459
+            - Range: 0x891588..0x891589
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x891459..0x891470
+            - Range: 0x891589..0x8915a0
               Pieces: []
           Role: Return
-    - ID: 121
+    - ID: 122
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0x891470..0x891650]
+      OutOfLinePCRanges: [0x8915a0..0x891780]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0x891470..0x8914dc
+            - Range: 0x8915a0..0x89160c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7043,7 +7129,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8914dc..0x8914f0
+            - Range: 0x89160c..0x891620
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7065,7 +7151,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8914f0..0x8914f4
+            - Range: 0x891620..0x891624
               Pieces:
                 - Size: 8
                   Op: null
@@ -7091,9 +7177,9 @@ Subprograms:
         - Name: ~r0
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0x891470..0x8915e8
+            - Range: 0x8915a0..0x891718
               Pieces: []
-            - Range: 0x8915e8..0x8915e9
+            - Range: 0x891718..0x891719
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7115,39 +7201,39 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8915e9..0x891650
+            - Range: 0x891719..0x891780
               Pieces: []
           Role: Return
-    - ID: 122
+    - ID: 123
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0x891650..0x891720]
+      OutOfLinePCRanges: [0x891780..0x891850]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 246 ArrayType [3]int
           Locations:
-            - Range: 0x891650..0x891720
+            - Range: 0x891780..0x891850
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 246 ArrayType [3]int
           Locations:
-            - Range: 0x891650..0x891704
+            - Range: 0x891780..0x891834
               Pieces: []
-            - Range: 0x891704..0x891705
+            - Range: 0x891834..0x891835
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x891705..0x891720
+            - Range: 0x891835..0x891850
               Pieces: []
           Role: Return
-    - ID: 123
+    - ID: 124
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0x891720..0x891980]
+      OutOfLinePCRanges: [0x891850..0x891ab0]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0x891720..0x891790
+            - Range: 0x891850..0x8918c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7169,7 +7255,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x891790..0x8917a4
+            - Range: 0x8918c0..0x8918d4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7191,7 +7277,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8917a4..0x8917a8
+            - Range: 0x8918d4..0x8918d8
               Pieces:
                 - Size: 8
                   Op: null
@@ -7217,15 +7303,15 @@ Subprograms:
         - Name: s2
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0x891720..0x891980
+            - Range: 0x891850..0x891ab0
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0x891720..0x891910
+            - Range: 0x891850..0x891a40
               Pieces: []
-            - Range: 0x891910..0x891911
+            - Range: 0x891a40..0x891a41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7247,175 +7333,175 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x891911..0x891980
+            - Range: 0x891a41..0x891ab0
               Pieces: []
           Role: Return
-    - ID: 124
+    - ID: 125
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0x891980..0x891b70]
+      OutOfLinePCRanges: [0x891ab0..0x891ca0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891980..0x8919f8
+            - Range: 0x891ab0..0x891b28
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8919f8..0x891b70
+            - Range: 0x891b28..0x891ca0
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891980..0x8919f8
+            - Range: 0x891ab0..0x891b28
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x8919f8..0x891b70
+            - Range: 0x891b28..0x891ca0
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
         - Name: c
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891980..0x8919f8
+            - Range: 0x891ab0..0x891b28
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x8919f8..0x891b70
+            - Range: 0x891b28..0x891ca0
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
         - Name: d
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891980..0x8919f8
+            - Range: 0x891ab0..0x891b28
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x8919f8..0x891b70
+            - Range: 0x891b28..0x891ca0
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
         - Name: e
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891980..0x8919f8
+            - Range: 0x891ab0..0x891b28
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x8919f8..0x891b70
+            - Range: 0x891b28..0x891ca0
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
         - Name: f
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891980..0x8919f8
+            - Range: 0x891ab0..0x891b28
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x8919f8..0x891b70
+            - Range: 0x891b28..0x891ca0
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
         - Name: g
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891980..0x8919f8
+            - Range: 0x891ab0..0x891b28
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x8919f8..0x891b70
+            - Range: 0x891b28..0x891ca0
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
         - Name: h
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891980..0x8919f8
+            - Range: 0x891ab0..0x891b28
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x8919f8..0x891b70
+            - Range: 0x891b28..0x891ca0
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891980..0x8919f8
+            - Range: 0x891ab0..0x891b28
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0x8919f8..0x891b70
+            - Range: 0x891b28..0x891ca0
               Pieces: [{Size: 8, Op: {CfaOffset: 88}}]
           Role: Parameter
         - Name: ~r0
           Type: 106 ArrayType [2]int
           Locations:
-            - Range: 0x891980..0x891b0c
+            - Range: 0x891ab0..0x891c3c
               Pieces: []
-            - Range: 0x891b0c..0x891b0d
+            - Range: 0x891c3c..0x891c3d
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-            - Range: 0x891b0d..0x891b70
+            - Range: 0x891c3d..0x891ca0
               Pieces: []
           Role: Return
-    - ID: 125
+    - ID: 126
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0x891b70..0x891db0]
+      OutOfLinePCRanges: [0x891ca0..0x891ee0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891b70..0x891bf8
+            - Range: 0x891ca0..0x891d28
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x891bf8..0x891db0
+            - Range: 0x891d28..0x891ee0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891b70..0x891bf8
+            - Range: 0x891ca0..0x891d28
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x891bf8..0x891db0
+            - Range: 0x891d28..0x891ee0
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
         - Name: c
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891b70..0x891bf8
+            - Range: 0x891ca0..0x891d28
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x891bf8..0x891db0
+            - Range: 0x891d28..0x891ee0
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
         - Name: d
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891b70..0x891bf8
+            - Range: 0x891ca0..0x891d28
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x891bf8..0x891db0
+            - Range: 0x891d28..0x891ee0
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
         - Name: e
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891b70..0x891bf8
+            - Range: 0x891ca0..0x891d28
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x891bf8..0x891db0
+            - Range: 0x891d28..0x891ee0
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
         - Name: f
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891b70..0x891bf8
+            - Range: 0x891ca0..0x891d28
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x891bf8..0x891db0
+            - Range: 0x891d28..0x891ee0
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
         - Name: g
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891b70..0x891bf8
+            - Range: 0x891ca0..0x891d28
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x891bf8..0x891db0
+            - Range: 0x891d28..0x891ee0
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
         - Name: h
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891b70..0x891bf8
+            - Range: 0x891ca0..0x891d28
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x891bf8..0x891db0
+            - Range: 0x891d28..0x891ee0
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
         - Name: s
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x891b70..0x891bf8
+            - Range: 0x891ca0..0x891d28
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x891bf8..0x891db0
+            - Range: 0x891d28..0x891ee0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 72}
@@ -7425,9 +7511,9 @@ Subprograms:
         - Name: ~r0
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0x891b70..0x891d40
+            - Range: 0x891ca0..0x891e70
               Pieces: []
-            - Range: 0x891d40..0x891d41
+            - Range: 0x891e70..0x891e71
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7449,191 +7535,174 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x891d41..0x891db0
+            - Range: 0x891e71..0x891ee0
               Pieces: []
           Role: Return
-    - ID: 126
+    - ID: 127
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0x891db0..0x891e50]
+      OutOfLinePCRanges: [0x891ee0..0x891f80]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 156 ArrayType [5]int
           Locations:
-            - Range: 0x891db0..0x891e50
+            - Range: 0x891ee0..0x891f80
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891db0..0x891e2c
+            - Range: 0x891ee0..0x891f5c
               Pieces: []
-            - Range: 0x891e2c..0x891e2d
+            - Range: 0x891f5c..0x891f5d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x891e2d..0x891e50
+            - Range: 0x891f5d..0x891f80
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891db0..0x891e2c
+            - Range: 0x891ee0..0x891f5c
               Pieces: []
-            - Range: 0x891e2c..0x891e2d
+            - Range: 0x891f5c..0x891f5d
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x891e2d..0x891e50
+            - Range: 0x891f5d..0x891f80
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891db0..0x891e2c
+            - Range: 0x891ee0..0x891f5c
               Pieces: []
-            - Range: 0x891e2c..0x891e2d
+            - Range: 0x891f5c..0x891f5d
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x891e2d..0x891e50
+            - Range: 0x891f5d..0x891f80
               Pieces: []
           Role: Return
-    - ID: 127
+    - ID: 128
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0x891e50..0x891f30]
+      OutOfLinePCRanges: [0x891f80..0x892060]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 106 ArrayType [2]int
           Locations:
-            - Range: 0x891e50..0x891f30
+            - Range: 0x891f80..0x892060
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: b
           Type: 246 ArrayType [3]int
           Locations:
-            - Range: 0x891e50..0x891f30
+            - Range: 0x891f80..0x892060
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
           Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891e50..0x891f10
+            - Range: 0x891f80..0x892040
               Pieces: []
-            - Range: 0x891f10..0x891f11
+            - Range: 0x892040..0x892041
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x891f11..0x891f30
+            - Range: 0x892041..0x892060
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 106 ArrayType [2]int
           Locations:
-            - Range: 0x891e50..0x891f10
+            - Range: 0x891f80..0x892040
               Pieces: []
-            - Range: 0x891f10..0x891f11
+            - Range: 0x892040..0x892041
               Pieces: [{Size: 16, Op: {CfaOffset: 48}}]
-            - Range: 0x891f11..0x891f30
+            - Range: 0x892041..0x892060
               Pieces: []
           Role: Return
-    - ID: 128
+    - ID: 129
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0x891f30..0x892000]
+      OutOfLinePCRanges: [0x892060..0x892130]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 251 StructureType main.structWithArray
           Locations:
-            - Range: 0x891f30..0x892000
+            - Range: 0x892060..0x892130
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891f30..0x891fdc
+            - Range: 0x892060..0x89210c
               Pieces: []
-            - Range: 0x891fdc..0x891fdd
+            - Range: 0x89210c..0x89210d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x891fdd..0x892000
+            - Range: 0x89210d..0x892130
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 251 StructureType main.structWithArray
           Locations:
-            - Range: 0x891f30..0x891fdc
+            - Range: 0x892060..0x89210c
               Pieces: []
-            - Range: 0x891fdc..0x891fdd
+            - Range: 0x89210c..0x89210d
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x891fdd..0x892000
+            - Range: 0x89210d..0x892130
               Pieces: []
           Role: Return
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891fb0..0x892000
+            - Range: 0x8920e0..0x892130
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 129
+    - ID: 130
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0x892000..0x8920b0]
+      OutOfLinePCRanges: [0x892130..0x8921e0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 248 ArrayType [0]int
-          Locations: [{Range: 0x892000..0x8920b0, Pieces: []}]
+          Locations: [{Range: 0x892130..0x8921e0, Pieces: []}]
           Role: Parameter
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0x892000..0x892040
+            - Range: 0x892130..0x892170
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x892040..0x89205c
+            - Range: 0x892170..0x89218c
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x89205c..0x892078
+            - Range: 0x89218c..0x8921a8
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x892078..0x8920b0
+            - Range: 0x8921a8..0x8921e0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x892000..0x892084
+            - Range: 0x892130..0x8921b4
               Pieces: []
-            - Range: 0x892084..0x892085
+            - Range: 0x8921b4..0x8921b5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x892085..0x8920b0
+            - Range: 0x8921b5..0x8921e0
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 248 ArrayType [0]int
           Locations:
-            - Range: 0x892000..0x892084
+            - Range: 0x892130..0x8921b4
               Pieces: []
-            - Range: 0x892084..0x892085
+            - Range: 0x8921b4..0x8921b5
               Pieces: []
-            - Range: 0x892085..0x8920b0
+            - Range: 0x8921b5..0x8921e0
               Pieces: []
           Role: Return
-    - ID: 130
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0x892520..0x892530]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 252 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x892520..0x892530
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
     - ID: 131
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0x892530..0x892540]
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0x892650..0x892660]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 252 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x892530..0x892540
+            - Range: 0x892650..0x892660
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7643,14 +7712,14 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
     - ID: 132
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0x892540..0x892550]
+      Name: main.testEmptySlice
+      OutOfLinePCRanges: [0x892660..0x892670]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 253 GoSliceHeaderType [][]uint
+          Type: 252 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x892540..0x892550
+            - Range: 0x892660..0x892670
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7660,14 +7729,14 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
     - ID: 133
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0x892550..0x892560]
+      Name: main.testSliceOfSlices
+      OutOfLinePCRanges: [0x892670..0x892680]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 255 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 253 GoSliceHeaderType [][]uint
           Locations:
-            - Range: 0x892550..0x892560
+            - Range: 0x892670..0x892680
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7675,22 +7744,16 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-        - Name: a
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0x892550..0x892560
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
     - ID: 134
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0x892560..0x892570]
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0x892680..0x892690]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 255 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x892560..0x892570
+            - Range: 0x892680..0x892690
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7702,18 +7765,18 @@ Subprograms:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0x892560..0x892570
+            - Range: 0x892680..0x892690
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
     - ID: 135
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0x892570..0x892580]
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0x892690..0x8926a0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 255 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x892570..0x892580
+            - Range: 0x892690..0x8926a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7725,18 +7788,41 @@ Subprograms:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0x892570..0x892580
+            - Range: 0x892690..0x8926a0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
     - ID: 136
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0x8926a0..0x8926b0]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 255 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x8926a0..0x8926b0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+        - Name: a
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x8926a0..0x8926b0
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          Role: Parameter
+    - ID: 137
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0x892580..0x892590]
+      OutOfLinePCRanges: [0x8926b0..0x8926c0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 258 GoSliceHeaderType []string
           Locations:
-            - Range: 0x892580..0x892590
+            - Range: 0x8926b0..0x8926c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7745,21 +7831,21 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 137
+    - ID: 138
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0x892590..0x8925a0]
+      OutOfLinePCRanges: [0x8926c0..0x8926d0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 15 BaseType int8
           Locations:
-            - Range: 0x892590..0x8925a0
+            - Range: 0x8926c0..0x8926d0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: s
           Type: 259 GoSliceHeaderType []bool
           Locations:
-            - Range: 0x892590..0x8925a0
+            - Range: 0x8926c0..0x8926d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -7771,35 +7857,18 @@ Subprograms:
         - Name: x
           Type: 12 BaseType uint
           Locations:
-            - Range: 0x892590..0x8925a0
+            - Range: 0x8926c0..0x8926d0
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
-    - ID: 138
+    - ID: 139
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0x8925a0..0x8925b0]
+      OutOfLinePCRanges: [0x8926d0..0x8926e0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 260 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0x8925a0..0x8925b0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-    - ID: 139
-      Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0x8925b0..0x8925c0]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 252 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x8925b0..0x8925c0
+            - Range: 0x8926d0..0x8926e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7809,14 +7878,14 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
     - ID: 140
-      Name: main.testSliceEmptyStructs
-      OutOfLinePCRanges: [0x8925c0..0x8925d0]
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0x8926e0..0x8926f0]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 261 GoSliceHeaderType []struct {}
+          Type: 252 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x8925c0..0x8925d0
+            - Range: 0x8926e0..0x8926f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7826,14 +7895,31 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
     - ID: 141
+      Name: main.testSliceEmptyStructs
+      OutOfLinePCRanges: [0x8926f0..0x892700]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 261 GoSliceHeaderType []struct {}
+          Locations:
+            - Range: 0x8926f0..0x892700
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+    - ID: 142
       Name: main.testSubslices
-      OutOfLinePCRanges: [0x8925d0..0x8925e0]
+      OutOfLinePCRanges: [0x892700..0x892710]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 252 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x8925d0..0x8925e0
+            - Range: 0x892700..0x892710
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7845,7 +7931,7 @@ Subprograms:
         - Name: bs
           Type: 252 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x8925d0..0x8925e0
+            - Range: 0x892700..0x892710
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -7857,7 +7943,7 @@ Subprograms:
         - Name: cs
           Type: 252 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x8925d0..0x8925e0
+            - Range: 0x892700..0x892710
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -7866,49 +7952,49 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 142
+    - ID: 143
       Name: main.stackC
-      OutOfLinePCRanges: [0x8928f0..0x892960]
+      OutOfLinePCRanges: [0x892a20..0x892a90]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x8928f0..0x89293c
+            - Range: 0x892a20..0x892a6c
               Pieces: []
-            - Range: 0x89293c..0x89293d
+            - Range: 0x892a6c..0x892a6d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89293d..0x892960
+            - Range: 0x892a6d..0x892a90
               Pieces: []
           Role: Return
-    - ID: 143
+    - ID: 144
       Name: main.testSingleString
-      OutOfLinePCRanges: [0x892960..0x892970]
+      OutOfLinePCRanges: [0x892a90..0x892aa0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x892960..0x892970
+            - Range: 0x892a90..0x892aa0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 144
+    - ID: 145
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0x892970..0x892980]
+      OutOfLinePCRanges: [0x892aa0..0x892ab0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x892970..0x892980
+            - Range: 0x892aa0..0x892ab0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7918,7 +8004,7 @@ Subprograms:
         - Name: y
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x892970..0x892980
+            - Range: 0x892aa0..0x892ab0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -7928,22 +8014,22 @@ Subprograms:
         - Name: z
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x892970..0x892980
+            - Range: 0x892aa0..0x892ab0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
-    - ID: 145
+    - ID: 146
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x892980..0x8929a0]
+      OutOfLinePCRanges: [0x892ab0..0x892ad0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 263 StructureType main.threeStringStruct
           Locations:
-            - Range: 0x892980..0x8929a0
+            - Range: 0x892ab0..0x892ad0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7958,52 +8044,37 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
-    - ID: 146
+    - ID: 147
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x8929a0..0x8929b0]
+      OutOfLinePCRanges: [0x892ad0..0x892ae0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 264 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0x8929a0..0x8929b0
+            - Range: 0x892ad0..0x892ae0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 147
+    - ID: 148
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0x8929b0..0x8929c0]
+      OutOfLinePCRanges: [0x892ae0..0x892af0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 265 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0x8929b0..0x8929c0
+            - Range: 0x892ae0..0x892af0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 148
-      Name: main.testMassiveString
-      OutOfLinePCRanges: [0x8929c0..0x8929d0]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 11 GoStringHeaderType string
-          Locations:
-            - Range: 0x8929c0..0x8929d0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          Role: Parameter
     - ID: 149
-      Name: main.testUnitializedString
-      OutOfLinePCRanges: [0x8929d0..0x8929e0]
+      Name: main.testMassiveString
+      OutOfLinePCRanges: [0x892af0..0x892b00]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x8929d0..0x8929e0
+            - Range: 0x892af0..0x892b00
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8011,14 +8082,14 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
     - ID: 150
-      Name: main.testEmptyString
-      OutOfLinePCRanges: [0x8929e0..0x8929f0]
+      Name: main.testUnitializedString
+      OutOfLinePCRanges: [0x892b00..0x892b10]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x8929e0..0x8929f0
+            - Range: 0x892b00..0x892b10
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8026,14 +8097,29 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
     - ID: 151
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0x892b10..0x892b20]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 11 GoStringHeaderType string
+          Locations:
+            - Range: 0x892b10..0x892b20
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          Role: Parameter
+    - ID: 152
       Name: main.testSubstrings
-      OutOfLinePCRanges: [0x8929f0..0x892a00]
+      OutOfLinePCRanges: [0x892b20..0x892b30]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x8929f0..0x892a00
+            - Range: 0x892b20..0x892b30
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8043,7 +8129,7 @@ Subprograms:
         - Name: b
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x8929f0..0x892a00
+            - Range: 0x892b20..0x892b30
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -8053,33 +8139,33 @@ Subprograms:
         - Name: c
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x8929f0..0x892a00
+            - Range: 0x892b20..0x892b30
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
-    - ID: 152
+    - ID: 153
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0x892b60..0x892b70]
+      OutOfLinePCRanges: [0x892c90..0x892ca0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 267 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0x892b60..0x892b70
+            - Range: 0x892c90..0x892ca0
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
-    - ID: 153
+    - ID: 154
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0x892b70..0x892b90]
+      OutOfLinePCRanges: [0x892ca0..0x892cc0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 280 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0x892b70..0x892b90
+            - Range: 0x892ca0..0x892cc0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8094,15 +8180,15 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
-    - ID: 154
+    - ID: 155
       Name: main.testStruct
-      OutOfLinePCRanges: [0x892c60..0x892c80]
+      OutOfLinePCRanges: [0x892d90..0x892db0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 311 StructureType main.aStruct
           Locations:
-            - Range: 0x892c60..0x892c80
+            - Range: 0x892d90..0x892db0
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -8119,134 +8205,134 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
           Role: Parameter
-    - ID: 155
+    - ID: 156
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0x892d00..0x892d10]
+      OutOfLinePCRanges: [0x892e30..0x892e40]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 312 PointerType *main.anotherStruct
           Locations:
-            - Range: 0x892d00..0x892d10
+            - Range: 0x892e30..0x892e40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 156
+    - ID: 157
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x892d60..0x892d70]
+      OutOfLinePCRanges: [0x892e90..0x892ea0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 314 StructureType main.emptyStruct
-          Locations: [{Range: 0x892d60..0x892d70, Pieces: []}]
+          Locations: [{Range: 0x892e90..0x892ea0, Pieces: []}]
           Role: Parameter
-    - ID: 157
+    - ID: 158
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x892d70..0x892d80]
+      OutOfLinePCRanges: [0x892ea0..0x892eb0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 315 PointerType *main.emptyStruct
           Locations:
-            - Range: 0x892d70..0x892d80
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-    - ID: 158
-      Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0x88d5f0..0x88d660]
-      InlinePCRanges:
-        - Ranges: [0x88d67c..0x88d6b4]
-          RootRanges: [0x88d660..0x88d6e0]
-        - Ranges: [0x88d7c8..0x88d800]
-          RootRanges: [0x88d790..0x88d820]
-        - Ranges: [0x88d844..0x88d87c]
-          RootRanges: [0x88d820..0x88d8f0]
-        - Ranges: [0x88d90c..0x88d944]
-          RootRanges: [0x88d8f0..0x88d970]
-      Variables:
-        - Name: x
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0x88d5f0..0x88d610
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88d67c..0x88d684
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88d7c8..0x88d7d0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88d83c..0x88d84c
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88d84c..0x88d8f0
-              Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x88d8f0..0x88d914
+            - Range: 0x892ea0..0x892eb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 159
-      Name: main.testInlinedBBB
-      OutOfLinePCRanges: []
+      Name: main.testInlinedPrint
+      OutOfLinePCRanges: [0x88d720..0x88d790]
       InlinePCRanges:
-        - Ranges: [0x88d888..0x88d8c0]
-          RootRanges: [0x88d820..0x88d8f0]
-      Variables: []
-    - ID: 160
-      Name: main.testInlinedBCA
-      OutOfLinePCRanges: []
-      InlinePCRanges:
-        - Ranges: [0x88d98c..0x88d9d0]
-          RootRanges: [0x88d970..0x88da90]
-      Variables: []
-    - ID: 161
-      Name: main.testInlinedBCB
-      OutOfLinePCRanges: []
-      InlinePCRanges:
-        - Ranges: [0x88da40..0x88da78]
-          RootRanges: [0x88d970..0x88da90]
-      Variables: []
-    - ID: 162
-      Name: main.testInlinedSq
-      OutOfLinePCRanges: []
-      InlinePCRanges:
-        - Ranges: [0x88da94..0x88da98]
-          RootRanges: [0x88da90..0x88daa0]
+        - Ranges: [0x88d7ac..0x88d7e4]
+          RootRanges: [0x88d790..0x88d810]
+        - Ranges: [0x88d8f8..0x88d930]
+          RootRanges: [0x88d8c0..0x88d950]
+        - Ranges: [0x88d974..0x88d9ac]
+          RootRanges: [0x88d950..0x88da20]
+        - Ranges: [0x88da3c..0x88da74]
+          RootRanges: [0x88da20..0x88daa0]
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88da90..0x88da98
+            - Range: 0x88d720..0x88d740
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x88d7ac..0x88d7b4
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x88d8f8..0x88d900
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x88d96c..0x88d97c
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x88d97c..0x88da20
+              Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
+            - Range: 0x88da20..0x88da44
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
+    - ID: 160
+      Name: main.testInlinedBBB
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0x88d9b8..0x88d9f0]
+          RootRanges: [0x88d950..0x88da20]
+      Variables: []
+    - ID: 161
+      Name: main.testInlinedBCA
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0x88dabc..0x88db00]
+          RootRanges: [0x88daa0..0x88dbc0]
+      Variables: []
+    - ID: 162
+      Name: main.testInlinedBCB
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0x88db70..0x88dba8]
+          RootRanges: [0x88daa0..0x88dbc0]
+      Variables: []
     - ID: 163
+      Name: main.testInlinedSq
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0x88dbc4..0x88dbc8]
+          RootRanges: [0x88dbc0..0x88dbd0]
+      Variables:
+        - Name: x
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x88dbc0..0x88dbc8
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+    - ID: 164
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x88dac4..0x88dae8]
-          RootRanges: [0x88daa0..0x88db00]
-        - Ranges: [0x88db5c..0x88db84]
-          RootRanges: [0x88db00..0x88dc50]
+        - Ranges: [0x88dbf4..0x88dc18]
+          RootRanges: [0x88dbd0..0x88dc30]
+        - Ranges: [0x88dc8c..0x88dcb4]
+          RootRanges: [0x88dc30..0x88dd80]
       Variables:
         - Name: a
           Type: 156 ArrayType [5]int
           Locations:
-            - Range: 0x88dab0..0x88db00
+            - Range: 0x88dbe0..0x88dc30
               Pieces: [{Size: 40, Op: {CfaOffset: -48}}]
-            - Range: 0x88db48..0x88dc50
+            - Range: 0x88dc78..0x88dd80
               Pieces: [{Size: 40, Op: {CfaOffset: -120}}]
           Role: Parameter
-    - ID: 164
+    - ID: 165
       Name: main.firstBehavior.DoSomething
-      OutOfLinePCRanges: [0x88dc50..0x88dcd0]
+      OutOfLinePCRanges: [0x88dd80..0x88de00]
       InlinePCRanges:
-        - Ranges: [0x893abc..0x893af0]
-          RootRanges: [0x893a90..0x893b40]
+        - Ranges: [0x893bec..0x893c20]
+          RootRanges: [0x893bc0..0x893c70]
       Variables:
         - Name: b
           Type: 316 StructureType main.firstBehavior
           Locations:
-            - Range: 0x88dc50..0x88dc7c
+            - Range: 0x88dd80..0x88ddac
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x88dc7c..0x88dc80
+            - Range: 0x88ddac..0x88ddb0
               Pieces:
                 - Size: 8
                   Op: null
@@ -8256,23 +8342,23 @@ Subprograms:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x88dc50..0x88dca0
+            - Range: 0x88dd80..0x88ddd0
               Pieces: []
-            - Range: 0x88dca0..0x88dca1
+            - Range: 0x88ddd0..0x88ddd1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x88dca1..0x88dcd0
+            - Range: 0x88ddd1..0x88de00
               Pieces: []
           Role: Return
-    - ID: 165
+    - ID: 166
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x88e328..0x88e334, 0x88e338..0x88e340]
-          RootRanges: [0x88e210..0x88e380]
+        - Ranges: [0x88e458..0x88e464, 0x88e468..0x88e470]
+          RootRanges: [0x88e340..0x88e4b0]
         - Ranges: [0x88bd84..0x88bd88, 0x88bd8c..0x88bd94]
           RootRanges: [0x88bd70..0x88bda0]
       Variables: []
@@ -11229,10 +11315,10 @@ Types:
       GoKind: 22
       Pointee: 674 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1376
+      ID: 1377
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
     - __kind: EventRootType
-      ID: 1374
+      ID: 1375
       Name: Probe[main.firstBehavior.DoSomething]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11244,11 +11330,11 @@ Types:
             Type: 316 StructureType main.firstBehavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 0, name: b}
+                  Variable: {subprogram: 165, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1375
+      ID: 1376
       Name: Probe[main.firstBehavior.DoSomething]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11260,14 +11346,14 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 1, name: ~r0}
+                  Variable: {subprogram: 165, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1332
+      ID: 1333
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1333
+      ID: 1334
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11279,11 +11365,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: ~r0}
+                  Variable: {subprogram: 143, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1199
+      ID: 1200
       Name: Probe[main.testAnyPtr]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11295,7 +11381,7 @@ Types:
             Type: 158 PointerType *interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: a}
+                  Variable: {subprogram: 59, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -11305,11 +11391,11 @@ Types:
             Type: 158 PointerType *interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: a}
+                  Variable: {subprogram: 59, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1200
+      ID: 1201
       Name: Probe[main.testAnyPtr]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11321,11 +11407,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 1, name: ~r0}
+                  Variable: {subprogram: 59, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1196
+      ID: 1197
       Name: Probe[main.testAny]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11337,7 +11423,7 @@ Types:
             Type: 152 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: a}
+                  Variable: {subprogram: 57, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -11347,11 +11433,11 @@ Types:
             Type: 152 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: a}
+                  Variable: {subprogram: 57, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1197
+      ID: 1198
       Name: Probe[main.testAny]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11363,11 +11449,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 1, name: ~r0}
+                  Variable: {subprogram: 57, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1303
+      ID: 1304
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11379,7 +11465,7 @@ Types:
             Type: 246 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: arg}
+                  Variable: {subprogram: 123, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
         - Name: arg
@@ -11389,11 +11475,11 @@ Types:
             Type: 246 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: arg}
+                  Variable: {subprogram: 123, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1304
+      ID: 1305
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11405,7 +11491,7 @@ Types:
             Type: 246 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 1, name: ~r0}
+                  Variable: {subprogram: 123, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -11487,7 +11573,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1208
+      ID: 1209
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11499,7 +11585,7 @@ Types:
             Type: 186 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: m}
+                  Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
         - Name: m
@@ -11509,7 +11595,7 @@ Types:
             Type: 186 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: m}
+                  Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -11565,7 +11651,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1230
+      ID: 1231
       Name: Probe[main.testAtomicAdd]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11577,7 +11663,7 @@ Types:
             Type: 10 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: x}
+                  Variable: {subprogram: 87, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -11587,11 +11673,11 @@ Types:
             Type: 10 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: x}
+                  Variable: {subprogram: 87, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1231
+      ID: 1232
       Name: Probe[main.testAtomicAdd]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11603,7 +11689,7 @@ Types:
             Type: 10 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 1, name: ~r0}
+                  Variable: {subprogram: 87, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -11688,7 +11774,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1232
+      ID: 1233
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11700,7 +11786,7 @@ Types:
             Type: 238 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: c}
+                  Variable: {subprogram: 88, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
         - Name: c
@@ -11710,11 +11796,11 @@ Types:
             Type: 238 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: c}
+                  Variable: {subprogram: 88, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1226
+      ID: 1227
       Name: Probe[main.testCombinedByte]
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -11726,7 +11812,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: w}
+                  Variable: {subprogram: 84, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: w
@@ -11736,7 +11822,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: w}
+                  Variable: {subprogram: 84, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: x
@@ -11746,7 +11832,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 1, name: x}
+                  Variable: {subprogram: 84, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: x
@@ -11756,7 +11842,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 1, name: x}
+                  Variable: {subprogram: 84, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: y
@@ -11766,7 +11852,7 @@ Types:
             Type: 16 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 2, name: y}
+                  Variable: {subprogram: 84, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
         - Name: y
@@ -11776,11 +11862,11 @@ Types:
             Type: 16 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 2, name: y}
+                  Variable: {subprogram: 84, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1227
+      ID: 1228
       Name: Probe[main.testCombinedString]
       ByteSize: 18
       PresenceBitsetSize: 1
@@ -11792,7 +11878,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 1, name: x}
+                  Variable: {subprogram: 85, index: 1, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: w_val
@@ -11802,11 +11888,11 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: w}
+                  Variable: {subprogram: 85, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1228
+      ID: 1229
       Name: Probe[main.testCombinedString]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -11818,7 +11904,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 1, name: x}
+                  Variable: {subprogram: 85, index: 1, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x_val
@@ -11828,7 +11914,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 1, name: x}
+                  Variable: {subprogram: 85, index: 1, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: w_val
@@ -11838,11 +11924,11 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: w}
+                  Variable: {subprogram: 85, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1240
+      ID: 1241
       Name: Probe[main.testCycle]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11854,7 +11940,7 @@ Types:
             Type: 243 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: t}
+                  Variable: {subprogram: 96, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
         - Name: t
@@ -11864,11 +11950,11 @@ Types:
             Type: 243 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: t}
+                  Variable: {subprogram: 96, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1171
+      ID: 1172
       Name: Probe[main.testDeepMap1]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11880,7 +11966,7 @@ Types:
             Type: 136 StructureType main.deepMap1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: a}
+                  Variable: {subprogram: 43, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -11890,11 +11976,11 @@ Types:
             Type: 136 StructureType main.deepMap1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: a}
+                  Variable: {subprogram: 43, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1172
+      ID: 1173
       Name: Probe[main.testDeepMap7]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11906,7 +11992,7 @@ Types:
             Type: 144 PointerType *main.deepMap7
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 0, name: a}
+                  Variable: {subprogram: 44, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -11916,11 +12002,11 @@ Types:
             Type: 144 PointerType *main.deepMap7
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 0, name: a}
+                  Variable: {subprogram: 44, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1167
+      ID: 1168
       Name: Probe[main.testDeepPtr1]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11932,7 +12018,7 @@ Types:
             Type: 125 StructureType main.deepPtr1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: a}
+                  Variable: {subprogram: 39, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -11942,11 +12028,11 @@ Types:
             Type: 125 StructureType main.deepPtr1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: a}
+                  Variable: {subprogram: 39, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1168
+      ID: 1169
       Name: Probe[main.testDeepPtr7]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11958,7 +12044,7 @@ Types:
             Type: 128 PointerType *main.deepPtr7
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: a}
+                  Variable: {subprogram: 40, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -11968,11 +12054,11 @@ Types:
             Type: 128 PointerType *main.deepPtr7
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: a}
+                  Variable: {subprogram: 40, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1169
+      ID: 1170
       Name: Probe[main.testDeepSlice1]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11984,7 +12070,7 @@ Types:
             Type: 130 StructureType main.deepSlice1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: a}
+                  Variable: {subprogram: 41, index: 0, name: a}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -11994,11 +12080,11 @@ Types:
             Type: 130 StructureType main.deepSlice1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: a}
+                  Variable: {subprogram: 41, index: 0, name: a}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1170
+      ID: 1171
       Name: Probe[main.testDeepSlice7]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12010,7 +12096,7 @@ Types:
             Type: 134 PointerType *main.deepSlice7
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: a}
+                  Variable: {subprogram: 42, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12020,11 +12106,11 @@ Types:
             Type: 134 PointerType *main.deepSlice7
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: a}
+                  Variable: {subprogram: 42, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1323
+      ID: 1324
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -12036,7 +12122,7 @@ Types:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: xs}
+                  Variable: {subprogram: 135, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -12046,7 +12132,7 @@ Types:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: xs}
+                  Variable: {subprogram: 135, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -12056,7 +12142,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 1, name: a}
+                  Variable: {subprogram: 135, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12066,11 +12152,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 1, name: a}
+                  Variable: {subprogram: 135, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1320
+      ID: 1321
       Name: Probe[main.testEmptySlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12082,7 +12168,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: u}
+                  Variable: {subprogram: 132, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -12092,11 +12178,11 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: u}
+                  Variable: {subprogram: 132, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1346
+      ID: 1347
       Name: Probe[main.testEmptyString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12108,7 +12194,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: x}
+                  Variable: {subprogram: 151, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -12118,11 +12204,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: x}
+                  Variable: {subprogram: 151, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1360
+      ID: 1361
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12134,7 +12220,7 @@ Types:
             Type: 315 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: e}
+                  Variable: {subprogram: 158, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -12144,11 +12230,11 @@ Types:
             Type: 315 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: e}
+                  Variable: {subprogram: 158, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1359
+      ID: 1360
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -12160,7 +12246,7 @@ Types:
             Type: 314 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: e}
+                  Variable: {subprogram: 157, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
         - Name: e
@@ -12170,11 +12256,67 @@ Types:
             Type: 314 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: e}
+                  Variable: {subprogram: 157, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1198
+      ID: 1167
+      Name: Probe[main.testErrorAtLine]Line
+      ByteSize: 57
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 2, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 2, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: err
+          Offset: 25
+          Kind: local
+          Expression:
+            Type: 18 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 3, name: err}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: err
+          Offset: 41
+          Kind: template_segment
+          Expression:
+            Type: 18 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 3, name: err}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1199
       Name: Probe[main.testError]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12186,7 +12328,7 @@ Types:
             Type: 18 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: e}
+                  Variable: {subprogram: 58, index: 0, name: e}
                   Offset: 0
                   ByteSize: 16
         - Name: e
@@ -12196,11 +12338,11 @@ Types:
             Type: 18 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: e}
+                  Variable: {subprogram: 58, index: 0, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1180
+      ID: 1181
       Name: Probe[main.testEsotericHeap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12212,7 +12354,7 @@ Types:
             Type: 154 PointerType *main.esotericHeap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 48, index: 0, name: e}
+                  Variable: {subprogram: 49, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -12222,14 +12364,14 @@ Types:
             Type: 154 PointerType *main.esotericHeap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 48, index: 0, name: e}
+                  Variable: {subprogram: 49, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1181
+      ID: 1182
       Name: Probe[main.testEsotericHeap]Return
     - __kind: EventRootType
-      ID: 1178
+      ID: 1179
       Name: Probe[main.testEsotericStack]
       ByteSize: 129
       PresenceBitsetSize: 1
@@ -12241,7 +12383,7 @@ Types:
             Type: 150 StructureType main.esotericStack
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 0, name: e}
+                  Variable: {subprogram: 48, index: 0, name: e}
                   Offset: 0
                   ByteSize: 64
         - Name: e
@@ -12251,14 +12393,14 @@ Types:
             Type: 150 StructureType main.esotericStack
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 0, name: e}
+                  Variable: {subprogram: 48, index: 0, name: e}
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1179
+      ID: 1180
       Name: Probe[main.testEsotericStack]Return
     - __kind: EventRootType
-      ID: 1192
+      ID: 1193
       Name: Probe[main.testFramelessArray]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12270,7 +12412,7 @@ Types:
             Type: 156 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: a}
+                  Variable: {subprogram: 55, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: a
@@ -12280,11 +12422,11 @@ Types:
             Type: 156 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: a}
+                  Variable: {subprogram: 55, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1194
+      ID: 1195
       Name: Probe[main.testFramelessArray]Line
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -12296,7 +12438,7 @@ Types:
             Type: 156 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: a}
+                  Variable: {subprogram: 55, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: a
@@ -12306,7 +12448,7 @@ Types:
             Type: 156 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: a}
+                  Variable: {subprogram: 55, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: ~r0
@@ -12316,11 +12458,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 1, name: ~r0}
+                  Variable: {subprogram: 55, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1193
+      ID: 1194
       Name: Probe[main.testFramelessArray]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12332,11 +12474,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 1, name: ~r0}
+                  Variable: {subprogram: 55, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1190
+      ID: 1191
       Name: Probe[main.testFrameless]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12348,7 +12490,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: x}
+                  Variable: {subprogram: 54, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12358,11 +12500,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: x}
+                  Variable: {subprogram: 54, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1191
+      ID: 1192
       Name: Probe[main.testFrameless]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12374,11 +12516,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 1, name: ~r0}
+                  Variable: {subprogram: 54, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1182
+      ID: 1183
       Name: Probe[main.testInlinedBA]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12390,7 +12532,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: x}
+                  Variable: {subprogram: 50, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12400,14 +12542,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: x}
+                  Variable: {subprogram: 50, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1183
+      ID: 1184
       Name: Probe[main.testInlinedBA]Return
     - __kind: EventRootType
-      ID: 1186
+      ID: 1187
       Name: Probe[main.testInlinedBBA]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12419,7 +12561,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: x}
+                  Variable: {subprogram: 52, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12429,17 +12571,17 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: x}
+                  Variable: {subprogram: 52, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1187
+      ID: 1188
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1366
+      ID: 1367
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 1184
+      ID: 1185
       Name: Probe[main.testInlinedBB]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12451,7 +12593,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: x}
+                  Variable: {subprogram: 51, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12461,7 +12603,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: x}
+                  Variable: {subprogram: 51, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: y
@@ -12471,7 +12613,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 1, name: y}
+                  Variable: {subprogram: 51, index: 1, name: y}
                   Offset: 0
                   ByteSize: 8
         - Name: y
@@ -12481,32 +12623,32 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 1, name: y}
+                  Variable: {subprogram: 51, index: 1, name: y}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1185
+      ID: 1186
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1367
+      ID: 1368
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1368
+      ID: 1369
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1369
+      ID: 1370
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1370
+      ID: 1371
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
-      ID: 1188
+      ID: 1189
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 1189
+      ID: 1190
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1363
+      ID: 1364
       Name: Probe[main.testInlinedPrint]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12518,7 +12660,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12528,11 +12670,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1361
+      ID: 1362
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12544,11 +12686,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1362
+      ID: 1363
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12560,7 +12702,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x_val
@@ -12570,11 +12712,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1365
+      ID: 1366
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12586,7 +12728,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12596,14 +12738,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1364
+      ID: 1365
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1371
+      ID: 1372
       Name: Probe[main.testInlinedSq]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12615,7 +12757,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12625,11 +12767,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1372
+      ID: 1373
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12641,7 +12783,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12651,11 +12793,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1373
+      ID: 1374
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12667,7 +12809,7 @@ Types:
             Type: 156 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: a}
+                  Variable: {subprogram: 164, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: a
@@ -12677,7 +12819,7 @@ Types:
             Type: 156 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: a}
+                  Variable: {subprogram: 164, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
@@ -12811,7 +12953,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1195
+      ID: 1196
       Name: Probe[main.testInterface]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12823,7 +12965,7 @@ Types:
             Type: 157 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: b}
+                  Variable: {subprogram: 56, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -12833,11 +12975,11 @@ Types:
             Type: 157 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: b}
+                  Variable: {subprogram: 56, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1301
+      ID: 1302
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 161
       PresenceBitsetSize: 1
@@ -12849,7 +12991,7 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: arg}
+                  Variable: {subprogram: 122, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
         - Name: arg
@@ -12859,11 +13001,11 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: arg}
+                  Variable: {subprogram: 122, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1302
+      ID: 1303
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12875,11 +13017,11 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 1, name: ~r0}
+                  Variable: {subprogram: 122, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1234
+      ID: 1235
       Name: Probe[main.testLinkedList]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12891,7 +13033,7 @@ Types:
             Type: 241 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: a}
+                  Variable: {subprogram: 90, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -12901,38 +13043,12 @@ Types:
             Type: 241 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: a}
+                  Variable: {subprogram: 90, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1175
-      Name: Probe[main.testLongFunctionWithChangingState]Line
-    - __kind: EventRootType
       ID: 1176
       Name: Probe[main.testLongFunctionWithChangingState]Line
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: aPerArch
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 1, name: aPerArch}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: b
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 2, name: b}
-                  Offset: 0
-                  ByteSize: 8
     - __kind: EventRootType
       ID: 1177
       Name: Probe[main.testLongFunctionWithChangingState]Line
@@ -12946,7 +13062,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 1, name: aPerArch}
+                  Variable: {subprogram: 47, index: 1, name: aPerArch}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -12956,11 +13072,37 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 2, name: b}
+                  Variable: {subprogram: 47, index: 2, name: b}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1307
+      ID: 1178
+      Name: Probe[main.testLongFunctionWithChangingState]Line
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: aPerArch
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 47, index: 1, name: aPerArch}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 47, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1308
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 147
       PresenceBitsetSize: 3
@@ -12972,7 +13114,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: a}
+                  Variable: {subprogram: 125, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12982,7 +13124,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: a}
+                  Variable: {subprogram: 125, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -12992,7 +13134,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 1, name: b}
+                  Variable: {subprogram: 125, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13002,7 +13144,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 1, name: b}
+                  Variable: {subprogram: 125, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13012,7 +13154,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 2, name: c}
+                  Variable: {subprogram: 125, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13022,7 +13164,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 2, name: c}
+                  Variable: {subprogram: 125, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13032,7 +13174,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 3, name: d}
+                  Variable: {subprogram: 125, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13042,7 +13184,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 3, name: d}
+                  Variable: {subprogram: 125, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13052,7 +13194,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 4, name: e}
+                  Variable: {subprogram: 125, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13062,7 +13204,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 4, name: e}
+                  Variable: {subprogram: 125, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13072,7 +13214,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 5, name: f}
+                  Variable: {subprogram: 125, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13082,7 +13224,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 5, name: f}
+                  Variable: {subprogram: 125, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13092,7 +13234,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 6, name: g}
+                  Variable: {subprogram: 125, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13102,7 +13244,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 6, name: g}
+                  Variable: {subprogram: 125, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13112,7 +13254,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 7, name: h}
+                  Variable: {subprogram: 125, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13122,7 +13264,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 7, name: h}
+                  Variable: {subprogram: 125, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13132,7 +13274,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 8, name: i}
+                  Variable: {subprogram: 125, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13142,11 +13284,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 8, name: i}
+                  Variable: {subprogram: 125, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1308
+      ID: 1309
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13158,11 +13300,11 @@ Types:
             Type: 106 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 9, name: ~r0}
+                  Variable: {subprogram: 125, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1206
+      ID: 1207
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13174,7 +13316,7 @@ Types:
             Type: 181 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13184,11 +13326,11 @@ Types:
             Type: 181 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1213
+      ID: 1214
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13200,7 +13342,7 @@ Types:
             Type: 188 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: m}
+                  Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13210,11 +13352,11 @@ Types:
             Type: 188 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: m}
+                  Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1225
+      ID: 1226
       Name: Probe[main.testMapEmptyKeyAndValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13226,7 +13368,7 @@ Types:
             Type: 233 GoMapType map[struct {}]struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: m}
+                  Variable: {subprogram: 83, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13236,11 +13378,11 @@ Types:
             Type: 233 GoMapType map[struct {}]struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: m}
+                  Variable: {subprogram: 83, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1223
+      ID: 1224
       Name: Probe[main.testMapEmptyKey]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13252,7 +13394,7 @@ Types:
             Type: 223 GoMapType map[struct {}]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: m}
+                  Variable: {subprogram: 81, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13262,11 +13404,11 @@ Types:
             Type: 223 GoMapType map[struct {}]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: m}
+                  Variable: {subprogram: 81, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1224
+      ID: 1225
       Name: Probe[main.testMapEmptyValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13278,7 +13420,7 @@ Types:
             Type: 228 GoMapType map[int]struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: m}
+                  Variable: {subprogram: 82, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13288,11 +13430,11 @@ Types:
             Type: 228 GoMapType map[int]struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: m}
+                  Variable: {subprogram: 82, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1210
+      ID: 1211
       Name: Probe[main.testMapIntToInt]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13304,7 +13446,7 @@ Types:
             Type: 161 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
+                  Variable: {subprogram: 69, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13314,11 +13456,11 @@ Types:
             Type: 161 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
+                  Variable: {subprogram: 69, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1222
+      ID: 1223
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13330,7 +13472,7 @@ Types:
             Type: 218 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: m}
+                  Variable: {subprogram: 80, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13340,11 +13482,11 @@ Types:
             Type: 218 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: m}
+                  Variable: {subprogram: 80, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1221
+      ID: 1222
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13356,7 +13498,7 @@ Types:
             Type: 213 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: m}
+                  Variable: {subprogram: 79, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13366,33 +13508,7 @@ Types:
             Type: 213 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1211
-      Name: Probe[main.testMapMassive]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: redactMyEntries
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 188 GoMapType map[string][]main.structWithMap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: redactMyEntries
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 188 GoMapType map[string][]main.structWithMap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 79, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -13408,7 +13524,7 @@ Types:
             Type: 188 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 70, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
         - Name: redactMyEntries
@@ -13418,11 +13534,37 @@ Types:
             Type: 188 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 70, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1220
+      ID: 1213
+      Name: Probe[main.testMapMassive]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: redactMyEntries
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 188 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 70, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: redactMyEntries
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 188 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 70, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1221
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13434,7 +13576,7 @@ Types:
             Type: 208 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: m}
+                  Variable: {subprogram: 78, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13444,11 +13586,11 @@ Types:
             Type: 208 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: m}
+                  Variable: {subprogram: 78, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1219
+      ID: 1220
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13460,6 +13602,136 @@ Types:
             Type: 203 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
+                  Variable: {subprogram: 77, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 203 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 77, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1205
+      Name: Probe[main.testMapStringToInt]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 171 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 63, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 171 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 63, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1206
+      Name: Probe[main.testMapStringToSlice]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 176 GoMapType map[string][]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 64, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 176 GoMapType map[string][]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 64, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1204
+      Name: Probe[main.testMapStringToStruct]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 166 GoMapType map[string]main.nestedStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 62, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 166 GoMapType map[string]main.nestedStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 62, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1215
+      Name: Probe[main.testMapWithLinkedList]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 193 GoMapType map[bool]main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 72, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 193 GoMapType map[bool]main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 72, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1219
+      Name: Probe[main.testMapWithSmallKeyAndValueMassive]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 203 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
                   Variable: {subprogram: 76, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
@@ -13474,112 +13746,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1204
-      Name: Probe[main.testMapStringToInt]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 171 GoMapType map[string]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: m
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 171 GoMapType map[string]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1205
-      Name: Probe[main.testMapStringToSlice]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 176 GoMapType map[string][]string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: m
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 176 GoMapType map[string][]string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1203
-      Name: Probe[main.testMapStringToStruct]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 166 GoMapType map[string]main.nestedStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: m
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 166 GoMapType map[string]main.nestedStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1214
-      Name: Probe[main.testMapWithLinkedList]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 193 GoMapType map[bool]main.node
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: m
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 193 GoMapType map[bool]main.node
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
       ID: 1218
-      Name: Probe[main.testMapWithSmallKeyAndValueMassive]
+      Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
@@ -13605,32 +13773,6 @@ Types:
                   ByteSize: 8
     - __kind: EventRootType
       ID: 1217
-      Name: Probe[main.testMapWithSmallKeyAndValue]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 203 GoMapType map[uint8]uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: m
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 203 GoMapType map[uint8]uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1216
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13642,7 +13784,7 @@ Types:
             Type: 198 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 74, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
         - Name: redactMyEntries
@@ -13652,11 +13794,11 @@ Types:
             Type: 198 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 74, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1215
+      ID: 1216
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13668,7 +13810,7 @@ Types:
             Type: 198 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: m}
+                  Variable: {subprogram: 73, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13678,35 +13820,9 @@ Types:
             Type: 198 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: m}
+                  Variable: {subprogram: 73, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
-    - __kind: EventRootType
-      ID: 1343
-      Name: Probe[main.testMassiveString]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 11 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: x
-          Offset: 17
-          Kind: template_segment
-          Expression:
-            Type: 11 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
     - __kind: EventRootType
       ID: 1344
       Name: Probe[main.testMassiveString]
@@ -13720,7 +13836,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
+                  Variable: {subprogram: 149, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -13730,11 +13846,37 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
+                  Variable: {subprogram: 149, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1309
+      ID: 1345
+      Name: Probe[main.testMassiveString]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 149, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 149, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1310
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 163
       PresenceBitsetSize: 3
@@ -13746,7 +13888,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: a}
+                  Variable: {subprogram: 126, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -13756,7 +13898,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: a}
+                  Variable: {subprogram: 126, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13766,7 +13908,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: b}
+                  Variable: {subprogram: 126, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13776,7 +13918,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: b}
+                  Variable: {subprogram: 126, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13786,7 +13928,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: c}
+                  Variable: {subprogram: 126, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13796,7 +13938,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: c}
+                  Variable: {subprogram: 126, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13806,7 +13948,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 3, name: d}
+                  Variable: {subprogram: 126, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13816,7 +13958,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 3, name: d}
+                  Variable: {subprogram: 126, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13826,7 +13968,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 4, name: e}
+                  Variable: {subprogram: 126, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13836,7 +13978,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 4, name: e}
+                  Variable: {subprogram: 126, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13846,7 +13988,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 5, name: f}
+                  Variable: {subprogram: 126, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13856,7 +13998,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 5, name: f}
+                  Variable: {subprogram: 126, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13866,7 +14008,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 6, name: g}
+                  Variable: {subprogram: 126, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13876,7 +14018,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 6, name: g}
+                  Variable: {subprogram: 126, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13886,7 +14028,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 7, name: h}
+                  Variable: {subprogram: 126, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13896,7 +14038,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 7, name: h}
+                  Variable: {subprogram: 126, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: s
@@ -13906,7 +14048,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 8, name: s}
+                  Variable: {subprogram: 126, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
         - Name: s
@@ -13916,11 +14058,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 8, name: s}
+                  Variable: {subprogram: 126, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1310
+      ID: 1311
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13932,11 +14074,11 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 9, name: ~r0}
+                  Variable: {subprogram: 126, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1313
+      ID: 1314
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13948,7 +14090,7 @@ Types:
             Type: 106 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -13958,7 +14100,7 @@ Types:
             Type: 106 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -13968,7 +14110,7 @@ Types:
             Type: 246 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: b}
+                  Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
         - Name: b
@@ -13978,11 +14120,11 @@ Types:
             Type: 246 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: b}
+                  Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1314
+      ID: 1315
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13994,7 +14136,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 2, name: ~r0}
+                  Variable: {subprogram: 128, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -14004,11 +14146,11 @@ Types:
             Type: 106 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 3, name: ~r1}
+                  Variable: {subprogram: 128, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1305
+      ID: 1306
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 321
       PresenceBitsetSize: 1
@@ -14020,7 +14162,7 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: s1}
+                  Variable: {subprogram: 124, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
         - Name: s1
@@ -14030,7 +14172,7 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: s1}
+                  Variable: {subprogram: 124, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
         - Name: s2
@@ -14040,7 +14182,7 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: s2}
+                  Variable: {subprogram: 124, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
         - Name: s2
@@ -14050,11 +14192,11 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: s2}
+                  Variable: {subprogram: 124, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1306
+      ID: 1307
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -14066,11 +14208,11 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 2, name: ~r0}
+                  Variable: {subprogram: 124, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1259
+      ID: 1260
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14082,7 +14224,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14092,11 +14234,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1261
+      ID: 1262
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14108,7 +14250,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14118,7 +14260,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14128,7 +14270,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14138,11 +14280,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1263
+      ID: 1264
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14154,11 +14296,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1265
+      ID: 1266
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14170,11 +14312,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1267
+      ID: 1268
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14186,11 +14328,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1260
+      ID: 1261
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14202,7 +14344,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14212,11 +14354,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1262
+      ID: 1263
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -14228,7 +14370,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14238,7 +14380,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14248,7 +14390,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14258,7 +14400,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14268,7 +14410,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14278,11 +14420,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1264
+      ID: 1265
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14294,7 +14436,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14304,11 +14446,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1266
+      ID: 1267
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14320,7 +14462,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14330,11 +14472,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1268
+      ID: 1269
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14346,7 +14488,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14356,11 +14498,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1229
+      ID: 1230
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 62
       PresenceBitsetSize: 2
@@ -14372,7 +14514,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: a}
+                  Variable: {subprogram: 86, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: a
@@ -14382,7 +14524,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: a}
+                  Variable: {subprogram: 86, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -14392,7 +14534,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 1, name: b}
+                  Variable: {subprogram: 86, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -14402,7 +14544,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 1, name: b}
+                  Variable: {subprogram: 86, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: c
@@ -14412,7 +14554,7 @@ Types:
             Type: 13 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 2, name: c}
+                  Variable: {subprogram: 86, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: c
@@ -14422,7 +14564,7 @@ Types:
             Type: 13 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 2, name: c}
+                  Variable: {subprogram: 86, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: d
@@ -14432,7 +14574,7 @@ Types:
             Type: 12 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 3, name: d}
+                  Variable: {subprogram: 86, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -14442,7 +14584,7 @@ Types:
             Type: 12 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 3, name: d}
+                  Variable: {subprogram: 86, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -14452,7 +14594,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 4, name: e}
+                  Variable: {subprogram: 86, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
         - Name: e
@@ -14462,11 +14604,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 4, name: e}
+                  Variable: {subprogram: 86, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1255
+      ID: 1256
       Name: Probe[main.testNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14478,7 +14620,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14488,37 +14630,37 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1258
+      Name: Probe[main.testNamedReturn]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
       ID: 1257
-      Name: Probe[main.testNamedReturn]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1256
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14530,11 +14672,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1258
+      ID: 1259
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14546,7 +14688,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14556,11 +14698,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1355
+      ID: 1356
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14572,7 +14714,7 @@ Types:
             Type: 312 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: x}
+                  Variable: {subprogram: 156, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -14582,11 +14724,11 @@ Types:
             Type: 312 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: x}
+                  Variable: {subprogram: 156, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1356
+      ID: 1357
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14598,7 +14740,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: x}
+                  Variable: {subprogram: 156, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -14608,10 +14750,10 @@ Types:
                   Bias: 8
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1357
+      ID: 1358
       Name: Probe[main.testNestedPointer]
     - __kind: EventRootType
-      ID: 1358
+      ID: 1359
       Name: Probe[main.testNestedPointer]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -14623,7 +14765,7 @@ Types:
             Type: 116 StructureType main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: x}
+                  Variable: {subprogram: 156, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -14633,7 +14775,7 @@ Types:
                   Bias: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1239
+      ID: 1240
       Name: Probe[main.testNilPointer]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14645,7 +14787,7 @@ Types:
             Type: 5 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: z}
+                  Variable: {subprogram: 95, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: z
@@ -14655,7 +14797,7 @@ Types:
             Type: 5 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: z}
+                  Variable: {subprogram: 95, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14665,7 +14807,7 @@ Types:
             Type: 12 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 1, name: a}
+                  Variable: {subprogram: 95, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14675,11 +14817,11 @@ Types:
             Type: 12 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 1, name: a}
+                  Variable: {subprogram: 95, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1324
+      ID: 1325
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -14691,7 +14833,7 @@ Types:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: xs}
+                  Variable: {subprogram: 136, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -14701,7 +14843,7 @@ Types:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: xs}
+                  Variable: {subprogram: 136, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -14711,7 +14853,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 1, name: a}
+                  Variable: {subprogram: 136, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14721,11 +14863,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 1, name: a}
+                  Variable: {subprogram: 136, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1326
+      ID: 1327
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 67
       PresenceBitsetSize: 1
@@ -14737,7 +14879,7 @@ Types:
             Type: 15 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: a}
+                  Variable: {subprogram: 138, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: a
@@ -14747,7 +14889,7 @@ Types:
             Type: 15 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: a}
+                  Variable: {subprogram: 138, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
@@ -14757,7 +14899,7 @@ Types:
             Type: 259 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 1, name: s}
+                  Variable: {subprogram: 138, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: s
@@ -14767,7 +14909,7 @@ Types:
             Type: 259 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 1, name: s}
+                  Variable: {subprogram: 138, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -14777,7 +14919,7 @@ Types:
             Type: 12 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 2, name: x}
+                  Variable: {subprogram: 138, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -14787,11 +14929,11 @@ Types:
             Type: 12 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 2, name: x}
+                  Variable: {subprogram: 138, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1327
+      ID: 1328
       Name: Probe[main.testNilSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -14803,7 +14945,7 @@ Types:
             Type: 260 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -14813,11 +14955,11 @@ Types:
             Type: 260 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1342
+      ID: 1343
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14829,7 +14971,7 @@ Types:
             Type: 265 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14839,11 +14981,11 @@ Types:
             Type: 265 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1235
+      ID: 1236
       Name: Probe[main.testPointerLoop]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14855,7 +14997,7 @@ Types:
             Type: 242 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: a}
+                  Variable: {subprogram: 91, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14865,11 +15007,11 @@ Types:
             Type: 242 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: a}
+                  Variable: {subprogram: 91, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1209
+      ID: 1210
       Name: Probe[main.testPointerToMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14881,7 +15023,7 @@ Types:
             Type: 187 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: m}
+                  Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -14891,11 +15033,11 @@ Types:
             Type: 187 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: m}
+                  Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1233
+      ID: 1234
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14907,7 +15049,7 @@ Types:
             Type: 239 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: a}
+                  Variable: {subprogram: 89, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14917,11 +15059,11 @@ Types:
             Type: 239 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: a}
+                  Variable: {subprogram: 89, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1249
+      ID: 1250
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 35
       PresenceBitsetSize: 1
@@ -14933,7 +15075,7 @@ Types:
             Type: 152 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: v}
+                  Variable: {subprogram: 101, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: v
@@ -14943,7 +15085,7 @@ Types:
             Type: 152 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: v}
+                  Variable: {subprogram: 101, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: failed
@@ -14953,7 +15095,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 1, name: failed}
+                  Variable: {subprogram: 101, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
         - Name: failed
@@ -14963,11 +15105,11 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 1, name: failed}
+                  Variable: {subprogram: 101, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1250
+      ID: 1251
       Name: Probe[main.testReturnsAnyAndError]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14979,7 +15121,7 @@ Types:
             Type: 152 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 2, name: ~r0}
+                  Variable: {subprogram: 101, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
         - Name: ~r1
@@ -14989,11 +15131,11 @@ Types:
             Type: 18 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 3, name: ~r1}
+                  Variable: {subprogram: 101, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1251
+      ID: 1252
       Name: Probe[main.testReturnsAny]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15005,7 +15147,7 @@ Types:
             Type: 152 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: v}
+                  Variable: {subprogram: 102, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: v
@@ -15015,11 +15157,11 @@ Types:
             Type: 152 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: v}
+                  Variable: {subprogram: 102, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1252
+      ID: 1253
       Name: Probe[main.testReturnsAny]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15031,14 +15173,14 @@ Types:
             Type: 152 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 1, name: ~r0}
+                  Variable: {subprogram: 102, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1281
+      ID: 1282
       Name: Probe[main.testReturnsArrayOne]
     - __kind: EventRootType
-      ID: 1282
+      ID: 1283
       Name: Probe[main.testReturnsArrayOne]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15050,14 +15192,14 @@ Types:
             Type: 247 ArrayType [1]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 0, name: ~r0}
+                  Variable: {subprogram: 112, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1283
+      ID: 1284
       Name: Probe[main.testReturnsArrayZero]
     - __kind: EventRootType
-      ID: 1284
+      ID: 1285
       Name: Probe[main.testReturnsArrayZero]Return
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -15069,14 +15211,14 @@ Types:
             Type: 248 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 0, name: ~r0}
+                  Variable: {subprogram: 113, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1279
+      ID: 1280
       Name: Probe[main.testReturnsArray]
     - __kind: EventRootType
-      ID: 1280
+      ID: 1281
       Name: Probe[main.testReturnsArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15088,14 +15230,14 @@ Types:
             Type: 246 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 0, name: ~r0}
+                  Variable: {subprogram: 111, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1287
+      ID: 1288
       Name: Probe[main.testReturnsBacktrackInt]
     - __kind: EventRootType
-      ID: 1288
+      ID: 1289
       Name: Probe[main.testReturnsBacktrackInt]Return
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -15107,7 +15249,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: ~r0}
+                  Variable: {subprogram: 115, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15117,7 +15259,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 1, name: ~r1}
+                  Variable: {subprogram: 115, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15127,7 +15269,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 2, name: ~r2}
+                  Variable: {subprogram: 115, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -15137,7 +15279,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 3, name: ~r3}
+                  Variable: {subprogram: 115, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15147,7 +15289,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 4, name: ~r4}
+                  Variable: {subprogram: 115, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r5
@@ -15157,7 +15299,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 5, name: ~r5}
+                  Variable: {subprogram: 115, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r6
@@ -15167,7 +15309,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 6, name: ~r6}
+                  Variable: {subprogram: 115, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r7
@@ -15177,7 +15319,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 7, name: ~r7}
+                  Variable: {subprogram: 115, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r8
@@ -15187,14 +15329,14 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 8, name: ~r8}
+                  Variable: {subprogram: 115, index: 8, name: ~r8}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1299
+      ID: 1300
       Name: Probe[main.testReturnsBoolAndUintptr]
     - __kind: EventRootType
-      ID: 1300
+      ID: 1301
       Name: Probe[main.testReturnsBoolAndUintptr]Return
       ByteSize: 10
       PresenceBitsetSize: 1
@@ -15206,7 +15348,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: ~r0}
+                  Variable: {subprogram: 121, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r1
@@ -15216,14 +15358,14 @@ Types:
             Type: 1 BaseType uintptr
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 1, name: ~r1}
+                  Variable: {subprogram: 121, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1275
+      ID: 1276
       Name: Probe[main.testReturnsComplex]
     - __kind: EventRootType
-      ID: 1276
+      ID: 1277
       Name: Probe[main.testReturnsComplex]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15235,7 +15377,7 @@ Types:
             Type: 90 BaseType complex64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: ~r0}
+                  Variable: {subprogram: 109, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15245,11 +15387,11 @@ Types:
             Type: 91 BaseType complex128
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: ~r1}
+                  Variable: {subprogram: 109, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1247
+      ID: 1248
       Name: Probe[main.testReturnsError]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -15261,7 +15403,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: failed}
+                  Variable: {subprogram: 100, index: 0, name: failed}
                   Offset: 0
                   ByteSize: 1
         - Name: failed
@@ -15271,11 +15413,11 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: failed}
+                  Variable: {subprogram: 100, index: 0, name: failed}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1248
+      ID: 1249
       Name: Probe[main.testReturnsError]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15287,11 +15429,11 @@ Types:
             Type: 18 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 1, name: ~r0}
+                  Variable: {subprogram: 100, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1245
+      ID: 1246
       Name: Probe[main.testReturnsIntAndFloat]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15303,7 +15445,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: i}
+                  Variable: {subprogram: 99, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -15313,11 +15455,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: i}
+                  Variable: {subprogram: 99, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1246
+      ID: 1247
       Name: Probe[main.testReturnsIntAndFloat]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15329,7 +15471,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 1, name: ~r0}
+                  Variable: {subprogram: 99, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15339,11 +15481,11 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 2, name: ~r1}
+                  Variable: {subprogram: 99, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1243
+      ID: 1244
       Name: Probe[main.testReturnsIntPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15355,7 +15497,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: i}
+                  Variable: {subprogram: 98, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -15365,11 +15507,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: i}
+                  Variable: {subprogram: 98, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1244
+      ID: 1245
       Name: Probe[main.testReturnsIntPointer]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15381,11 +15523,11 @@ Types:
             Type: 94 PointerType *int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 1, name: ~r0}
+                  Variable: {subprogram: 98, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1241
+      ID: 1242
       Name: Probe[main.testReturnsInt]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15397,7 +15539,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: i}
+                  Variable: {subprogram: 97, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -15407,11 +15549,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: i}
+                  Variable: {subprogram: 97, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1242
+      ID: 1243
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15423,11 +15565,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 1, name: ~r0}
+                  Variable: {subprogram: 97, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1253
+      ID: 1254
       Name: Probe[main.testReturnsInterface]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15439,7 +15581,7 @@ Types:
             Type: 152 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: v}
+                  Variable: {subprogram: 103, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: v
@@ -15449,11 +15591,11 @@ Types:
             Type: 152 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: v}
+                  Variable: {subprogram: 103, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1254
+      ID: 1255
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15465,14 +15607,14 @@ Types:
             Type: 157 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: ~r0}
+                  Variable: {subprogram: 103, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1277
+      ID: 1278
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1278
+      ID: 1279
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -15484,14 +15626,14 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: ~r0}
+                  Variable: {subprogram: 110, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1273
+      ID: 1274
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1274
+      ID: 1275
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 139
       PresenceBitsetSize: 3
@@ -15503,7 +15645,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: ~r0}
+                  Variable: {subprogram: 108, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15513,7 +15655,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 1, name: ~r1}
+                  Variable: {subprogram: 108, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15523,7 +15665,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 2, name: ~r2}
+                  Variable: {subprogram: 108, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -15533,7 +15675,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 3, name: ~r3}
+                  Variable: {subprogram: 108, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15543,7 +15685,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 4, name: ~r4}
+                  Variable: {subprogram: 108, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r5
@@ -15553,7 +15695,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 5, name: ~r5}
+                  Variable: {subprogram: 108, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r6
@@ -15563,7 +15705,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 6, name: ~r6}
+                  Variable: {subprogram: 108, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r7
@@ -15573,7 +15715,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 7, name: ~r7}
+                  Variable: {subprogram: 108, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r8
@@ -15583,7 +15725,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 8, name: ~r8}
+                  Variable: {subprogram: 108, index: 8, name: ~r8}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r9
@@ -15593,7 +15735,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 9, name: ~r9}
+                  Variable: {subprogram: 108, index: 9, name: ~r9}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r10
@@ -15603,7 +15745,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 10, name: ~r10}
+                  Variable: {subprogram: 108, index: 10, name: ~r10}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r11
@@ -15613,7 +15755,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 11, name: ~r11}
+                  Variable: {subprogram: 108, index: 11, name: ~r11}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r12
@@ -15623,7 +15765,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 12, name: ~r12}
+                  Variable: {subprogram: 108, index: 12, name: ~r12}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r13
@@ -15633,7 +15775,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 13, name: ~r13}
+                  Variable: {subprogram: 108, index: 13, name: ~r13}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r14
@@ -15643,7 +15785,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 14, name: ~r14}
+                  Variable: {subprogram: 108, index: 14, name: ~r14}
                   Offset: 0
                   ByteSize: 8
         - Name: onlyOnAmd64_16
@@ -15653,7 +15795,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 15, name: onlyOnAmd64_16}
+                  Variable: {subprogram: 108, index: 15, name: onlyOnAmd64_16}
                   Offset: 0
                   ByteSize: 8
         - Name: bothArmAndAmd64
@@ -15663,14 +15805,14 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 16, name: bothArmAndAmd64}
+                  Variable: {subprogram: 108, index: 16, name: bothArmAndAmd64}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1285
+      ID: 1286
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1286
+      ID: 1287
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15682,14 +15824,14 @@ Types:
             Type: 249 StructureType main.mixedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: ~r0}
+                  Variable: {subprogram: 114, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1291
+      ID: 1292
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1292
+      ID: 1293
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -15701,7 +15843,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 0, name: ~r0}
+                  Variable: {subprogram: 117, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15711,7 +15853,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 1, name: ~r1}
+                  Variable: {subprogram: 117, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15721,7 +15863,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 2, name: ~r2}
+                  Variable: {subprogram: 117, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -15731,7 +15873,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 3, name: ~r3}
+                  Variable: {subprogram: 117, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15741,14 +15883,14 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 4, name: ~r4}
+                  Variable: {subprogram: 117, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1297
+      ID: 1298
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1298
+      ID: 1299
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -15760,7 +15902,7 @@ Types:
             Type: 16 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: ~r0}
+                  Variable: {subprogram: 120, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r1
@@ -15770,14 +15912,14 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 1, name: ~r1}
+                  Variable: {subprogram: 120, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1295
+      ID: 1296
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1296
+      ID: 1297
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15789,14 +15931,14 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 0, name: ~r0}
+                  Variable: {subprogram: 119, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1271
+      ID: 1272
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1272
+      ID: 1273
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -15808,7 +15950,7 @@ Types:
             Type: 15 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 0, name: ~r0}
+                  Variable: {subprogram: 107, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r1
@@ -15818,7 +15960,7 @@ Types:
             Type: 89 BaseType int16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 1, name: ~r1}
+                  Variable: {subprogram: 107, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 2
         - Name: ~r2
@@ -15828,7 +15970,7 @@ Types:
             Type: 13 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 2, name: ~r2}
+                  Variable: {subprogram: 107, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r3
@@ -15838,7 +15980,7 @@ Types:
             Type: 14 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 3, name: ~r3}
+                  Variable: {subprogram: 107, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15848,7 +15990,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 4, name: ~r4}
+                  Variable: {subprogram: 107, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r5
@@ -15858,7 +16000,7 @@ Types:
             Type: 7 BaseType uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 5, name: ~r5}
+                  Variable: {subprogram: 107, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 2
         - Name: ~r6
@@ -15868,7 +16010,7 @@ Types:
             Type: 2 BaseType uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 6, name: ~r6}
+                  Variable: {subprogram: 107, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r7
@@ -15878,14 +16020,14 @@ Types:
             Type: 10 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 7, name: ~r7}
+                  Variable: {subprogram: 107, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1293
+      ID: 1294
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1294
+      ID: 1295
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15897,14 +16039,14 @@ Types:
             Type: 251 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 0, name: ~r0}
+                  Variable: {subprogram: 118, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1289
+      ID: 1290
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1290
+      ID: 1291
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -15916,7 +16058,7 @@ Types:
             Type: 250 StructureType main.wideStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 0, name: ~r0}
+                  Variable: {subprogram: 116, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 88
     - __kind: EventRootType
@@ -16226,7 +16368,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1334
+      ID: 1335
       Name: Probe[main.testSingleString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16238,7 +16380,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: x}
+                  Variable: {subprogram: 144, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -16248,7 +16390,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: x}
+                  Variable: {subprogram: 144, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -16382,7 +16524,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1330
+      ID: 1331
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16394,7 +16536,7 @@ Types:
             Type: 261 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: xs}
+                  Variable: {subprogram: 141, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -16404,11 +16546,11 @@ Types:
             Type: 261 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: xs}
+                  Variable: {subprogram: 141, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1321
+      ID: 1322
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16420,7 +16562,7 @@ Types:
             Type: 253 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: u}
+                  Variable: {subprogram: 133, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -16430,11 +16572,11 @@ Types:
             Type: 253 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: u}
+                  Variable: {subprogram: 133, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1207
+      ID: 1208
       Name: Probe[main.testSmallMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16446,7 +16588,7 @@ Types:
             Type: 171 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -16456,11 +16598,11 @@ Types:
             Type: 171 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1269
+      ID: 1270
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16472,7 +16614,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: i}
+                  Variable: {subprogram: 106, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -16482,11 +16624,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: i}
+                  Variable: {subprogram: 106, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1270
+      ID: 1271
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16498,7 +16640,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 1, name: ~r0}
+                  Variable: {subprogram: 106, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -16508,7 +16650,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 2, name: result2}
+                  Variable: {subprogram: 106, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -16518,11 +16660,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 3, name: ~r2}
+                  Variable: {subprogram: 106, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1311
+      ID: 1312
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -16534,7 +16676,7 @@ Types:
             Type: 156 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: arg}
+                  Variable: {subprogram: 127, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
         - Name: arg
@@ -16544,11 +16686,11 @@ Types:
             Type: 156 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: arg}
+                  Variable: {subprogram: 127, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1312
+      ID: 1313
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16560,7 +16702,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: ~r0}
+                  Variable: {subprogram: 127, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -16570,7 +16712,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: ~r1}
+                  Variable: {subprogram: 127, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -16580,7 +16722,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 3, name: ~r2}
+                  Variable: {subprogram: 127, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -16610,7 +16752,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1238
+      ID: 1239
       Name: Probe[main.testStringPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16622,7 +16764,7 @@ Types:
             Type: 88 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: z}
+                  Variable: {subprogram: 94, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: z
@@ -16632,11 +16774,11 @@ Types:
             Type: 88 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: z}
+                  Variable: {subprogram: 94, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1325
+      ID: 1326
       Name: Probe[main.testStringSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16648,7 +16790,7 @@ Types:
             Type: 258 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: s}
+                  Variable: {subprogram: 137, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: s
@@ -16658,11 +16800,11 @@ Types:
             Type: 258 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: s}
+                  Variable: {subprogram: 137, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1173
+      ID: 1174
       Name: Probe[main.testStringType1]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16674,7 +16816,7 @@ Types:
             Type: 146 PointerType *main.stringType1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 0, name: a}
+                  Variable: {subprogram: 45, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -16684,11 +16826,11 @@ Types:
             Type: 146 PointerType *main.stringType1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 0, name: a}
+                  Variable: {subprogram: 45, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1174
+      ID: 1175
       Name: Probe[main.testStringType2]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16700,7 +16842,7 @@ Types:
             Type: 148 PointerType **main.stringType2
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: a}
+                  Variable: {subprogram: 46, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -16710,11 +16852,11 @@ Types:
             Type: 148 PointerType **main.stringType2
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: a}
+                  Variable: {subprogram: 46, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1322
+      ID: 1323
       Name: Probe[main.testStructSlice]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -16726,7 +16868,7 @@ Types:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Variable: {subprogram: 134, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -16736,7 +16878,7 @@ Types:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Variable: {subprogram: 134, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -16746,7 +16888,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 1, name: a}
+                  Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -16756,11 +16898,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 1, name: a}
+                  Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1201
+      ID: 1202
       Name: Probe[main.testStructWithAny]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16772,7 +16914,7 @@ Types:
             Type: 159 StructureType main.structWithAny
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: s}
+                  Variable: {subprogram: 60, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
         - Name: s
@@ -16782,11 +16924,11 @@ Types:
             Type: 159 StructureType main.structWithAny
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: s}
+                  Variable: {subprogram: 60, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1315
+      ID: 1316
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16798,7 +16940,7 @@ Types:
             Type: 251 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: arg}
+                  Variable: {subprogram: 129, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
         - Name: arg
@@ -16808,11 +16950,11 @@ Types:
             Type: 251 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: arg}
+                  Variable: {subprogram: 129, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1316
+      ID: 1317
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16824,7 +16966,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 1, name: ~r0}
+                  Variable: {subprogram: 129, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -16834,11 +16976,11 @@ Types:
             Type: 251 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 2, name: ~r1}
+                  Variable: {subprogram: 129, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1349
+      ID: 1350
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16850,7 +16992,7 @@ Types:
             Type: 280 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: a}
+                  Variable: {subprogram: 154, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
         - Name: a
@@ -16860,14 +17002,14 @@ Types:
             Type: 280 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: a}
+                  Variable: {subprogram: 154, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1350
+      ID: 1351
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1348
+      ID: 1349
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 289
       PresenceBitsetSize: 1
@@ -16879,7 +17021,7 @@ Types:
             Type: 267 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: a}
+                  Variable: {subprogram: 153, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
         - Name: a
@@ -16889,11 +17031,11 @@ Types:
             Type: 267 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: a}
+                  Variable: {subprogram: 153, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
     - __kind: EventRootType
-      ID: 1202
+      ID: 1203
       Name: Probe[main.testStructWithMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16905,7 +17047,7 @@ Types:
             Type: 160 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: s}
+                  Variable: {subprogram: 61, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
         - Name: s
@@ -16915,11 +17057,11 @@ Types:
             Type: 160 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: s}
+                  Variable: {subprogram: 61, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1351
+      ID: 1352
       Name: Probe[main.testStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16931,11 +17073,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 8
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1353
+      ID: 1354
       Name: Probe[main.testStruct]
       ByteSize: 113
       PresenceBitsetSize: 1
@@ -16947,7 +17089,7 @@ Types:
             Type: 311 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
         - Name: x
@@ -16957,17 +17099,17 @@ Types:
             Type: 311 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1352
+      ID: 1353
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1354
+      ID: 1355
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1331
+      ID: 1332
       Name: Probe[main.testSubslices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -16979,7 +17121,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: as}
+                  Variable: {subprogram: 142, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
         - Name: as
@@ -16989,7 +17131,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: as}
+                  Variable: {subprogram: 142, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
         - Name: bs
@@ -16999,7 +17141,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 1, name: bs}
+                  Variable: {subprogram: 142, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
         - Name: bs
@@ -17009,7 +17151,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 1, name: bs}
+                  Variable: {subprogram: 142, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
         - Name: cs
@@ -17019,7 +17161,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 2, name: cs}
+                  Variable: {subprogram: 142, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
         - Name: cs
@@ -17029,11 +17171,11 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 2, name: cs}
+                  Variable: {subprogram: 142, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1347
+      ID: 1348
       Name: Probe[main.testSubstrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17045,7 +17187,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: a}
+                  Variable: {subprogram: 152, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -17055,7 +17197,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: a}
+                  Variable: {subprogram: 152, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -17065,7 +17207,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 1, name: b}
+                  Variable: {subprogram: 152, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -17075,7 +17217,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 1, name: b}
+                  Variable: {subprogram: 152, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: c
@@ -17085,7 +17227,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 2, name: c}
+                  Variable: {subprogram: 152, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
         - Name: c
@@ -17095,11 +17237,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 2, name: c}
+                  Variable: {subprogram: 152, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1340
+      ID: 1341
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17111,7 +17253,7 @@ Types:
             Type: 264 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -17121,11 +17263,11 @@ Types:
             Type: 264 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1341
+      ID: 1342
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17137,7 +17279,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -17150,7 +17292,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -17163,14 +17305,14 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
                   Bias: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1336
+      ID: 1337
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17182,7 +17324,7 @@ Types:
             Type: 263 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
         - Name: a
@@ -17192,11 +17334,11 @@ Types:
             Type: 263 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1338
+      ID: 1339
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17208,7 +17350,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: t.b
@@ -17218,7 +17360,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 16
                   ByteSize: 16
         - Name: t.c
@@ -17228,17 +17370,17 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1337
+      ID: 1338
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1339
+      ID: 1340
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1335
+      ID: 1336
       Name: Probe[main.testThreeStrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17250,7 +17392,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: x}
+                  Variable: {subprogram: 145, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -17260,7 +17402,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: x}
+                  Variable: {subprogram: 145, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -17270,7 +17412,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 1, name: y}
+                  Variable: {subprogram: 145, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -17280,7 +17422,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 1, name: y}
+                  Variable: {subprogram: 145, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -17290,7 +17432,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 2, name: z}
+                  Variable: {subprogram: 145, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -17300,7 +17442,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 2, name: z}
+                  Variable: {subprogram: 145, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -17460,7 +17602,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1237
+      ID: 1238
       Name: Probe[main.testUintPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17472,7 +17614,7 @@ Types:
             Type: 100 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: x}
+                  Variable: {subprogram: 93, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -17482,11 +17624,11 @@ Types:
             Type: 100 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: x}
+                  Variable: {subprogram: 93, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1319
+      ID: 1320
       Name: Probe[main.testUintSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17498,7 +17640,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: u}
+                  Variable: {subprogram: 131, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -17508,11 +17650,11 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: u}
+                  Variable: {subprogram: 131, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1345
+      ID: 1346
       Name: Probe[main.testUnitializedString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17524,7 +17666,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: x}
+                  Variable: {subprogram: 150, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -17534,11 +17676,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: x}
+                  Variable: {subprogram: 150, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1236
+      ID: 1237
       Name: Probe[main.testUnsafePointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17550,7 +17692,7 @@ Types:
             Type: 19 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: x}
+                  Variable: {subprogram: 92, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -17560,7 +17702,7 @@ Types:
             Type: 19 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: x}
+                  Variable: {subprogram: 92, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -17590,32 +17732,6 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1328
-      Name: Probe[main.testVeryLargeSlice]
-      ByteSize: 49
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: xs
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 252 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: xs
-          Offset: 25
-          Kind: template_segment
-          Expression:
-            Type: 252 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
       ID: 1329
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
@@ -17628,7 +17744,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: xs}
+                  Variable: {subprogram: 140, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -17638,11 +17754,37 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: xs}
+                  Variable: {subprogram: 140, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1317
+      ID: 1330
+      Name: Probe[main.testVeryLargeSlice]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 252 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 140, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: xs
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 252 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 140, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1318
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17654,7 +17796,7 @@ Types:
             Type: 248 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: a}
+                  Variable: {subprogram: 130, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
         - Name: a
@@ -17664,7 +17806,7 @@ Types:
             Type: 248 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: a}
+                  Variable: {subprogram: 130, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
         - Name: b
@@ -17674,7 +17816,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 1, name: b}
+                  Variable: {subprogram: 130, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -17684,11 +17826,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 1, name: b}
+                  Variable: {subprogram: 130, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1318
+      ID: 1319
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -17700,7 +17842,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 2, name: ~r0}
+                  Variable: {subprogram: 130, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -17710,7 +17852,7 @@ Types:
             Type: 248 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 3, name: ~r1}
+                  Variable: {subprogram: 130, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 0
     - __kind: ArrayType
@@ -24763,7 +24905,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 952416
       GoKind: 5
-MaxTypeID: 1376
+MaxTypeID: 1377
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x12cd8e0", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -8,15 +8,15 @@ Probes:
       template: stackC
       segments: [stackC]
       captureSnapshot: true
-      subprogram: {subprogram: 142}
+      subprogram: {subprogram: 143}
       events:
         - Kind: Entry
-          Type: 1507 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0x84fef8", Frameless: false}]
+          Type: 1508 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0x850028", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1508 EventRootType Probe[main.stackC]Return
-          InjectionPoints: [{PC: "0x84ff2c", Frameless: false}]
+          Type: 1509 EventRootType Probe[main.stackC]Return
+          InjectionPoints: [{PC: "0x85005c", Frameless: false}]
           Condition: null
       probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -27,15 +27,15 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 56}
+      subprogram: {subprogram: 57}
       events:
         - Kind: Entry
-          Type: 1371 EventRootType Probe[main.testAny]
-          InjectionPoints: [{PC: "0x84b458", Frameless: false}]
+          Type: 1372 EventRootType Probe[main.testAny]
+          InjectionPoints: [{PC: "0x84b588", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1372 EventRootType Probe[main.testAny]Return
-          InjectionPoints: [{PC: "0x84b484", Frameless: false}]
+          Type: 1373 EventRootType Probe[main.testAny]Return
+          InjectionPoints: [{PC: "0x84b5b4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -52,15 +52,15 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 58}
+      subprogram: {subprogram: 59}
       events:
         - Kind: Entry
-          Type: 1374 EventRootType Probe[main.testAnyPtr]
-          InjectionPoints: [{PC: "0x84b4d8", Frameless: false}]
+          Type: 1375 EventRootType Probe[main.testAnyPtr]
+          InjectionPoints: [{PC: "0x84b608", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1375 EventRootType Probe[main.testAnyPtr]Return
-          InjectionPoints: [{PC: "0x84b504", Frameless: false}]
+          Type: 1376 EventRootType Probe[main.testAnyPtr]Return
+          InjectionPoints: [{PC: "0x84b634", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -76,15 +76,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 122}
+      subprogram: {subprogram: 123}
       events:
         - Kind: Entry
-          Type: 1478 EventRootType Probe[main.testArrayArgAndReturn]
-          InjectionPoints: [{PC: "0x84ecfc", Frameless: false}]
+          Type: 1479 EventRootType Probe[main.testArrayArgAndReturn]
+          InjectionPoints: [{PC: "0x84ee2c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1479 EventRootType Probe[main.testArrayArgAndReturn]Return
-          InjectionPoints: [{PC: "0x84ed94", Frameless: false}]
+          Type: 1480 EventRootType Probe[main.testArrayArgAndReturn]Return
+          InjectionPoints: [{PC: "0x84eec4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -164,11 +164,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 66}
+      subprogram: {subprogram: 67}
       events:
         - Kind: Entry
-          Type: 1383 EventRootType Probe[main.testArrayOfMaps]
-          InjectionPoints: [{PC: "0x84bb40", Frameless: true}]
+          Type: 1384 EventRootType Probe[main.testArrayOfMaps]
+          InjectionPoints: [{PC: "0x84bc70", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -226,15 +226,15 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 87}
       events:
         - Kind: Entry
-          Type: 1405 EventRootType Probe[main.testAtomicAdd]
-          InjectionPoints: [{PC: "0x84d2e0", Frameless: true}]
+          Type: 1406 EventRootType Probe[main.testAtomicAdd]
+          InjectionPoints: [{PC: "0x84d410", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1406 EventRootType Probe[main.testAtomicAdd]Return
-          InjectionPoints: [{PC: "0x84d31c", Frameless: true}]
+          Type: 1407 EventRootType Probe[main.testAtomicAdd]Return
+          InjectionPoints: [{PC: "0x84d44c", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -323,15 +323,15 @@ Probes:
           expr:
             dsl: x.aString
             json: {getmember: [{ref: x}, aString]}
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1526 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0x850250", Frameless: true}]
+          Type: 1527 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0x850380", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1527 EventRootType Probe[main.testStruct]Return
-          InjectionPoints: [{PC: "0x85026c", Frameless: true}]
+          Type: 1528 EventRootType Probe[main.testStruct]Return
+          InjectionPoints: [{PC: "0x85039c", Frameless: true}]
           Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -345,20 +345,20 @@ Probes:
       segments: []
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1536 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1537 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
-            - PC: "0x84ad18"
+            - PC: "0x84ae48"
               Frameless: false
-            - PC: "0x84ad8c"
+            - PC: "0x84aebc"
               Frameless: false
-            - PC: "0x84aed8"
+            - PC: "0x84b008"
               Frameless: false
-            - PC: "0x84af54"
+            - PC: "0x84b084"
               Frameless: false
-            - PC: "0x84b00c"
+            - PC: "0x84b13c"
               Frameless: false
           Condition: null
     - id: testCaptureExprLineWithTemplate
@@ -373,20 +373,20 @@ Probes:
       segments: [x=, {json: {ref: x}, dsl: x}]
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1537 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1538 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
-            - PC: "0x84ad18"
+            - PC: "0x84ae48"
               Frameless: false
-            - PC: "0x84ad8c"
+            - PC: "0x84aebc"
               Frameless: false
-            - PC: "0x84aed8"
+            - PC: "0x84b008"
               Frameless: false
-            - PC: "0x84af54"
+            - PC: "0x84b084"
               Frameless: false
-            - PC: "0x84b00c"
+            - PC: "0x84b13c"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -409,11 +409,11 @@ Probes:
           expr: {dsl: x, json: {ref: x}}
         - name: w_val
           expr: {dsl: w, json: {ref: w}}
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 85}
       events:
         - Kind: Entry
-          Type: 1402 EventRootType Probe[main.testCombinedString]
-          InjectionPoints: [{PC: "0x84d080", Frameless: true}]
+          Type: 1403 EventRootType Probe[main.testCombinedString]
+          InjectionPoints: [{PC: "0x84d1b0", Frameless: true}]
           Condition: null
     - id: testCaptureExprWithTemplate
       version: 0
@@ -427,11 +427,11 @@ Probes:
           expr: {dsl: x, json: {ref: x}}
         - name: w_val
           expr: {dsl: w, json: {ref: w}}
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 85}
       events:
         - Kind: Entry
-          Type: 1403 EventRootType Probe[main.testCombinedString]
-          InjectionPoints: [{PC: "0x84d080", Frameless: true}]
+          Type: 1404 EventRootType Probe[main.testCombinedString]
+          InjectionPoints: [{PC: "0x84d1b0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: x={x}
@@ -449,11 +449,11 @@ Probes:
       template: '{c}'
       segments: [{json: {ref: c}, dsl: c}]
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 88}
       events:
         - Kind: Entry
-          Type: 1407 EventRootType Probe[main.testChannel]
-          InjectionPoints: [{PC: "0x84d320", Frameless: true}]
+          Type: 1408 EventRootType Probe[main.testChannel]
+          InjectionPoints: [{PC: "0x84d450", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{c}'
@@ -478,11 +478,11 @@ Probes:
         - json: {ref: y}
           dsl: y
       captureSnapshot: true
-      subprogram: {subprogram: 83}
+      subprogram: {subprogram: 84}
       events:
         - Kind: Entry
-          Type: 1401 EventRootType Probe[main.testCombinedByte]
-          InjectionPoints: [{PC: "0x84d060", Frameless: true}]
+          Type: 1402 EventRootType Probe[main.testCombinedByte]
+          InjectionPoints: [{PC: "0x84d190", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{w}, {x}, {y}'
@@ -509,11 +509,11 @@ Probes:
       template: '{t}'
       segments: [{json: {ref: t}, dsl: t}]
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 96}
       events:
         - Kind: Entry
-          Type: 1415 EventRootType Probe[main.testCycle]
-          InjectionPoints: [{PC: "0x84d5d0", Frameless: true}]
+          Type: 1416 EventRootType Probe[main.testCycle]
+          InjectionPoints: [{PC: "0x84d700", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{t}'
@@ -530,11 +530,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 42}
+      subprogram: {subprogram: 43}
       events:
         - Kind: Entry
-          Type: 1346 EventRootType Probe[main.testDeepMap1]
-          InjectionPoints: [{PC: "0x84a3d0", Frameless: true}]
+          Type: 1347 EventRootType Probe[main.testDeepMap1]
+          InjectionPoints: [{PC: "0x84a4f0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -551,11 +551,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 43}
+      subprogram: {subprogram: 44}
       events:
         - Kind: Entry
-          Type: 1347 EventRootType Probe[main.testDeepMap7]
-          InjectionPoints: [{PC: "0x84a3e0", Frameless: true}]
+          Type: 1348 EventRootType Probe[main.testDeepMap7]
+          InjectionPoints: [{PC: "0x84a500", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -572,11 +572,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 38}
+      subprogram: {subprogram: 39}
       events:
         - Kind: Entry
-          Type: 1342 EventRootType Probe[main.testDeepPtr1]
-          InjectionPoints: [{PC: "0x84a0c0", Frameless: true}]
+          Type: 1343 EventRootType Probe[main.testDeepPtr1]
+          InjectionPoints: [{PC: "0x84a1e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -593,11 +593,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 39}
+      subprogram: {subprogram: 40}
       events:
         - Kind: Entry
-          Type: 1343 EventRootType Probe[main.testDeepPtr7]
-          InjectionPoints: [{PC: "0x84a0d0", Frameless: true}]
+          Type: 1344 EventRootType Probe[main.testDeepPtr7]
+          InjectionPoints: [{PC: "0x84a1f0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -614,11 +614,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 40}
+      subprogram: {subprogram: 41}
       events:
         - Kind: Entry
-          Type: 1344 EventRootType Probe[main.testDeepSlice1]
-          InjectionPoints: [{PC: "0x84a270", Frameless: true}]
+          Type: 1345 EventRootType Probe[main.testDeepSlice1]
+          InjectionPoints: [{PC: "0x84a390", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -635,11 +635,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 41}
+      subprogram: {subprogram: 42}
       events:
         - Kind: Entry
-          Type: 1345 EventRootType Probe[main.testDeepSlice7]
-          InjectionPoints: [{PC: "0x84a280", Frameless: true}]
+          Type: 1346 EventRootType Probe[main.testDeepSlice7]
+          InjectionPoints: [{PC: "0x84a3a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -656,11 +656,11 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 131}
+      subprogram: {subprogram: 132}
       events:
         - Kind: Entry
-          Type: 1495 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0x84fb20", Frameless: true}]
+          Type: 1496 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0x84fc50", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{u}'
@@ -682,11 +682,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 134}
+      subprogram: {subprogram: 135}
       events:
         - Kind: Entry
-          Type: 1498 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0x84fb50", Frameless: true}]
+          Type: 1499 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0x84fc80", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}, {a}'
@@ -709,11 +709,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 150}
+      subprogram: {subprogram: 151}
       events:
         - Kind: Entry
-          Type: 1521 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0x84ffd0", Frameless: true}]
+          Type: 1522 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0x850100", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -730,11 +730,11 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 156}
+      subprogram: {subprogram: 157}
       events:
         - Kind: Entry
-          Type: 1534 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0x850350", Frameless: true}]
+          Type: 1535 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0x850480", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -750,11 +750,11 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 157}
+      subprogram: {subprogram: 158}
       events:
         - Kind: Entry
-          Type: 1535 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0x850360", Frameless: true}]
+          Type: 1536 EventRootType Probe[main.testEmptyStructPointer]
+          InjectionPoints: [{PC: "0x850490", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -771,11 +771,11 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 57}
+      subprogram: {subprogram: 58}
       events:
         - Kind: Entry
-          Type: 1373 EventRootType Probe[main.testError]
-          InjectionPoints: [{PC: "0x84b4b0", Frameless: true}]
+          Type: 1374 EventRootType Probe[main.testError]
+          InjectionPoints: [{PC: "0x84b5e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -784,6 +784,45 @@ Probes:
               DSL: e
               EventKind: Entry
               EventExpressionIndex: 1
+    - id: testErrorAtLine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testErrorAtLine
+        sourceFile: complex.go
+        lines: ["108"]
+      tags:
+        - config_diff:arch=amd64,toolchain=go1.26rc1
+        - skip_integration:arch=arm64,toolchain=go1.25.0
+      sampling: {snapshotsPerSecond: 100}
+      template: x={x}, err={err}
+      segments:
+        - x=
+        - json: {ref: x}
+          dsl: x
+        - ', err='
+        - json: {ref: err}
+          dsl: err
+      captureSnapshot: true
+      subprogram: {subprogram: 38}
+      events:
+        - Kind: Line
+          Type: 1342 EventRootType Probe[main.testErrorAtLine]Line
+          InjectionPoints: [{PC: "0x84a07c", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: x={x}, err={err}
+        Segments:
+            - x=
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Line
+              EventExpressionIndex: 2
+            - ', err='
+            - JSON: {Ref: err}
+              DSL: err
+              EventKind: Line
+              EventExpressionIndex: 4
     - id: testEsotericHeap
       version: 0
       type: LOG_PROBE
@@ -792,15 +831,15 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 48}
+      subprogram: {subprogram: 49}
       events:
         - Kind: Entry
-          Type: 1355 EventRootType Probe[main.testEsotericHeap]
-          InjectionPoints: [{PC: "0x84aa78", Frameless: false}]
+          Type: 1356 EventRootType Probe[main.testEsotericHeap]
+          InjectionPoints: [{PC: "0x84aba8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1356 EventRootType Probe[main.testEsotericHeap]Return
-          InjectionPoints: [{PC: "0x84aab4", Frameless: false}]
+          Type: 1357 EventRootType Probe[main.testEsotericHeap]Return
+          InjectionPoints: [{PC: "0x84abe4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -817,15 +856,15 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 47}
+      subprogram: {subprogram: 48}
       events:
         - Kind: Entry
-          Type: 1353 EventRootType Probe[main.testEsotericStack]
-          InjectionPoints: [{PC: "0x84a9ac", Frameless: false}]
+          Type: 1354 EventRootType Probe[main.testEsotericStack]
+          InjectionPoints: [{PC: "0x84aadc", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1354 EventRootType Probe[main.testEsotericStack]Return
-          InjectionPoints: [{PC: "0x84aa1c", Frameless: false}]
+          Type: 1355 EventRootType Probe[main.testEsotericStack]Return
+          InjectionPoints: [{PC: "0x84ab4c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -842,15 +881,15 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 53}
+      subprogram: {subprogram: 54}
       events:
         - Kind: Entry
-          Type: 1365 EventRootType Probe[main.testFrameless]
-          InjectionPoints: [{PC: "0x84b190", Frameless: true}]
+          Type: 1366 EventRootType Probe[main.testFrameless]
+          InjectionPoints: [{PC: "0x84b2c0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1366 EventRootType Probe[main.testFrameless]Return
-          InjectionPoints: [{PC: "0x84b198", Frameless: true}]
+          Type: 1367 EventRootType Probe[main.testFrameless]Return
+          InjectionPoints: [{PC: "0x84b2c8", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -867,15 +906,15 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 54}
+      subprogram: {subprogram: 55}
       events:
         - Kind: Entry
-          Type: 1367 EventRootType Probe[main.testFramelessArray]
-          InjectionPoints: [{PC: "0x84b1ac", Frameless: false}]
+          Type: 1368 EventRootType Probe[main.testFramelessArray]
+          InjectionPoints: [{PC: "0x84b2dc", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1368 EventRootType Probe[main.testFramelessArray]Return
-          InjectionPoints: [{PC: "0x84b1e8", Frameless: false}]
+          Type: 1369 EventRootType Probe[main.testFramelessArray]Return
+          InjectionPoints: [{PC: "0x84b318", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -895,11 +934,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 54}
+      subprogram: {subprogram: 55}
       events:
         - Kind: Line
-          Type: 1369 EventRootType Probe[main.testFramelessArray]Line
-          InjectionPoints: [{PC: "0x84b1ac", Frameless: false}]
+          Type: 1370 EventRootType Probe[main.testFramelessArray]Line
+          InjectionPoints: [{PC: "0x84b2dc", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -916,15 +955,15 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 49}
+      subprogram: {subprogram: 50}
       events:
         - Kind: Entry
-          Type: 1357 EventRootType Probe[main.testInlinedBA]
-          InjectionPoints: [{PC: "0x84aeb8", Frameless: false}]
+          Type: 1358 EventRootType Probe[main.testInlinedBA]
+          InjectionPoints: [{PC: "0x84afe8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1358 EventRootType Probe[main.testInlinedBA]Return
-          InjectionPoints: [{PC: "0x84af10", Frameless: false}]
+          Type: 1359 EventRootType Probe[main.testInlinedBA]Return
+          InjectionPoints: [{PC: "0x84b040", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -946,15 +985,15 @@ Probes:
         - json: {ref: y}
           dsl: y
       captureSnapshot: true
-      subprogram: {subprogram: 50}
+      subprogram: {subprogram: 51}
       events:
         - Kind: Entry
-          Type: 1359 EventRootType Probe[main.testInlinedBB]
-          InjectionPoints: [{PC: "0x84af48", Frameless: false}]
+          Type: 1360 EventRootType Probe[main.testInlinedBB]
+          InjectionPoints: [{PC: "0x84b078", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1360 EventRootType Probe[main.testInlinedBB]Return
-          InjectionPoints: [{PC: "0x84afd0", Frameless: false}]
+          Type: 1361 EventRootType Probe[main.testInlinedBB]Return
+          InjectionPoints: [{PC: "0x84b100", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}, {y}'
@@ -976,15 +1015,15 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 51}
+      subprogram: {subprogram: 52}
       events:
         - Kind: Entry
-          Type: 1361 EventRootType Probe[main.testInlinedBBA]
-          InjectionPoints: [{PC: "0x84b008", Frameless: false}]
+          Type: 1362 EventRootType Probe[main.testInlinedBBA]
+          InjectionPoints: [{PC: "0x84b138", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1362 EventRootType Probe[main.testInlinedBBA]Return
-          InjectionPoints: [{PC: "0x84b044", Frameless: false}]
+          Type: 1363 EventRootType Probe[main.testInlinedBBA]Return
+          InjectionPoints: [{PC: "0x84b174", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1001,11 +1040,11 @@ Probes:
       template: testInlinedBBB
       segments: [testInlinedBBB]
       captureSnapshot: true
-      subprogram: {subprogram: 159}
+      subprogram: {subprogram: 160}
       events:
         - Kind: Entry
-          Type: 1541 EventRootType Probe[main.testInlinedBBB]
-          InjectionPoints: [{PC: "0x84af98", Frameless: false}]
+          Type: 1542 EventRootType Probe[main.testInlinedBBB]
+          InjectionPoints: [{PC: "0x84b0c8", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBBB
@@ -1018,15 +1057,15 @@ Probes:
       template: testInlinedBC
       segments: [testInlinedBC]
       captureSnapshot: true
-      subprogram: {subprogram: 52}
+      subprogram: {subprogram: 53}
       events:
         - Kind: Entry
-          Type: 1363 EventRootType Probe[main.testInlinedBC]
-          InjectionPoints: [{PC: "0x84b088", Frameless: false}]
+          Type: 1364 EventRootType Probe[main.testInlinedBC]
+          InjectionPoints: [{PC: "0x84b1b8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1364 EventRootType Probe[main.testInlinedBC]Return
-          InjectionPoints: [{PC: "0x84b178", Frameless: false}]
+          Type: 1365 EventRootType Probe[main.testInlinedBC]Return
+          InjectionPoints: [{PC: "0x84b2a8", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBC
@@ -1039,11 +1078,11 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Entry
-          Type: 1542 EventRootType Probe[main.testInlinedBCA]
-          InjectionPoints: [{PC: "0x84b08c", Frameless: false}]
+          Type: 1543 EventRootType Probe[main.testInlinedBCA]
+          InjectionPoints: [{PC: "0x84b1bc", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBCA
@@ -1059,11 +1098,11 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Line
-          Type: 1543 EventRootType Probe[main.testInlinedBCA]Line
-          InjectionPoints: [{PC: "0x84b08c", Frameless: false}]
+          Type: 1544 EventRootType Probe[main.testInlinedBCA]Line
+          InjectionPoints: [{PC: "0x84b1bc", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBCA
@@ -1076,11 +1115,11 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Entry
-          Type: 1544 EventRootType Probe[main.testInlinedBCB]
-          InjectionPoints: [{PC: "0x84b140", Frameless: false}]
+          Type: 1545 EventRootType Probe[main.testInlinedBCB]
+          InjectionPoints: [{PC: "0x84b270", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBCB
@@ -1096,11 +1135,11 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Line
-          Type: 1545 EventRootType Probe[main.testInlinedBCB]Line
-          InjectionPoints: [{PC: "0x84b140", Frameless: false}]
+          Type: 1546 EventRootType Probe[main.testInlinedBCB]Line
+          InjectionPoints: [{PC: "0x84b270", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBCB
@@ -1113,14 +1152,14 @@ Probes:
       template: testInlinedFuncFromOtherPackage
       segments: [testInlinedFuncFromOtherPackage]
       captureSnapshot: true
-      subprogram: {subprogram: 165}
+      subprogram: {subprogram: 166}
       events:
         - Kind: Entry
-          Type: 1551 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
+          Type: 1552 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
           InjectionPoints:
             - PC: "0x8494b8"
               Frameless: true
-            - PC: "0x84ba18"
+            - PC: "0x84bb48"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -1135,25 +1174,25 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Entry
-          Type: 1538 EventRootType Probe[main.testInlinedPrint]
+          Type: 1539 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
-            - PC: "0x84ad18"
+            - PC: "0x84ae48"
               Frameless: false
-            - PC: "0x84ad8c"
+            - PC: "0x84aebc"
               Frameless: false
-            - PC: "0x84aed8"
+            - PC: "0x84b008"
               Frameless: false
-            - PC: "0x84af54"
+            - PC: "0x84b084"
               Frameless: false
-            - PC: "0x84b00c"
+            - PC: "0x84b13c"
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1539 EventRootType Probe[main.testInlinedPrint]Return
-          InjectionPoints: [{PC: "0x84ad50", Frameless: false}]
+          Type: 1540 EventRootType Probe[main.testInlinedPrint]Return
+          InjectionPoints: [{PC: "0x84ae80", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1173,20 +1212,20 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1540 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1541 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
-            - PC: "0x84ad18"
+            - PC: "0x84ae48"
               Frameless: false
-            - PC: "0x84ad8c"
+            - PC: "0x84aebc"
               Frameless: false
-            - PC: "0x84aed8"
+            - PC: "0x84b008"
               Frameless: false
-            - PC: "0x84af54"
+            - PC: "0x84b084"
               Frameless: false
-            - PC: "0x84b00c"
+            - PC: "0x84b13c"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -1204,11 +1243,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 162}
+      subprogram: {subprogram: 163}
       events:
         - Kind: Entry
-          Type: 1546 EventRootType Probe[main.testInlinedSq]
-          InjectionPoints: [{PC: "0x84b194", Frameless: true}]
+          Type: 1547 EventRootType Probe[main.testInlinedSq]
+          InjectionPoints: [{PC: "0x84b2c4", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1228,11 +1267,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 162}
+      subprogram: {subprogram: 163}
       events:
         - Kind: Line
-          Type: 1547 EventRootType Probe[main.testInlinedSq]Line
-          InjectionPoints: [{PC: "0x84b194", Frameless: true}]
+          Type: 1548 EventRootType Probe[main.testInlinedSq]Line
+          InjectionPoints: [{PC: "0x84b2c4", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1250,14 +1289,14 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 163}
+      subprogram: {subprogram: 164}
       events:
         - Kind: Entry
-          Type: 1548 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1549 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
-            - PC: "0x84b1c4"
+            - PC: "0x84b2f4"
               Frameless: false
-            - PC: "0x84b25c"
+            - PC: "0x84b38c"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -1380,11 +1419,11 @@ Probes:
       template: '{b}'
       segments: [{json: {ref: b}, dsl: b}]
       captureSnapshot: true
-      subprogram: {subprogram: 55}
+      subprogram: {subprogram: 56}
       events:
         - Kind: Entry
-          Type: 1370 EventRootType Probe[main.testInterface]
-          InjectionPoints: [{PC: "0x84b430", Frameless: true}]
+          Type: 1371 EventRootType Probe[main.testInterface]
+          InjectionPoints: [{PC: "0x84b560", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{b}'
@@ -1400,15 +1439,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 121}
+      subprogram: {subprogram: 122}
       events:
         - Kind: Entry
-          Type: 1476 EventRootType Probe[main.testLargeArgAndReturn]
-          InjectionPoints: [{PC: "0x84eb40", Frameless: false}]
+          Type: 1477 EventRootType Probe[main.testLargeArgAndReturn]
+          InjectionPoints: [{PC: "0x84ec70", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1477 EventRootType Probe[main.testLargeArgAndReturn]Return
-          InjectionPoints: [{PC: "0x84ec98", Frameless: false}]
+          Type: 1478 EventRootType Probe[main.testLargeArgAndReturn]Return
+          InjectionPoints: [{PC: "0x84edc8", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -1425,11 +1464,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 90}
       events:
         - Kind: Entry
-          Type: 1409 EventRootType Probe[main.testLinkedList]
-          InjectionPoints: [{PC: "0x84d4e0", Frameless: true}]
+          Type: 1410 EventRootType Probe[main.testLinkedList]
+          InjectionPoints: [{PC: "0x84d610", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -1444,16 +1483,16 @@ Probes:
       where:
         methodName: main.testLongFunctionWithChangingState
         sourceFile: complex.go
-        lines: ["211"]
+        lines: ["230"]
       sampling: {snapshotsPerSecond: 100}
       template: testLongFunctionWithChangingState
       segments: [testLongFunctionWithChangingState]
       captureSnapshot: true
-      subprogram: {subprogram: 46}
+      subprogram: {subprogram: 47}
       events:
         - Kind: Line
-          Type: 1350 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-          InjectionPoints: [{PC: "0x84a42c", Frameless: false}]
+          Type: 1351 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          InjectionPoints: [{PC: "0x84a54c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testLongFunctionWithChangingState
@@ -1464,17 +1503,17 @@ Probes:
       where:
         methodName: main.testLongFunctionWithChangingState
         sourceFile: complex.go
-        lines: ["218"]
+        lines: ["237"]
       tags: ['version_diff:go1.26rc1']
       sampling: {snapshotsPerSecond: 100}
       template: testLongFunctionWithChangingState
       segments: [testLongFunctionWithChangingState]
       captureSnapshot: true
-      subprogram: {subprogram: 46}
+      subprogram: {subprogram: 47}
       events:
         - Kind: Line
-          Type: 1351 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-          InjectionPoints: [{PC: "0x84a4bc", Frameless: false}]
+          Type: 1352 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          InjectionPoints: [{PC: "0x84a5dc", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testLongFunctionWithChangingState
@@ -1485,17 +1524,17 @@ Probes:
       where:
         methodName: main.testLongFunctionWithChangingState
         sourceFile: complex.go
-        lines: ["223"]
+        lines: ["242"]
       tags: ['version_diff:go1.26rc1']
       sampling: {snapshotsPerSecond: 100}
       template: testLongFunctionWithChangingState
       segments: [testLongFunctionWithChangingState]
       captureSnapshot: true
-      subprogram: {subprogram: 46}
+      subprogram: {subprogram: 47}
       events:
         - Kind: Line
-          Type: 1352 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-          InjectionPoints: [{PC: "0x84a564", Frameless: false}]
+          Type: 1353 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          InjectionPoints: [{PC: "0x84a684", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testLongFunctionWithChangingState
@@ -1533,15 +1572,15 @@ Probes:
         - json: {ref: i}
           dsl: i
       captureSnapshot: true
-      subprogram: {subprogram: 124}
+      subprogram: {subprogram: 125}
       events:
         - Kind: Entry
-          Type: 1482 EventRootType Probe[main.testManyArgsArrayReturn]
-          InjectionPoints: [{PC: "0x84effc", Frameless: false}]
+          Type: 1483 EventRootType Probe[main.testManyArgsArrayReturn]
+          InjectionPoints: [{PC: "0x84f12c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1483 EventRootType Probe[main.testManyArgsArrayReturn]Return
-          InjectionPoints: [{PC: "0x84f168", Frameless: false}]
+          Type: 1484 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          InjectionPoints: [{PC: "0x84f298", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -1598,11 +1637,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 64}
+      subprogram: {subprogram: 65}
       events:
         - Kind: Entry
-          Type: 1381 EventRootType Probe[main.testMapArrayToArray]
-          InjectionPoints: [{PC: "0x84bb20", Frameless: true}]
+          Type: 1382 EventRootType Probe[main.testMapArrayToArray]
+          InjectionPoints: [{PC: "0x84bc50", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1619,11 +1658,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 70}
+      subprogram: {subprogram: 71}
       events:
         - Kind: Entry
-          Type: 1388 EventRootType Probe[main.testMapEmbeddedMaps]
-          InjectionPoints: [{PC: "0x84bb80", Frameless: true}]
+          Type: 1389 EventRootType Probe[main.testMapEmbeddedMaps]
+          InjectionPoints: [{PC: "0x84bcb0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1640,11 +1679,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 80}
+      subprogram: {subprogram: 81}
       events:
         - Kind: Entry
-          Type: 1398 EventRootType Probe[main.testMapEmptyKey]
-          InjectionPoints: [{PC: "0x84bc20", Frameless: true}]
+          Type: 1399 EventRootType Probe[main.testMapEmptyKey]
+          InjectionPoints: [{PC: "0x84bd50", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1661,11 +1700,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 82}
+      subprogram: {subprogram: 83}
       events:
         - Kind: Entry
-          Type: 1400 EventRootType Probe[main.testMapEmptyKeyAndValue]
-          InjectionPoints: [{PC: "0x84bc40", Frameless: true}]
+          Type: 1401 EventRootType Probe[main.testMapEmptyKeyAndValue]
+          InjectionPoints: [{PC: "0x84bd70", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1682,11 +1721,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 81}
+      subprogram: {subprogram: 82}
       events:
         - Kind: Entry
-          Type: 1399 EventRootType Probe[main.testMapEmptyValue]
-          InjectionPoints: [{PC: "0x84bc30", Frameless: true}]
+          Type: 1400 EventRootType Probe[main.testMapEmptyValue]
+          InjectionPoints: [{PC: "0x84bd60", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1703,11 +1742,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 68}
+      subprogram: {subprogram: 69}
       events:
         - Kind: Entry
-          Type: 1385 EventRootType Probe[main.testMapIntToInt]
-          InjectionPoints: [{PC: "0x84bb60", Frameless: true}]
+          Type: 1386 EventRootType Probe[main.testMapIntToInt]
+          InjectionPoints: [{PC: "0x84bc90", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1724,11 +1763,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 79}
+      subprogram: {subprogram: 80}
       events:
         - Kind: Entry
-          Type: 1397 EventRootType Probe[main.testMapLargeKeyLargeValue]
-          InjectionPoints: [{PC: "0x84bc10", Frameless: true}]
+          Type: 1398 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          InjectionPoints: [{PC: "0x84bd40", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1745,11 +1784,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 78}
+      subprogram: {subprogram: 79}
       events:
         - Kind: Entry
-          Type: 1396 EventRootType Probe[main.testMapLargeKeySmallValue]
-          InjectionPoints: [{PC: "0x84bc00", Frameless: true}]
+          Type: 1397 EventRootType Probe[main.testMapLargeKeySmallValue]
+          InjectionPoints: [{PC: "0x84bd30", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1768,11 +1807,11 @@ Probes:
         - json: {ref: redactMyEntries}
           dsl: redactMyEntries
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 70}
       events:
         - Kind: Entry
-          Type: 1386 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0x84bb70", Frameless: true}]
+          Type: 1387 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0x84bca0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{redactMyEntries}'
@@ -1791,11 +1830,11 @@ Probes:
         - json: {ref: redactMyEntries}
           dsl: redactMyEntries
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 70}
       events:
         - Kind: Entry
-          Type: 1387 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0x84bb70", Frameless: true}]
+          Type: 1388 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0x84bca0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{redactMyEntries}'
@@ -1812,11 +1851,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 77}
+      subprogram: {subprogram: 78}
       events:
         - Kind: Entry
-          Type: 1395 EventRootType Probe[main.testMapSmallKeyLargeValue]
-          InjectionPoints: [{PC: "0x84bbf0", Frameless: true}]
+          Type: 1396 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          InjectionPoints: [{PC: "0x84bd20", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1833,11 +1872,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 76}
+      subprogram: {subprogram: 77}
       events:
         - Kind: Entry
-          Type: 1394 EventRootType Probe[main.testMapSmallKeySmallValue]
-          InjectionPoints: [{PC: "0x84bbe0", Frameless: true}]
+          Type: 1395 EventRootType Probe[main.testMapSmallKeySmallValue]
+          InjectionPoints: [{PC: "0x84bd10", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1854,11 +1893,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 62}
+      subprogram: {subprogram: 63}
       events:
         - Kind: Entry
-          Type: 1379 EventRootType Probe[main.testMapStringToInt]
-          InjectionPoints: [{PC: "0x84bb00", Frameless: true}]
+          Type: 1380 EventRootType Probe[main.testMapStringToInt]
+          InjectionPoints: [{PC: "0x84bc30", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1875,11 +1914,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 63}
+      subprogram: {subprogram: 64}
       events:
         - Kind: Entry
-          Type: 1380 EventRootType Probe[main.testMapStringToSlice]
-          InjectionPoints: [{PC: "0x84bb10", Frameless: true}]
+          Type: 1381 EventRootType Probe[main.testMapStringToSlice]
+          InjectionPoints: [{PC: "0x84bc40", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1896,11 +1935,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 61}
+      subprogram: {subprogram: 62}
       events:
         - Kind: Entry
-          Type: 1378 EventRootType Probe[main.testMapStringToStruct]
-          InjectionPoints: [{PC: "0x84baf0", Frameless: true}]
+          Type: 1379 EventRootType Probe[main.testMapStringToStruct]
+          InjectionPoints: [{PC: "0x84bc20", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1917,11 +1956,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 71}
+      subprogram: {subprogram: 72}
       events:
         - Kind: Entry
-          Type: 1389 EventRootType Probe[main.testMapWithLinkedList]
-          InjectionPoints: [{PC: "0x84bb90", Frameless: true}]
+          Type: 1390 EventRootType Probe[main.testMapWithLinkedList]
+          InjectionPoints: [{PC: "0x84bcc0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1938,11 +1977,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 74}
+      subprogram: {subprogram: 75}
       events:
         - Kind: Entry
-          Type: 1392 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-          InjectionPoints: [{PC: "0x84bbc0", Frameless: true}]
+          Type: 1393 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          InjectionPoints: [{PC: "0x84bcf0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1959,11 +1998,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 75}
+      subprogram: {subprogram: 76}
       events:
         - Kind: Entry
-          Type: 1393 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-          InjectionPoints: [{PC: "0x84bbd0", Frameless: true}]
+          Type: 1394 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          InjectionPoints: [{PC: "0x84bd00", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1980,11 +2019,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 72}
+      subprogram: {subprogram: 73}
       events:
         - Kind: Entry
-          Type: 1390 EventRootType Probe[main.testMapWithSmallValue]
-          InjectionPoints: [{PC: "0x84bba0", Frameless: true}]
+          Type: 1391 EventRootType Probe[main.testMapWithSmallValue]
+          InjectionPoints: [{PC: "0x84bcd0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -2003,11 +2042,11 @@ Probes:
         - json: {ref: redactMyEntries}
           dsl: redactMyEntries
       captureSnapshot: true
-      subprogram: {subprogram: 73}
+      subprogram: {subprogram: 74}
       events:
         - Kind: Entry
-          Type: 1391 EventRootType Probe[main.testMapWithSmallValueMassive]
-          InjectionPoints: [{PC: "0x84bbb0", Frameless: true}]
+          Type: 1392 EventRootType Probe[main.testMapWithSmallValueMassive]
+          InjectionPoints: [{PC: "0x84bce0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{redactMyEntries}'
@@ -2024,11 +2063,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 148}
+      subprogram: {subprogram: 149}
       events:
         - Kind: Entry
-          Type: 1518 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0x84ffb0", Frameless: true}]
+          Type: 1519 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0x8500e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -2046,11 +2085,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 148}
+      subprogram: {subprogram: 149}
       events:
         - Kind: Entry
-          Type: 1519 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0x84ffb0", Frameless: true}]
+          Type: 1520 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0x8500e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -2092,15 +2131,15 @@ Probes:
         - json: {ref: s}
           dsl: s
       captureSnapshot: true
-      subprogram: {subprogram: 125}
+      subprogram: {subprogram: 126}
       events:
         - Kind: Entry
-          Type: 1484 EventRootType Probe[main.testMixedArgsStackReturn]
-          InjectionPoints: [{PC: "0x84f1d0", Frameless: false}]
+          Type: 1485 EventRootType Probe[main.testMixedArgsStackReturn]
+          InjectionPoints: [{PC: "0x84f300", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1485 EventRootType Probe[main.testMixedArgsStackReturn]Return
-          InjectionPoints: [{PC: "0x84f37c", Frameless: false}]
+          Type: 1486 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          InjectionPoints: [{PC: "0x84f4ac", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -2161,15 +2200,15 @@ Probes:
         - json: {ref: b}
           dsl: b
       captureSnapshot: true
-      subprogram: {subprogram: 127}
+      subprogram: {subprogram: 128}
       events:
         - Kind: Entry
-          Type: 1488 EventRootType Probe[main.testMultipleArrayArgs]
-          InjectionPoints: [{PC: "0x84f47c", Frameless: false}]
+          Type: 1489 EventRootType Probe[main.testMultipleArrayArgs]
+          InjectionPoints: [{PC: "0x84f5ac", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1489 EventRootType Probe[main.testMultipleArrayArgs]Return
-          InjectionPoints: [{PC: "0x84f524", Frameless: false}]
+          Type: 1490 EventRootType Probe[main.testMultipleArrayArgs]Return
+          InjectionPoints: [{PC: "0x84f654", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}'
@@ -2195,15 +2234,15 @@ Probes:
         - json: {ref: s2}
           dsl: s2
       captureSnapshot: true
-      subprogram: {subprogram: 123}
+      subprogram: {subprogram: 124}
       events:
         - Kind: Entry
-          Type: 1480 EventRootType Probe[main.testMultipleLargeArgs]
-          InjectionPoints: [{PC: "0x84edd0", Frameless: false}]
+          Type: 1481 EventRootType Probe[main.testMultipleLargeArgs]
+          InjectionPoints: [{PC: "0x84ef00", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1481 EventRootType Probe[main.testMultipleLargeArgs]Return
-          InjectionPoints: [{PC: "0x84efa0", Frameless: false}]
+          Type: 1482 EventRootType Probe[main.testMultipleLargeArgs]Return
+          InjectionPoints: [{PC: "0x84f0d0", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{s1}, {s2}'
@@ -2224,15 +2263,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1434 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0x84e118", Frameless: false}]
+          Type: 1435 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x84e248", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1435 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0x84e1a4", Frameless: false}]
+          Type: 1436 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x84e2d4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2263,11 +2302,11 @@ Probes:
         - json: {ref: e}
           dsl: e
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 86}
       events:
         - Kind: Entry
-          Type: 1404 EventRootType Probe[main.testMultipleSimpleParams]
-          InjectionPoints: [{PC: "0x84d140", Frameless: true}]
+          Type: 1405 EventRootType Probe[main.testMultipleSimpleParams]
+          InjectionPoints: [{PC: "0x84d270", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}, {d}, {e}'
@@ -2303,15 +2342,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1430 EventRootType Probe[main.testNamedReturn]
-          InjectionPoints: [{PC: "0x84e078", Frameless: false}]
+          Type: 1431 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0x84e1a8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1431 EventRootType Probe[main.testNamedReturn]Return
-          InjectionPoints: [{PC: "0x84e0d8", Frameless: false}]
+          Type: 1432 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0x84e208", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2333,15 +2372,15 @@ Probes:
         - json: {ref: result}
           dsl: result
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1432 EventRootType Probe[main.testNamedReturn]
-          InjectionPoints: [{PC: "0x84e078", Frameless: false}]
+          Type: 1433 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0x84e1a8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1433 EventRootType Probe[main.testNamedReturn]Return
-          InjectionPoints: [{PC: "0x84e0d8", Frameless: false}]
+          Type: 1434 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0x84e208", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: Parameter {i} * 2 = result {result}
@@ -2364,11 +2403,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 155}
+      subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1530 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0x8502f0", Frameless: true}]
+          Type: 1531 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0x850420", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -2388,11 +2427,11 @@ Probes:
             getmember: [{getmember: [{ref: x}, nested]}, anotherString]
           dsl: x.nested.anotherString
       captureSnapshot: false
-      subprogram: {subprogram: 155}
+      subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1531 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0x8502f0", Frameless: true}]
+          Type: 1532 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0x850420", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x.nested.anotherString}'
@@ -2418,11 +2457,11 @@ Probes:
         - json: {getmember: [{ref: x}, notAMember]}
           dsl: x.notAMember
       captureSnapshot: false
-      subprogram: {subprogram: 155}
+      subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1532 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0x8502f0", Frameless: true}]
+          Type: 1533 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0x850420", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -2442,11 +2481,11 @@ Probes:
         - json: {getmember: [{ref: x}, nested]}
           dsl: x.nested
       captureSnapshot: false
-      subprogram: {subprogram: 155}
+      subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1533 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0x8502f0", Frameless: true}]
+          Type: 1534 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0x850420", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x.nested}'
@@ -2468,11 +2507,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 95}
       events:
         - Kind: Entry
-          Type: 1414 EventRootType Probe[main.testNilPointer]
-          InjectionPoints: [{PC: "0x84d5b0", Frameless: true}]
+          Type: 1415 EventRootType Probe[main.testNilPointer]
+          InjectionPoints: [{PC: "0x84d6e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{z}, {a}'
@@ -2494,11 +2533,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 138}
+      subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1502 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0x84fb90", Frameless: true}]
+          Type: 1503 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0x84fcc0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -2520,11 +2559,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 135}
+      subprogram: {subprogram: 136}
       events:
         - Kind: Entry
-          Type: 1499 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0x84fb60", Frameless: true}]
+          Type: 1500 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0x84fc90", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}, {a}'
@@ -2554,11 +2593,11 @@ Probes:
         - json: {ref: x}
           dsl: x
       captureSnapshot: true
-      subprogram: {subprogram: 137}
+      subprogram: {subprogram: 138}
       events:
         - Kind: Entry
-          Type: 1501 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0x84fb80", Frameless: true}]
+          Type: 1502 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0x84fcb0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {s}, {x}'
@@ -2585,11 +2624,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 147}
+      subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1517 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0x84ffa0", Frameless: true}]
+          Type: 1518 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0x8500d0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -2606,11 +2645,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 91}
       events:
         - Kind: Entry
-          Type: 1410 EventRootType Probe[main.testPointerLoop]
-          InjectionPoints: [{PC: "0x84d4f0", Frameless: true}]
+          Type: 1411 EventRootType Probe[main.testPointerLoop]
+          InjectionPoints: [{PC: "0x84d620", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -2627,11 +2666,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 67}
+      subprogram: {subprogram: 68}
       events:
         - Kind: Entry
-          Type: 1384 EventRootType Probe[main.testPointerToMap]
-          InjectionPoints: [{PC: "0x84bb50", Frameless: true}]
+          Type: 1385 EventRootType Probe[main.testPointerToMap]
+          InjectionPoints: [{PC: "0x84bc80", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -2648,11 +2687,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 89}
       events:
         - Kind: Entry
-          Type: 1408 EventRootType Probe[main.testPointerToSimpleStruct]
-          InjectionPoints: [{PC: "0x84d4d0", Frameless: true}]
+          Type: 1409 EventRootType Probe[main.testPointerToSimpleStruct]
+          InjectionPoints: [{PC: "0x84d600", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -2669,22 +2708,22 @@ Probes:
       template: '{v}'
       segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
         - Kind: Entry
-          Type: 1426 EventRootType Probe[main.testReturnsAny]
-          InjectionPoints: [{PC: "0x84dd18", Frameless: false}]
+          Type: 1427 EventRootType Probe[main.testReturnsAny]
+          InjectionPoints: [{PC: "0x84de48", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1427 EventRootType Probe[main.testReturnsAny]Return
+          Type: 1428 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints:
-            - PC: "0x84ddb4"
+            - PC: "0x84dee4"
               Frameless: false
-            - PC: "0x84ddfc"
+            - PC: "0x84df2c"
               Frameless: false
-            - PC: "0x84dec0"
+            - PC: "0x84dff0"
               Frameless: false
-            - PC: "0x84ded4"
+            - PC: "0x84e004"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2707,22 +2746,22 @@ Probes:
         - json: {ref: failed}
           dsl: failed
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 101}
       events:
         - Kind: Entry
-          Type: 1424 EventRootType Probe[main.testReturnsAnyAndError]
-          InjectionPoints: [{PC: "0x84db98", Frameless: false}]
+          Type: 1425 EventRootType Probe[main.testReturnsAnyAndError]
+          InjectionPoints: [{PC: "0x84dcc8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1425 EventRootType Probe[main.testReturnsAnyAndError]Return
+          Type: 1426 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
-            - PC: "0x84dbec"
+            - PC: "0x84dd1c"
               Frameless: false
-            - PC: "0x84dc50"
+            - PC: "0x84dd80"
               Frameless: false
-            - PC: "0x84dc90"
+            - PC: "0x84ddc0"
               Frameless: false
-            - PC: "0x84dcd0"
+            - PC: "0x84de00"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2744,15 +2783,15 @@ Probes:
       template: testReturnsArray
       segments: [testReturnsArray]
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 111}
       events:
         - Kind: Entry
-          Type: 1454 EventRootType Probe[main.testReturnsArray]
-          InjectionPoints: [{PC: "0x84e54c", Frameless: false}]
+          Type: 1455 EventRootType Probe[main.testReturnsArray]
+          InjectionPoints: [{PC: "0x84e67c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1455 EventRootType Probe[main.testReturnsArray]Return
-          InjectionPoints: [{PC: "0x84e5a0", Frameless: false}]
+          Type: 1456 EventRootType Probe[main.testReturnsArray]Return
+          InjectionPoints: [{PC: "0x84e6d0", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsArray
@@ -2764,15 +2803,15 @@ Probes:
       template: testReturnsArrayOne
       segments: [testReturnsArrayOne]
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 112}
       events:
         - Kind: Entry
-          Type: 1456 EventRootType Probe[main.testReturnsArrayOne]
-          InjectionPoints: [{PC: "0x84e5d8", Frameless: false}]
+          Type: 1457 EventRootType Probe[main.testReturnsArrayOne]
+          InjectionPoints: [{PC: "0x84e708", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1457 EventRootType Probe[main.testReturnsArrayOne]Return
-          InjectionPoints: [{PC: "0x84e614", Frameless: false}]
+          Type: 1458 EventRootType Probe[main.testReturnsArrayOne]Return
+          InjectionPoints: [{PC: "0x84e744", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsArrayOne
@@ -2784,15 +2823,15 @@ Probes:
       template: testReturnsArrayZero
       segments: [testReturnsArrayZero]
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 113}
       events:
         - Kind: Entry
-          Type: 1458 EventRootType Probe[main.testReturnsArrayZero]
-          InjectionPoints: [{PC: "0x84e648", Frameless: false}]
+          Type: 1459 EventRootType Probe[main.testReturnsArrayZero]
+          InjectionPoints: [{PC: "0x84e778", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1459 EventRootType Probe[main.testReturnsArrayZero]Return
-          InjectionPoints: [{PC: "0x84e680", Frameless: false}]
+          Type: 1460 EventRootType Probe[main.testReturnsArrayZero]Return
+          InjectionPoints: [{PC: "0x84e7b0", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsArrayZero
@@ -2804,15 +2843,15 @@ Probes:
       template: testReturnsBacktrackInt
       segments: [testReturnsBacktrackInt]
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 115}
       events:
         - Kind: Entry
-          Type: 1462 EventRootType Probe[main.testReturnsBacktrackInt]
-          InjectionPoints: [{PC: "0x84e738", Frameless: false}]
+          Type: 1463 EventRootType Probe[main.testReturnsBacktrackInt]
+          InjectionPoints: [{PC: "0x84e868", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1463 EventRootType Probe[main.testReturnsBacktrackInt]Return
-          InjectionPoints: [{PC: "0x84e79c", Frameless: false}]
+          Type: 1464 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          InjectionPoints: [{PC: "0x84e8cc", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsBacktrackInt
@@ -2824,15 +2863,15 @@ Probes:
       template: testReturnsBoolAndUintptr
       segments: [testReturnsBoolAndUintptr]
       captureSnapshot: true
-      subprogram: {subprogram: 120}
+      subprogram: {subprogram: 121}
       events:
         - Kind: Entry
-          Type: 1474 EventRootType Probe[main.testReturnsBoolAndUintptr]
-          InjectionPoints: [{PC: "0x84eac8", Frameless: false}]
+          Type: 1475 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          InjectionPoints: [{PC: "0x84ebf8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1475 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-          InjectionPoints: [{PC: "0x84eb08", Frameless: false}]
+          Type: 1476 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          InjectionPoints: [{PC: "0x84ec38", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsBoolAndUintptr
@@ -2844,15 +2883,15 @@ Probes:
       template: testReturnsComplex
       segments: [testReturnsComplex]
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 109}
       events:
         - Kind: Entry
-          Type: 1450 EventRootType Probe[main.testReturnsComplex]
-          InjectionPoints: [{PC: "0x84e3f8", Frameless: false}]
+          Type: 1451 EventRootType Probe[main.testReturnsComplex]
+          InjectionPoints: [{PC: "0x84e528", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1451 EventRootType Probe[main.testReturnsComplex]Return
-          InjectionPoints: [{PC: "0x84e444", Frameless: false}]
+          Type: 1452 EventRootType Probe[main.testReturnsComplex]Return
+          InjectionPoints: [{PC: "0x84e574", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsComplex
@@ -2865,18 +2904,18 @@ Probes:
       template: '{failed}'
       segments: [{json: {ref: failed}, dsl: failed}]
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 100}
       events:
         - Kind: Entry
-          Type: 1422 EventRootType Probe[main.testReturnsError]
-          InjectionPoints: [{PC: "0x84db18", Frameless: false}]
+          Type: 1423 EventRootType Probe[main.testReturnsError]
+          InjectionPoints: [{PC: "0x84dc48", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1423 EventRootType Probe[main.testReturnsError]Return
+          Type: 1424 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
-            - PC: "0x84db48"
+            - PC: "0x84dc78"
               Frameless: false
-            - PC: "0x84db5c"
+            - PC: "0x84dc8c"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2893,15 +2932,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 97}
       events:
         - Kind: Entry
-          Type: 1416 EventRootType Probe[main.testReturnsInt]
-          InjectionPoints: [{PC: "0x84d928", Frameless: false}]
+          Type: 1417 EventRootType Probe[main.testReturnsInt]
+          InjectionPoints: [{PC: "0x84da58", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1417 EventRootType Probe[main.testReturnsInt]Return
-          InjectionPoints: [{PC: "0x84d96c", Frameless: false}]
+          Type: 1418 EventRootType Probe[main.testReturnsInt]Return
+          InjectionPoints: [{PC: "0x84da9c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2917,15 +2956,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 99}
       events:
         - Kind: Entry
-          Type: 1420 EventRootType Probe[main.testReturnsIntAndFloat]
-          InjectionPoints: [{PC: "0x84da48", Frameless: false}]
+          Type: 1421 EventRootType Probe[main.testReturnsIntAndFloat]
+          InjectionPoints: [{PC: "0x84db78", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1421 EventRootType Probe[main.testReturnsIntAndFloat]Return
-          InjectionPoints: [{PC: "0x84dae0", Frameless: false}]
+          Type: 1422 EventRootType Probe[main.testReturnsIntAndFloat]Return
+          InjectionPoints: [{PC: "0x84dc10", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2941,15 +2980,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 98}
       events:
         - Kind: Entry
-          Type: 1418 EventRootType Probe[main.testReturnsIntPointer]
-          InjectionPoints: [{PC: "0x84d9a8", Frameless: false}]
+          Type: 1419 EventRootType Probe[main.testReturnsIntPointer]
+          InjectionPoints: [{PC: "0x84dad8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1419 EventRootType Probe[main.testReturnsIntPointer]Return
-          InjectionPoints: [{PC: "0x84da08", Frameless: false}]
+          Type: 1420 EventRootType Probe[main.testReturnsIntPointer]Return
+          InjectionPoints: [{PC: "0x84db38", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2966,18 +3005,18 @@ Probes:
       template: '{v}'
       segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1428 EventRootType Probe[main.testReturnsInterface]
-          InjectionPoints: [{PC: "0x84df18", Frameless: false}]
+          Type: 1429 EventRootType Probe[main.testReturnsInterface]
+          InjectionPoints: [{PC: "0x84e048", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1429 EventRootType Probe[main.testReturnsInterface]Return
+          Type: 1430 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
-            - PC: "0x84dfe4"
+            - PC: "0x84e114"
               Frameless: false
-            - PC: "0x84dff8"
+            - PC: "0x84e128"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2994,15 +3033,15 @@ Probes:
       template: testReturnsLargeStruct
       segments: [testReturnsLargeStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 110}
       events:
         - Kind: Entry
-          Type: 1452 EventRootType Probe[main.testReturnsLargeStruct]
-          InjectionPoints: [{PC: "0x84e480", Frameless: false}]
+          Type: 1453 EventRootType Probe[main.testReturnsLargeStruct]
+          InjectionPoints: [{PC: "0x84e5b0", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1453 EventRootType Probe[main.testReturnsLargeStruct]Return
-          InjectionPoints: [{PC: "0x84e514", Frameless: false}]
+          Type: 1454 EventRootType Probe[main.testReturnsLargeStruct]Return
+          InjectionPoints: [{PC: "0x84e644", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsLargeStruct
@@ -3014,15 +3053,15 @@ Probes:
       template: testReturnsManyFloats
       segments: [testReturnsManyFloats]
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 108}
       events:
         - Kind: Entry
-          Type: 1448 EventRootType Probe[main.testReturnsManyFloats]
-          InjectionPoints: [{PC: "0x84e338", Frameless: false}]
+          Type: 1449 EventRootType Probe[main.testReturnsManyFloats]
+          InjectionPoints: [{PC: "0x84e468", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1449 EventRootType Probe[main.testReturnsManyFloats]Return
-          InjectionPoints: [{PC: "0x84e3bc", Frameless: false}]
+          Type: 1450 EventRootType Probe[main.testReturnsManyFloats]Return
+          InjectionPoints: [{PC: "0x84e4ec", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsManyFloats
@@ -3034,15 +3073,15 @@ Probes:
       template: testReturnsMixed
       segments: [testReturnsMixed]
       captureSnapshot: true
-      subprogram: {subprogram: 116}
+      subprogram: {subprogram: 117}
       events:
         - Kind: Entry
-          Type: 1466 EventRootType Probe[main.testReturnsMixed]
-          InjectionPoints: [{PC: "0x84e8b8", Frameless: false}]
+          Type: 1467 EventRootType Probe[main.testReturnsMixed]
+          InjectionPoints: [{PC: "0x84e9e8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1467 EventRootType Probe[main.testReturnsMixed]Return
-          InjectionPoints: [{PC: "0x84e910", Frameless: false}]
+          Type: 1468 EventRootType Probe[main.testReturnsMixed]Return
+          InjectionPoints: [{PC: "0x84ea40", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsMixed
@@ -3054,15 +3093,15 @@ Probes:
       template: testReturnsMixedStruct
       segments: [testReturnsMixedStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 114}
       events:
         - Kind: Entry
-          Type: 1460 EventRootType Probe[main.testReturnsMixedStruct]
-          InjectionPoints: [{PC: "0x84e6b8", Frameless: false}]
+          Type: 1461 EventRootType Probe[main.testReturnsMixedStruct]
+          InjectionPoints: [{PC: "0x84e7e8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1461 EventRootType Probe[main.testReturnsMixedStruct]Return
-          InjectionPoints: [{PC: "0x84e700", Frameless: false}]
+          Type: 1462 EventRootType Probe[main.testReturnsMixedStruct]Return
+          InjectionPoints: [{PC: "0x84e830", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsMixedStruct
@@ -3074,15 +3113,15 @@ Probes:
       template: testReturnsMultipleFloats
       segments: [testReturnsMultipleFloats]
       captureSnapshot: true
-      subprogram: {subprogram: 119}
+      subprogram: {subprogram: 120}
       events:
         - Kind: Entry
-          Type: 1472 EventRootType Probe[main.testReturnsMultipleFloats]
-          InjectionPoints: [{PC: "0x84ea48", Frameless: false}]
+          Type: 1473 EventRootType Probe[main.testReturnsMultipleFloats]
+          InjectionPoints: [{PC: "0x84eb78", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1473 EventRootType Probe[main.testReturnsMultipleFloats]Return
-          InjectionPoints: [{PC: "0x84ea8c", Frameless: false}]
+          Type: 1474 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          InjectionPoints: [{PC: "0x84ebbc", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsMultipleFloats
@@ -3094,15 +3133,15 @@ Probes:
       template: testReturnsOnlyFloat
       segments: [testReturnsOnlyFloat]
       captureSnapshot: true
-      subprogram: {subprogram: 118}
+      subprogram: {subprogram: 119}
       events:
         - Kind: Entry
-          Type: 1470 EventRootType Probe[main.testReturnsOnlyFloat]
-          InjectionPoints: [{PC: "0x84e9d8", Frameless: false}]
+          Type: 1471 EventRootType Probe[main.testReturnsOnlyFloat]
+          InjectionPoints: [{PC: "0x84eb08", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1471 EventRootType Probe[main.testReturnsOnlyFloat]Return
-          InjectionPoints: [{PC: "0x84ea18", Frameless: false}]
+          Type: 1472 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          InjectionPoints: [{PC: "0x84eb48", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsOnlyFloat
@@ -3114,15 +3153,15 @@ Probes:
       template: testReturnsPrimitives
       segments: [testReturnsPrimitives]
       captureSnapshot: true
-      subprogram: {subprogram: 106}
+      subprogram: {subprogram: 107}
       events:
         - Kind: Entry
-          Type: 1446 EventRootType Probe[main.testReturnsPrimitives]
-          InjectionPoints: [{PC: "0x84e2a8", Frameless: false}]
+          Type: 1447 EventRootType Probe[main.testReturnsPrimitives]
+          InjectionPoints: [{PC: "0x84e3d8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1447 EventRootType Probe[main.testReturnsPrimitives]Return
-          InjectionPoints: [{PC: "0x84e300", Frameless: false}]
+          Type: 1448 EventRootType Probe[main.testReturnsPrimitives]Return
+          InjectionPoints: [{PC: "0x84e430", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsPrimitives
@@ -3134,15 +3173,15 @@ Probes:
       template: testReturnsStructWithArray
       segments: [testReturnsStructWithArray]
       captureSnapshot: true
-      subprogram: {subprogram: 117}
+      subprogram: {subprogram: 118}
       events:
         - Kind: Entry
-          Type: 1468 EventRootType Probe[main.testReturnsStructWithArray]
-          InjectionPoints: [{PC: "0x84e94c", Frameless: false}]
+          Type: 1469 EventRootType Probe[main.testReturnsStructWithArray]
+          InjectionPoints: [{PC: "0x84ea7c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1469 EventRootType Probe[main.testReturnsStructWithArray]Return
-          InjectionPoints: [{PC: "0x84e9a0", Frameless: false}]
+          Type: 1470 EventRootType Probe[main.testReturnsStructWithArray]Return
+          InjectionPoints: [{PC: "0x84ead0", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsStructWithArray
@@ -3154,15 +3193,15 @@ Probes:
       template: testReturnsWideStruct
       segments: [testReturnsWideStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 115}
+      subprogram: {subprogram: 116}
       events:
         - Kind: Entry
-          Type: 1464 EventRootType Probe[main.testReturnsWideStruct]
-          InjectionPoints: [{PC: "0x84e7e0", Frameless: false}]
+          Type: 1465 EventRootType Probe[main.testReturnsWideStruct]
+          InjectionPoints: [{PC: "0x84e910", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1465 EventRootType Probe[main.testReturnsWideStruct]Return
-          InjectionPoints: [{PC: "0x84e884", Frameless: false}]
+          Type: 1466 EventRootType Probe[main.testReturnsWideStruct]Return
+          InjectionPoints: [{PC: "0x84e9b4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsWideStruct
@@ -3209,15 +3248,15 @@ Probes:
         - json: {ref: result}
           dsl: result
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1436 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0x84e118", Frameless: false}]
+          Type: 1437 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x84e248", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1437 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0x84e1a4", Frameless: false}]
+          Type: 1438 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x84e2d4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -3485,11 +3524,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 143}
+      subprogram: {subprogram: 144}
       events:
         - Kind: Entry
-          Type: 1509 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0x84ff50", Frameless: true}]
+          Type: 1510 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0x850080", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -3611,11 +3650,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 140}
+      subprogram: {subprogram: 141}
       events:
         - Kind: Entry
-          Type: 1505 EventRootType Probe[main.testSliceEmptyStructs]
-          InjectionPoints: [{PC: "0x84fbb0", Frameless: true}]
+          Type: 1506 EventRootType Probe[main.testSliceEmptyStructs]
+          InjectionPoints: [{PC: "0x84fce0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -3632,11 +3671,11 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 132}
+      subprogram: {subprogram: 133}
       events:
         - Kind: Entry
-          Type: 1496 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0x84fb30", Frameless: true}]
+          Type: 1497 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0x84fc60", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{u}'
@@ -3653,11 +3692,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 65}
+      subprogram: {subprogram: 66}
       events:
         - Kind: Entry
-          Type: 1382 EventRootType Probe[main.testSmallMap]
-          InjectionPoints: [{PC: "0x84bb30", Frameless: true}]
+          Type: 1383 EventRootType Probe[main.testSmallMap]
+          InjectionPoints: [{PC: "0x84bc60", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -3673,15 +3712,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 105}
+      subprogram: {subprogram: 106}
       events:
         - Kind: Entry
-          Type: 1444 EventRootType Probe[main.testSomeNamedReturn]
-          InjectionPoints: [{PC: "0x84e1e8", Frameless: false}]
+          Type: 1445 EventRootType Probe[main.testSomeNamedReturn]
+          InjectionPoints: [{PC: "0x84e318", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1445 EventRootType Probe[main.testSomeNamedReturn]Return
-          InjectionPoints: [{PC: "0x84e270", Frameless: false}]
+          Type: 1446 EventRootType Probe[main.testSomeNamedReturn]Return
+          InjectionPoints: [{PC: "0x84e3a0", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -3697,15 +3736,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 126}
+      subprogram: {subprogram: 127}
       events:
         - Kind: Entry
-          Type: 1486 EventRootType Probe[main.testStackArgRegReturns]
-          InjectionPoints: [{PC: "0x84f3d8", Frameless: false}]
+          Type: 1487 EventRootType Probe[main.testStackArgRegReturns]
+          InjectionPoints: [{PC: "0x84f508", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1487 EventRootType Probe[main.testStackArgRegReturns]Return
-          InjectionPoints: [{PC: "0x84f43c", Frameless: false}]
+          Type: 1488 EventRootType Probe[main.testStackArgRegReturns]Return
+          InjectionPoints: [{PC: "0x84f56c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -3743,11 +3782,11 @@ Probes:
       template: '{z}'
       segments: [{json: {ref: z}, dsl: z}]
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 94}
       events:
         - Kind: Entry
-          Type: 1413 EventRootType Probe[main.testStringPointer]
-          InjectionPoints: [{PC: "0x84d590", Frameless: true}]
+          Type: 1414 EventRootType Probe[main.testStringPointer]
+          InjectionPoints: [{PC: "0x84d6c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{z}'
@@ -3764,11 +3803,11 @@ Probes:
       template: '{s}'
       segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
-      subprogram: {subprogram: 136}
+      subprogram: {subprogram: 137}
       events:
         - Kind: Entry
-          Type: 1500 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0x84fb70", Frameless: true}]
+          Type: 1501 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0x84fca0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{s}'
@@ -3785,11 +3824,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 44}
+      subprogram: {subprogram: 45}
       events:
         - Kind: Entry
-          Type: 1348 EventRootType Probe[main.testStringType1]
-          InjectionPoints: [{PC: "0x84a3f0", Frameless: true}]
+          Type: 1349 EventRootType Probe[main.testStringType1]
+          InjectionPoints: [{PC: "0x84a510", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3806,11 +3845,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 45}
+      subprogram: {subprogram: 46}
       events:
         - Kind: Entry
-          Type: 1349 EventRootType Probe[main.testStringType2]
-          InjectionPoints: [{PC: "0x84a400", Frameless: true}]
+          Type: 1350 EventRootType Probe[main.testStringType2]
+          InjectionPoints: [{PC: "0x84a520", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3827,15 +3866,15 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1528 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0x850250", Frameless: true}]
+          Type: 1529 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0x850380", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1529 EventRootType Probe[main.testStruct]Return
-          InjectionPoints: [{PC: "0x85026c", Frameless: true}]
+          Type: 1530 EventRootType Probe[main.testStruct]Return
+          InjectionPoints: [{PC: "0x85039c", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -3857,11 +3896,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 133}
+      subprogram: {subprogram: 134}
       events:
         - Kind: Entry
-          Type: 1497 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0x84fb40", Frameless: true}]
+          Type: 1498 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0x84fc70", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}, {a}'
@@ -3883,11 +3922,11 @@ Probes:
       template: '{s}'
       segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
-      subprogram: {subprogram: 59}
+      subprogram: {subprogram: 60}
       events:
         - Kind: Entry
-          Type: 1376 EventRootType Probe[main.testStructWithAny]
-          InjectionPoints: [{PC: "0x84b530", Frameless: true}]
+          Type: 1377 EventRootType Probe[main.testStructWithAny]
+          InjectionPoints: [{PC: "0x84b660", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{s}'
@@ -3903,15 +3942,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 128}
+      subprogram: {subprogram: 129}
       events:
         - Kind: Entry
-          Type: 1490 EventRootType Probe[main.testStructWithArrayArg]
-          InjectionPoints: [{PC: "0x84f55c", Frameless: false}]
+          Type: 1491 EventRootType Probe[main.testStructWithArrayArg]
+          InjectionPoints: [{PC: "0x84f68c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1491 EventRootType Probe[main.testStructWithArrayArg]Return
-          InjectionPoints: [{PC: "0x84f5ec", Frameless: false}]
+          Type: 1492 EventRootType Probe[main.testStructWithArrayArg]Return
+          InjectionPoints: [{PC: "0x84f71c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -3928,15 +3967,15 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 153}
+      subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1524 EventRootType Probe[main.testStructWithCyclicMaps]
-          InjectionPoints: [{PC: "0x850160", Frameless: true}]
+          Type: 1525 EventRootType Probe[main.testStructWithCyclicMaps]
+          InjectionPoints: [{PC: "0x850290", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1525 EventRootType Probe[main.testStructWithCyclicMaps]Return
-          InjectionPoints: [{PC: "0x850178", Frameless: true}]
+          Type: 1526 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          InjectionPoints: [{PC: "0x8502a8", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3952,11 +3991,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 152}
+      subprogram: {subprogram: 153}
       events:
         - Kind: Entry
-          Type: 1523 EventRootType Probe[main.testStructWithCyclicSlices]
-          InjectionPoints: [{PC: "0x850150", Frameless: true}]
+          Type: 1524 EventRootType Probe[main.testStructWithCyclicSlices]
+          InjectionPoints: [{PC: "0x850280", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3978,11 +4017,11 @@ Probes:
         - json: {ref: '@duration'}
           dsl: '@duration'
       captureSnapshot: true
-      subprogram: {subprogram: 60}
+      subprogram: {subprogram: 61}
       events:
         - Kind: Entry
-          Type: 1377 EventRootType Probe[main.testStructWithMap]
-          InjectionPoints: [{PC: "0x84bae0", Frameless: true}]
+          Type: 1378 EventRootType Probe[main.testStructWithMap]
+          InjectionPoints: [{PC: "0x84bc10", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{s} {@duration}'
@@ -4009,11 +4048,11 @@ Probes:
         - json: {ref: cs}
           dsl: cs
       captureSnapshot: true
-      subprogram: {subprogram: 141}
+      subprogram: {subprogram: 142}
       events:
         - Kind: Entry
-          Type: 1506 EventRootType Probe[main.testSubslices]
-          InjectionPoints: [{PC: "0x84fbc0", Frameless: true}]
+          Type: 1507 EventRootType Probe[main.testSubslices]
+          InjectionPoints: [{PC: "0x84fcf0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{as}, {bs}, {cs}'
@@ -4048,11 +4087,11 @@ Probes:
         - json: {ref: c}
           dsl: c
       captureSnapshot: true
-      subprogram: {subprogram: 151}
+      subprogram: {subprogram: 152}
       events:
         - Kind: Entry
-          Type: 1522 EventRootType Probe[main.testSubstrings]
-          InjectionPoints: [{PC: "0x84ffe0", Frameless: true}]
+          Type: 1523 EventRootType Probe[main.testSubstrings]
+          InjectionPoints: [{PC: "0x850110", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}'
@@ -4080,15 +4119,15 @@ Probes:
         - json: {ref: nonexistentVariable}
           dsl: nonexistentVariable
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1438 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0x84e118", Frameless: false}]
+          Type: 1439 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x84e248", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1439 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0x84e1a4", Frameless: false}]
+          Type: 1440 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x84e2d4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{nonexistentVariable}'
@@ -4104,15 +4143,15 @@ Probes:
         - json: {foobar: unsupportedExpression}
           dsl: unsupportedExpression
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1440 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0x84e118", Frameless: false}]
+          Type: 1441 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x84e248", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1441 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0x84e1a4", Frameless: false}]
+          Type: 1442 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x84e2d4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{unsupportedExpression}'
@@ -4130,15 +4169,15 @@ Probes:
           dsl: '@duration'
         - ms
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1442 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0x84e118", Frameless: false}]
+          Type: 1443 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x84e248", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1443 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0x84e1a4", Frameless: false}]
+          Type: 1444 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x84e2d4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -4162,11 +4201,11 @@ Probes:
         - json: {ref: z}
           dsl: z
       captureSnapshot: true
-      subprogram: {subprogram: 144}
+      subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1510 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0x84ff60", Frameless: true}]
+          Type: 1511 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0x850090", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}, {y}, {z}'
@@ -4193,15 +4232,15 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 145}
+      subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1511 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0x84ff70", Frameless: true}]
+          Type: 1512 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0x8500a0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1512 EventRootType Probe[main.testThreeStringsInStruct]Return
-          InjectionPoints: [{PC: "0x84ff88", Frameless: true}]
+          Type: 1513 EventRootType Probe[main.testThreeStringsInStruct]Return
+          InjectionPoints: [{PC: "0x8500b8", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -4226,15 +4265,15 @@ Probes:
         - json: {getmember: [{ref: a}, c]}
           dsl: t.c
       captureSnapshot: false
-      subprogram: {subprogram: 145}
+      subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1513 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0x84ff70", Frameless: true}]
+          Type: 1514 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0x8500a0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1514 EventRootType Probe[main.testThreeStringsInStruct]Return
-          InjectionPoints: [{PC: "0x84ff88", Frameless: true}]
+          Type: 1515 EventRootType Probe[main.testThreeStringsInStruct]Return
+          InjectionPoints: [{PC: "0x8500b8", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a.a} {a.b} {a.c}'
@@ -4261,11 +4300,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 146}
+      subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1515 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0x84ff90", Frameless: true}]
+          Type: 1516 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0x8500c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -4290,11 +4329,11 @@ Probes:
         - json: {getmember: [{ref: a}, c]}
           dsl: a.c
       captureSnapshot: false
-      subprogram: {subprogram: 146}
+      subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1516 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0x84ff90", Frameless: true}]
+          Type: 1517 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0x8500c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a.a} {a.b} {a.c}'
@@ -4447,11 +4486,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 93}
       events:
         - Kind: Entry
-          Type: 1412 EventRootType Probe[main.testUintPointer]
-          InjectionPoints: [{PC: "0x84d520", Frameless: true}]
+          Type: 1413 EventRootType Probe[main.testUintPointer]
+          InjectionPoints: [{PC: "0x84d650", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4468,11 +4507,11 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 130}
+      subprogram: {subprogram: 131}
       events:
         - Kind: Entry
-          Type: 1494 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0x84fb10", Frameless: true}]
+          Type: 1495 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0x84fc40", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{u}'
@@ -4489,11 +4528,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 149}
+      subprogram: {subprogram: 150}
       events:
         - Kind: Entry
-          Type: 1520 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0x84ffc0", Frameless: true}]
+          Type: 1521 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0x8500f0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4510,11 +4549,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 92}
       events:
         - Kind: Entry
-          Type: 1411 EventRootType Probe[main.testUnsafePointer]
-          InjectionPoints: [{PC: "0x84d500", Frameless: true}]
+          Type: 1412 EventRootType Probe[main.testUnsafePointer]
+          InjectionPoints: [{PC: "0x84d630", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4552,11 +4591,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 139}
+      subprogram: {subprogram: 140}
       events:
         - Kind: Entry
-          Type: 1503 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0x84fba0", Frameless: true}]
+          Type: 1504 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0x84fcd0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -4573,11 +4612,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 139}
+      subprogram: {subprogram: 140}
       events:
         - Kind: Entry
-          Type: 1504 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0x84fba0", Frameless: true}]
+          Type: 1505 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0x84fcd0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -4593,19 +4632,19 @@ Probes:
       template: testWhollyInlinedSubroutine
       segments: [testWhollyInlinedSubroutine]
       captureSnapshot: true
-      subprogram: {subprogram: 164}
+      subprogram: {subprogram: 165}
       events:
         - Kind: Entry
-          Type: 1549 EventRootType Probe[main.firstBehavior.DoSomething]
+          Type: 1550 EventRootType Probe[main.firstBehavior.DoSomething]
           InjectionPoints:
-            - PC: "0x84b368"
+            - PC: "0x84b498"
               Frameless: false
-            - PC: "0x85106c"
+            - PC: "0x85119c"
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1550 EventRootType Probe[main.firstBehavior.DoSomething]Return
-          InjectionPoints: [{PC: "0x84b3a0", Frameless: false}]
+          Type: 1551 EventRootType Probe[main.firstBehavior.DoSomething]Return
+          InjectionPoints: [{PC: "0x84b4d0", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testWhollyInlinedSubroutine
@@ -4622,15 +4661,15 @@ Probes:
         - json: {ref: b}
           dsl: b
       captureSnapshot: true
-      subprogram: {subprogram: 129}
+      subprogram: {subprogram: 130}
       events:
         - Kind: Entry
-          Type: 1492 EventRootType Probe[main.testZeroSizeArgAndReturn]
-          InjectionPoints: [{PC: "0x84f628", Frameless: false}]
+          Type: 1493 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          InjectionPoints: [{PC: "0x84f758", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1493 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-          InjectionPoints: [{PC: "0x84f690", Frameless: false}]
+          Type: 1494 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          InjectionPoints: [{PC: "0x84f7c0", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}'
@@ -5065,36 +5104,83 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
     - ID: 38
+      Name: main.testErrorAtLine
+      OutOfLinePCRanges: [0x84a030..0x84a150]
+      InlinePCRanges: []
+      Variables:
+        - Name: shouldErr
+          Type: 4 BaseType bool
+          Locations:
+            - Range: 0x84a030..0x84a050
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+        - Name: ~r0
+          Type: 7 BaseType int
+          Locations: [{Range: 0x84a030..0x84a150, Pieces: []}]
+          Role: Return
+        - Name: x
+          Type: 7 BaseType int
+          Locations: [{Range: 0x84a030..0x84a150, Pieces: []}]
+          Role: Local
+        - Name: err
+          Type: 14 GoInterfaceType error
+          Locations:
+            - Range: 0x84a068..0x84a088
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+            - Range: 0x84a088..0x84a0a4
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x84a0a4..0x84a0b8
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: -72}
+                - Size: 8
+                  Op: {CfaOffset: -64}
+            - Range: 0x84a0b8..0x84a150
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: -72}
+                - Size: 8
+                  Op: {CfaOffset: -64}
+          Role: Local
+    - ID: 39
       Name: main.testDeepPtr1
-      OutOfLinePCRanges: [0x84a0c0..0x84a0d0]
+      OutOfLinePCRanges: [0x84a1e0..0x84a1f0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 130 StructureType main.deepPtr1
           Locations:
-            - Range: 0x84a0c0..0x84a0d0
+            - Range: 0x84a1e0..0x84a1f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 39
+    - ID: 40
       Name: main.testDeepPtr7
-      OutOfLinePCRanges: [0x84a0d0..0x84a0e0]
+      OutOfLinePCRanges: [0x84a1f0..0x84a200]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 133 PointerType *main.deepPtr7
           Locations:
-            - Range: 0x84a0d0..0x84a0e0
+            - Range: 0x84a1f0..0x84a200
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 40
+    - ID: 41
       Name: main.testDeepSlice1
-      OutOfLinePCRanges: [0x84a270..0x84a280]
+      OutOfLinePCRanges: [0x84a390..0x84a3a0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 135 StructureType main.deepSlice1
           Locations:
-            - Range: 0x84a270..0x84a280
+            - Range: 0x84a390..0x84a3a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -5103,117 +5189,117 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 41
+    - ID: 42
       Name: main.testDeepSlice7
-      OutOfLinePCRanges: [0x84a280..0x84a290]
+      OutOfLinePCRanges: [0x84a3a0..0x84a3b0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 139 PointerType *main.deepSlice7
           Locations:
-            - Range: 0x84a280..0x84a290
+            - Range: 0x84a3a0..0x84a3b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 42
+    - ID: 43
       Name: main.testDeepMap1
-      OutOfLinePCRanges: [0x84a3d0..0x84a3e0]
+      OutOfLinePCRanges: [0x84a4f0..0x84a500]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 141 StructureType main.deepMap1
           Locations:
-            - Range: 0x84a3d0..0x84a3e0
+            - Range: 0x84a4f0..0x84a500
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 43
+    - ID: 44
       Name: main.testDeepMap7
-      OutOfLinePCRanges: [0x84a3e0..0x84a3f0]
+      OutOfLinePCRanges: [0x84a500..0x84a510]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 147 PointerType *main.deepMap7
           Locations:
-            - Range: 0x84a3e0..0x84a3f0
+            - Range: 0x84a500..0x84a510
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 44
+    - ID: 45
       Name: main.testStringType1
-      OutOfLinePCRanges: [0x84a3f0..0x84a400]
+      OutOfLinePCRanges: [0x84a510..0x84a520]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 149 PointerType *main.stringType1
           Locations:
-            - Range: 0x84a3f0..0x84a400
+            - Range: 0x84a510..0x84a520
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 45
+    - ID: 46
       Name: main.testStringType2
-      OutOfLinePCRanges: [0x84a400..0x84a410]
+      OutOfLinePCRanges: [0x84a520..0x84a530]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 151 PointerType **main.stringType2
           Locations:
-            - Range: 0x84a400..0x84a410
+            - Range: 0x84a520..0x84a530
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 46
+    - ID: 47
       Name: main.testLongFunctionWithChangingState
-      OutOfLinePCRanges: [0x84a410..0x84a610]
+      OutOfLinePCRanges: [0x84a530..0x84a730]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84a4d4..0x84a4e4
+            - Range: 0x84a5f4..0x84a604
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84a580..0x84a590
+            - Range: 0x84a6a0..0x84a6b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
         - Name: aPerArch
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84a4bc..0x84a4c0
+            - Range: 0x84a5dc..0x84a5e0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x84a4c0..0x84a4e4
+            - Range: 0x84a5e0..0x84a604
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x84a4e4..0x84a574
+            - Range: 0x84a604..0x84a694
               Pieces: [{Size: 8, Op: {CfaOffset: -160}}]
-            - Range: 0x84a574..0x84a57c
+            - Range: 0x84a694..0x84a69c
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0x84a57c..0x84a610
+            - Range: 0x84a69c..0x84a730
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
           Role: Local
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84a4b8..0x84a4c0
+            - Range: 0x84a5d8..0x84a5e0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x84a4c0..0x84a4c0
+            - Range: 0x84a5e0..0x84a5e0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x84a4c0..0x84a4e4
+            - Range: 0x84a5e0..0x84a604
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x84a4e4..0x84a574
+            - Range: 0x84a604..0x84a694
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0x84a574..0x84a578
+            - Range: 0x84a694..0x84a698
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0x84a578..0x84a57c
+            - Range: 0x84a698..0x84a69c
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0x84a57c..0x84a590
+            - Range: 0x84a69c..0x84a6b0
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0x84a590..0x84a610
+            - Range: 0x84a6b0..0x84a730
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
           Role: Local
-    - ID: 47
+    - ID: 48
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0x84a990..0x84aa60]
+      OutOfLinePCRanges: [0x84aac0..0x84ab90]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 153 StructureType main.esotericStack
           Locations:
-            - Range: 0x84a990..0x84a9d8
+            - Range: 0x84aac0..0x84ab08
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -5233,7 +5319,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x84a9d8..0x84a9dc
+            - Range: 0x84ab08..0x84ab0c
               Pieces:
                 - Size: 4
                   Op: null
@@ -5253,7 +5339,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x84a9dc..0x84a9e0
+            - Range: 0x84ab0c..0x84ab10
               Pieces:
                 - Size: 4
                   Op: null
@@ -5274,161 +5360,161 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 48
+    - ID: 49
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0x84aa60..0x84aae0]
+      OutOfLinePCRanges: [0x84ab90..0x84ac10]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 157 PointerType *main.esotericHeap
           Locations:
-            - Range: 0x84aa60..0x84aa98
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-    - ID: 49
-      Name: main.testInlinedBA
-      OutOfLinePCRanges: [0x84aea0..0x84af30]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x84aea0..0x84aed8
+            - Range: 0x84ab90..0x84abc8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 50
-      Name: main.testInlinedBB
-      OutOfLinePCRanges: [0x84af30..0x84aff0]
+      Name: main.testInlinedBA
+      OutOfLinePCRanges: [0x84afd0..0x84b060]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84af30..0x84af4c
+            - Range: 0x84afd0..0x84b008
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+    - ID: 51
+      Name: main.testInlinedBB
+      OutOfLinePCRanges: [0x84b060..0x84b120]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84b060..0x84b07c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: y
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84af30..0x84af5c
+            - Range: 0x84b060..0x84b08c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
         - Name: z
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84af4c..0x84af5c
+            - Range: 0x84b07c..0x84b08c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84af5c..0x84aff0
+            - Range: 0x84b08c..0x84b120
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Local
-    - ID: 51
+    - ID: 52
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0x84aff0..0x84b070]
+      OutOfLinePCRanges: [0x84b120..0x84b1a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84aff0..0x84b014
+            - Range: 0x84b120..0x84b144
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 52
+    - ID: 53
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0x84b070..0x84b190]
+      OutOfLinePCRanges: [0x84b1a0..0x84b2c0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84b0d8..0x84b0e0
+            - Range: 0x84b208..0x84b210
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0x84b0e0..0x84b0f8
+            - Range: 0x84b210..0x84b228
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0x84b0f8..0x84b10c
+            - Range: 0x84b228..0x84b23c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84b0d4..0x84b0dc
+            - Range: 0x84b204..0x84b20c
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
-            - Range: 0x84b0dc..0x84b0f8
+            - Range: 0x84b20c..0x84b228
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
-            - Range: 0x84b0f8..0x84b108
+            - Range: 0x84b228..0x84b238
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 53
+    - ID: 54
       Name: main.testFrameless
-      OutOfLinePCRanges: [0x84b190..0x84b1a0]
+      OutOfLinePCRanges: [0x84b2c0..0x84b2d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84b190..0x84b198
+            - Range: 0x84b2c0..0x84b2c8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84b190..0x84b198
+            - Range: 0x84b2c0..0x84b2c8
               Pieces: []
-            - Range: 0x84b198..0x84b199
+            - Range: 0x84b2c8..0x84b2c9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84b199..0x84b1a0
+            - Range: 0x84b2c9..0x84b2d0
               Pieces: []
           Role: Return
-    - ID: 54
+    - ID: 55
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0x84b1a0..0x84b200]
+      OutOfLinePCRanges: [0x84b2d0..0x84b330]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 159 ArrayType [5]int
           Locations:
-            - Range: 0x84b1a0..0x84b200
+            - Range: 0x84b2d0..0x84b330
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84b1a0..0x84b1e8
+            - Range: 0x84b2d0..0x84b318
               Pieces: []
-            - Range: 0x84b1e8..0x84b1e9
+            - Range: 0x84b318..0x84b319
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84b1e9..0x84b200
+            - Range: 0x84b319..0x84b330
               Pieces: []
           Role: Return
-    - ID: 55
+    - ID: 56
       Name: main.testInterface
-      OutOfLinePCRanges: [0x84b430..0x84b440]
+      OutOfLinePCRanges: [0x84b560..0x84b570]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 160 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x84b430..0x84b440
+            - Range: 0x84b560..0x84b570
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 56
+    - ID: 57
       Name: main.testAny
-      OutOfLinePCRanges: [0x84b440..0x84b4b0]
+      OutOfLinePCRanges: [0x84b570..0x84b5e0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x84b440..0x84b470
+            - Range: 0x84b570..0x84b5a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84b470..0x84b474
+            - Range: 0x84b5a0..0x84b5a4
               Pieces:
                 - Size: 8
                   Op: null
@@ -5438,363 +5524,363 @@ Subprograms:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84b440..0x84b484
+            - Range: 0x84b570..0x84b5b4
               Pieces: []
-            - Range: 0x84b484..0x84b485
+            - Range: 0x84b5b4..0x84b5b5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84b485..0x84b4b0
+            - Range: 0x84b5b5..0x84b5e0
               Pieces: []
           Role: Return
-    - ID: 57
+    - ID: 58
       Name: main.testError
-      OutOfLinePCRanges: [0x84b4b0..0x84b4c0]
+      OutOfLinePCRanges: [0x84b5e0..0x84b5f0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 14 GoInterfaceType error
           Locations:
-            - Range: 0x84b4b0..0x84b4c0
+            - Range: 0x84b5e0..0x84b5f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 58
+    - ID: 59
       Name: main.testAnyPtr
-      OutOfLinePCRanges: [0x84b4c0..0x84b530]
+      OutOfLinePCRanges: [0x84b5f0..0x84b660]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 161 PointerType *interface {}
           Locations:
-            - Range: 0x84b4c0..0x84b4f0
+            - Range: 0x84b5f0..0x84b620
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84b4c0..0x84b504
+            - Range: 0x84b5f0..0x84b634
               Pieces: []
-            - Range: 0x84b504..0x84b505
+            - Range: 0x84b634..0x84b635
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84b505..0x84b530
+            - Range: 0x84b635..0x84b660
               Pieces: []
           Role: Return
-    - ID: 59
+    - ID: 60
       Name: main.testStructWithAny
-      OutOfLinePCRanges: [0x84b530..0x84b540]
+      OutOfLinePCRanges: [0x84b660..0x84b670]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 162 StructureType main.structWithAny
           Locations:
-            - Range: 0x84b530..0x84b540
+            - Range: 0x84b660..0x84b670
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 60
+    - ID: 61
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0x84bae0..0x84baf0]
+      OutOfLinePCRanges: [0x84bc10..0x84bc20]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 163 StructureType main.structWithMap
           Locations:
-            - Range: 0x84bae0..0x84baf0
+            - Range: 0x84bc10..0x84bc20
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 61
+    - ID: 62
       Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0x84baf0..0x84bb00]
+      OutOfLinePCRanges: [0x84bc20..0x84bc30]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 169 GoMapType map[string]main.nestedStruct
           Locations:
-            - Range: 0x84baf0..0x84bb00
+            - Range: 0x84bc20..0x84bc30
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 62
+    - ID: 63
       Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0x84bb00..0x84bb10]
+      OutOfLinePCRanges: [0x84bc30..0x84bc40]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 174 GoMapType map[string]int
           Locations:
-            - Range: 0x84bb00..0x84bb10
+            - Range: 0x84bc30..0x84bc40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 63
+    - ID: 64
       Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0x84bb10..0x84bb20]
+      OutOfLinePCRanges: [0x84bc40..0x84bc50]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 179 GoMapType map[string][]string
           Locations:
-            - Range: 0x84bb10..0x84bb20
+            - Range: 0x84bc40..0x84bc50
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 64
+    - ID: 65
       Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0x84bb20..0x84bb30]
+      OutOfLinePCRanges: [0x84bc50..0x84bc60]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 184 GoMapType map[[4]string][2]int
           Locations:
-            - Range: 0x84bb20..0x84bb30
+            - Range: 0x84bc50..0x84bc60
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 65
+    - ID: 66
       Name: main.testSmallMap
-      OutOfLinePCRanges: [0x84bb30..0x84bb40]
+      OutOfLinePCRanges: [0x84bc60..0x84bc70]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 174 GoMapType map[string]int
           Locations:
-            - Range: 0x84bb30..0x84bb40
+            - Range: 0x84bc60..0x84bc70
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 66
+    - ID: 67
       Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0x84bb40..0x84bb50]
+      OutOfLinePCRanges: [0x84bc70..0x84bc80]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 189 ArrayType [2]map[string]int
           Locations:
-            - Range: 0x84bb40..0x84bb50
+            - Range: 0x84bc70..0x84bc80
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
-    - ID: 67
+    - ID: 68
       Name: main.testPointerToMap
-      OutOfLinePCRanges: [0x84bb50..0x84bb60]
+      OutOfLinePCRanges: [0x84bc80..0x84bc90]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 190 PointerType *map[string]int
           Locations:
-            - Range: 0x84bb50..0x84bb60
+            - Range: 0x84bc80..0x84bc90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 68
+    - ID: 69
       Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0x84bb60..0x84bb70]
+      OutOfLinePCRanges: [0x84bc90..0x84bca0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 164 GoMapType map[int]int
           Locations:
-            - Range: 0x84bb60..0x84bb70
+            - Range: 0x84bc90..0x84bca0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 69
+    - ID: 70
       Name: main.testMapMassive
-      OutOfLinePCRanges: [0x84bb70..0x84bb80]
+      OutOfLinePCRanges: [0x84bca0..0x84bcb0]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 191 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0x84bb70..0x84bb80
+            - Range: 0x84bca0..0x84bcb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 70
+    - ID: 71
       Name: main.testMapEmbeddedMaps
-      OutOfLinePCRanges: [0x84bb80..0x84bb90]
+      OutOfLinePCRanges: [0x84bcb0..0x84bcc0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 191 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0x84bb80..0x84bb90
+            - Range: 0x84bcb0..0x84bcc0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 71
+    - ID: 72
       Name: main.testMapWithLinkedList
-      OutOfLinePCRanges: [0x84bb90..0x84bba0]
+      OutOfLinePCRanges: [0x84bcc0..0x84bcd0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 196 GoMapType map[bool]main.node
           Locations:
-            - Range: 0x84bb90..0x84bba0
+            - Range: 0x84bcc0..0x84bcd0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 72
+    - ID: 73
       Name: main.testMapWithSmallValue
-      OutOfLinePCRanges: [0x84bba0..0x84bbb0]
+      OutOfLinePCRanges: [0x84bcd0..0x84bce0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 201 GoMapType map[int]uint8
           Locations:
-            - Range: 0x84bba0..0x84bbb0
+            - Range: 0x84bcd0..0x84bce0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 73
+    - ID: 74
       Name: main.testMapWithSmallValueMassive
-      OutOfLinePCRanges: [0x84bbb0..0x84bbc0]
+      OutOfLinePCRanges: [0x84bce0..0x84bcf0]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 201 GoMapType map[int]uint8
           Locations:
-            - Range: 0x84bbb0..0x84bbc0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-    - ID: 74
-      Name: main.testMapWithSmallKeyAndValue
-      OutOfLinePCRanges: [0x84bbc0..0x84bbd0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 206 GoMapType map[uint8]uint8
-          Locations:
-            - Range: 0x84bbc0..0x84bbd0
+            - Range: 0x84bce0..0x84bcf0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 75
-      Name: main.testMapWithSmallKeyAndValueMassive
-      OutOfLinePCRanges: [0x84bbd0..0x84bbe0]
+      Name: main.testMapWithSmallKeyAndValue
+      OutOfLinePCRanges: [0x84bcf0..0x84bd00]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 206 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0x84bbd0..0x84bbe0
+            - Range: 0x84bcf0..0x84bd00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 76
-      Name: main.testMapSmallKeySmallValue
-      OutOfLinePCRanges: [0x84bbe0..0x84bbf0]
+      Name: main.testMapWithSmallKeyAndValueMassive
+      OutOfLinePCRanges: [0x84bd00..0x84bd10]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 206 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0x84bbe0..0x84bbf0
+            - Range: 0x84bd00..0x84bd10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 77
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0x84bd10..0x84bd20]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 206 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0x84bd10..0x84bd20
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+    - ID: 78
       Name: main.testMapSmallKeyLargeValue
-      OutOfLinePCRanges: [0x84bbf0..0x84bc00]
+      OutOfLinePCRanges: [0x84bd20..0x84bd30]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 211 GoMapType map[uint8][4]int
           Locations:
-            - Range: 0x84bbf0..0x84bc00
+            - Range: 0x84bd20..0x84bd30
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 78
+    - ID: 79
       Name: main.testMapLargeKeySmallValue
-      OutOfLinePCRanges: [0x84bc00..0x84bc10]
+      OutOfLinePCRanges: [0x84bd30..0x84bd40]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 216 GoMapType map[[4]int]uint8
           Locations:
-            - Range: 0x84bc00..0x84bc10
+            - Range: 0x84bd30..0x84bd40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 79
+    - ID: 80
       Name: main.testMapLargeKeyLargeValue
-      OutOfLinePCRanges: [0x84bc10..0x84bc20]
+      OutOfLinePCRanges: [0x84bd40..0x84bd50]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 221 GoMapType map[[4]int][4]int
           Locations:
-            - Range: 0x84bc10..0x84bc20
+            - Range: 0x84bd40..0x84bd50
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 80
+    - ID: 81
       Name: main.testMapEmptyKey
-      OutOfLinePCRanges: [0x84bc20..0x84bc30]
+      OutOfLinePCRanges: [0x84bd50..0x84bd60]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 226 GoMapType map[struct {}]int
           Locations:
-            - Range: 0x84bc20..0x84bc30
+            - Range: 0x84bd50..0x84bd60
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 81
+    - ID: 82
       Name: main.testMapEmptyValue
-      OutOfLinePCRanges: [0x84bc30..0x84bc40]
+      OutOfLinePCRanges: [0x84bd60..0x84bd70]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 231 GoMapType map[int]struct {}
           Locations:
-            - Range: 0x84bc30..0x84bc40
+            - Range: 0x84bd60..0x84bd70
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 82
+    - ID: 83
       Name: main.testMapEmptyKeyAndValue
-      OutOfLinePCRanges: [0x84bc40..0x84bc50]
+      OutOfLinePCRanges: [0x84bd70..0x84bd80]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 236 GoMapType map[struct {}]struct {}
           Locations:
-            - Range: 0x84bc40..0x84bc50
+            - Range: 0x84bd70..0x84bd80
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 83
+    - ID: 84
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0x84d060..0x84d070]
+      OutOfLinePCRanges: [0x84d190..0x84d1a0]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x84d060..0x84d070
+            - Range: 0x84d190..0x84d1a0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x84d060..0x84d070
+            - Range: 0x84d190..0x84d1a0
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
         - Name: y
           Type: 17 BaseType float32
           Locations:
-            - Range: 0x84d060..0x84d070
+            - Range: 0x84d190..0x84d1a0
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
-    - ID: 84
+    - ID: 85
       Name: main.testCombinedString
-      OutOfLinePCRanges: [0x84d080..0x84d090]
+      OutOfLinePCRanges: [0x84d1b0..0x84d1c0]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x84d080..0x84d090
+            - Range: 0x84d1b0..0x84d1c0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84d080..0x84d090
+            - Range: 0x84d1b0..0x84d1c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -5804,345 +5890,345 @@ Subprograms:
         - Name: y
           Type: 17 BaseType float32
           Locations:
-            - Range: 0x84d080..0x84d090
+            - Range: 0x84d1b0..0x84d1c0
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
-    - ID: 85
+    - ID: 86
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0x84d140..0x84d150]
+      OutOfLinePCRanges: [0x84d270..0x84d280]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x84d140..0x84d150
+            - Range: 0x84d270..0x84d280
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: b
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x84d140..0x84d150
+            - Range: 0x84d270..0x84d280
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
         - Name: c
           Type: 12 BaseType int32
           Locations:
-            - Range: 0x84d140..0x84d150
+            - Range: 0x84d270..0x84d280
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
         - Name: d
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x84d140..0x84d150
+            - Range: 0x84d270..0x84d280
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
         - Name: e
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84d140..0x84d150
+            - Range: 0x84d270..0x84d280
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
-    - ID: 86
+    - ID: 87
       Name: main.testAtomicAdd
-      OutOfLinePCRanges: [0x84d2e0..0x84d320]
+      OutOfLinePCRanges: [0x84d410..0x84d450]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0x84d2e0..0x84d31c
+            - Range: 0x84d410..0x84d44c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0x84d2e0..0x84d31c
+            - Range: 0x84d410..0x84d44c
               Pieces: []
-            - Range: 0x84d31c..0x84d31d
+            - Range: 0x84d44c..0x84d44d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84d31d..0x84d320
+            - Range: 0x84d44d..0x84d450
               Pieces: []
           Role: Return
-    - ID: 87
+    - ID: 88
       Name: main.testChannel
-      OutOfLinePCRanges: [0x84d320..0x84d330]
+      OutOfLinePCRanges: [0x84d450..0x84d460]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 241 GoChannelType chan bool
           Locations:
-            - Range: 0x84d320..0x84d330
+            - Range: 0x84d450..0x84d460
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 88
+    - ID: 89
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0x84d4d0..0x84d4e0]
+      OutOfLinePCRanges: [0x84d600..0x84d610]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 242 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0x84d4d0..0x84d4e0
+            - Range: 0x84d600..0x84d610
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 89
+    - ID: 90
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0x84d4e0..0x84d4f0]
+      OutOfLinePCRanges: [0x84d610..0x84d620]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 244 StructureType main.node
           Locations:
-            - Range: 0x84d4e0..0x84d4f0
+            - Range: 0x84d610..0x84d620
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 90
+    - ID: 91
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0x84d4f0..0x84d500]
+      OutOfLinePCRanges: [0x84d620..0x84d630]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 245 PointerType *main.node
           Locations:
-            - Range: 0x84d4f0..0x84d500
+            - Range: 0x84d620..0x84d630
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 91
+    - ID: 92
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0x84d500..0x84d510]
+      OutOfLinePCRanges: [0x84d630..0x84d640]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 15 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0x84d500..0x84d510
+            - Range: 0x84d630..0x84d640
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 92
+    - ID: 93
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0x84d520..0x84d530]
+      OutOfLinePCRanges: [0x84d650..0x84d660]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 105 PointerType *uint
           Locations:
-            - Range: 0x84d520..0x84d530
+            - Range: 0x84d650..0x84d660
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 93
+    - ID: 94
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0x84d590..0x84d5a0]
+      OutOfLinePCRanges: [0x84d6c0..0x84d6d0]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 93 PointerType *string
           Locations:
-            - Range: 0x84d590..0x84d5a0
+            - Range: 0x84d6c0..0x84d6d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 94
+    - ID: 95
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0x84d5b0..0x84d5c0]
+      OutOfLinePCRanges: [0x84d6e0..0x84d6f0]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 11 PointerType *bool
           Locations:
-            - Range: 0x84d5b0..0x84d5c0
+            - Range: 0x84d6e0..0x84d6f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: a
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x84d5b0..0x84d5c0
+            - Range: 0x84d6e0..0x84d6f0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
-    - ID: 95
+    - ID: 96
       Name: main.testCycle
-      OutOfLinePCRanges: [0x84d5d0..0x84d5e0]
+      OutOfLinePCRanges: [0x84d700..0x84d710]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 246 PointerType *main.t
           Locations:
-            - Range: 0x84d5d0..0x84d5e0
+            - Range: 0x84d700..0x84d710
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 96
+    - ID: 97
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0x84d910..0x84d990]
+      OutOfLinePCRanges: [0x84da40..0x84dac0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84d910..0x84d92c
+            - Range: 0x84da40..0x84da5c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84d910..0x84d96c
+            - Range: 0x84da40..0x84da9c
               Pieces: []
-            - Range: 0x84d96c..0x84d96d
+            - Range: 0x84da9c..0x84da9d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84d96d..0x84d990
+            - Range: 0x84da9d..0x84dac0
               Pieces: []
           Role: Return
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84d92c..0x84d938
+            - Range: 0x84da5c..0x84da68
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84d938..0x84d990
+            - Range: 0x84da68..0x84dac0
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
-    - ID: 97
+    - ID: 98
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0x84d990..0x84da30]
+      OutOfLinePCRanges: [0x84dac0..0x84db60]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84d990..0x84d9b4
+            - Range: 0x84dac0..0x84dae4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84d9b4..0x84da30
+            - Range: 0x84dae4..0x84db60
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 99 PointerType *int
           Locations:
-            - Range: 0x84d990..0x84da08
+            - Range: 0x84dac0..0x84db38
               Pieces: []
-            - Range: 0x84da08..0x84da09
+            - Range: 0x84db38..0x84db39
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84da09..0x84da30
+            - Range: 0x84db39..0x84db60
               Pieces: []
           Role: Return
         - Name: '&result'
           Type: 99 PointerType *int
           Locations:
-            - Range: 0x84d9b8..0x84d9d0
+            - Range: 0x84dae8..0x84db00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84d9d0..0x84da30
+            - Range: 0x84db00..0x84db60
               Pieces: [{Size: 8, Op: {CfaOffset: -16}}]
           Role: Local
-    - ID: 98
+    - ID: 99
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0x84da30..0x84db00]
+      OutOfLinePCRanges: [0x84db60..0x84dc30]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84da30..0x84da88
+            - Range: 0x84db60..0x84dbb8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84da30..0x84dae0
+            - Range: 0x84db60..0x84dc10
               Pieces: []
-            - Range: 0x84dae0..0x84dae1
+            - Range: 0x84dc10..0x84dc11
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84dae1..0x84db00
+            - Range: 0x84dc11..0x84dc30
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0x84da30..0x84db00, Pieces: []}]
+          Locations: [{Range: 0x84db60..0x84dc30, Pieces: []}]
           Role: Return
         - Name: resultInt
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84da4c..0x84da8c
+            - Range: 0x84db7c..0x84dbbc
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x84da8c..0x84db00
+            - Range: 0x84dbbc..0x84dc30
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
         - Name: resultFloat
           Type: 18 BaseType float64
           Locations:
-            - Range: 0x84da5c..0x84da8c
+            - Range: 0x84db8c..0x84dbbc
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
-            - Range: 0x84da8c..0x84db00
+            - Range: 0x84dbbc..0x84dc30
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
           Role: Local
-    - ID: 99
+    - ID: 100
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0x84db00..0x84db80]
+      OutOfLinePCRanges: [0x84dc30..0x84dcb0]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x84db00..0x84db24
+            - Range: 0x84dc30..0x84dc54
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 14 GoInterfaceType error
           Locations:
-            - Range: 0x84db00..0x84db48
+            - Range: 0x84dc30..0x84dc78
               Pieces: []
-            - Range: 0x84db48..0x84db49
+            - Range: 0x84dc78..0x84dc79
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84db49..0x84db5c
+            - Range: 0x84dc79..0x84dc8c
               Pieces: []
-            - Range: 0x84db5c..0x84db5d
+            - Range: 0x84dc8c..0x84dc8d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84db5d..0x84db80
+            - Range: 0x84dc8d..0x84dcb0
               Pieces: []
           Role: Return
-    - ID: 100
+    - ID: 101
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0x84db80..0x84dd00]
+      OutOfLinePCRanges: [0x84dcb0..0x84de30]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x84db80..0x84dbd0
+            - Range: 0x84dcb0..0x84dd00
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84dbd0..0x84dbd4
+            - Range: 0x84dd00..0x84dd04
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: null
-            - Range: 0x84dc24..0x84dc28
+            - Range: 0x84dd54..0x84dd58
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84dc64..0x84dc68
+            - Range: 0x84dd94..0x84dd98
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84dca4..0x84dca8
+            - Range: 0x84ddd4..0x84ddd8
               Pieces:
                 - Size: 8
                   Op: null
@@ -6152,112 +6238,112 @@ Subprograms:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x84db80..0x84dbc4
+            - Range: 0x84dcb0..0x84dcf4
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x84db80..0x84dbec
+            - Range: 0x84dcb0..0x84dd1c
               Pieces: []
-            - Range: 0x84dbec..0x84dbed
+            - Range: 0x84dd1c..0x84dd1d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84dbed..0x84dc50
+            - Range: 0x84dd1d..0x84dd80
               Pieces: []
-            - Range: 0x84dc50..0x84dc51
+            - Range: 0x84dd80..0x84dd81
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84dc51..0x84dc90
+            - Range: 0x84dd81..0x84ddc0
               Pieces: []
-            - Range: 0x84dc90..0x84dc91
+            - Range: 0x84ddc0..0x84ddc1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84dc91..0x84dcd0
+            - Range: 0x84ddc1..0x84de00
               Pieces: []
-            - Range: 0x84dcd0..0x84dcd1
+            - Range: 0x84de00..0x84de01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84dcd1..0x84dd00
+            - Range: 0x84de01..0x84de30
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 14 GoInterfaceType error
           Locations:
-            - Range: 0x84db80..0x84dbec
+            - Range: 0x84dcb0..0x84dd1c
               Pieces: []
-            - Range: 0x84dbec..0x84dbed
+            - Range: 0x84dd1c..0x84dd1d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x84dbed..0x84dc50
+            - Range: 0x84dd1d..0x84dd80
               Pieces: []
-            - Range: 0x84dc50..0x84dc51
+            - Range: 0x84dd80..0x84dd81
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x84dc51..0x84dc90
+            - Range: 0x84dd81..0x84ddc0
               Pieces: []
-            - Range: 0x84dc90..0x84dc91
+            - Range: 0x84ddc0..0x84ddc1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x84dc91..0x84dcd0
+            - Range: 0x84ddc1..0x84de00
               Pieces: []
-            - Range: 0x84dcd0..0x84dcd1
+            - Range: 0x84de00..0x84de01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x84dcd1..0x84dd00
+            - Range: 0x84de01..0x84de30
               Pieces: []
           Role: Return
         - Name: val
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84dbd0..0x84dbd8
+            - Range: 0x84dd00..0x84dd08
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
-    - ID: 101
+    - ID: 102
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0x84dd00..0x84df00]
+      OutOfLinePCRanges: [0x84de30..0x84e030]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x84dd00..0x84dd48
+            - Range: 0x84de30..0x84de78
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84dd48..0x84dd50
+            - Range: 0x84de78..0x84de80
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x84dd50..0x84df00
+            - Range: 0x84de80..0x84e030
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -6267,429 +6353,429 @@ Subprograms:
         - Name: ~r0
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x84dd00..0x84ddb4
+            - Range: 0x84de30..0x84dee4
               Pieces: []
-            - Range: 0x84ddb4..0x84ddb5
+            - Range: 0x84dee4..0x84dee5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84ddb5..0x84ddfc
+            - Range: 0x84dee5..0x84df2c
               Pieces: []
-            - Range: 0x84ddfc..0x84ddfd
+            - Range: 0x84df2c..0x84df2d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84ddfd..0x84dec0
+            - Range: 0x84df2d..0x84dff0
               Pieces: []
-            - Range: 0x84dec0..0x84dec1
+            - Range: 0x84dff0..0x84dff1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84dec1..0x84ded4
+            - Range: 0x84dff1..0x84e004
               Pieces: []
-            - Range: 0x84ded4..0x84ded5
+            - Range: 0x84e004..0x84e005
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84ded5..0x84df00
+            - Range: 0x84e005..0x84e030
               Pieces: []
           Role: Return
         - Name: val
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84dde8..0x84ddf0
+            - Range: 0x84df18..0x84df20
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
         - Name: '&result'
           Type: 99 PointerType *int
           Locations:
-            - Range: 0x84dd98..0x84ddb4
+            - Range: 0x84dec8..0x84dee4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 102
+    - ID: 103
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0x84df00..0x84e060]
+      OutOfLinePCRanges: [0x84e030..0x84e190]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x84df00..0x84df3c
+            - Range: 0x84e030..0x84e06c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84df3c..0x84df84
+            - Range: 0x84e06c..0x84e0b4
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x84df84..0x84e004
+            - Range: 0x84e0b4..0x84e134
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x84e004..0x84e02c
+            - Range: 0x84e134..0x84e15c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x84e02c..0x84e030
+            - Range: 0x84e15c..0x84e160
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x84e030..0x84e060
+            - Range: 0x84e160..0x84e190
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
         - Name: ~r0
           Type: 160 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x84df00..0x84dfe4
+            - Range: 0x84e030..0x84e114
               Pieces: []
-            - Range: 0x84dfe4..0x84dfe5
+            - Range: 0x84e114..0x84e115
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84dfe5..0x84dff8
+            - Range: 0x84e115..0x84e128
               Pieces: []
-            - Range: 0x84dff8..0x84dff9
+            - Range: 0x84e128..0x84e129
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84dff9..0x84e060
+            - Range: 0x84e129..0x84e190
               Pieces: []
           Role: Return
         - Name: b
           Type: 160 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x84df00..0x84df3c
+            - Range: 0x84e030..0x84e06c
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84df3c..0x84df84
+            - Range: 0x84e06c..0x84e0b4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x84df84..0x84df8c
+            - Range: 0x84e0b4..0x84e0bc
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -64}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x84df8c..0x84dff0
+            - Range: 0x84e0bc..0x84e120
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -64}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x84dff0..0x84dff4
+            - Range: 0x84e120..0x84e124
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x84dff4..0x84dff8
+            - Range: 0x84e124..0x84e128
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x84dff8..0x84e060
+            - Range: 0x84e128..0x84e190
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Local
-    - ID: 103
+    - ID: 104
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0x84e060..0x84e100]
+      OutOfLinePCRanges: [0x84e190..0x84e230]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84e060..0x84e07c
+            - Range: 0x84e190..0x84e1ac
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84e060..0x84e0d8
+            - Range: 0x84e190..0x84e208
               Pieces: []
-            - Range: 0x84e0d8..0x84e0d9
+            - Range: 0x84e208..0x84e209
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84e0d9..0x84e100
+            - Range: 0x84e209..0x84e230
               Pieces: []
           Role: Return
-    - ID: 104
+    - ID: 105
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0x84e100..0x84e1d0]
+      OutOfLinePCRanges: [0x84e230..0x84e300]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84e100..0x84e150
+            - Range: 0x84e230..0x84e280
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84e100..0x84e1a4
+            - Range: 0x84e230..0x84e2d4
               Pieces: []
-            - Range: 0x84e1a4..0x84e1a5
+            - Range: 0x84e2d4..0x84e2d5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84e1a5..0x84e1d0
+            - Range: 0x84e2d5..0x84e300
               Pieces: []
           Role: Return
         - Name: result2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84e100..0x84e1a4
+            - Range: 0x84e230..0x84e2d4
               Pieces: []
-            - Range: 0x84e1a4..0x84e1a5
+            - Range: 0x84e2d4..0x84e2d5
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x84e1a5..0x84e1d0
+            - Range: 0x84e2d5..0x84e300
               Pieces: []
           Role: Return
-    - ID: 105
+    - ID: 106
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0x84e1d0..0x84e290]
+      OutOfLinePCRanges: [0x84e300..0x84e3c0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84e1d0..0x84e210
+            - Range: 0x84e300..0x84e340
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84e210..0x84e290
+            - Range: 0x84e340..0x84e3c0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84e1d0..0x84e270
+            - Range: 0x84e300..0x84e3a0
               Pieces: []
-            - Range: 0x84e270..0x84e271
+            - Range: 0x84e3a0..0x84e3a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84e271..0x84e290
+            - Range: 0x84e3a1..0x84e3c0
               Pieces: []
           Role: Return
         - Name: result2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84e1d0..0x84e270
+            - Range: 0x84e300..0x84e3a0
               Pieces: []
-            - Range: 0x84e270..0x84e271
+            - Range: 0x84e3a0..0x84e3a1
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x84e271..0x84e290
+            - Range: 0x84e3a1..0x84e3c0
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84e1d0..0x84e270
+            - Range: 0x84e300..0x84e3a0
               Pieces: []
-            - Range: 0x84e270..0x84e271
+            - Range: 0x84e3a0..0x84e3a1
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x84e271..0x84e290
+            - Range: 0x84e3a1..0x84e3c0
               Pieces: []
           Role: Return
-    - ID: 106
+    - ID: 107
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0x84e290..0x84e320]
+      OutOfLinePCRanges: [0x84e3c0..0x84e450]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 16 BaseType int8
           Locations:
-            - Range: 0x84e290..0x84e300
+            - Range: 0x84e3c0..0x84e430
               Pieces: []
-            - Range: 0x84e300..0x84e301
+            - Range: 0x84e430..0x84e431
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84e301..0x84e320
+            - Range: 0x84e431..0x84e450
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 94 BaseType int16
           Locations:
-            - Range: 0x84e290..0x84e300
+            - Range: 0x84e3c0..0x84e430
               Pieces: []
-            - Range: 0x84e300..0x84e301
+            - Range: 0x84e430..0x84e431
               Pieces: [{Size: 2, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x84e301..0x84e320
+            - Range: 0x84e431..0x84e450
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 12 BaseType int32
           Locations:
-            - Range: 0x84e290..0x84e300
+            - Range: 0x84e3c0..0x84e430
               Pieces: []
-            - Range: 0x84e300..0x84e301
+            - Range: 0x84e430..0x84e431
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x84e301..0x84e320
+            - Range: 0x84e431..0x84e450
               Pieces: []
           Role: Return
         - Name: ~r3
           Type: 13 BaseType int64
           Locations:
-            - Range: 0x84e290..0x84e300
+            - Range: 0x84e3c0..0x84e430
               Pieces: []
-            - Range: 0x84e300..0x84e301
+            - Range: 0x84e430..0x84e431
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x84e301..0x84e320
+            - Range: 0x84e431..0x84e450
               Pieces: []
           Role: Return
         - Name: ~r4
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x84e290..0x84e300
+            - Range: 0x84e3c0..0x84e430
               Pieces: []
-            - Range: 0x84e300..0x84e301
+            - Range: 0x84e430..0x84e431
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x84e301..0x84e320
+            - Range: 0x84e431..0x84e450
               Pieces: []
           Role: Return
         - Name: ~r5
           Type: 6 BaseType uint16
           Locations:
-            - Range: 0x84e290..0x84e300
+            - Range: 0x84e3c0..0x84e430
               Pieces: []
-            - Range: 0x84e300..0x84e301
+            - Range: 0x84e430..0x84e431
               Pieces: [{Size: 2, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x84e301..0x84e320
+            - Range: 0x84e431..0x84e450
               Pieces: []
           Role: Return
         - Name: ~r6
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0x84e290..0x84e300
+            - Range: 0x84e3c0..0x84e430
               Pieces: []
-            - Range: 0x84e300..0x84e301
+            - Range: 0x84e430..0x84e431
               Pieces: [{Size: 4, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x84e301..0x84e320
+            - Range: 0x84e431..0x84e450
               Pieces: []
           Role: Return
         - Name: ~r7
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0x84e290..0x84e300
+            - Range: 0x84e3c0..0x84e430
               Pieces: []
-            - Range: 0x84e300..0x84e301
+            - Range: 0x84e430..0x84e431
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x84e301..0x84e320
+            - Range: 0x84e431..0x84e450
               Pieces: []
           Role: Return
-    - ID: 107
+    - ID: 108
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0x84e320..0x84e3e0]
+      OutOfLinePCRanges: [0x84e450..0x84e510]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 18 BaseType float64
-          Locations: [{Range: 0x84e320..0x84e3e0, Pieces: []}]
+          Locations: [{Range: 0x84e450..0x84e510, Pieces: []}]
           Role: Return
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0x84e320..0x84e3e0, Pieces: []}]
+          Locations: [{Range: 0x84e450..0x84e510, Pieces: []}]
           Role: Return
         - Name: ~r2
           Type: 18 BaseType float64
-          Locations: [{Range: 0x84e320..0x84e3e0, Pieces: []}]
+          Locations: [{Range: 0x84e450..0x84e510, Pieces: []}]
           Role: Return
         - Name: ~r3
           Type: 18 BaseType float64
-          Locations: [{Range: 0x84e320..0x84e3e0, Pieces: []}]
+          Locations: [{Range: 0x84e450..0x84e510, Pieces: []}]
           Role: Return
         - Name: ~r4
           Type: 18 BaseType float64
-          Locations: [{Range: 0x84e320..0x84e3e0, Pieces: []}]
+          Locations: [{Range: 0x84e450..0x84e510, Pieces: []}]
           Role: Return
         - Name: ~r5
           Type: 18 BaseType float64
-          Locations: [{Range: 0x84e320..0x84e3e0, Pieces: []}]
+          Locations: [{Range: 0x84e450..0x84e510, Pieces: []}]
           Role: Return
         - Name: ~r6
           Type: 18 BaseType float64
-          Locations: [{Range: 0x84e320..0x84e3e0, Pieces: []}]
+          Locations: [{Range: 0x84e450..0x84e510, Pieces: []}]
           Role: Return
         - Name: ~r7
           Type: 18 BaseType float64
-          Locations: [{Range: 0x84e320..0x84e3e0, Pieces: []}]
+          Locations: [{Range: 0x84e450..0x84e510, Pieces: []}]
           Role: Return
         - Name: ~r8
           Type: 18 BaseType float64
-          Locations: [{Range: 0x84e320..0x84e3e0, Pieces: []}]
+          Locations: [{Range: 0x84e450..0x84e510, Pieces: []}]
           Role: Return
         - Name: ~r9
           Type: 18 BaseType float64
-          Locations: [{Range: 0x84e320..0x84e3e0, Pieces: []}]
+          Locations: [{Range: 0x84e450..0x84e510, Pieces: []}]
           Role: Return
         - Name: ~r10
           Type: 18 BaseType float64
-          Locations: [{Range: 0x84e320..0x84e3e0, Pieces: []}]
+          Locations: [{Range: 0x84e450..0x84e510, Pieces: []}]
           Role: Return
         - Name: ~r11
           Type: 18 BaseType float64
-          Locations: [{Range: 0x84e320..0x84e3e0, Pieces: []}]
+          Locations: [{Range: 0x84e450..0x84e510, Pieces: []}]
           Role: Return
         - Name: ~r12
           Type: 18 BaseType float64
-          Locations: [{Range: 0x84e320..0x84e3e0, Pieces: []}]
+          Locations: [{Range: 0x84e450..0x84e510, Pieces: []}]
           Role: Return
         - Name: ~r13
           Type: 18 BaseType float64
-          Locations: [{Range: 0x84e320..0x84e3e0, Pieces: []}]
+          Locations: [{Range: 0x84e450..0x84e510, Pieces: []}]
           Role: Return
         - Name: ~r14
           Type: 18 BaseType float64
-          Locations: [{Range: 0x84e320..0x84e3e0, Pieces: []}]
+          Locations: [{Range: 0x84e450..0x84e510, Pieces: []}]
           Role: Return
         - Name: onlyOnAmd64_16
           Type: 18 BaseType float64
-          Locations: [{Range: 0x84e320..0x84e3e0, Pieces: []}]
+          Locations: [{Range: 0x84e450..0x84e510, Pieces: []}]
           Role: Return
         - Name: bothArmAndAmd64
           Type: 18 BaseType float64
           Locations:
-            - Range: 0x84e320..0x84e3bc
+            - Range: 0x84e450..0x84e4ec
               Pieces: []
-            - Range: 0x84e3bc..0x84e3bd
+            - Range: 0x84e4ec..0x84e4ed
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x84e3bd..0x84e3e0
+            - Range: 0x84e4ed..0x84e510
               Pieces: []
           Role: Return
-    - ID: 108
+    - ID: 109
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0x84e3e0..0x84e460]
+      OutOfLinePCRanges: [0x84e510..0x84e590]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 95 BaseType complex64
-          Locations: [{Range: 0x84e3e0..0x84e460, Pieces: []}]
+          Locations: [{Range: 0x84e510..0x84e590, Pieces: []}]
           Role: Return
         - Name: ~r1
           Type: 96 BaseType complex128
-          Locations: [{Range: 0x84e3e0..0x84e460, Pieces: []}]
+          Locations: [{Range: 0x84e510..0x84e590, Pieces: []}]
           Role: Return
-    - ID: 109
+    - ID: 110
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0x84e460..0x84e530]
+      OutOfLinePCRanges: [0x84e590..0x84e660]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0x84e460..0x84e514
+            - Range: 0x84e590..0x84e644
               Pieces: []
-            - Range: 0x84e514..0x84e515
+            - Range: 0x84e644..0x84e645
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6711,173 +6797,173 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x84e515..0x84e530
+            - Range: 0x84e645..0x84e660
               Pieces: []
           Role: Return
-    - ID: 110
+    - ID: 111
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0x84e530..0x84e5c0]
+      OutOfLinePCRanges: [0x84e660..0x84e6f0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 249 ArrayType [3]int
           Locations:
-            - Range: 0x84e530..0x84e5a0
+            - Range: 0x84e660..0x84e6d0
               Pieces: []
-            - Range: 0x84e5a0..0x84e5a1
+            - Range: 0x84e6d0..0x84e6d1
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x84e5a1..0x84e5c0
+            - Range: 0x84e6d1..0x84e6f0
               Pieces: []
           Role: Return
-    - ID: 111
+    - ID: 112
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0x84e5c0..0x84e630]
+      OutOfLinePCRanges: [0x84e6f0..0x84e760]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 250 ArrayType [1]int
           Locations:
-            - Range: 0x84e5c0..0x84e614
+            - Range: 0x84e6f0..0x84e744
               Pieces: []
-            - Range: 0x84e614..0x84e615
+            - Range: 0x84e744..0x84e745
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84e615..0x84e630
+            - Range: 0x84e745..0x84e760
               Pieces: []
           Role: Return
-    - ID: 112
+    - ID: 113
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0x84e630..0x84e6a0]
+      OutOfLinePCRanges: [0x84e760..0x84e7d0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 251 ArrayType [0]int
           Locations:
-            - Range: 0x84e630..0x84e680
+            - Range: 0x84e760..0x84e7b0
               Pieces: []
-            - Range: 0x84e680..0x84e681
+            - Range: 0x84e7b0..0x84e7b1
               Pieces: []
-            - Range: 0x84e681..0x84e6a0
+            - Range: 0x84e7b1..0x84e7d0
               Pieces: []
           Role: Return
-    - ID: 113
+    - ID: 114
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0x84e6a0..0x84e720]
+      OutOfLinePCRanges: [0x84e7d0..0x84e850]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 252 StructureType main.mixedStruct
-          Locations: [{Range: 0x84e6a0..0x84e720, Pieces: []}]
+          Locations: [{Range: 0x84e7d0..0x84e850, Pieces: []}]
           Role: Return
-    - ID: 114
+    - ID: 115
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0x84e720..0x84e7c0]
+      OutOfLinePCRanges: [0x84e850..0x84e8f0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84e720..0x84e79c
+            - Range: 0x84e850..0x84e8cc
               Pieces: []
-            - Range: 0x84e79c..0x84e79d
+            - Range: 0x84e8cc..0x84e8cd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84e79d..0x84e7c0
+            - Range: 0x84e8cd..0x84e8f0
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84e720..0x84e79c
+            - Range: 0x84e850..0x84e8cc
               Pieces: []
-            - Range: 0x84e79c..0x84e79d
+            - Range: 0x84e8cc..0x84e8cd
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x84e79d..0x84e7c0
+            - Range: 0x84e8cd..0x84e8f0
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84e720..0x84e79c
+            - Range: 0x84e850..0x84e8cc
               Pieces: []
-            - Range: 0x84e79c..0x84e79d
+            - Range: 0x84e8cc..0x84e8cd
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x84e79d..0x84e7c0
+            - Range: 0x84e8cd..0x84e8f0
               Pieces: []
           Role: Return
         - Name: ~r3
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84e720..0x84e79c
+            - Range: 0x84e850..0x84e8cc
               Pieces: []
-            - Range: 0x84e79c..0x84e79d
+            - Range: 0x84e8cc..0x84e8cd
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x84e79d..0x84e7c0
+            - Range: 0x84e8cd..0x84e8f0
               Pieces: []
           Role: Return
         - Name: ~r4
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84e720..0x84e79c
+            - Range: 0x84e850..0x84e8cc
               Pieces: []
-            - Range: 0x84e79c..0x84e79d
+            - Range: 0x84e8cc..0x84e8cd
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x84e79d..0x84e7c0
+            - Range: 0x84e8cd..0x84e8f0
               Pieces: []
           Role: Return
         - Name: ~r5
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84e720..0x84e79c
+            - Range: 0x84e850..0x84e8cc
               Pieces: []
-            - Range: 0x84e79c..0x84e79d
+            - Range: 0x84e8cc..0x84e8cd
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x84e79d..0x84e7c0
+            - Range: 0x84e8cd..0x84e8f0
               Pieces: []
           Role: Return
         - Name: ~r6
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84e720..0x84e79c
+            - Range: 0x84e850..0x84e8cc
               Pieces: []
-            - Range: 0x84e79c..0x84e79d
+            - Range: 0x84e8cc..0x84e8cd
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x84e79d..0x84e7c0
+            - Range: 0x84e8cd..0x84e8f0
               Pieces: []
           Role: Return
         - Name: ~r7
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84e720..0x84e79c
+            - Range: 0x84e850..0x84e8cc
               Pieces: []
-            - Range: 0x84e79c..0x84e79d
+            - Range: 0x84e8cc..0x84e8cd
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x84e79d..0x84e7c0
+            - Range: 0x84e8cd..0x84e8f0
               Pieces: []
           Role: Return
         - Name: ~r8
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84e720..0x84e79c
+            - Range: 0x84e850..0x84e8cc
               Pieces: []
-            - Range: 0x84e79c..0x84e79d
+            - Range: 0x84e8cc..0x84e8cd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x84e79d..0x84e7c0
+            - Range: 0x84e8cd..0x84e8f0
               Pieces: []
           Role: Return
-    - ID: 115
+    - ID: 116
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0x84e7c0..0x84e8a0]
+      OutOfLinePCRanges: [0x84e8f0..0x84e9d0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 253 StructureType main.wideStruct
           Locations:
-            - Range: 0x84e7c0..0x84e884
+            - Range: 0x84e8f0..0x84e9b4
               Pieces: []
-            - Range: 0x84e884..0x84e885
+            - Range: 0x84e9b4..0x84e9b5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6901,127 +6987,127 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0x84e885..0x84e8a0
+            - Range: 0x84e9b5..0x84e9d0
               Pieces: []
           Role: Return
-    - ID: 116
+    - ID: 117
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0x84e8a0..0x84e930]
+      OutOfLinePCRanges: [0x84e9d0..0x84ea60]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84e8a0..0x84e910
+            - Range: 0x84e9d0..0x84ea40
               Pieces: []
-            - Range: 0x84e910..0x84e911
+            - Range: 0x84ea40..0x84ea41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84e911..0x84e930
+            - Range: 0x84ea41..0x84ea60
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0x84e8a0..0x84e930, Pieces: []}]
+          Locations: [{Range: 0x84e9d0..0x84ea60, Pieces: []}]
           Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84e8a0..0x84e910
+            - Range: 0x84e9d0..0x84ea40
               Pieces: []
-            - Range: 0x84e910..0x84e911
+            - Range: 0x84ea40..0x84ea41
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x84e911..0x84e930
+            - Range: 0x84ea41..0x84ea60
               Pieces: []
           Role: Return
         - Name: ~r3
           Type: 18 BaseType float64
-          Locations: [{Range: 0x84e8a0..0x84e930, Pieces: []}]
+          Locations: [{Range: 0x84e9d0..0x84ea60, Pieces: []}]
           Role: Return
         - Name: ~r4
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84e8a0..0x84e910
+            - Range: 0x84e9d0..0x84ea40
               Pieces: []
-            - Range: 0x84e910..0x84e911
+            - Range: 0x84ea40..0x84ea41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x84e911..0x84e930
+            - Range: 0x84ea41..0x84ea60
               Pieces: []
           Role: Return
-    - ID: 117
+    - ID: 118
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0x84e930..0x84e9c0]
+      OutOfLinePCRanges: [0x84ea60..0x84eaf0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 254 StructureType main.structWithArray
           Locations:
-            - Range: 0x84e930..0x84e9a0
+            - Range: 0x84ea60..0x84ead0
               Pieces: []
-            - Range: 0x84e9a0..0x84e9a1
+            - Range: 0x84ead0..0x84ead1
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x84e9a1..0x84e9c0
+            - Range: 0x84ead1..0x84eaf0
               Pieces: []
           Role: Return
-    - ID: 118
+    - ID: 119
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0x84e9c0..0x84ea30]
+      OutOfLinePCRanges: [0x84eaf0..0x84eb60]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 18 BaseType float64
-          Locations: [{Range: 0x84e9c0..0x84ea30, Pieces: []}]
+          Locations: [{Range: 0x84eaf0..0x84eb60, Pieces: []}]
           Role: Return
-    - ID: 119
+    - ID: 120
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0x84ea30..0x84eab0]
+      OutOfLinePCRanges: [0x84eb60..0x84ebe0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType float32
-          Locations: [{Range: 0x84ea30..0x84eab0, Pieces: []}]
+          Locations: [{Range: 0x84eb60..0x84ebe0, Pieces: []}]
           Role: Return
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0x84ea30..0x84eab0, Pieces: []}]
+          Locations: [{Range: 0x84eb60..0x84ebe0, Pieces: []}]
           Role: Return
-    - ID: 120
+    - ID: 121
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0x84eab0..0x84eb20]
+      OutOfLinePCRanges: [0x84ebe0..0x84ec50]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x84eab0..0x84eb08
+            - Range: 0x84ebe0..0x84ec38
               Pieces: []
-            - Range: 0x84eb08..0x84eb09
+            - Range: 0x84ec38..0x84ec39
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84eb09..0x84eb20
+            - Range: 0x84ec39..0x84ec50
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 1 BaseType uintptr
           Locations:
-            - Range: 0x84eab0..0x84eb08
+            - Range: 0x84ebe0..0x84ec38
               Pieces: []
-            - Range: 0x84eb08..0x84eb09
+            - Range: 0x84ec38..0x84ec39
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x84eb09..0x84eb20
+            - Range: 0x84ec39..0x84ec50
               Pieces: []
           Role: Return
-    - ID: 121
+    - ID: 122
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0x84eb20..0x84ece0]
+      OutOfLinePCRanges: [0x84ec50..0x84ee10]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0x84eb20..0x84eb8c
+            - Range: 0x84ec50..0x84ecbc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7043,7 +7129,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x84eb8c..0x84eba0
+            - Range: 0x84ecbc..0x84ecd0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7065,7 +7151,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x84eba0..0x84eba4
+            - Range: 0x84ecd0..0x84ecd4
               Pieces:
                 - Size: 8
                   Op: null
@@ -7091,9 +7177,9 @@ Subprograms:
         - Name: ~r0
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0x84eb20..0x84ec98
+            - Range: 0x84ec50..0x84edc8
               Pieces: []
-            - Range: 0x84ec98..0x84ec99
+            - Range: 0x84edc8..0x84edc9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7115,39 +7201,39 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x84ec99..0x84ece0
+            - Range: 0x84edc9..0x84ee10
               Pieces: []
           Role: Return
-    - ID: 122
+    - ID: 123
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0x84ece0..0x84edb0]
+      OutOfLinePCRanges: [0x84ee10..0x84eee0]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 249 ArrayType [3]int
           Locations:
-            - Range: 0x84ece0..0x84edb0
+            - Range: 0x84ee10..0x84eee0
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 249 ArrayType [3]int
           Locations:
-            - Range: 0x84ece0..0x84ed94
+            - Range: 0x84ee10..0x84eec4
               Pieces: []
-            - Range: 0x84ed94..0x84ed95
+            - Range: 0x84eec4..0x84eec5
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x84ed95..0x84edb0
+            - Range: 0x84eec5..0x84eee0
               Pieces: []
           Role: Return
-    - ID: 123
+    - ID: 124
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0x84edb0..0x84efe0]
+      OutOfLinePCRanges: [0x84eee0..0x84f110]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0x84edb0..0x84ee20
+            - Range: 0x84eee0..0x84ef50
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7169,7 +7255,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x84ee20..0x84ee34
+            - Range: 0x84ef50..0x84ef64
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7191,7 +7277,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x84ee34..0x84ee38
+            - Range: 0x84ef64..0x84ef68
               Pieces:
                 - Size: 8
                   Op: null
@@ -7217,15 +7303,15 @@ Subprograms:
         - Name: s2
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0x84edb0..0x84efe0
+            - Range: 0x84eee0..0x84f110
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0x84edb0..0x84efa0
+            - Range: 0x84eee0..0x84f0d0
               Pieces: []
-            - Range: 0x84efa0..0x84efa1
+            - Range: 0x84f0d0..0x84f0d1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7247,175 +7333,175 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x84efa1..0x84efe0
+            - Range: 0x84f0d1..0x84f110
               Pieces: []
           Role: Return
-    - ID: 124
+    - ID: 125
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0x84efe0..0x84f1b0]
+      OutOfLinePCRanges: [0x84f110..0x84f2e0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84efe0..0x84f058
+            - Range: 0x84f110..0x84f188
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84f058..0x84f1b0
+            - Range: 0x84f188..0x84f2e0
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84efe0..0x84f044
+            - Range: 0x84f110..0x84f174
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x84f044..0x84f1b0
+            - Range: 0x84f174..0x84f2e0
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84efe0..0x84f058
+            - Range: 0x84f110..0x84f188
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x84f058..0x84f1b0
+            - Range: 0x84f188..0x84f2e0
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84efe0..0x84f058
+            - Range: 0x84f110..0x84f188
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x84f058..0x84f1b0
+            - Range: 0x84f188..0x84f2e0
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84efe0..0x84f058
+            - Range: 0x84f110..0x84f188
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x84f058..0x84f1b0
+            - Range: 0x84f188..0x84f2e0
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84efe0..0x84f058
+            - Range: 0x84f110..0x84f188
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x84f058..0x84f1b0
+            - Range: 0x84f188..0x84f2e0
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84efe0..0x84f058
+            - Range: 0x84f110..0x84f188
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x84f058..0x84f1b0
+            - Range: 0x84f188..0x84f2e0
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84efe0..0x84f058
+            - Range: 0x84f110..0x84f188
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x84f058..0x84f1b0
+            - Range: 0x84f188..0x84f2e0
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84efe0..0x84f058
+            - Range: 0x84f110..0x84f188
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0x84f058..0x84f1b0
+            - Range: 0x84f188..0x84f2e0
               Pieces: [{Size: 8, Op: {CfaOffset: 88}}]
           Role: Parameter
         - Name: ~r0
           Type: 111 ArrayType [2]int
           Locations:
-            - Range: 0x84efe0..0x84f168
+            - Range: 0x84f110..0x84f298
               Pieces: []
-            - Range: 0x84f168..0x84f169
+            - Range: 0x84f298..0x84f299
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-            - Range: 0x84f169..0x84f1b0
+            - Range: 0x84f299..0x84f2e0
               Pieces: []
           Role: Return
-    - ID: 125
+    - ID: 126
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0x84f1b0..0x84f3c0]
+      OutOfLinePCRanges: [0x84f2e0..0x84f4f0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84f1b0..0x84f238
+            - Range: 0x84f2e0..0x84f368
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84f238..0x84f3c0
+            - Range: 0x84f368..0x84f4f0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84f1b0..0x84f224
+            - Range: 0x84f2e0..0x84f354
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x84f224..0x84f3c0
+            - Range: 0x84f354..0x84f4f0
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84f1b0..0x84f238
+            - Range: 0x84f2e0..0x84f368
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x84f238..0x84f3c0
+            - Range: 0x84f368..0x84f4f0
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84f1b0..0x84f238
+            - Range: 0x84f2e0..0x84f368
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x84f238..0x84f3c0
+            - Range: 0x84f368..0x84f4f0
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84f1b0..0x84f238
+            - Range: 0x84f2e0..0x84f368
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x84f238..0x84f3c0
+            - Range: 0x84f368..0x84f4f0
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84f1b0..0x84f238
+            - Range: 0x84f2e0..0x84f368
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x84f238..0x84f3c0
+            - Range: 0x84f368..0x84f4f0
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84f1b0..0x84f238
+            - Range: 0x84f2e0..0x84f368
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x84f238..0x84f3c0
+            - Range: 0x84f368..0x84f4f0
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84f1b0..0x84f238
+            - Range: 0x84f2e0..0x84f368
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x84f238..0x84f3c0
+            - Range: 0x84f368..0x84f4f0
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84f1b0..0x84f238
+            - Range: 0x84f2e0..0x84f368
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x84f238..0x84f3c0
+            - Range: 0x84f368..0x84f4f0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 72}
@@ -7425,9 +7511,9 @@ Subprograms:
         - Name: ~r0
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0x84f1b0..0x84f37c
+            - Range: 0x84f2e0..0x84f4ac
               Pieces: []
-            - Range: 0x84f37c..0x84f37d
+            - Range: 0x84f4ac..0x84f4ad
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7449,191 +7535,174 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x84f37d..0x84f3c0
+            - Range: 0x84f4ad..0x84f4f0
               Pieces: []
           Role: Return
-    - ID: 126
+    - ID: 127
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0x84f3c0..0x84f460]
+      OutOfLinePCRanges: [0x84f4f0..0x84f590]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 159 ArrayType [5]int
           Locations:
-            - Range: 0x84f3c0..0x84f460
+            - Range: 0x84f4f0..0x84f590
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84f3c0..0x84f43c
+            - Range: 0x84f4f0..0x84f56c
               Pieces: []
-            - Range: 0x84f43c..0x84f43d
+            - Range: 0x84f56c..0x84f56d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84f43d..0x84f460
+            - Range: 0x84f56d..0x84f590
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84f3c0..0x84f43c
+            - Range: 0x84f4f0..0x84f56c
               Pieces: []
-            - Range: 0x84f43c..0x84f43d
+            - Range: 0x84f56c..0x84f56d
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x84f43d..0x84f460
+            - Range: 0x84f56d..0x84f590
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84f3c0..0x84f43c
+            - Range: 0x84f4f0..0x84f56c
               Pieces: []
-            - Range: 0x84f43c..0x84f43d
+            - Range: 0x84f56c..0x84f56d
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x84f43d..0x84f460
+            - Range: 0x84f56d..0x84f590
               Pieces: []
           Role: Return
-    - ID: 127
+    - ID: 128
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0x84f460..0x84f540]
+      OutOfLinePCRanges: [0x84f590..0x84f670]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 111 ArrayType [2]int
           Locations:
-            - Range: 0x84f460..0x84f540
+            - Range: 0x84f590..0x84f670
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: b
           Type: 249 ArrayType [3]int
           Locations:
-            - Range: 0x84f460..0x84f540
+            - Range: 0x84f590..0x84f670
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84f460..0x84f524
+            - Range: 0x84f590..0x84f654
               Pieces: []
-            - Range: 0x84f524..0x84f525
+            - Range: 0x84f654..0x84f655
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84f525..0x84f540
+            - Range: 0x84f655..0x84f670
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 111 ArrayType [2]int
           Locations:
-            - Range: 0x84f460..0x84f524
+            - Range: 0x84f590..0x84f654
               Pieces: []
-            - Range: 0x84f524..0x84f525
+            - Range: 0x84f654..0x84f655
               Pieces: [{Size: 16, Op: {CfaOffset: 48}}]
-            - Range: 0x84f525..0x84f540
+            - Range: 0x84f655..0x84f670
               Pieces: []
           Role: Return
-    - ID: 128
+    - ID: 129
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0x84f540..0x84f610]
+      OutOfLinePCRanges: [0x84f670..0x84f740]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 254 StructureType main.structWithArray
           Locations:
-            - Range: 0x84f540..0x84f610
+            - Range: 0x84f670..0x84f740
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84f540..0x84f5ec
+            - Range: 0x84f670..0x84f71c
               Pieces: []
-            - Range: 0x84f5ec..0x84f5ed
+            - Range: 0x84f71c..0x84f71d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84f5ed..0x84f610
+            - Range: 0x84f71d..0x84f740
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 254 StructureType main.structWithArray
           Locations:
-            - Range: 0x84f540..0x84f5ec
+            - Range: 0x84f670..0x84f71c
               Pieces: []
-            - Range: 0x84f5ec..0x84f5ed
+            - Range: 0x84f71c..0x84f71d
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x84f5ed..0x84f610
+            - Range: 0x84f71d..0x84f740
               Pieces: []
           Role: Return
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84f5c0..0x84f610
+            - Range: 0x84f6f0..0x84f740
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 129
+    - ID: 130
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0x84f610..0x84f6b0]
+      OutOfLinePCRanges: [0x84f740..0x84f7e0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 251 ArrayType [0]int
-          Locations: [{Range: 0x84f610..0x84f6b0, Pieces: []}]
+          Locations: [{Range: 0x84f740..0x84f7e0, Pieces: []}]
           Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84f610..0x84f650
+            - Range: 0x84f740..0x84f780
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84f650..0x84f66c
+            - Range: 0x84f780..0x84f79c
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x84f66c..0x84f674
+            - Range: 0x84f79c..0x84f7a4
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x84f674..0x84f6b0
+            - Range: 0x84f7a4..0x84f7e0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84f610..0x84f690
+            - Range: 0x84f740..0x84f7c0
               Pieces: []
-            - Range: 0x84f690..0x84f691
+            - Range: 0x84f7c0..0x84f7c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84f691..0x84f6b0
+            - Range: 0x84f7c1..0x84f7e0
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 251 ArrayType [0]int
           Locations:
-            - Range: 0x84f610..0x84f690
+            - Range: 0x84f740..0x84f7c0
               Pieces: []
-            - Range: 0x84f690..0x84f691
+            - Range: 0x84f7c0..0x84f7c1
               Pieces: []
-            - Range: 0x84f691..0x84f6b0
+            - Range: 0x84f7c1..0x84f7e0
               Pieces: []
           Role: Return
-    - ID: 130
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0x84fb10..0x84fb20]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 255 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x84fb10..0x84fb20
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
     - ID: 131
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0x84fb20..0x84fb30]
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0x84fc40..0x84fc50]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 255 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x84fb20..0x84fb30
+            - Range: 0x84fc40..0x84fc50
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7643,14 +7712,14 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
     - ID: 132
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0x84fb30..0x84fb40]
+      Name: main.testEmptySlice
+      OutOfLinePCRanges: [0x84fc50..0x84fc60]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 256 GoSliceHeaderType [][]uint
+          Type: 255 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x84fb30..0x84fb40
+            - Range: 0x84fc50..0x84fc60
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7660,14 +7729,14 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
     - ID: 133
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0x84fb40..0x84fb50]
+      Name: main.testSliceOfSlices
+      OutOfLinePCRanges: [0x84fc60..0x84fc70]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 258 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 256 GoSliceHeaderType [][]uint
           Locations:
-            - Range: 0x84fb40..0x84fb50
+            - Range: 0x84fc60..0x84fc70
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7675,22 +7744,16 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x84fb40..0x84fb50
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
     - ID: 134
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0x84fb50..0x84fb60]
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0x84fc70..0x84fc80]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 258 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x84fb50..0x84fb60
+            - Range: 0x84fc70..0x84fc80
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7702,18 +7765,18 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84fb50..0x84fb60
+            - Range: 0x84fc70..0x84fc80
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
     - ID: 135
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0x84fb60..0x84fb70]
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0x84fc80..0x84fc90]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 258 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x84fb60..0x84fb70
+            - Range: 0x84fc80..0x84fc90
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7725,18 +7788,41 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84fb60..0x84fb70
+            - Range: 0x84fc80..0x84fc90
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
     - ID: 136
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0x84fc90..0x84fca0]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 258 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x84fc90..0x84fca0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84fc90..0x84fca0
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          Role: Parameter
+    - ID: 137
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0x84fb70..0x84fb80]
+      OutOfLinePCRanges: [0x84fca0..0x84fcb0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 261 GoSliceHeaderType []string
           Locations:
-            - Range: 0x84fb70..0x84fb80
+            - Range: 0x84fca0..0x84fcb0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7745,21 +7831,21 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 137
+    - ID: 138
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0x84fb80..0x84fb90]
+      OutOfLinePCRanges: [0x84fcb0..0x84fcc0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 16 BaseType int8
           Locations:
-            - Range: 0x84fb80..0x84fb90
+            - Range: 0x84fcb0..0x84fcc0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: s
           Type: 262 GoSliceHeaderType []bool
           Locations:
-            - Range: 0x84fb80..0x84fb90
+            - Range: 0x84fcb0..0x84fcc0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -7771,35 +7857,18 @@ Subprograms:
         - Name: x
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x84fb80..0x84fb90
+            - Range: 0x84fcb0..0x84fcc0
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
-    - ID: 138
+    - ID: 139
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0x84fb90..0x84fba0]
+      OutOfLinePCRanges: [0x84fcc0..0x84fcd0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 263 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0x84fb90..0x84fba0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-    - ID: 139
-      Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0x84fba0..0x84fbb0]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 255 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x84fba0..0x84fbb0
+            - Range: 0x84fcc0..0x84fcd0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7809,14 +7878,14 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
     - ID: 140
-      Name: main.testSliceEmptyStructs
-      OutOfLinePCRanges: [0x84fbb0..0x84fbc0]
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0x84fcd0..0x84fce0]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 264 GoSliceHeaderType []struct {}
+          Type: 255 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x84fbb0..0x84fbc0
+            - Range: 0x84fcd0..0x84fce0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7826,14 +7895,31 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
     - ID: 141
+      Name: main.testSliceEmptyStructs
+      OutOfLinePCRanges: [0x84fce0..0x84fcf0]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 264 GoSliceHeaderType []struct {}
+          Locations:
+            - Range: 0x84fce0..0x84fcf0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+    - ID: 142
       Name: main.testSubslices
-      OutOfLinePCRanges: [0x84fbc0..0x84fbd0]
+      OutOfLinePCRanges: [0x84fcf0..0x84fd00]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 255 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x84fbc0..0x84fbd0
+            - Range: 0x84fcf0..0x84fd00
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7845,7 +7931,7 @@ Subprograms:
         - Name: bs
           Type: 255 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x84fbc0..0x84fbd0
+            - Range: 0x84fcf0..0x84fd00
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -7857,7 +7943,7 @@ Subprograms:
         - Name: cs
           Type: 255 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x84fbc0..0x84fbd0
+            - Range: 0x84fcf0..0x84fd00
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -7866,49 +7952,49 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 142
+    - ID: 143
       Name: main.stackC
-      OutOfLinePCRanges: [0x84fee0..0x84ff50]
+      OutOfLinePCRanges: [0x850010..0x850080]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84fee0..0x84ff2c
+            - Range: 0x850010..0x85005c
               Pieces: []
-            - Range: 0x84ff2c..0x84ff2d
+            - Range: 0x85005c..0x85005d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84ff2d..0x84ff50
+            - Range: 0x85005d..0x850080
               Pieces: []
           Role: Return
-    - ID: 143
+    - ID: 144
       Name: main.testSingleString
-      OutOfLinePCRanges: [0x84ff50..0x84ff60]
+      OutOfLinePCRanges: [0x850080..0x850090]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84ff50..0x84ff60
+            - Range: 0x850080..0x850090
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 144
+    - ID: 145
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0x84ff60..0x84ff70]
+      OutOfLinePCRanges: [0x850090..0x8500a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84ff60..0x84ff70
+            - Range: 0x850090..0x8500a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7918,7 +8004,7 @@ Subprograms:
         - Name: y
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84ff60..0x84ff70
+            - Range: 0x850090..0x8500a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -7928,22 +8014,22 @@ Subprograms:
         - Name: z
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84ff60..0x84ff70
+            - Range: 0x850090..0x8500a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
-    - ID: 145
+    - ID: 146
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x84ff70..0x84ff90]
+      OutOfLinePCRanges: [0x8500a0..0x8500c0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 266 StructureType main.threeStringStruct
           Locations:
-            - Range: 0x84ff70..0x84ff90
+            - Range: 0x8500a0..0x8500c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7958,52 +8044,37 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
-    - ID: 146
+    - ID: 147
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x84ff90..0x84ffa0]
+      OutOfLinePCRanges: [0x8500c0..0x8500d0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 267 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0x84ff90..0x84ffa0
+            - Range: 0x8500c0..0x8500d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 147
+    - ID: 148
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0x84ffa0..0x84ffb0]
+      OutOfLinePCRanges: [0x8500d0..0x8500e0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 268 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0x84ffa0..0x84ffb0
+            - Range: 0x8500d0..0x8500e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 148
-      Name: main.testMassiveString
-      OutOfLinePCRanges: [0x84ffb0..0x84ffc0]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0x84ffb0..0x84ffc0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          Role: Parameter
     - ID: 149
-      Name: main.testUnitializedString
-      OutOfLinePCRanges: [0x84ffc0..0x84ffd0]
+      Name: main.testMassiveString
+      OutOfLinePCRanges: [0x8500e0..0x8500f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84ffc0..0x84ffd0
+            - Range: 0x8500e0..0x8500f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8011,14 +8082,14 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
     - ID: 150
-      Name: main.testEmptyString
-      OutOfLinePCRanges: [0x84ffd0..0x84ffe0]
+      Name: main.testUnitializedString
+      OutOfLinePCRanges: [0x8500f0..0x850100]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84ffd0..0x84ffe0
+            - Range: 0x8500f0..0x850100
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8026,14 +8097,29 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
     - ID: 151
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0x850100..0x850110]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x850100..0x850110
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          Role: Parameter
+    - ID: 152
       Name: main.testSubstrings
-      OutOfLinePCRanges: [0x84ffe0..0x84fff0]
+      OutOfLinePCRanges: [0x850110..0x850120]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84ffe0..0x84fff0
+            - Range: 0x850110..0x850120
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8043,7 +8129,7 @@ Subprograms:
         - Name: b
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84ffe0..0x84fff0
+            - Range: 0x850110..0x850120
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -8053,33 +8139,33 @@ Subprograms:
         - Name: c
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84ffe0..0x84fff0
+            - Range: 0x850110..0x850120
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
-    - ID: 152
+    - ID: 153
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0x850150..0x850160]
+      OutOfLinePCRanges: [0x850280..0x850290]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 270 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0x850150..0x850160
+            - Range: 0x850280..0x850290
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
-    - ID: 153
+    - ID: 154
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0x850160..0x850180]
+      OutOfLinePCRanges: [0x850290..0x8502b0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 283 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0x850160..0x850180
+            - Range: 0x850290..0x8502b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8094,15 +8180,15 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
-    - ID: 154
+    - ID: 155
       Name: main.testStruct
-      OutOfLinePCRanges: [0x850250..0x850270]
+      OutOfLinePCRanges: [0x850380..0x8503a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 314 StructureType main.aStruct
           Locations:
-            - Range: 0x850250..0x850270
+            - Range: 0x850380..0x8503a0
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -8119,134 +8205,134 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
           Role: Parameter
-    - ID: 155
+    - ID: 156
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0x8502f0..0x850300]
+      OutOfLinePCRanges: [0x850420..0x850430]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 315 PointerType *main.anotherStruct
           Locations:
-            - Range: 0x8502f0..0x850300
+            - Range: 0x850420..0x850430
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 156
+    - ID: 157
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x850350..0x850360]
+      OutOfLinePCRanges: [0x850480..0x850490]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 317 StructureType main.emptyStruct
-          Locations: [{Range: 0x850350..0x850360, Pieces: []}]
+          Locations: [{Range: 0x850480..0x850490, Pieces: []}]
           Role: Parameter
-    - ID: 157
+    - ID: 158
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x850360..0x850370]
+      OutOfLinePCRanges: [0x850490..0x8504a0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 318 PointerType *main.emptyStruct
           Locations:
-            - Range: 0x850360..0x850370
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-    - ID: 158
-      Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0x84ad00..0x84ad70]
-      InlinePCRanges:
-        - Ranges: [0x84ad8c..0x84adc4]
-          RootRanges: [0x84ad70..0x84adf0]
-        - Ranges: [0x84aed8..0x84af10]
-          RootRanges: [0x84aea0..0x84af30]
-        - Ranges: [0x84af54..0x84af8c]
-          RootRanges: [0x84af30..0x84aff0]
-        - Ranges: [0x84b00c..0x84b044]
-          RootRanges: [0x84aff0..0x84b070]
-      Variables:
-        - Name: x
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x84ad00..0x84ad20
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84ad8c..0x84ad94
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84aed8..0x84aee0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84af4c..0x84af5c
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84af5c..0x84aff0
-              Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x84aff0..0x84b014
+            - Range: 0x850490..0x8504a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 159
-      Name: main.testInlinedBBB
-      OutOfLinePCRanges: []
+      Name: main.testInlinedPrint
+      OutOfLinePCRanges: [0x84ae30..0x84aea0]
       InlinePCRanges:
-        - Ranges: [0x84af98..0x84afd0]
-          RootRanges: [0x84af30..0x84aff0]
-      Variables: []
-    - ID: 160
-      Name: main.testInlinedBCA
-      OutOfLinePCRanges: []
-      InlinePCRanges:
-        - Ranges: [0x84b08c..0x84b0d0]
-          RootRanges: [0x84b070..0x84b190]
-      Variables: []
-    - ID: 161
-      Name: main.testInlinedBCB
-      OutOfLinePCRanges: []
-      InlinePCRanges:
-        - Ranges: [0x84b140..0x84b178]
-          RootRanges: [0x84b070..0x84b190]
-      Variables: []
-    - ID: 162
-      Name: main.testInlinedSq
-      OutOfLinePCRanges: []
-      InlinePCRanges:
-        - Ranges: [0x84b194..0x84b198]
-          RootRanges: [0x84b190..0x84b1a0]
+        - Ranges: [0x84aebc..0x84aef4]
+          RootRanges: [0x84aea0..0x84af20]
+        - Ranges: [0x84b008..0x84b040]
+          RootRanges: [0x84afd0..0x84b060]
+        - Ranges: [0x84b084..0x84b0bc]
+          RootRanges: [0x84b060..0x84b120]
+        - Ranges: [0x84b13c..0x84b174]
+          RootRanges: [0x84b120..0x84b1a0]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84b190..0x84b198
+            - Range: 0x84ae30..0x84ae50
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x84aebc..0x84aec4
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x84b008..0x84b010
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x84b07c..0x84b08c
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x84b08c..0x84b120
+              Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
+            - Range: 0x84b120..0x84b144
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
+    - ID: 160
+      Name: main.testInlinedBBB
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0x84b0c8..0x84b100]
+          RootRanges: [0x84b060..0x84b120]
+      Variables: []
+    - ID: 161
+      Name: main.testInlinedBCA
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0x84b1bc..0x84b200]
+          RootRanges: [0x84b1a0..0x84b2c0]
+      Variables: []
+    - ID: 162
+      Name: main.testInlinedBCB
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0x84b270..0x84b2a8]
+          RootRanges: [0x84b1a0..0x84b2c0]
+      Variables: []
     - ID: 163
+      Name: main.testInlinedSq
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0x84b2c4..0x84b2c8]
+          RootRanges: [0x84b2c0..0x84b2d0]
+      Variables:
+        - Name: x
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84b2c0..0x84b2c8
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+    - ID: 164
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x84b1c4..0x84b1e8]
-          RootRanges: [0x84b1a0..0x84b200]
-        - Ranges: [0x84b25c..0x84b284]
-          RootRanges: [0x84b200..0x84b350]
+        - Ranges: [0x84b2f4..0x84b318]
+          RootRanges: [0x84b2d0..0x84b330]
+        - Ranges: [0x84b38c..0x84b3b4]
+          RootRanges: [0x84b330..0x84b480]
       Variables:
         - Name: a
           Type: 159 ArrayType [5]int
           Locations:
-            - Range: 0x84b1b0..0x84b200
+            - Range: 0x84b2e0..0x84b330
               Pieces: [{Size: 40, Op: {CfaOffset: -48}}]
-            - Range: 0x84b248..0x84b350
+            - Range: 0x84b378..0x84b480
               Pieces: [{Size: 40, Op: {CfaOffset: -120}}]
           Role: Parameter
-    - ID: 164
+    - ID: 165
       Name: main.firstBehavior.DoSomething
-      OutOfLinePCRanges: [0x84b350..0x84b3c0]
+      OutOfLinePCRanges: [0x84b480..0x84b4f0]
       InlinePCRanges:
-        - Ranges: [0x85106c..0x8510a0]
-          RootRanges: [0x851040..0x8510f0]
+        - Ranges: [0x85119c..0x8511d0]
+          RootRanges: [0x851170..0x851220]
       Variables:
         - Name: b
           Type: 319 StructureType main.firstBehavior
           Locations:
-            - Range: 0x84b350..0x84b37c
+            - Range: 0x84b480..0x84b4ac
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84b37c..0x84b380
+            - Range: 0x84b4ac..0x84b4b0
               Pieces:
                 - Size: 8
                   Op: null
@@ -8256,23 +8342,23 @@ Subprograms:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84b350..0x84b3a0
+            - Range: 0x84b480..0x84b4d0
               Pieces: []
-            - Range: 0x84b3a0..0x84b3a1
+            - Range: 0x84b4d0..0x84b4d1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84b3a1..0x84b3c0
+            - Range: 0x84b4d1..0x84b4f0
               Pieces: []
           Role: Return
-    - ID: 165
+    - ID: 166
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x84ba18..0x84ba24, 0x84ba28..0x84ba30]
-          RootRanges: [0x84b900..0x84ba70]
+        - Ranges: [0x84bb48..0x84bb54, 0x84bb58..0x84bb60]
+          RootRanges: [0x84ba30..0x84bba0]
         - Ranges: [0x8494b8..0x8494bc, 0x8494c0..0x8494c8]
           RootRanges: [0x8494b0..0x8494d0]
       Variables: []
@@ -11534,10 +11620,10 @@ Types:
       GoKind: 22
       Pointee: 811 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1551
+      ID: 1552
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
     - __kind: EventRootType
-      ID: 1549
+      ID: 1550
       Name: Probe[main.firstBehavior.DoSomething]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11549,11 +11635,11 @@ Types:
             Type: 319 StructureType main.firstBehavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 0, name: b}
+                  Variable: {subprogram: 165, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1550
+      ID: 1551
       Name: Probe[main.firstBehavior.DoSomething]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11565,14 +11651,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 1, name: ~r0}
+                  Variable: {subprogram: 165, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1507
+      ID: 1508
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1508
+      ID: 1509
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11584,11 +11670,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: ~r0}
+                  Variable: {subprogram: 143, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1374
+      ID: 1375
       Name: Probe[main.testAnyPtr]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11600,7 +11686,7 @@ Types:
             Type: 161 PointerType *interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: a}
+                  Variable: {subprogram: 59, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -11610,11 +11696,11 @@ Types:
             Type: 161 PointerType *interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: a}
+                  Variable: {subprogram: 59, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1375
+      ID: 1376
       Name: Probe[main.testAnyPtr]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11626,11 +11712,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 1, name: ~r0}
+                  Variable: {subprogram: 59, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1371
+      ID: 1372
       Name: Probe[main.testAny]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11642,7 +11728,7 @@ Types:
             Type: 155 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: a}
+                  Variable: {subprogram: 57, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -11652,11 +11738,11 @@ Types:
             Type: 155 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: a}
+                  Variable: {subprogram: 57, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1372
+      ID: 1373
       Name: Probe[main.testAny]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11668,11 +11754,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 1, name: ~r0}
+                  Variable: {subprogram: 57, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1478
+      ID: 1479
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11684,7 +11770,7 @@ Types:
             Type: 249 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: arg}
+                  Variable: {subprogram: 123, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
         - Name: arg
@@ -11694,11 +11780,11 @@ Types:
             Type: 249 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: arg}
+                  Variable: {subprogram: 123, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1479
+      ID: 1480
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11710,7 +11796,7 @@ Types:
             Type: 249 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 1, name: ~r0}
+                  Variable: {subprogram: 123, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -11792,7 +11878,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1383
+      ID: 1384
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11804,7 +11890,7 @@ Types:
             Type: 189 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: m}
+                  Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
         - Name: m
@@ -11814,7 +11900,7 @@ Types:
             Type: 189 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: m}
+                  Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -11870,7 +11956,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1405
+      ID: 1406
       Name: Probe[main.testAtomicAdd]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11882,7 +11968,7 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: x}
+                  Variable: {subprogram: 87, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -11892,11 +11978,11 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: x}
+                  Variable: {subprogram: 87, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1406
+      ID: 1407
       Name: Probe[main.testAtomicAdd]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11908,7 +11994,7 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 1, name: ~r0}
+                  Variable: {subprogram: 87, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -11993,7 +12079,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1407
+      ID: 1408
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -12005,7 +12091,7 @@ Types:
             Type: 241 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: c}
+                  Variable: {subprogram: 88, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
         - Name: c
@@ -12015,11 +12101,11 @@ Types:
             Type: 241 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: c}
+                  Variable: {subprogram: 88, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1401
+      ID: 1402
       Name: Probe[main.testCombinedByte]
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -12031,7 +12117,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: w}
+                  Variable: {subprogram: 84, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: w
@@ -12041,7 +12127,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: w}
+                  Variable: {subprogram: 84, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: x
@@ -12051,7 +12137,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 1, name: x}
+                  Variable: {subprogram: 84, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: x
@@ -12061,7 +12147,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 1, name: x}
+                  Variable: {subprogram: 84, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: y
@@ -12071,7 +12157,7 @@ Types:
             Type: 17 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 2, name: y}
+                  Variable: {subprogram: 84, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
         - Name: y
@@ -12081,11 +12167,11 @@ Types:
             Type: 17 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 2, name: y}
+                  Variable: {subprogram: 84, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1402
+      ID: 1403
       Name: Probe[main.testCombinedString]
       ByteSize: 18
       PresenceBitsetSize: 1
@@ -12097,7 +12183,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 1, name: x}
+                  Variable: {subprogram: 85, index: 1, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: w_val
@@ -12107,11 +12193,11 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: w}
+                  Variable: {subprogram: 85, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1403
+      ID: 1404
       Name: Probe[main.testCombinedString]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -12123,7 +12209,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 1, name: x}
+                  Variable: {subprogram: 85, index: 1, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x_val
@@ -12133,7 +12219,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 1, name: x}
+                  Variable: {subprogram: 85, index: 1, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: w_val
@@ -12143,11 +12229,11 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: w}
+                  Variable: {subprogram: 85, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1415
+      ID: 1416
       Name: Probe[main.testCycle]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12159,7 +12245,7 @@ Types:
             Type: 246 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: t}
+                  Variable: {subprogram: 96, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
         - Name: t
@@ -12169,11 +12255,11 @@ Types:
             Type: 246 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: t}
+                  Variable: {subprogram: 96, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1346
+      ID: 1347
       Name: Probe[main.testDeepMap1]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12185,7 +12271,7 @@ Types:
             Type: 141 StructureType main.deepMap1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: a}
+                  Variable: {subprogram: 43, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12195,11 +12281,11 @@ Types:
             Type: 141 StructureType main.deepMap1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: a}
+                  Variable: {subprogram: 43, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1347
+      ID: 1348
       Name: Probe[main.testDeepMap7]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12211,7 +12297,7 @@ Types:
             Type: 147 PointerType *main.deepMap7
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 0, name: a}
+                  Variable: {subprogram: 44, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12221,11 +12307,11 @@ Types:
             Type: 147 PointerType *main.deepMap7
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 0, name: a}
+                  Variable: {subprogram: 44, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1342
+      ID: 1343
       Name: Probe[main.testDeepPtr1]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12237,7 +12323,7 @@ Types:
             Type: 130 StructureType main.deepPtr1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: a}
+                  Variable: {subprogram: 39, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12247,11 +12333,11 @@ Types:
             Type: 130 StructureType main.deepPtr1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: a}
+                  Variable: {subprogram: 39, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1343
+      ID: 1344
       Name: Probe[main.testDeepPtr7]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12263,7 +12349,7 @@ Types:
             Type: 133 PointerType *main.deepPtr7
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: a}
+                  Variable: {subprogram: 40, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12273,11 +12359,11 @@ Types:
             Type: 133 PointerType *main.deepPtr7
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: a}
+                  Variable: {subprogram: 40, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1344
+      ID: 1345
       Name: Probe[main.testDeepSlice1]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12289,7 +12375,7 @@ Types:
             Type: 135 StructureType main.deepSlice1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: a}
+                  Variable: {subprogram: 41, index: 0, name: a}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -12299,11 +12385,11 @@ Types:
             Type: 135 StructureType main.deepSlice1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: a}
+                  Variable: {subprogram: 41, index: 0, name: a}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1345
+      ID: 1346
       Name: Probe[main.testDeepSlice7]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12315,7 +12401,7 @@ Types:
             Type: 139 PointerType *main.deepSlice7
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: a}
+                  Variable: {subprogram: 42, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12325,11 +12411,11 @@ Types:
             Type: 139 PointerType *main.deepSlice7
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: a}
+                  Variable: {subprogram: 42, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1498
+      ID: 1499
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -12341,7 +12427,7 @@ Types:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: xs}
+                  Variable: {subprogram: 135, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -12351,7 +12437,7 @@ Types:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: xs}
+                  Variable: {subprogram: 135, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -12361,7 +12447,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 1, name: a}
+                  Variable: {subprogram: 135, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12371,11 +12457,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 1, name: a}
+                  Variable: {subprogram: 135, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1495
+      ID: 1496
       Name: Probe[main.testEmptySlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12387,7 +12473,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: u}
+                  Variable: {subprogram: 132, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -12397,11 +12483,11 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: u}
+                  Variable: {subprogram: 132, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1521
+      ID: 1522
       Name: Probe[main.testEmptyString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12413,7 +12499,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: x}
+                  Variable: {subprogram: 151, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -12423,11 +12509,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: x}
+                  Variable: {subprogram: 151, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1535
+      ID: 1536
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12439,7 +12525,7 @@ Types:
             Type: 318 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: e}
+                  Variable: {subprogram: 158, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -12449,11 +12535,11 @@ Types:
             Type: 318 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: e}
+                  Variable: {subprogram: 158, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1534
+      ID: 1535
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -12465,7 +12551,7 @@ Types:
             Type: 317 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: e}
+                  Variable: {subprogram: 157, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
         - Name: e
@@ -12475,11 +12561,67 @@ Types:
             Type: 317 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: e}
+                  Variable: {subprogram: 157, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1373
+      ID: 1342
+      Name: Probe[main.testErrorAtLine]Line
+      ByteSize: 57
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 2, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 2, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: err
+          Offset: 25
+          Kind: local
+          Expression:
+            Type: 14 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 3, name: err}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: err
+          Offset: 41
+          Kind: template_segment
+          Expression:
+            Type: 14 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 3, name: err}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1374
       Name: Probe[main.testError]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12491,7 +12633,7 @@ Types:
             Type: 14 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: e}
+                  Variable: {subprogram: 58, index: 0, name: e}
                   Offset: 0
                   ByteSize: 16
         - Name: e
@@ -12501,11 +12643,11 @@ Types:
             Type: 14 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: e}
+                  Variable: {subprogram: 58, index: 0, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1355
+      ID: 1356
       Name: Probe[main.testEsotericHeap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12517,7 +12659,7 @@ Types:
             Type: 157 PointerType *main.esotericHeap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 48, index: 0, name: e}
+                  Variable: {subprogram: 49, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -12527,14 +12669,14 @@ Types:
             Type: 157 PointerType *main.esotericHeap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 48, index: 0, name: e}
+                  Variable: {subprogram: 49, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1356
+      ID: 1357
       Name: Probe[main.testEsotericHeap]Return
     - __kind: EventRootType
-      ID: 1353
+      ID: 1354
       Name: Probe[main.testEsotericStack]
       ByteSize: 129
       PresenceBitsetSize: 1
@@ -12546,7 +12688,7 @@ Types:
             Type: 153 StructureType main.esotericStack
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 0, name: e}
+                  Variable: {subprogram: 48, index: 0, name: e}
                   Offset: 0
                   ByteSize: 64
         - Name: e
@@ -12556,14 +12698,14 @@ Types:
             Type: 153 StructureType main.esotericStack
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 0, name: e}
+                  Variable: {subprogram: 48, index: 0, name: e}
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1354
+      ID: 1355
       Name: Probe[main.testEsotericStack]Return
     - __kind: EventRootType
-      ID: 1367
+      ID: 1368
       Name: Probe[main.testFramelessArray]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12575,7 +12717,7 @@ Types:
             Type: 159 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: a}
+                  Variable: {subprogram: 55, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: a
@@ -12585,11 +12727,11 @@ Types:
             Type: 159 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: a}
+                  Variable: {subprogram: 55, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1369
+      ID: 1370
       Name: Probe[main.testFramelessArray]Line
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -12601,7 +12743,7 @@ Types:
             Type: 159 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: a}
+                  Variable: {subprogram: 55, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: a
@@ -12611,7 +12753,7 @@ Types:
             Type: 159 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: a}
+                  Variable: {subprogram: 55, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: ~r0
@@ -12621,11 +12763,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 1, name: ~r0}
+                  Variable: {subprogram: 55, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1368
+      ID: 1369
       Name: Probe[main.testFramelessArray]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12637,11 +12779,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 1, name: ~r0}
+                  Variable: {subprogram: 55, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1365
+      ID: 1366
       Name: Probe[main.testFrameless]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12653,7 +12795,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: x}
+                  Variable: {subprogram: 54, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12663,11 +12805,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: x}
+                  Variable: {subprogram: 54, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1366
+      ID: 1367
       Name: Probe[main.testFrameless]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12679,11 +12821,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 1, name: ~r0}
+                  Variable: {subprogram: 54, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1357
+      ID: 1358
       Name: Probe[main.testInlinedBA]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12695,7 +12837,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: x}
+                  Variable: {subprogram: 50, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12705,14 +12847,14 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: x}
+                  Variable: {subprogram: 50, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1358
+      ID: 1359
       Name: Probe[main.testInlinedBA]Return
     - __kind: EventRootType
-      ID: 1361
+      ID: 1362
       Name: Probe[main.testInlinedBBA]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12724,7 +12866,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: x}
+                  Variable: {subprogram: 52, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12734,17 +12876,17 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: x}
+                  Variable: {subprogram: 52, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1362
+      ID: 1363
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1541
+      ID: 1542
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 1359
+      ID: 1360
       Name: Probe[main.testInlinedBB]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12756,7 +12898,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: x}
+                  Variable: {subprogram: 51, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12766,7 +12908,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: x}
+                  Variable: {subprogram: 51, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: y
@@ -12776,7 +12918,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 1, name: y}
+                  Variable: {subprogram: 51, index: 1, name: y}
                   Offset: 0
                   ByteSize: 8
         - Name: y
@@ -12786,32 +12928,32 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 1, name: y}
+                  Variable: {subprogram: 51, index: 1, name: y}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1360
+      ID: 1361
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1542
+      ID: 1543
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1543
+      ID: 1544
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1544
+      ID: 1545
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1545
+      ID: 1546
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
-      ID: 1363
+      ID: 1364
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 1364
+      ID: 1365
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1538
+      ID: 1539
       Name: Probe[main.testInlinedPrint]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12823,7 +12965,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12833,11 +12975,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1536
+      ID: 1537
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12849,11 +12991,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1537
+      ID: 1538
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12865,7 +13007,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x_val
@@ -12875,11 +13017,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1540
+      ID: 1541
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12891,7 +13033,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12901,14 +13043,14 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1539
+      ID: 1540
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1546
+      ID: 1547
       Name: Probe[main.testInlinedSq]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12920,7 +13062,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12930,11 +13072,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1547
+      ID: 1548
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12946,7 +13088,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12956,11 +13098,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1548
+      ID: 1549
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12972,7 +13114,7 @@ Types:
             Type: 159 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: a}
+                  Variable: {subprogram: 164, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: a
@@ -12982,7 +13124,7 @@ Types:
             Type: 159 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: a}
+                  Variable: {subprogram: 164, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
@@ -13116,7 +13258,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1370
+      ID: 1371
       Name: Probe[main.testInterface]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13128,7 +13270,7 @@ Types:
             Type: 160 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: b}
+                  Variable: {subprogram: 56, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -13138,11 +13280,11 @@ Types:
             Type: 160 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: b}
+                  Variable: {subprogram: 56, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1476
+      ID: 1477
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 161
       PresenceBitsetSize: 1
@@ -13154,7 +13296,7 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: arg}
+                  Variable: {subprogram: 122, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
         - Name: arg
@@ -13164,11 +13306,11 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: arg}
+                  Variable: {subprogram: 122, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1477
+      ID: 1478
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13180,11 +13322,11 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 1, name: ~r0}
+                  Variable: {subprogram: 122, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1409
+      ID: 1410
       Name: Probe[main.testLinkedList]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13196,7 +13338,7 @@ Types:
             Type: 244 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: a}
+                  Variable: {subprogram: 90, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -13206,38 +13348,12 @@ Types:
             Type: 244 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: a}
+                  Variable: {subprogram: 90, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1350
-      Name: Probe[main.testLongFunctionWithChangingState]Line
-    - __kind: EventRootType
       ID: 1351
       Name: Probe[main.testLongFunctionWithChangingState]Line
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: aPerArch
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 1, name: aPerArch}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: b
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 2, name: b}
-                  Offset: 0
-                  ByteSize: 8
     - __kind: EventRootType
       ID: 1352
       Name: Probe[main.testLongFunctionWithChangingState]Line
@@ -13251,7 +13367,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 1, name: aPerArch}
+                  Variable: {subprogram: 47, index: 1, name: aPerArch}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13261,11 +13377,37 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 2, name: b}
+                  Variable: {subprogram: 47, index: 2, name: b}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1482
+      ID: 1353
+      Name: Probe[main.testLongFunctionWithChangingState]Line
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: aPerArch
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 47, index: 1, name: aPerArch}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 47, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1483
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 147
       PresenceBitsetSize: 3
@@ -13277,7 +13419,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: a}
+                  Variable: {subprogram: 125, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -13287,7 +13429,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: a}
+                  Variable: {subprogram: 125, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13297,7 +13439,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 1, name: b}
+                  Variable: {subprogram: 125, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13307,7 +13449,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 1, name: b}
+                  Variable: {subprogram: 125, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13317,7 +13459,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 2, name: c}
+                  Variable: {subprogram: 125, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13327,7 +13469,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 2, name: c}
+                  Variable: {subprogram: 125, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13337,7 +13479,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 3, name: d}
+                  Variable: {subprogram: 125, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13347,7 +13489,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 3, name: d}
+                  Variable: {subprogram: 125, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13357,7 +13499,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 4, name: e}
+                  Variable: {subprogram: 125, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13367,7 +13509,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 4, name: e}
+                  Variable: {subprogram: 125, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13377,7 +13519,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 5, name: f}
+                  Variable: {subprogram: 125, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13387,7 +13529,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 5, name: f}
+                  Variable: {subprogram: 125, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13397,7 +13539,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 6, name: g}
+                  Variable: {subprogram: 125, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13407,7 +13549,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 6, name: g}
+                  Variable: {subprogram: 125, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13417,7 +13559,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 7, name: h}
+                  Variable: {subprogram: 125, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13427,7 +13569,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 7, name: h}
+                  Variable: {subprogram: 125, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13437,7 +13579,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 8, name: i}
+                  Variable: {subprogram: 125, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13447,11 +13589,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 8, name: i}
+                  Variable: {subprogram: 125, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1483
+      ID: 1484
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13463,11 +13605,11 @@ Types:
             Type: 111 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 9, name: ~r0}
+                  Variable: {subprogram: 125, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1381
+      ID: 1382
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13479,7 +13621,7 @@ Types:
             Type: 184 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13489,11 +13631,11 @@ Types:
             Type: 184 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1388
+      ID: 1389
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13505,7 +13647,7 @@ Types:
             Type: 191 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: m}
+                  Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13515,11 +13657,11 @@ Types:
             Type: 191 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: m}
+                  Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1400
+      ID: 1401
       Name: Probe[main.testMapEmptyKeyAndValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13531,7 +13673,7 @@ Types:
             Type: 236 GoMapType map[struct {}]struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: m}
+                  Variable: {subprogram: 83, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13541,11 +13683,11 @@ Types:
             Type: 236 GoMapType map[struct {}]struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: m}
+                  Variable: {subprogram: 83, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1398
+      ID: 1399
       Name: Probe[main.testMapEmptyKey]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13557,7 +13699,7 @@ Types:
             Type: 226 GoMapType map[struct {}]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: m}
+                  Variable: {subprogram: 81, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13567,11 +13709,11 @@ Types:
             Type: 226 GoMapType map[struct {}]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: m}
+                  Variable: {subprogram: 81, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1399
+      ID: 1400
       Name: Probe[main.testMapEmptyValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13583,7 +13725,7 @@ Types:
             Type: 231 GoMapType map[int]struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: m}
+                  Variable: {subprogram: 82, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13593,11 +13735,11 @@ Types:
             Type: 231 GoMapType map[int]struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: m}
+                  Variable: {subprogram: 82, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1385
+      ID: 1386
       Name: Probe[main.testMapIntToInt]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13609,7 +13751,7 @@ Types:
             Type: 164 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
+                  Variable: {subprogram: 69, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13619,11 +13761,11 @@ Types:
             Type: 164 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
+                  Variable: {subprogram: 69, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1397
+      ID: 1398
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13635,7 +13777,7 @@ Types:
             Type: 221 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: m}
+                  Variable: {subprogram: 80, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13645,11 +13787,11 @@ Types:
             Type: 221 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: m}
+                  Variable: {subprogram: 80, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1396
+      ID: 1397
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13661,7 +13803,7 @@ Types:
             Type: 216 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: m}
+                  Variable: {subprogram: 79, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13671,33 +13813,7 @@ Types:
             Type: 216 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1386
-      Name: Probe[main.testMapMassive]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: redactMyEntries
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 191 GoMapType map[string][]main.structWithMap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: redactMyEntries
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 191 GoMapType map[string][]main.structWithMap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 79, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -13713,7 +13829,7 @@ Types:
             Type: 191 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 70, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
         - Name: redactMyEntries
@@ -13723,11 +13839,37 @@ Types:
             Type: 191 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 70, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1395
+      ID: 1388
+      Name: Probe[main.testMapMassive]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: redactMyEntries
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 191 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 70, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: redactMyEntries
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 191 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 70, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1396
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13739,7 +13881,7 @@ Types:
             Type: 211 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: m}
+                  Variable: {subprogram: 78, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13749,11 +13891,11 @@ Types:
             Type: 211 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: m}
+                  Variable: {subprogram: 78, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1394
+      ID: 1395
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13765,6 +13907,136 @@ Types:
             Type: 206 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
+                  Variable: {subprogram: 77, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 206 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 77, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1380
+      Name: Probe[main.testMapStringToInt]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 174 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 63, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 174 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 63, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1381
+      Name: Probe[main.testMapStringToSlice]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 179 GoMapType map[string][]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 64, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 179 GoMapType map[string][]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 64, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1379
+      Name: Probe[main.testMapStringToStruct]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 169 GoMapType map[string]main.nestedStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 62, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 169 GoMapType map[string]main.nestedStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 62, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1390
+      Name: Probe[main.testMapWithLinkedList]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 196 GoMapType map[bool]main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 72, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 196 GoMapType map[bool]main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 72, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1394
+      Name: Probe[main.testMapWithSmallKeyAndValueMassive]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 206 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
                   Variable: {subprogram: 76, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
@@ -13779,112 +14051,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1379
-      Name: Probe[main.testMapStringToInt]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 174 GoMapType map[string]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: m
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 174 GoMapType map[string]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1380
-      Name: Probe[main.testMapStringToSlice]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 179 GoMapType map[string][]string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: m
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 179 GoMapType map[string][]string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1378
-      Name: Probe[main.testMapStringToStruct]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 169 GoMapType map[string]main.nestedStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: m
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 169 GoMapType map[string]main.nestedStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1389
-      Name: Probe[main.testMapWithLinkedList]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 196 GoMapType map[bool]main.node
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: m
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 196 GoMapType map[bool]main.node
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
       ID: 1393
-      Name: Probe[main.testMapWithSmallKeyAndValueMassive]
+      Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
@@ -13910,32 +14078,6 @@ Types:
                   ByteSize: 8
     - __kind: EventRootType
       ID: 1392
-      Name: Probe[main.testMapWithSmallKeyAndValue]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 206 GoMapType map[uint8]uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: m
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 206 GoMapType map[uint8]uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1391
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13947,7 +14089,7 @@ Types:
             Type: 201 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 74, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
         - Name: redactMyEntries
@@ -13957,11 +14099,11 @@ Types:
             Type: 201 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 74, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1390
+      ID: 1391
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13973,7 +14115,7 @@ Types:
             Type: 201 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: m}
+                  Variable: {subprogram: 73, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13983,35 +14125,9 @@ Types:
             Type: 201 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: m}
+                  Variable: {subprogram: 73, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
-    - __kind: EventRootType
-      ID: 1518
-      Name: Probe[main.testMassiveString]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: x
-          Offset: 17
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
     - __kind: EventRootType
       ID: 1519
       Name: Probe[main.testMassiveString]
@@ -14025,7 +14141,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
+                  Variable: {subprogram: 149, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -14035,11 +14151,37 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
+                  Variable: {subprogram: 149, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1484
+      ID: 1520
+      Name: Probe[main.testMassiveString]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 149, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 149, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1485
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 163
       PresenceBitsetSize: 3
@@ -14051,7 +14193,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: a}
+                  Variable: {subprogram: 126, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14061,7 +14203,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: a}
+                  Variable: {subprogram: 126, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -14071,7 +14213,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: b}
+                  Variable: {subprogram: 126, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -14081,7 +14223,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: b}
+                  Variable: {subprogram: 126, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -14091,7 +14233,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: c}
+                  Variable: {subprogram: 126, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -14101,7 +14243,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: c}
+                  Variable: {subprogram: 126, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -14111,7 +14253,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 3, name: d}
+                  Variable: {subprogram: 126, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -14121,7 +14263,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 3, name: d}
+                  Variable: {subprogram: 126, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -14131,7 +14273,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 4, name: e}
+                  Variable: {subprogram: 126, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -14141,7 +14283,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 4, name: e}
+                  Variable: {subprogram: 126, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -14151,7 +14293,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 5, name: f}
+                  Variable: {subprogram: 126, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -14161,7 +14303,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 5, name: f}
+                  Variable: {subprogram: 126, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -14171,7 +14313,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 6, name: g}
+                  Variable: {subprogram: 126, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -14181,7 +14323,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 6, name: g}
+                  Variable: {subprogram: 126, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -14191,7 +14333,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 7, name: h}
+                  Variable: {subprogram: 126, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -14201,7 +14343,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 7, name: h}
+                  Variable: {subprogram: 126, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: s
@@ -14211,7 +14353,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 8, name: s}
+                  Variable: {subprogram: 126, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
         - Name: s
@@ -14221,11 +14363,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 8, name: s}
+                  Variable: {subprogram: 126, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1485
+      ID: 1486
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -14237,11 +14379,11 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 9, name: ~r0}
+                  Variable: {subprogram: 126, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1488
+      ID: 1489
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -14253,7 +14395,7 @@ Types:
             Type: 111 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -14263,7 +14405,7 @@ Types:
             Type: 111 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -14273,7 +14415,7 @@ Types:
             Type: 249 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: b}
+                  Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
         - Name: b
@@ -14283,11 +14425,11 @@ Types:
             Type: 249 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: b}
+                  Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1489
+      ID: 1490
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -14299,7 +14441,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 2, name: ~r0}
+                  Variable: {subprogram: 128, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -14309,11 +14451,11 @@ Types:
             Type: 111 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 3, name: ~r1}
+                  Variable: {subprogram: 128, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1480
+      ID: 1481
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 321
       PresenceBitsetSize: 1
@@ -14325,7 +14467,7 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: s1}
+                  Variable: {subprogram: 124, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
         - Name: s1
@@ -14335,7 +14477,7 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: s1}
+                  Variable: {subprogram: 124, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
         - Name: s2
@@ -14345,7 +14487,7 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: s2}
+                  Variable: {subprogram: 124, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
         - Name: s2
@@ -14355,11 +14497,11 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: s2}
+                  Variable: {subprogram: 124, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1481
+      ID: 1482
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -14371,11 +14513,11 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 2, name: ~r0}
+                  Variable: {subprogram: 124, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1434
+      ID: 1435
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14387,7 +14529,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14397,11 +14539,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1436
+      ID: 1437
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14413,7 +14555,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14423,7 +14565,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14433,7 +14575,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14443,11 +14585,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1438
+      ID: 1439
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14459,11 +14601,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1440
+      ID: 1441
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14475,11 +14617,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1442
+      ID: 1443
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14491,11 +14633,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1435
+      ID: 1436
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14507,7 +14649,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14517,11 +14659,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1437
+      ID: 1438
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -14533,7 +14675,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14543,7 +14685,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14553,7 +14695,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14563,7 +14705,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14573,7 +14715,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14583,11 +14725,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1439
+      ID: 1440
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14599,7 +14741,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14609,11 +14751,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1441
+      ID: 1442
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14625,7 +14767,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14635,11 +14777,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1443
+      ID: 1444
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14651,7 +14793,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14661,11 +14803,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1404
+      ID: 1405
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 62
       PresenceBitsetSize: 2
@@ -14677,7 +14819,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: a}
+                  Variable: {subprogram: 86, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: a
@@ -14687,7 +14829,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: a}
+                  Variable: {subprogram: 86, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -14697,7 +14839,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 1, name: b}
+                  Variable: {subprogram: 86, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -14707,7 +14849,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 1, name: b}
+                  Variable: {subprogram: 86, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: c
@@ -14717,7 +14859,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 2, name: c}
+                  Variable: {subprogram: 86, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: c
@@ -14727,7 +14869,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 2, name: c}
+                  Variable: {subprogram: 86, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: d
@@ -14737,7 +14879,7 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 3, name: d}
+                  Variable: {subprogram: 86, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -14747,7 +14889,7 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 3, name: d}
+                  Variable: {subprogram: 86, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -14757,7 +14899,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 4, name: e}
+                  Variable: {subprogram: 86, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
         - Name: e
@@ -14767,11 +14909,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 4, name: e}
+                  Variable: {subprogram: 86, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1430
+      ID: 1431
       Name: Probe[main.testNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14783,7 +14925,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14793,37 +14935,37 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1433
+      Name: Probe[main.testNamedReturn]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
       ID: 1432
-      Name: Probe[main.testNamedReturn]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1431
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14835,11 +14977,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1433
+      ID: 1434
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14851,7 +14993,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14861,11 +15003,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1530
+      ID: 1531
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14877,7 +15019,7 @@ Types:
             Type: 315 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: x}
+                  Variable: {subprogram: 156, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -14887,11 +15029,11 @@ Types:
             Type: 315 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: x}
+                  Variable: {subprogram: 156, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1531
+      ID: 1532
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14903,7 +15045,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: x}
+                  Variable: {subprogram: 156, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -14913,10 +15055,10 @@ Types:
                   Bias: 8
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1532
+      ID: 1533
       Name: Probe[main.testNestedPointer]
     - __kind: EventRootType
-      ID: 1533
+      ID: 1534
       Name: Probe[main.testNestedPointer]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -14928,7 +15070,7 @@ Types:
             Type: 121 StructureType main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: x}
+                  Variable: {subprogram: 156, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -14938,7 +15080,7 @@ Types:
                   Bias: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1414
+      ID: 1415
       Name: Probe[main.testNilPointer]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14950,7 +15092,7 @@ Types:
             Type: 11 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: z}
+                  Variable: {subprogram: 95, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: z
@@ -14960,7 +15102,7 @@ Types:
             Type: 11 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: z}
+                  Variable: {subprogram: 95, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14970,7 +15112,7 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 1, name: a}
+                  Variable: {subprogram: 95, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14980,11 +15122,11 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 1, name: a}
+                  Variable: {subprogram: 95, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1499
+      ID: 1500
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -14996,7 +15138,7 @@ Types:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: xs}
+                  Variable: {subprogram: 136, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -15006,7 +15148,7 @@ Types:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: xs}
+                  Variable: {subprogram: 136, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -15016,7 +15158,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 1, name: a}
+                  Variable: {subprogram: 136, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -15026,11 +15168,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 1, name: a}
+                  Variable: {subprogram: 136, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1501
+      ID: 1502
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 67
       PresenceBitsetSize: 1
@@ -15042,7 +15184,7 @@ Types:
             Type: 16 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: a}
+                  Variable: {subprogram: 138, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: a
@@ -15052,7 +15194,7 @@ Types:
             Type: 16 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: a}
+                  Variable: {subprogram: 138, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
@@ -15062,7 +15204,7 @@ Types:
             Type: 262 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 1, name: s}
+                  Variable: {subprogram: 138, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: s
@@ -15072,7 +15214,7 @@ Types:
             Type: 262 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 1, name: s}
+                  Variable: {subprogram: 138, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -15082,7 +15224,7 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 2, name: x}
+                  Variable: {subprogram: 138, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -15092,11 +15234,11 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 2, name: x}
+                  Variable: {subprogram: 138, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1502
+      ID: 1503
       Name: Probe[main.testNilSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -15108,7 +15250,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -15118,11 +15260,11 @@ Types:
             Type: 263 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1517
+      ID: 1518
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15134,7 +15276,7 @@ Types:
             Type: 268 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -15144,11 +15286,11 @@ Types:
             Type: 268 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1410
+      ID: 1411
       Name: Probe[main.testPointerLoop]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15160,7 +15302,7 @@ Types:
             Type: 245 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: a}
+                  Variable: {subprogram: 91, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -15170,11 +15312,11 @@ Types:
             Type: 245 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: a}
+                  Variable: {subprogram: 91, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1384
+      ID: 1385
       Name: Probe[main.testPointerToMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15186,7 +15328,7 @@ Types:
             Type: 190 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: m}
+                  Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -15196,11 +15338,11 @@ Types:
             Type: 190 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: m}
+                  Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1408
+      ID: 1409
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15212,7 +15354,7 @@ Types:
             Type: 242 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: a}
+                  Variable: {subprogram: 89, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -15222,11 +15364,11 @@ Types:
             Type: 242 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: a}
+                  Variable: {subprogram: 89, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1424
+      ID: 1425
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 35
       PresenceBitsetSize: 1
@@ -15238,7 +15380,7 @@ Types:
             Type: 155 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: v}
+                  Variable: {subprogram: 101, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: v
@@ -15248,7 +15390,7 @@ Types:
             Type: 155 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: v}
+                  Variable: {subprogram: 101, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: failed
@@ -15258,7 +15400,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 1, name: failed}
+                  Variable: {subprogram: 101, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
         - Name: failed
@@ -15268,11 +15410,11 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 1, name: failed}
+                  Variable: {subprogram: 101, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1425
+      ID: 1426
       Name: Probe[main.testReturnsAnyAndError]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15284,7 +15426,7 @@ Types:
             Type: 155 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 2, name: ~r0}
+                  Variable: {subprogram: 101, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
         - Name: ~r1
@@ -15294,11 +15436,11 @@ Types:
             Type: 14 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 3, name: ~r1}
+                  Variable: {subprogram: 101, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1426
+      ID: 1427
       Name: Probe[main.testReturnsAny]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15310,7 +15452,7 @@ Types:
             Type: 155 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: v}
+                  Variable: {subprogram: 102, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: v
@@ -15320,11 +15462,11 @@ Types:
             Type: 155 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: v}
+                  Variable: {subprogram: 102, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1427
+      ID: 1428
       Name: Probe[main.testReturnsAny]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15336,14 +15478,14 @@ Types:
             Type: 155 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 1, name: ~r0}
+                  Variable: {subprogram: 102, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1456
+      ID: 1457
       Name: Probe[main.testReturnsArrayOne]
     - __kind: EventRootType
-      ID: 1457
+      ID: 1458
       Name: Probe[main.testReturnsArrayOne]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15355,14 +15497,14 @@ Types:
             Type: 250 ArrayType [1]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 0, name: ~r0}
+                  Variable: {subprogram: 112, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1458
+      ID: 1459
       Name: Probe[main.testReturnsArrayZero]
     - __kind: EventRootType
-      ID: 1459
+      ID: 1460
       Name: Probe[main.testReturnsArrayZero]Return
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -15374,14 +15516,14 @@ Types:
             Type: 251 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 0, name: ~r0}
+                  Variable: {subprogram: 113, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1454
+      ID: 1455
       Name: Probe[main.testReturnsArray]
     - __kind: EventRootType
-      ID: 1455
+      ID: 1456
       Name: Probe[main.testReturnsArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15393,14 +15535,14 @@ Types:
             Type: 249 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 0, name: ~r0}
+                  Variable: {subprogram: 111, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1462
+      ID: 1463
       Name: Probe[main.testReturnsBacktrackInt]
     - __kind: EventRootType
-      ID: 1463
+      ID: 1464
       Name: Probe[main.testReturnsBacktrackInt]Return
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -15412,7 +15554,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: ~r0}
+                  Variable: {subprogram: 115, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15422,7 +15564,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 1, name: ~r1}
+                  Variable: {subprogram: 115, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15432,7 +15574,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 2, name: ~r2}
+                  Variable: {subprogram: 115, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -15442,7 +15584,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 3, name: ~r3}
+                  Variable: {subprogram: 115, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15452,7 +15594,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 4, name: ~r4}
+                  Variable: {subprogram: 115, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r5
@@ -15462,7 +15604,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 5, name: ~r5}
+                  Variable: {subprogram: 115, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r6
@@ -15472,7 +15614,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 6, name: ~r6}
+                  Variable: {subprogram: 115, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r7
@@ -15482,7 +15624,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 7, name: ~r7}
+                  Variable: {subprogram: 115, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r8
@@ -15492,14 +15634,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 8, name: ~r8}
+                  Variable: {subprogram: 115, index: 8, name: ~r8}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1474
+      ID: 1475
       Name: Probe[main.testReturnsBoolAndUintptr]
     - __kind: EventRootType
-      ID: 1475
+      ID: 1476
       Name: Probe[main.testReturnsBoolAndUintptr]Return
       ByteSize: 10
       PresenceBitsetSize: 1
@@ -15511,7 +15653,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: ~r0}
+                  Variable: {subprogram: 121, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r1
@@ -15521,14 +15663,14 @@ Types:
             Type: 1 BaseType uintptr
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 1, name: ~r1}
+                  Variable: {subprogram: 121, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1450
+      ID: 1451
       Name: Probe[main.testReturnsComplex]
     - __kind: EventRootType
-      ID: 1451
+      ID: 1452
       Name: Probe[main.testReturnsComplex]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15540,7 +15682,7 @@ Types:
             Type: 95 BaseType complex64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: ~r0}
+                  Variable: {subprogram: 109, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15550,11 +15692,11 @@ Types:
             Type: 96 BaseType complex128
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: ~r1}
+                  Variable: {subprogram: 109, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1422
+      ID: 1423
       Name: Probe[main.testReturnsError]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -15566,7 +15708,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: failed}
+                  Variable: {subprogram: 100, index: 0, name: failed}
                   Offset: 0
                   ByteSize: 1
         - Name: failed
@@ -15576,11 +15718,11 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: failed}
+                  Variable: {subprogram: 100, index: 0, name: failed}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1423
+      ID: 1424
       Name: Probe[main.testReturnsError]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15592,11 +15734,11 @@ Types:
             Type: 14 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 1, name: ~r0}
+                  Variable: {subprogram: 100, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1420
+      ID: 1421
       Name: Probe[main.testReturnsIntAndFloat]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15608,7 +15750,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: i}
+                  Variable: {subprogram: 99, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -15618,11 +15760,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: i}
+                  Variable: {subprogram: 99, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1421
+      ID: 1422
       Name: Probe[main.testReturnsIntAndFloat]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15634,7 +15776,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 1, name: ~r0}
+                  Variable: {subprogram: 99, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15644,11 +15786,11 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 2, name: ~r1}
+                  Variable: {subprogram: 99, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1418
+      ID: 1419
       Name: Probe[main.testReturnsIntPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15660,7 +15802,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: i}
+                  Variable: {subprogram: 98, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -15670,11 +15812,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: i}
+                  Variable: {subprogram: 98, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1419
+      ID: 1420
       Name: Probe[main.testReturnsIntPointer]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15686,11 +15828,11 @@ Types:
             Type: 99 PointerType *int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 1, name: ~r0}
+                  Variable: {subprogram: 98, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1416
+      ID: 1417
       Name: Probe[main.testReturnsInt]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15702,7 +15844,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: i}
+                  Variable: {subprogram: 97, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -15712,11 +15854,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: i}
+                  Variable: {subprogram: 97, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1417
+      ID: 1418
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15728,11 +15870,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 1, name: ~r0}
+                  Variable: {subprogram: 97, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1428
+      ID: 1429
       Name: Probe[main.testReturnsInterface]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15744,7 +15886,7 @@ Types:
             Type: 155 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: v}
+                  Variable: {subprogram: 103, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: v
@@ -15754,11 +15896,11 @@ Types:
             Type: 155 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: v}
+                  Variable: {subprogram: 103, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1429
+      ID: 1430
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15770,14 +15912,14 @@ Types:
             Type: 160 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: ~r0}
+                  Variable: {subprogram: 103, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1452
+      ID: 1453
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1453
+      ID: 1454
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -15789,14 +15931,14 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: ~r0}
+                  Variable: {subprogram: 110, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1448
+      ID: 1449
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1449
+      ID: 1450
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 139
       PresenceBitsetSize: 3
@@ -15808,7 +15950,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: ~r0}
+                  Variable: {subprogram: 108, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15818,7 +15960,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 1, name: ~r1}
+                  Variable: {subprogram: 108, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15828,7 +15970,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 2, name: ~r2}
+                  Variable: {subprogram: 108, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -15838,7 +15980,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 3, name: ~r3}
+                  Variable: {subprogram: 108, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15848,7 +15990,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 4, name: ~r4}
+                  Variable: {subprogram: 108, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r5
@@ -15858,7 +16000,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 5, name: ~r5}
+                  Variable: {subprogram: 108, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r6
@@ -15868,7 +16010,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 6, name: ~r6}
+                  Variable: {subprogram: 108, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r7
@@ -15878,7 +16020,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 7, name: ~r7}
+                  Variable: {subprogram: 108, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r8
@@ -15888,7 +16030,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 8, name: ~r8}
+                  Variable: {subprogram: 108, index: 8, name: ~r8}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r9
@@ -15898,7 +16040,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 9, name: ~r9}
+                  Variable: {subprogram: 108, index: 9, name: ~r9}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r10
@@ -15908,7 +16050,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 10, name: ~r10}
+                  Variable: {subprogram: 108, index: 10, name: ~r10}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r11
@@ -15918,7 +16060,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 11, name: ~r11}
+                  Variable: {subprogram: 108, index: 11, name: ~r11}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r12
@@ -15928,7 +16070,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 12, name: ~r12}
+                  Variable: {subprogram: 108, index: 12, name: ~r12}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r13
@@ -15938,7 +16080,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 13, name: ~r13}
+                  Variable: {subprogram: 108, index: 13, name: ~r13}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r14
@@ -15948,7 +16090,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 14, name: ~r14}
+                  Variable: {subprogram: 108, index: 14, name: ~r14}
                   Offset: 0
                   ByteSize: 8
         - Name: onlyOnAmd64_16
@@ -15958,7 +16100,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 15, name: onlyOnAmd64_16}
+                  Variable: {subprogram: 108, index: 15, name: onlyOnAmd64_16}
                   Offset: 0
                   ByteSize: 8
         - Name: bothArmAndAmd64
@@ -15968,14 +16110,14 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 16, name: bothArmAndAmd64}
+                  Variable: {subprogram: 108, index: 16, name: bothArmAndAmd64}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1460
+      ID: 1461
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1461
+      ID: 1462
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15987,14 +16129,14 @@ Types:
             Type: 252 StructureType main.mixedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: ~r0}
+                  Variable: {subprogram: 114, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1466
+      ID: 1467
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1467
+      ID: 1468
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16006,7 +16148,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 0, name: ~r0}
+                  Variable: {subprogram: 117, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -16016,7 +16158,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 1, name: ~r1}
+                  Variable: {subprogram: 117, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -16026,7 +16168,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 2, name: ~r2}
+                  Variable: {subprogram: 117, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -16036,7 +16178,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 3, name: ~r3}
+                  Variable: {subprogram: 117, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -16046,14 +16188,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 4, name: ~r4}
+                  Variable: {subprogram: 117, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1472
+      ID: 1473
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1473
+      ID: 1474
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -16065,7 +16207,7 @@ Types:
             Type: 17 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: ~r0}
+                  Variable: {subprogram: 120, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r1
@@ -16075,14 +16217,14 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 1, name: ~r1}
+                  Variable: {subprogram: 120, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1470
+      ID: 1471
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1471
+      ID: 1472
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -16094,14 +16236,14 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 0, name: ~r0}
+                  Variable: {subprogram: 119, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1446
+      ID: 1447
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1447
+      ID: 1448
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -16113,7 +16255,7 @@ Types:
             Type: 16 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 0, name: ~r0}
+                  Variable: {subprogram: 107, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r1
@@ -16123,7 +16265,7 @@ Types:
             Type: 94 BaseType int16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 1, name: ~r1}
+                  Variable: {subprogram: 107, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 2
         - Name: ~r2
@@ -16133,7 +16275,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 2, name: ~r2}
+                  Variable: {subprogram: 107, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r3
@@ -16143,7 +16285,7 @@ Types:
             Type: 13 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 3, name: ~r3}
+                  Variable: {subprogram: 107, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -16153,7 +16295,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 4, name: ~r4}
+                  Variable: {subprogram: 107, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r5
@@ -16163,7 +16305,7 @@ Types:
             Type: 6 BaseType uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 5, name: ~r5}
+                  Variable: {subprogram: 107, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 2
         - Name: ~r6
@@ -16173,7 +16315,7 @@ Types:
             Type: 2 BaseType uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 6, name: ~r6}
+                  Variable: {subprogram: 107, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r7
@@ -16183,14 +16325,14 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 7, name: ~r7}
+                  Variable: {subprogram: 107, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1468
+      ID: 1469
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1469
+      ID: 1470
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16202,14 +16344,14 @@ Types:
             Type: 254 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 0, name: ~r0}
+                  Variable: {subprogram: 118, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1464
+      ID: 1465
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1465
+      ID: 1466
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -16221,7 +16363,7 @@ Types:
             Type: 253 StructureType main.wideStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 0, name: ~r0}
+                  Variable: {subprogram: 116, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 88
     - __kind: EventRootType
@@ -16531,7 +16673,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1509
+      ID: 1510
       Name: Probe[main.testSingleString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16543,7 +16685,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: x}
+                  Variable: {subprogram: 144, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -16553,7 +16695,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: x}
+                  Variable: {subprogram: 144, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -16687,7 +16829,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1505
+      ID: 1506
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16699,7 +16841,7 @@ Types:
             Type: 264 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: xs}
+                  Variable: {subprogram: 141, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -16709,11 +16851,11 @@ Types:
             Type: 264 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: xs}
+                  Variable: {subprogram: 141, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1496
+      ID: 1497
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16725,7 +16867,7 @@ Types:
             Type: 256 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: u}
+                  Variable: {subprogram: 133, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -16735,11 +16877,11 @@ Types:
             Type: 256 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: u}
+                  Variable: {subprogram: 133, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1382
+      ID: 1383
       Name: Probe[main.testSmallMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16751,7 +16893,7 @@ Types:
             Type: 174 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -16761,11 +16903,11 @@ Types:
             Type: 174 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1444
+      ID: 1445
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16777,7 +16919,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: i}
+                  Variable: {subprogram: 106, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -16787,11 +16929,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: i}
+                  Variable: {subprogram: 106, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1445
+      ID: 1446
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16803,7 +16945,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 1, name: ~r0}
+                  Variable: {subprogram: 106, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -16813,7 +16955,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 2, name: result2}
+                  Variable: {subprogram: 106, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -16823,11 +16965,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 3, name: ~r2}
+                  Variable: {subprogram: 106, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1486
+      ID: 1487
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -16839,7 +16981,7 @@ Types:
             Type: 159 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: arg}
+                  Variable: {subprogram: 127, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
         - Name: arg
@@ -16849,11 +16991,11 @@ Types:
             Type: 159 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: arg}
+                  Variable: {subprogram: 127, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1487
+      ID: 1488
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16865,7 +17007,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: ~r0}
+                  Variable: {subprogram: 127, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -16875,7 +17017,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: ~r1}
+                  Variable: {subprogram: 127, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -16885,7 +17027,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 3, name: ~r2}
+                  Variable: {subprogram: 127, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -16915,7 +17057,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1413
+      ID: 1414
       Name: Probe[main.testStringPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16927,7 +17069,7 @@ Types:
             Type: 93 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: z}
+                  Variable: {subprogram: 94, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: z
@@ -16937,11 +17079,11 @@ Types:
             Type: 93 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: z}
+                  Variable: {subprogram: 94, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1500
+      ID: 1501
       Name: Probe[main.testStringSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16953,7 +17095,7 @@ Types:
             Type: 261 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: s}
+                  Variable: {subprogram: 137, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: s
@@ -16963,11 +17105,11 @@ Types:
             Type: 261 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: s}
+                  Variable: {subprogram: 137, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1348
+      ID: 1349
       Name: Probe[main.testStringType1]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16979,7 +17121,7 @@ Types:
             Type: 149 PointerType *main.stringType1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 0, name: a}
+                  Variable: {subprogram: 45, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -16989,11 +17131,11 @@ Types:
             Type: 149 PointerType *main.stringType1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 0, name: a}
+                  Variable: {subprogram: 45, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1349
+      ID: 1350
       Name: Probe[main.testStringType2]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17005,7 +17147,7 @@ Types:
             Type: 151 PointerType **main.stringType2
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: a}
+                  Variable: {subprogram: 46, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -17015,11 +17157,11 @@ Types:
             Type: 151 PointerType **main.stringType2
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: a}
+                  Variable: {subprogram: 46, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1497
+      ID: 1498
       Name: Probe[main.testStructSlice]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -17031,7 +17173,7 @@ Types:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Variable: {subprogram: 134, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -17041,7 +17183,7 @@ Types:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Variable: {subprogram: 134, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -17051,7 +17193,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 1, name: a}
+                  Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -17061,11 +17203,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 1, name: a}
+                  Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1376
+      ID: 1377
       Name: Probe[main.testStructWithAny]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17077,7 +17219,7 @@ Types:
             Type: 162 StructureType main.structWithAny
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: s}
+                  Variable: {subprogram: 60, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
         - Name: s
@@ -17087,11 +17229,11 @@ Types:
             Type: 162 StructureType main.structWithAny
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: s}
+                  Variable: {subprogram: 60, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1490
+      ID: 1491
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17103,7 +17245,7 @@ Types:
             Type: 254 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: arg}
+                  Variable: {subprogram: 129, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
         - Name: arg
@@ -17113,11 +17255,11 @@ Types:
             Type: 254 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: arg}
+                  Variable: {subprogram: 129, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1491
+      ID: 1492
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17129,7 +17271,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 1, name: ~r0}
+                  Variable: {subprogram: 129, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -17139,11 +17281,11 @@ Types:
             Type: 254 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 2, name: ~r1}
+                  Variable: {subprogram: 129, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1524
+      ID: 1525
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17155,7 +17297,7 @@ Types:
             Type: 283 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: a}
+                  Variable: {subprogram: 154, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
         - Name: a
@@ -17165,14 +17307,14 @@ Types:
             Type: 283 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: a}
+                  Variable: {subprogram: 154, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1525
+      ID: 1526
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1523
+      ID: 1524
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 289
       PresenceBitsetSize: 1
@@ -17184,7 +17326,7 @@ Types:
             Type: 270 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: a}
+                  Variable: {subprogram: 153, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
         - Name: a
@@ -17194,11 +17336,11 @@ Types:
             Type: 270 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: a}
+                  Variable: {subprogram: 153, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
     - __kind: EventRootType
-      ID: 1377
+      ID: 1378
       Name: Probe[main.testStructWithMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17210,7 +17352,7 @@ Types:
             Type: 163 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: s}
+                  Variable: {subprogram: 61, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
         - Name: s
@@ -17220,11 +17362,11 @@ Types:
             Type: 163 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: s}
+                  Variable: {subprogram: 61, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1526
+      ID: 1527
       Name: Probe[main.testStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17236,11 +17378,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 8
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1528
+      ID: 1529
       Name: Probe[main.testStruct]
       ByteSize: 113
       PresenceBitsetSize: 1
@@ -17252,7 +17394,7 @@ Types:
             Type: 314 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
         - Name: x
@@ -17262,17 +17404,17 @@ Types:
             Type: 314 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1527
+      ID: 1528
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1529
+      ID: 1530
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1506
+      ID: 1507
       Name: Probe[main.testSubslices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -17284,7 +17426,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: as}
+                  Variable: {subprogram: 142, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
         - Name: as
@@ -17294,7 +17436,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: as}
+                  Variable: {subprogram: 142, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
         - Name: bs
@@ -17304,7 +17446,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 1, name: bs}
+                  Variable: {subprogram: 142, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
         - Name: bs
@@ -17314,7 +17456,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 1, name: bs}
+                  Variable: {subprogram: 142, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
         - Name: cs
@@ -17324,7 +17466,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 2, name: cs}
+                  Variable: {subprogram: 142, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
         - Name: cs
@@ -17334,11 +17476,11 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 2, name: cs}
+                  Variable: {subprogram: 142, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1522
+      ID: 1523
       Name: Probe[main.testSubstrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17350,7 +17492,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: a}
+                  Variable: {subprogram: 152, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -17360,7 +17502,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: a}
+                  Variable: {subprogram: 152, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -17370,7 +17512,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 1, name: b}
+                  Variable: {subprogram: 152, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -17380,7 +17522,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 1, name: b}
+                  Variable: {subprogram: 152, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: c
@@ -17390,7 +17532,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 2, name: c}
+                  Variable: {subprogram: 152, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
         - Name: c
@@ -17400,11 +17542,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 2, name: c}
+                  Variable: {subprogram: 152, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1515
+      ID: 1516
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17416,7 +17558,7 @@ Types:
             Type: 267 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -17426,11 +17568,11 @@ Types:
             Type: 267 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1516
+      ID: 1517
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17442,7 +17584,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -17455,7 +17597,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -17468,14 +17610,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
                   Bias: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1511
+      ID: 1512
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17487,7 +17629,7 @@ Types:
             Type: 266 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
         - Name: a
@@ -17497,11 +17639,11 @@ Types:
             Type: 266 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1513
+      ID: 1514
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17513,7 +17655,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: t.b
@@ -17523,7 +17665,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 16
                   ByteSize: 16
         - Name: t.c
@@ -17533,17 +17675,17 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1512
+      ID: 1513
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1514
+      ID: 1515
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1510
+      ID: 1511
       Name: Probe[main.testThreeStrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17555,7 +17697,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: x}
+                  Variable: {subprogram: 145, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -17565,7 +17707,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: x}
+                  Variable: {subprogram: 145, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -17575,7 +17717,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 1, name: y}
+                  Variable: {subprogram: 145, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -17585,7 +17727,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 1, name: y}
+                  Variable: {subprogram: 145, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -17595,7 +17737,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 2, name: z}
+                  Variable: {subprogram: 145, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -17605,7 +17747,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 2, name: z}
+                  Variable: {subprogram: 145, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -17765,7 +17907,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1412
+      ID: 1413
       Name: Probe[main.testUintPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17777,7 +17919,7 @@ Types:
             Type: 105 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: x}
+                  Variable: {subprogram: 93, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -17787,11 +17929,11 @@ Types:
             Type: 105 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: x}
+                  Variable: {subprogram: 93, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1494
+      ID: 1495
       Name: Probe[main.testUintSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17803,7 +17945,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: u}
+                  Variable: {subprogram: 131, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -17813,11 +17955,11 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: u}
+                  Variable: {subprogram: 131, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1520
+      ID: 1521
       Name: Probe[main.testUnitializedString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17829,7 +17971,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: x}
+                  Variable: {subprogram: 150, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -17839,11 +17981,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: x}
+                  Variable: {subprogram: 150, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1411
+      ID: 1412
       Name: Probe[main.testUnsafePointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17855,7 +17997,7 @@ Types:
             Type: 15 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: x}
+                  Variable: {subprogram: 92, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -17865,7 +18007,7 @@ Types:
             Type: 15 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: x}
+                  Variable: {subprogram: 92, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -17895,32 +18037,6 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1503
-      Name: Probe[main.testVeryLargeSlice]
-      ByteSize: 49
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: xs
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 255 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: xs
-          Offset: 25
-          Kind: template_segment
-          Expression:
-            Type: 255 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
       ID: 1504
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
@@ -17933,7 +18049,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: xs}
+                  Variable: {subprogram: 140, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -17943,11 +18059,37 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: xs}
+                  Variable: {subprogram: 140, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1492
+      ID: 1505
+      Name: Probe[main.testVeryLargeSlice]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 255 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 140, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: xs
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 255 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 140, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1493
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17959,7 +18101,7 @@ Types:
             Type: 251 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: a}
+                  Variable: {subprogram: 130, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
         - Name: a
@@ -17969,7 +18111,7 @@ Types:
             Type: 251 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: a}
+                  Variable: {subprogram: 130, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
         - Name: b
@@ -17979,7 +18121,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 1, name: b}
+                  Variable: {subprogram: 130, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -17989,11 +18131,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 1, name: b}
+                  Variable: {subprogram: 130, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1493
+      ID: 1494
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -18005,7 +18147,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 2, name: ~r0}
+                  Variable: {subprogram: 130, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -18015,7 +18157,7 @@ Types:
             Type: 251 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 3, name: ~r1}
+                  Variable: {subprogram: 130, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 0
     - __kind: ArrayType
@@ -26523,7 +26665,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 989760
       GoKind: 5
-MaxTypeID: 1551
+MaxTypeID: 1552
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x132d360", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -8,15 +8,15 @@ Probes:
       template: stackC
       segments: [stackC]
       captureSnapshot: true
-      subprogram: {subprogram: 142}
+      subprogram: {subprogram: 143}
       events:
         - Kind: Entry
-          Type: 1526 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0x80c388", Frameless: false}]
+          Type: 1527 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0x80c488", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1527 EventRootType Probe[main.stackC]Return
-          InjectionPoints: [{PC: "0x80c3b8", Frameless: false}]
+          Type: 1528 EventRootType Probe[main.stackC]Return
+          InjectionPoints: [{PC: "0x80c4b8", Frameless: false}]
           Condition: null
       probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -27,15 +27,15 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 56}
+      subprogram: {subprogram: 57}
       events:
         - Kind: Entry
-          Type: 1390 EventRootType Probe[main.testAny]
-          InjectionPoints: [{PC: "0x807c18", Frameless: false}]
+          Type: 1391 EventRootType Probe[main.testAny]
+          InjectionPoints: [{PC: "0x807d18", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1391 EventRootType Probe[main.testAny]Return
-          InjectionPoints: [{PC: "0x807c40", Frameless: false}]
+          Type: 1392 EventRootType Probe[main.testAny]Return
+          InjectionPoints: [{PC: "0x807d40", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -52,15 +52,15 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 58}
+      subprogram: {subprogram: 59}
       events:
         - Kind: Entry
-          Type: 1393 EventRootType Probe[main.testAnyPtr]
-          InjectionPoints: [{PC: "0x807c88", Frameless: false}]
+          Type: 1394 EventRootType Probe[main.testAnyPtr]
+          InjectionPoints: [{PC: "0x807d88", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1394 EventRootType Probe[main.testAnyPtr]Return
-          InjectionPoints: [{PC: "0x807cb0", Frameless: false}]
+          Type: 1395 EventRootType Probe[main.testAnyPtr]Return
+          InjectionPoints: [{PC: "0x807db0", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -76,15 +76,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 122}
+      subprogram: {subprogram: 123}
       events:
         - Kind: Entry
-          Type: 1497 EventRootType Probe[main.testArrayArgAndReturn]
-          InjectionPoints: [{PC: "0x80b29c", Frameless: false}]
+          Type: 1498 EventRootType Probe[main.testArrayArgAndReturn]
+          InjectionPoints: [{PC: "0x80b39c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1498 EventRootType Probe[main.testArrayArgAndReturn]Return
-          InjectionPoints: [{PC: "0x80b328", Frameless: false}]
+          Type: 1499 EventRootType Probe[main.testArrayArgAndReturn]Return
+          InjectionPoints: [{PC: "0x80b428", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -164,11 +164,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 66}
+      subprogram: {subprogram: 67}
       events:
         - Kind: Entry
-          Type: 1402 EventRootType Probe[main.testArrayOfMaps]
-          InjectionPoints: [{PC: "0x808280", Frameless: true}]
+          Type: 1403 EventRootType Probe[main.testArrayOfMaps]
+          InjectionPoints: [{PC: "0x808380", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -226,15 +226,15 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 87}
       events:
         - Kind: Entry
-          Type: 1424 EventRootType Probe[main.testAtomicAdd]
-          InjectionPoints: [{PC: "0x8099d0", Frameless: true}]
+          Type: 1425 EventRootType Probe[main.testAtomicAdd]
+          InjectionPoints: [{PC: "0x809ad0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1425 EventRootType Probe[main.testAtomicAdd]Return
-          InjectionPoints: [{PC: "0x809a0c", Frameless: true}]
+          Type: 1426 EventRootType Probe[main.testAtomicAdd]Return
+          InjectionPoints: [{PC: "0x809b0c", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -323,15 +323,15 @@ Probes:
           expr:
             dsl: x.aString
             json: {getmember: [{ref: x}, aString]}
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1545 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0x80c670", Frameless: true}]
+          Type: 1546 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0x80c770", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1546 EventRootType Probe[main.testStruct]Return
-          InjectionPoints: [{PC: "0x80c680", Frameless: true}]
+          Type: 1547 EventRootType Probe[main.testStruct]Return
+          InjectionPoints: [{PC: "0x80c780", Frameless: true}]
           Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -345,20 +345,20 @@ Probes:
       segments: []
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1555 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1556 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
-            - PC: "0x807538"
+            - PC: "0x807638"
               Frameless: false
-            - PC: "0x8075ac"
+            - PC: "0x8076ac"
               Frameless: false
-            - PC: "0x8076e8"
+            - PC: "0x8077e8"
               Frameless: false
-            - PC: "0x807764"
+            - PC: "0x807864"
               Frameless: false
-            - PC: "0x80781c"
+            - PC: "0x80791c"
               Frameless: false
           Condition: null
     - id: testCaptureExprLineWithTemplate
@@ -373,20 +373,20 @@ Probes:
       segments: [x=, {json: {ref: x}, dsl: x}]
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1556 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1557 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
-            - PC: "0x807538"
+            - PC: "0x807638"
               Frameless: false
-            - PC: "0x8075ac"
+            - PC: "0x8076ac"
               Frameless: false
-            - PC: "0x8076e8"
+            - PC: "0x8077e8"
               Frameless: false
-            - PC: "0x807764"
+            - PC: "0x807864"
               Frameless: false
-            - PC: "0x80781c"
+            - PC: "0x80791c"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -409,11 +409,11 @@ Probes:
           expr: {dsl: x, json: {ref: x}}
         - name: w_val
           expr: {dsl: w, json: {ref: w}}
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 85}
       events:
         - Kind: Entry
-          Type: 1421 EventRootType Probe[main.testCombinedString]
-          InjectionPoints: [{PC: "0x809770", Frameless: true}]
+          Type: 1422 EventRootType Probe[main.testCombinedString]
+          InjectionPoints: [{PC: "0x809870", Frameless: true}]
           Condition: null
     - id: testCaptureExprWithTemplate
       version: 0
@@ -427,11 +427,11 @@ Probes:
           expr: {dsl: x, json: {ref: x}}
         - name: w_val
           expr: {dsl: w, json: {ref: w}}
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 85}
       events:
         - Kind: Entry
-          Type: 1422 EventRootType Probe[main.testCombinedString]
-          InjectionPoints: [{PC: "0x809770", Frameless: true}]
+          Type: 1423 EventRootType Probe[main.testCombinedString]
+          InjectionPoints: [{PC: "0x809870", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: x={x}
@@ -449,11 +449,11 @@ Probes:
       template: '{c}'
       segments: [{json: {ref: c}, dsl: c}]
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 88}
       events:
         - Kind: Entry
-          Type: 1426 EventRootType Probe[main.testChannel]
-          InjectionPoints: [{PC: "0x809a10", Frameless: true}]
+          Type: 1427 EventRootType Probe[main.testChannel]
+          InjectionPoints: [{PC: "0x809b10", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{c}'
@@ -478,11 +478,11 @@ Probes:
         - json: {ref: y}
           dsl: y
       captureSnapshot: true
-      subprogram: {subprogram: 83}
+      subprogram: {subprogram: 84}
       events:
         - Kind: Entry
-          Type: 1420 EventRootType Probe[main.testCombinedByte]
-          InjectionPoints: [{PC: "0x809750", Frameless: true}]
+          Type: 1421 EventRootType Probe[main.testCombinedByte]
+          InjectionPoints: [{PC: "0x809850", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{w}, {x}, {y}'
@@ -509,11 +509,11 @@ Probes:
       template: '{t}'
       segments: [{json: {ref: t}, dsl: t}]
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 96}
       events:
         - Kind: Entry
-          Type: 1434 EventRootType Probe[main.testCycle]
-          InjectionPoints: [{PC: "0x809ca0", Frameless: true}]
+          Type: 1435 EventRootType Probe[main.testCycle]
+          InjectionPoints: [{PC: "0x809da0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{t}'
@@ -530,11 +530,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 42}
+      subprogram: {subprogram: 43}
       events:
         - Kind: Entry
-          Type: 1365 EventRootType Probe[main.testDeepMap1]
-          InjectionPoints: [{PC: "0x806c90", Frameless: true}]
+          Type: 1366 EventRootType Probe[main.testDeepMap1]
+          InjectionPoints: [{PC: "0x806d90", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -551,11 +551,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 43}
+      subprogram: {subprogram: 44}
       events:
         - Kind: Entry
-          Type: 1366 EventRootType Probe[main.testDeepMap7]
-          InjectionPoints: [{PC: "0x806ca0", Frameless: true}]
+          Type: 1367 EventRootType Probe[main.testDeepMap7]
+          InjectionPoints: [{PC: "0x806da0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -572,11 +572,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 38}
+      subprogram: {subprogram: 39}
       events:
         - Kind: Entry
-          Type: 1361 EventRootType Probe[main.testDeepPtr1]
-          InjectionPoints: [{PC: "0x8069b0", Frameless: true}]
+          Type: 1362 EventRootType Probe[main.testDeepPtr1]
+          InjectionPoints: [{PC: "0x806ab0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -593,11 +593,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 39}
+      subprogram: {subprogram: 40}
       events:
         - Kind: Entry
-          Type: 1362 EventRootType Probe[main.testDeepPtr7]
-          InjectionPoints: [{PC: "0x8069c0", Frameless: true}]
+          Type: 1363 EventRootType Probe[main.testDeepPtr7]
+          InjectionPoints: [{PC: "0x806ac0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -614,11 +614,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 40}
+      subprogram: {subprogram: 41}
       events:
         - Kind: Entry
-          Type: 1363 EventRootType Probe[main.testDeepSlice1]
-          InjectionPoints: [{PC: "0x806b30", Frameless: true}]
+          Type: 1364 EventRootType Probe[main.testDeepSlice1]
+          InjectionPoints: [{PC: "0x806c30", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -635,11 +635,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 41}
+      subprogram: {subprogram: 42}
       events:
         - Kind: Entry
-          Type: 1364 EventRootType Probe[main.testDeepSlice7]
-          InjectionPoints: [{PC: "0x806b40", Frameless: true}]
+          Type: 1365 EventRootType Probe[main.testDeepSlice7]
+          InjectionPoints: [{PC: "0x806c40", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -656,11 +656,11 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 131}
+      subprogram: {subprogram: 132}
       events:
         - Kind: Entry
-          Type: 1514 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0x80bfe0", Frameless: true}]
+          Type: 1515 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0x80c0e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{u}'
@@ -682,11 +682,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 134}
+      subprogram: {subprogram: 135}
       events:
         - Kind: Entry
-          Type: 1517 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0x80c010", Frameless: true}]
+          Type: 1518 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0x80c110", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}, {a}'
@@ -709,11 +709,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 150}
+      subprogram: {subprogram: 151}
       events:
         - Kind: Entry
-          Type: 1540 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0x80c440", Frameless: true}]
+          Type: 1541 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0x80c540", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -730,11 +730,11 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 156}
+      subprogram: {subprogram: 157}
       events:
         - Kind: Entry
-          Type: 1553 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0x80c740", Frameless: true}]
+          Type: 1554 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0x80c840", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -750,11 +750,11 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 157}
+      subprogram: {subprogram: 158}
       events:
         - Kind: Entry
-          Type: 1554 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0x80c750", Frameless: true}]
+          Type: 1555 EventRootType Probe[main.testEmptyStructPointer]
+          InjectionPoints: [{PC: "0x80c850", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -771,11 +771,11 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 57}
+      subprogram: {subprogram: 58}
       events:
         - Kind: Entry
-          Type: 1392 EventRootType Probe[main.testError]
-          InjectionPoints: [{PC: "0x807c60", Frameless: true}]
+          Type: 1393 EventRootType Probe[main.testError]
+          InjectionPoints: [{PC: "0x807d60", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -784,6 +784,45 @@ Probes:
               DSL: e
               EventKind: Entry
               EventExpressionIndex: 1
+    - id: testErrorAtLine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testErrorAtLine
+        sourceFile: complex.go
+        lines: ["108"]
+      tags:
+        - config_diff:arch=amd64,toolchain=go1.26rc1
+        - skip_integration:arch=arm64,toolchain=go1.25.0
+      sampling: {snapshotsPerSecond: 100}
+      template: x={x}, err={err}
+      segments:
+        - x=
+        - json: {ref: x}
+          dsl: x
+        - ', err='
+        - json: {ref: err}
+          dsl: err
+      captureSnapshot: true
+      subprogram: {subprogram: 38}
+      events:
+        - Kind: Line
+          Type: 1361 EventRootType Probe[main.testErrorAtLine]Line
+          InjectionPoints: [{PC: "0x80693c", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: x={x}, err={err}
+        Segments:
+            - x=
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Line
+              EventExpressionIndex: 3
+            - ', err='
+            - JSON: {Ref: err}
+              DSL: err
+              EventKind: Line
+              EventExpressionIndex: 5
     - id: testEsotericHeap
       version: 0
       type: LOG_PROBE
@@ -792,15 +831,15 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 48}
+      subprogram: {subprogram: 49}
       events:
         - Kind: Entry
-          Type: 1374 EventRootType Probe[main.testEsotericHeap]
-          InjectionPoints: [{PC: "0x8072b8", Frameless: false}]
+          Type: 1375 EventRootType Probe[main.testEsotericHeap]
+          InjectionPoints: [{PC: "0x8073b8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1375 EventRootType Probe[main.testEsotericHeap]Return
-          InjectionPoints: [{PC: "0x8072f0", Frameless: false}]
+          Type: 1376 EventRootType Probe[main.testEsotericHeap]Return
+          InjectionPoints: [{PC: "0x8073f0", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -817,15 +856,15 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 47}
+      subprogram: {subprogram: 48}
       events:
         - Kind: Entry
-          Type: 1372 EventRootType Probe[main.testEsotericStack]
-          InjectionPoints: [{PC: "0x8071fc", Frameless: false}]
+          Type: 1373 EventRootType Probe[main.testEsotericStack]
+          InjectionPoints: [{PC: "0x8072fc", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1373 EventRootType Probe[main.testEsotericStack]Return
-          InjectionPoints: [{PC: "0x807258", Frameless: false}]
+          Type: 1374 EventRootType Probe[main.testEsotericStack]Return
+          InjectionPoints: [{PC: "0x807358", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -842,15 +881,15 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 53}
+      subprogram: {subprogram: 54}
       events:
         - Kind: Entry
-          Type: 1384 EventRootType Probe[main.testFrameless]
-          InjectionPoints: [{PC: "0x807980", Frameless: true}]
+          Type: 1385 EventRootType Probe[main.testFrameless]
+          InjectionPoints: [{PC: "0x807a80", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1385 EventRootType Probe[main.testFrameless]Return
-          InjectionPoints: [{PC: "0x807988", Frameless: true}]
+          Type: 1386 EventRootType Probe[main.testFrameless]Return
+          InjectionPoints: [{PC: "0x807a88", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -867,15 +906,15 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 54}
+      subprogram: {subprogram: 55}
       events:
         - Kind: Entry
-          Type: 1386 EventRootType Probe[main.testFramelessArray]
-          InjectionPoints: [{PC: "0x80799c", Frameless: false}]
+          Type: 1387 EventRootType Probe[main.testFramelessArray]
+          InjectionPoints: [{PC: "0x807a9c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1387 EventRootType Probe[main.testFramelessArray]Return
-          InjectionPoints: [{PC: "0x8079d0", Frameless: false}]
+          Type: 1388 EventRootType Probe[main.testFramelessArray]Return
+          InjectionPoints: [{PC: "0x807ad0", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -895,11 +934,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 54}
+      subprogram: {subprogram: 55}
       events:
         - Kind: Line
-          Type: 1388 EventRootType Probe[main.testFramelessArray]Line
-          InjectionPoints: [{PC: "0x80799c", Frameless: false}]
+          Type: 1389 EventRootType Probe[main.testFramelessArray]Line
+          InjectionPoints: [{PC: "0x807a9c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -916,15 +955,15 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 49}
+      subprogram: {subprogram: 50}
       events:
         - Kind: Entry
-          Type: 1376 EventRootType Probe[main.testInlinedBA]
-          InjectionPoints: [{PC: "0x8076c8", Frameless: false}]
+          Type: 1377 EventRootType Probe[main.testInlinedBA]
+          InjectionPoints: [{PC: "0x8077c8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1377 EventRootType Probe[main.testInlinedBA]Return
-          InjectionPoints: [{PC: "0x80771c", Frameless: false}]
+          Type: 1378 EventRootType Probe[main.testInlinedBA]Return
+          InjectionPoints: [{PC: "0x80781c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -946,15 +985,15 @@ Probes:
         - json: {ref: y}
           dsl: y
       captureSnapshot: true
-      subprogram: {subprogram: 50}
+      subprogram: {subprogram: 51}
       events:
         - Kind: Entry
-          Type: 1378 EventRootType Probe[main.testInlinedBB]
-          InjectionPoints: [{PC: "0x807758", Frameless: false}]
+          Type: 1379 EventRootType Probe[main.testInlinedBB]
+          InjectionPoints: [{PC: "0x807858", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1379 EventRootType Probe[main.testInlinedBB]Return
-          InjectionPoints: [{PC: "0x8077d8", Frameless: false}]
+          Type: 1380 EventRootType Probe[main.testInlinedBB]Return
+          InjectionPoints: [{PC: "0x8078d8", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}, {y}'
@@ -976,15 +1015,15 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 51}
+      subprogram: {subprogram: 52}
       events:
         - Kind: Entry
-          Type: 1380 EventRootType Probe[main.testInlinedBBA]
-          InjectionPoints: [{PC: "0x807818", Frameless: false}]
+          Type: 1381 EventRootType Probe[main.testInlinedBBA]
+          InjectionPoints: [{PC: "0x807918", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1381 EventRootType Probe[main.testInlinedBBA]Return
-          InjectionPoints: [{PC: "0x807850", Frameless: false}]
+          Type: 1382 EventRootType Probe[main.testInlinedBBA]Return
+          InjectionPoints: [{PC: "0x807950", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1001,11 +1040,11 @@ Probes:
       template: testInlinedBBB
       segments: [testInlinedBBB]
       captureSnapshot: true
-      subprogram: {subprogram: 159}
+      subprogram: {subprogram: 160}
       events:
         - Kind: Entry
-          Type: 1560 EventRootType Probe[main.testInlinedBBB]
-          InjectionPoints: [{PC: "0x8077a4", Frameless: false}]
+          Type: 1561 EventRootType Probe[main.testInlinedBBB]
+          InjectionPoints: [{PC: "0x8078a4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBBB
@@ -1018,15 +1057,15 @@ Probes:
       template: testInlinedBC
       segments: [testInlinedBC]
       captureSnapshot: true
-      subprogram: {subprogram: 52}
+      subprogram: {subprogram: 53}
       events:
         - Kind: Entry
-          Type: 1382 EventRootType Probe[main.testInlinedBC]
-          InjectionPoints: [{PC: "0x807888", Frameless: false}]
+          Type: 1383 EventRootType Probe[main.testInlinedBC]
+          InjectionPoints: [{PC: "0x807988", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1383 EventRootType Probe[main.testInlinedBC]Return
-          InjectionPoints: [{PC: "0x807964", Frameless: false}]
+          Type: 1384 EventRootType Probe[main.testInlinedBC]Return
+          InjectionPoints: [{PC: "0x807a64", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBC
@@ -1039,11 +1078,11 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Entry
-          Type: 1561 EventRootType Probe[main.testInlinedBCA]
-          InjectionPoints: [{PC: "0x80788c", Frameless: false}]
+          Type: 1562 EventRootType Probe[main.testInlinedBCA]
+          InjectionPoints: [{PC: "0x80798c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBCA
@@ -1059,11 +1098,11 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Line
-          Type: 1562 EventRootType Probe[main.testInlinedBCA]Line
-          InjectionPoints: [{PC: "0x80788c", Frameless: false}]
+          Type: 1563 EventRootType Probe[main.testInlinedBCA]Line
+          InjectionPoints: [{PC: "0x80798c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBCA
@@ -1076,11 +1115,11 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Entry
-          Type: 1563 EventRootType Probe[main.testInlinedBCB]
-          InjectionPoints: [{PC: "0x807930", Frameless: false}]
+          Type: 1564 EventRootType Probe[main.testInlinedBCB]
+          InjectionPoints: [{PC: "0x807a30", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBCB
@@ -1096,11 +1135,11 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Line
-          Type: 1564 EventRootType Probe[main.testInlinedBCB]Line
-          InjectionPoints: [{PC: "0x807930", Frameless: false}]
+          Type: 1565 EventRootType Probe[main.testInlinedBCB]Line
+          InjectionPoints: [{PC: "0x807a30", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBCB
@@ -1113,14 +1152,14 @@ Probes:
       template: testInlinedFuncFromOtherPackage
       segments: [testInlinedFuncFromOtherPackage]
       captureSnapshot: true
-      subprogram: {subprogram: 165}
+      subprogram: {subprogram: 166}
       events:
         - Kind: Entry
-          Type: 1570 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
+          Type: 1571 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
           InjectionPoints:
             - PC: "0x805df8"
               Frameless: true
-            - PC: "0x808158"
+            - PC: "0x808258"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -1135,25 +1174,25 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Entry
-          Type: 1557 EventRootType Probe[main.testInlinedPrint]
+          Type: 1558 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
-            - PC: "0x807538"
+            - PC: "0x807638"
               Frameless: false
-            - PC: "0x8075ac"
+            - PC: "0x8076ac"
               Frameless: false
-            - PC: "0x8076e8"
+            - PC: "0x8077e8"
               Frameless: false
-            - PC: "0x807764"
+            - PC: "0x807864"
               Frameless: false
-            - PC: "0x80781c"
+            - PC: "0x80791c"
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1558 EventRootType Probe[main.testInlinedPrint]Return
-          InjectionPoints: [{PC: "0x80756c", Frameless: false}]
+          Type: 1559 EventRootType Probe[main.testInlinedPrint]Return
+          InjectionPoints: [{PC: "0x80766c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1173,20 +1212,20 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1559 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1560 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
-            - PC: "0x807538"
+            - PC: "0x807638"
               Frameless: false
-            - PC: "0x8075ac"
+            - PC: "0x8076ac"
               Frameless: false
-            - PC: "0x8076e8"
+            - PC: "0x8077e8"
               Frameless: false
-            - PC: "0x807764"
+            - PC: "0x807864"
               Frameless: false
-            - PC: "0x80781c"
+            - PC: "0x80791c"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -1204,11 +1243,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 162}
+      subprogram: {subprogram: 163}
       events:
         - Kind: Entry
-          Type: 1565 EventRootType Probe[main.testInlinedSq]
-          InjectionPoints: [{PC: "0x807984", Frameless: true}]
+          Type: 1566 EventRootType Probe[main.testInlinedSq]
+          InjectionPoints: [{PC: "0x807a84", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1228,11 +1267,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 162}
+      subprogram: {subprogram: 163}
       events:
         - Kind: Line
-          Type: 1566 EventRootType Probe[main.testInlinedSq]Line
-          InjectionPoints: [{PC: "0x807984", Frameless: true}]
+          Type: 1567 EventRootType Probe[main.testInlinedSq]Line
+          InjectionPoints: [{PC: "0x807a84", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1250,14 +1289,14 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 163}
+      subprogram: {subprogram: 164}
       events:
         - Kind: Entry
-          Type: 1567 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1568 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
-            - PC: "0x8079b4"
+            - PC: "0x807ab4"
               Frameless: false
-            - PC: "0x807a3c"
+            - PC: "0x807b3c"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -1380,11 +1419,11 @@ Probes:
       template: '{b}'
       segments: [{json: {ref: b}, dsl: b}]
       captureSnapshot: true
-      subprogram: {subprogram: 55}
+      subprogram: {subprogram: 56}
       events:
         - Kind: Entry
-          Type: 1389 EventRootType Probe[main.testInterface]
-          InjectionPoints: [{PC: "0x807bf0", Frameless: true}]
+          Type: 1390 EventRootType Probe[main.testInterface]
+          InjectionPoints: [{PC: "0x807cf0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{b}'
@@ -1400,15 +1439,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 121}
+      subprogram: {subprogram: 122}
       events:
         - Kind: Entry
-          Type: 1495 EventRootType Probe[main.testLargeArgAndReturn]
-          InjectionPoints: [{PC: "0x80b110", Frameless: false}]
+          Type: 1496 EventRootType Probe[main.testLargeArgAndReturn]
+          InjectionPoints: [{PC: "0x80b210", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1496 EventRootType Probe[main.testLargeArgAndReturn]Return
-          InjectionPoints: [{PC: "0x80b238", Frameless: false}]
+          Type: 1497 EventRootType Probe[main.testLargeArgAndReturn]Return
+          InjectionPoints: [{PC: "0x80b338", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -1425,11 +1464,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 90}
       events:
         - Kind: Entry
-          Type: 1428 EventRootType Probe[main.testLinkedList]
-          InjectionPoints: [{PC: "0x809bb0", Frameless: true}]
+          Type: 1429 EventRootType Probe[main.testLinkedList]
+          InjectionPoints: [{PC: "0x809cb0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -1444,16 +1483,16 @@ Probes:
       where:
         methodName: main.testLongFunctionWithChangingState
         sourceFile: complex.go
-        lines: ["211"]
+        lines: ["230"]
       sampling: {snapshotsPerSecond: 100}
       template: testLongFunctionWithChangingState
       segments: [testLongFunctionWithChangingState]
       captureSnapshot: true
-      subprogram: {subprogram: 46}
+      subprogram: {subprogram: 47}
       events:
         - Kind: Line
-          Type: 1369 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-          InjectionPoints: [{PC: "0x806cec", Frameless: false}]
+          Type: 1370 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          InjectionPoints: [{PC: "0x806dec", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testLongFunctionWithChangingState
@@ -1464,17 +1503,17 @@ Probes:
       where:
         methodName: main.testLongFunctionWithChangingState
         sourceFile: complex.go
-        lines: ["218"]
+        lines: ["237"]
       tags: ['version_diff:go1.26rc1']
       sampling: {snapshotsPerSecond: 100}
       template: testLongFunctionWithChangingState
       segments: [testLongFunctionWithChangingState]
       captureSnapshot: true
-      subprogram: {subprogram: 46}
+      subprogram: {subprogram: 47}
       events:
         - Kind: Line
-          Type: 1370 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-          InjectionPoints: [{PC: "0x806d70", Frameless: false}]
+          Type: 1371 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          InjectionPoints: [{PC: "0x806e70", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testLongFunctionWithChangingState
@@ -1485,17 +1524,17 @@ Probes:
       where:
         methodName: main.testLongFunctionWithChangingState
         sourceFile: complex.go
-        lines: ["223"]
+        lines: ["242"]
       tags: ['version_diff:go1.26rc1']
       sampling: {snapshotsPerSecond: 100}
       template: testLongFunctionWithChangingState
       segments: [testLongFunctionWithChangingState]
       captureSnapshot: true
-      subprogram: {subprogram: 46}
+      subprogram: {subprogram: 47}
       events:
         - Kind: Line
-          Type: 1371 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-          InjectionPoints: [{PC: "0x806e0c", Frameless: false}]
+          Type: 1372 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          InjectionPoints: [{PC: "0x806f0c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testLongFunctionWithChangingState
@@ -1533,15 +1572,15 @@ Probes:
         - json: {ref: i}
           dsl: i
       captureSnapshot: true
-      subprogram: {subprogram: 124}
+      subprogram: {subprogram: 125}
       events:
         - Kind: Entry
-          Type: 1501 EventRootType Probe[main.testManyArgsArrayReturn]
-          InjectionPoints: [{PC: "0x80b56c", Frameless: false}]
+          Type: 1502 EventRootType Probe[main.testManyArgsArrayReturn]
+          InjectionPoints: [{PC: "0x80b66c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1502 EventRootType Probe[main.testManyArgsArrayReturn]Return
-          InjectionPoints: [{PC: "0x80b6ac", Frameless: false}]
+          Type: 1503 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          InjectionPoints: [{PC: "0x80b7ac", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -1598,11 +1637,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 64}
+      subprogram: {subprogram: 65}
       events:
         - Kind: Entry
-          Type: 1400 EventRootType Probe[main.testMapArrayToArray]
-          InjectionPoints: [{PC: "0x808260", Frameless: true}]
+          Type: 1401 EventRootType Probe[main.testMapArrayToArray]
+          InjectionPoints: [{PC: "0x808360", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1619,11 +1658,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 70}
+      subprogram: {subprogram: 71}
       events:
         - Kind: Entry
-          Type: 1407 EventRootType Probe[main.testMapEmbeddedMaps]
-          InjectionPoints: [{PC: "0x8082c0", Frameless: true}]
+          Type: 1408 EventRootType Probe[main.testMapEmbeddedMaps]
+          InjectionPoints: [{PC: "0x8083c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1640,11 +1679,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 80}
+      subprogram: {subprogram: 81}
       events:
         - Kind: Entry
-          Type: 1417 EventRootType Probe[main.testMapEmptyKey]
-          InjectionPoints: [{PC: "0x808360", Frameless: true}]
+          Type: 1418 EventRootType Probe[main.testMapEmptyKey]
+          InjectionPoints: [{PC: "0x808460", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1661,11 +1700,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 82}
+      subprogram: {subprogram: 83}
       events:
         - Kind: Entry
-          Type: 1419 EventRootType Probe[main.testMapEmptyKeyAndValue]
-          InjectionPoints: [{PC: "0x808380", Frameless: true}]
+          Type: 1420 EventRootType Probe[main.testMapEmptyKeyAndValue]
+          InjectionPoints: [{PC: "0x808480", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1682,11 +1721,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 81}
+      subprogram: {subprogram: 82}
       events:
         - Kind: Entry
-          Type: 1418 EventRootType Probe[main.testMapEmptyValue]
-          InjectionPoints: [{PC: "0x808370", Frameless: true}]
+          Type: 1419 EventRootType Probe[main.testMapEmptyValue]
+          InjectionPoints: [{PC: "0x808470", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1703,11 +1742,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 68}
+      subprogram: {subprogram: 69}
       events:
         - Kind: Entry
-          Type: 1404 EventRootType Probe[main.testMapIntToInt]
-          InjectionPoints: [{PC: "0x8082a0", Frameless: true}]
+          Type: 1405 EventRootType Probe[main.testMapIntToInt]
+          InjectionPoints: [{PC: "0x8083a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1724,11 +1763,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 79}
+      subprogram: {subprogram: 80}
       events:
         - Kind: Entry
-          Type: 1416 EventRootType Probe[main.testMapLargeKeyLargeValue]
-          InjectionPoints: [{PC: "0x808350", Frameless: true}]
+          Type: 1417 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          InjectionPoints: [{PC: "0x808450", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1745,11 +1784,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 78}
+      subprogram: {subprogram: 79}
       events:
         - Kind: Entry
-          Type: 1415 EventRootType Probe[main.testMapLargeKeySmallValue]
-          InjectionPoints: [{PC: "0x808340", Frameless: true}]
+          Type: 1416 EventRootType Probe[main.testMapLargeKeySmallValue]
+          InjectionPoints: [{PC: "0x808440", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1768,11 +1807,11 @@ Probes:
         - json: {ref: redactMyEntries}
           dsl: redactMyEntries
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 70}
       events:
         - Kind: Entry
-          Type: 1405 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0x8082b0", Frameless: true}]
+          Type: 1406 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0x8083b0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{redactMyEntries}'
@@ -1791,11 +1830,11 @@ Probes:
         - json: {ref: redactMyEntries}
           dsl: redactMyEntries
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 70}
       events:
         - Kind: Entry
-          Type: 1406 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0x8082b0", Frameless: true}]
+          Type: 1407 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0x8083b0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{redactMyEntries}'
@@ -1812,11 +1851,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 77}
+      subprogram: {subprogram: 78}
       events:
         - Kind: Entry
-          Type: 1414 EventRootType Probe[main.testMapSmallKeyLargeValue]
-          InjectionPoints: [{PC: "0x808330", Frameless: true}]
+          Type: 1415 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          InjectionPoints: [{PC: "0x808430", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1833,11 +1872,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 76}
+      subprogram: {subprogram: 77}
       events:
         - Kind: Entry
-          Type: 1413 EventRootType Probe[main.testMapSmallKeySmallValue]
-          InjectionPoints: [{PC: "0x808320", Frameless: true}]
+          Type: 1414 EventRootType Probe[main.testMapSmallKeySmallValue]
+          InjectionPoints: [{PC: "0x808420", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1854,11 +1893,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 62}
+      subprogram: {subprogram: 63}
       events:
         - Kind: Entry
-          Type: 1398 EventRootType Probe[main.testMapStringToInt]
-          InjectionPoints: [{PC: "0x808240", Frameless: true}]
+          Type: 1399 EventRootType Probe[main.testMapStringToInt]
+          InjectionPoints: [{PC: "0x808340", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1875,11 +1914,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 63}
+      subprogram: {subprogram: 64}
       events:
         - Kind: Entry
-          Type: 1399 EventRootType Probe[main.testMapStringToSlice]
-          InjectionPoints: [{PC: "0x808250", Frameless: true}]
+          Type: 1400 EventRootType Probe[main.testMapStringToSlice]
+          InjectionPoints: [{PC: "0x808350", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1896,11 +1935,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 61}
+      subprogram: {subprogram: 62}
       events:
         - Kind: Entry
-          Type: 1397 EventRootType Probe[main.testMapStringToStruct]
-          InjectionPoints: [{PC: "0x808230", Frameless: true}]
+          Type: 1398 EventRootType Probe[main.testMapStringToStruct]
+          InjectionPoints: [{PC: "0x808330", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1917,11 +1956,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 71}
+      subprogram: {subprogram: 72}
       events:
         - Kind: Entry
-          Type: 1408 EventRootType Probe[main.testMapWithLinkedList]
-          InjectionPoints: [{PC: "0x8082d0", Frameless: true}]
+          Type: 1409 EventRootType Probe[main.testMapWithLinkedList]
+          InjectionPoints: [{PC: "0x8083d0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1938,11 +1977,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 74}
+      subprogram: {subprogram: 75}
       events:
         - Kind: Entry
-          Type: 1411 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-          InjectionPoints: [{PC: "0x808300", Frameless: true}]
+          Type: 1412 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          InjectionPoints: [{PC: "0x808400", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1959,11 +1998,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 75}
+      subprogram: {subprogram: 76}
       events:
         - Kind: Entry
-          Type: 1412 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-          InjectionPoints: [{PC: "0x808310", Frameless: true}]
+          Type: 1413 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          InjectionPoints: [{PC: "0x808410", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1980,11 +2019,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 72}
+      subprogram: {subprogram: 73}
       events:
         - Kind: Entry
-          Type: 1409 EventRootType Probe[main.testMapWithSmallValue]
-          InjectionPoints: [{PC: "0x8082e0", Frameless: true}]
+          Type: 1410 EventRootType Probe[main.testMapWithSmallValue]
+          InjectionPoints: [{PC: "0x8083e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -2003,11 +2042,11 @@ Probes:
         - json: {ref: redactMyEntries}
           dsl: redactMyEntries
       captureSnapshot: true
-      subprogram: {subprogram: 73}
+      subprogram: {subprogram: 74}
       events:
         - Kind: Entry
-          Type: 1410 EventRootType Probe[main.testMapWithSmallValueMassive]
-          InjectionPoints: [{PC: "0x8082f0", Frameless: true}]
+          Type: 1411 EventRootType Probe[main.testMapWithSmallValueMassive]
+          InjectionPoints: [{PC: "0x8083f0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{redactMyEntries}'
@@ -2024,11 +2063,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 148}
+      subprogram: {subprogram: 149}
       events:
         - Kind: Entry
-          Type: 1537 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0x80c420", Frameless: true}]
+          Type: 1538 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0x80c520", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -2046,11 +2085,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 148}
+      subprogram: {subprogram: 149}
       events:
         - Kind: Entry
-          Type: 1538 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0x80c420", Frameless: true}]
+          Type: 1539 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0x80c520", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -2092,15 +2131,15 @@ Probes:
         - json: {ref: s}
           dsl: s
       captureSnapshot: true
-      subprogram: {subprogram: 125}
+      subprogram: {subprogram: 126}
       events:
         - Kind: Entry
-          Type: 1503 EventRootType Probe[main.testMixedArgsStackReturn]
-          InjectionPoints: [{PC: "0x80b710", Frameless: false}]
+          Type: 1504 EventRootType Probe[main.testMixedArgsStackReturn]
+          InjectionPoints: [{PC: "0x80b810", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1504 EventRootType Probe[main.testMixedArgsStackReturn]Return
-          InjectionPoints: [{PC: "0x80b898", Frameless: false}]
+          Type: 1505 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          InjectionPoints: [{PC: "0x80b998", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -2161,15 +2200,15 @@ Probes:
         - json: {ref: b}
           dsl: b
       captureSnapshot: true
-      subprogram: {subprogram: 127}
+      subprogram: {subprogram: 128}
       events:
         - Kind: Entry
-          Type: 1507 EventRootType Probe[main.testMultipleArrayArgs]
-          InjectionPoints: [{PC: "0x80b98c", Frameless: false}]
+          Type: 1508 EventRootType Probe[main.testMultipleArrayArgs]
+          InjectionPoints: [{PC: "0x80ba8c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1508 EventRootType Probe[main.testMultipleArrayArgs]Return
-          InjectionPoints: [{PC: "0x80ba24", Frameless: false}]
+          Type: 1509 EventRootType Probe[main.testMultipleArrayArgs]Return
+          InjectionPoints: [{PC: "0x80bb24", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}'
@@ -2195,15 +2234,15 @@ Probes:
         - json: {ref: s2}
           dsl: s2
       captureSnapshot: true
-      subprogram: {subprogram: 123}
+      subprogram: {subprogram: 124}
       events:
         - Kind: Entry
-          Type: 1499 EventRootType Probe[main.testMultipleLargeArgs]
-          InjectionPoints: [{PC: "0x80b360", Frameless: false}]
+          Type: 1500 EventRootType Probe[main.testMultipleLargeArgs]
+          InjectionPoints: [{PC: "0x80b460", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1500 EventRootType Probe[main.testMultipleLargeArgs]Return
-          InjectionPoints: [{PC: "0x80b504", Frameless: false}]
+          Type: 1501 EventRootType Probe[main.testMultipleLargeArgs]Return
+          InjectionPoints: [{PC: "0x80b604", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{s1}, {s2}'
@@ -2224,15 +2263,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1453 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0x80a768", Frameless: false}]
+          Type: 1454 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x80a868", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1454 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0x80a7e8", Frameless: false}]
+          Type: 1455 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x80a8e8", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2263,11 +2302,11 @@ Probes:
         - json: {ref: e}
           dsl: e
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 86}
       events:
         - Kind: Entry
-          Type: 1423 EventRootType Probe[main.testMultipleSimpleParams]
-          InjectionPoints: [{PC: "0x809830", Frameless: true}]
+          Type: 1424 EventRootType Probe[main.testMultipleSimpleParams]
+          InjectionPoints: [{PC: "0x809930", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}, {d}, {e}'
@@ -2303,15 +2342,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1449 EventRootType Probe[main.testNamedReturn]
-          InjectionPoints: [{PC: "0x80a6d8", Frameless: false}]
+          Type: 1450 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0x80a7d8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1450 EventRootType Probe[main.testNamedReturn]Return
-          InjectionPoints: [{PC: "0x80a730", Frameless: false}]
+          Type: 1451 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0x80a830", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2333,15 +2372,15 @@ Probes:
         - json: {ref: result}
           dsl: result
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1451 EventRootType Probe[main.testNamedReturn]
-          InjectionPoints: [{PC: "0x80a6d8", Frameless: false}]
+          Type: 1452 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0x80a7d8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1452 EventRootType Probe[main.testNamedReturn]Return
-          InjectionPoints: [{PC: "0x80a730", Frameless: false}]
+          Type: 1453 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0x80a830", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: Parameter {i} * 2 = result {result}
@@ -2364,11 +2403,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 155}
+      subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1549 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0x80c700", Frameless: true}]
+          Type: 1550 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0x80c800", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -2388,11 +2427,11 @@ Probes:
             getmember: [{getmember: [{ref: x}, nested]}, anotherString]
           dsl: x.nested.anotherString
       captureSnapshot: false
-      subprogram: {subprogram: 155}
+      subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1550 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0x80c700", Frameless: true}]
+          Type: 1551 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0x80c800", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x.nested.anotherString}'
@@ -2418,11 +2457,11 @@ Probes:
         - json: {getmember: [{ref: x}, notAMember]}
           dsl: x.notAMember
       captureSnapshot: false
-      subprogram: {subprogram: 155}
+      subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1551 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0x80c700", Frameless: true}]
+          Type: 1552 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0x80c800", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -2442,11 +2481,11 @@ Probes:
         - json: {getmember: [{ref: x}, nested]}
           dsl: x.nested
       captureSnapshot: false
-      subprogram: {subprogram: 155}
+      subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1552 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0x80c700", Frameless: true}]
+          Type: 1553 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0x80c800", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x.nested}'
@@ -2468,11 +2507,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 95}
       events:
         - Kind: Entry
-          Type: 1433 EventRootType Probe[main.testNilPointer]
-          InjectionPoints: [{PC: "0x809c80", Frameless: true}]
+          Type: 1434 EventRootType Probe[main.testNilPointer]
+          InjectionPoints: [{PC: "0x809d80", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{z}, {a}'
@@ -2494,11 +2533,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 138}
+      subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1521 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0x80c050", Frameless: true}]
+          Type: 1522 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0x80c150", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -2520,11 +2559,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 135}
+      subprogram: {subprogram: 136}
       events:
         - Kind: Entry
-          Type: 1518 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0x80c020", Frameless: true}]
+          Type: 1519 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0x80c120", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}, {a}'
@@ -2554,11 +2593,11 @@ Probes:
         - json: {ref: x}
           dsl: x
       captureSnapshot: true
-      subprogram: {subprogram: 137}
+      subprogram: {subprogram: 138}
       events:
         - Kind: Entry
-          Type: 1520 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0x80c040", Frameless: true}]
+          Type: 1521 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0x80c140", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {s}, {x}'
@@ -2585,11 +2624,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 147}
+      subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1536 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0x80c410", Frameless: true}]
+          Type: 1537 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0x80c510", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -2606,11 +2645,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 91}
       events:
         - Kind: Entry
-          Type: 1429 EventRootType Probe[main.testPointerLoop]
-          InjectionPoints: [{PC: "0x809bc0", Frameless: true}]
+          Type: 1430 EventRootType Probe[main.testPointerLoop]
+          InjectionPoints: [{PC: "0x809cc0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -2627,11 +2666,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 67}
+      subprogram: {subprogram: 68}
       events:
         - Kind: Entry
-          Type: 1403 EventRootType Probe[main.testPointerToMap]
-          InjectionPoints: [{PC: "0x808290", Frameless: true}]
+          Type: 1404 EventRootType Probe[main.testPointerToMap]
+          InjectionPoints: [{PC: "0x808390", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -2648,11 +2687,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 89}
       events:
         - Kind: Entry
-          Type: 1427 EventRootType Probe[main.testPointerToSimpleStruct]
-          InjectionPoints: [{PC: "0x809ba0", Frameless: true}]
+          Type: 1428 EventRootType Probe[main.testPointerToSimpleStruct]
+          InjectionPoints: [{PC: "0x809ca0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -2669,22 +2708,22 @@ Probes:
       template: '{v}'
       segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
         - Kind: Entry
-          Type: 1445 EventRootType Probe[main.testReturnsAny]
-          InjectionPoints: [{PC: "0x80a3a8", Frameless: false}]
+          Type: 1446 EventRootType Probe[main.testReturnsAny]
+          InjectionPoints: [{PC: "0x80a4a8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1446 EventRootType Probe[main.testReturnsAny]Return
+          Type: 1447 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints:
-            - PC: "0x80a430"
+            - PC: "0x80a530"
               Frameless: false
-            - PC: "0x80a484"
+            - PC: "0x80a584"
               Frameless: false
-            - PC: "0x80a534"
+            - PC: "0x80a634"
               Frameless: false
-            - PC: "0x80a548"
+            - PC: "0x80a648"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2707,22 +2746,22 @@ Probes:
         - json: {ref: failed}
           dsl: failed
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 101}
       events:
         - Kind: Entry
-          Type: 1443 EventRootType Probe[main.testReturnsAnyAndError]
-          InjectionPoints: [{PC: "0x80a238", Frameless: false}]
+          Type: 1444 EventRootType Probe[main.testReturnsAnyAndError]
+          InjectionPoints: [{PC: "0x80a338", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1444 EventRootType Probe[main.testReturnsAnyAndError]Return
+          Type: 1445 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
-            - PC: "0x80a28c"
+            - PC: "0x80a38c"
               Frameless: false
-            - PC: "0x80a2e8"
+            - PC: "0x80a3e8"
               Frameless: false
-            - PC: "0x80a328"
+            - PC: "0x80a428"
               Frameless: false
-            - PC: "0x80a364"
+            - PC: "0x80a464"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2744,15 +2783,15 @@ Probes:
       template: testReturnsArray
       segments: [testReturnsArray]
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 111}
       events:
         - Kind: Entry
-          Type: 1473 EventRootType Probe[main.testReturnsArray]
-          InjectionPoints: [{PC: "0x80ab6c", Frameless: false}]
+          Type: 1474 EventRootType Probe[main.testReturnsArray]
+          InjectionPoints: [{PC: "0x80ac6c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1474 EventRootType Probe[main.testReturnsArray]Return
-          InjectionPoints: [{PC: "0x80abb8", Frameless: false}]
+          Type: 1475 EventRootType Probe[main.testReturnsArray]Return
+          InjectionPoints: [{PC: "0x80acb8", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsArray
@@ -2764,15 +2803,15 @@ Probes:
       template: testReturnsArrayOne
       segments: [testReturnsArrayOne]
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 112}
       events:
         - Kind: Entry
-          Type: 1475 EventRootType Probe[main.testReturnsArrayOne]
-          InjectionPoints: [{PC: "0x80abe8", Frameless: false}]
+          Type: 1476 EventRootType Probe[main.testReturnsArrayOne]
+          InjectionPoints: [{PC: "0x80ace8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1476 EventRootType Probe[main.testReturnsArrayOne]Return
-          InjectionPoints: [{PC: "0x80ac20", Frameless: false}]
+          Type: 1477 EventRootType Probe[main.testReturnsArrayOne]Return
+          InjectionPoints: [{PC: "0x80ad20", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsArrayOne
@@ -2784,15 +2823,15 @@ Probes:
       template: testReturnsArrayZero
       segments: [testReturnsArrayZero]
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 113}
       events:
         - Kind: Entry
-          Type: 1477 EventRootType Probe[main.testReturnsArrayZero]
-          InjectionPoints: [{PC: "0x80ac58", Frameless: false}]
+          Type: 1478 EventRootType Probe[main.testReturnsArrayZero]
+          InjectionPoints: [{PC: "0x80ad58", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1478 EventRootType Probe[main.testReturnsArrayZero]Return
-          InjectionPoints: [{PC: "0x80ac8c", Frameless: false}]
+          Type: 1479 EventRootType Probe[main.testReturnsArrayZero]Return
+          InjectionPoints: [{PC: "0x80ad8c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsArrayZero
@@ -2804,15 +2843,15 @@ Probes:
       template: testReturnsBacktrackInt
       segments: [testReturnsBacktrackInt]
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 115}
       events:
         - Kind: Entry
-          Type: 1481 EventRootType Probe[main.testReturnsBacktrackInt]
-          InjectionPoints: [{PC: "0x80ad48", Frameless: false}]
+          Type: 1482 EventRootType Probe[main.testReturnsBacktrackInt]
+          InjectionPoints: [{PC: "0x80ae48", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1482 EventRootType Probe[main.testReturnsBacktrackInt]Return
-          InjectionPoints: [{PC: "0x80ada8", Frameless: false}]
+          Type: 1483 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          InjectionPoints: [{PC: "0x80aea8", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsBacktrackInt
@@ -2824,15 +2863,15 @@ Probes:
       template: testReturnsBoolAndUintptr
       segments: [testReturnsBoolAndUintptr]
       captureSnapshot: true
-      subprogram: {subprogram: 120}
+      subprogram: {subprogram: 121}
       events:
         - Kind: Entry
-          Type: 1493 EventRootType Probe[main.testReturnsBoolAndUintptr]
-          InjectionPoints: [{PC: "0x80b098", Frameless: false}]
+          Type: 1494 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          InjectionPoints: [{PC: "0x80b198", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1494 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-          InjectionPoints: [{PC: "0x80b0d4", Frameless: false}]
+          Type: 1495 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          InjectionPoints: [{PC: "0x80b1d4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsBoolAndUintptr
@@ -2844,15 +2883,15 @@ Probes:
       template: testReturnsComplex
       segments: [testReturnsComplex]
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 109}
       events:
         - Kind: Entry
-          Type: 1469 EventRootType Probe[main.testReturnsComplex]
-          InjectionPoints: [{PC: "0x80aa28", Frameless: false}]
+          Type: 1470 EventRootType Probe[main.testReturnsComplex]
+          InjectionPoints: [{PC: "0x80ab28", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1470 EventRootType Probe[main.testReturnsComplex]Return
-          InjectionPoints: [{PC: "0x80aa70", Frameless: false}]
+          Type: 1471 EventRootType Probe[main.testReturnsComplex]Return
+          InjectionPoints: [{PC: "0x80ab70", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsComplex
@@ -2865,18 +2904,18 @@ Probes:
       template: '{failed}'
       segments: [{json: {ref: failed}, dsl: failed}]
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 100}
       events:
         - Kind: Entry
-          Type: 1441 EventRootType Probe[main.testReturnsError]
-          InjectionPoints: [{PC: "0x80a1b8", Frameless: false}]
+          Type: 1442 EventRootType Probe[main.testReturnsError]
+          InjectionPoints: [{PC: "0x80a2b8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1442 EventRootType Probe[main.testReturnsError]Return
+          Type: 1443 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
-            - PC: "0x80a1e4"
+            - PC: "0x80a2e4"
               Frameless: false
-            - PC: "0x80a1f8"
+            - PC: "0x80a2f8"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2893,15 +2932,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 97}
       events:
         - Kind: Entry
-          Type: 1435 EventRootType Probe[main.testReturnsInt]
-          InjectionPoints: [{PC: "0x809fc8", Frameless: false}]
+          Type: 1436 EventRootType Probe[main.testReturnsInt]
+          InjectionPoints: [{PC: "0x80a0c8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1436 EventRootType Probe[main.testReturnsInt]Return
-          InjectionPoints: [{PC: "0x80a008", Frameless: false}]
+          Type: 1437 EventRootType Probe[main.testReturnsInt]Return
+          InjectionPoints: [{PC: "0x80a108", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2917,15 +2956,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 99}
       events:
         - Kind: Entry
-          Type: 1439 EventRootType Probe[main.testReturnsIntAndFloat]
-          InjectionPoints: [{PC: "0x80a0e8", Frameless: false}]
+          Type: 1440 EventRootType Probe[main.testReturnsIntAndFloat]
+          InjectionPoints: [{PC: "0x80a1e8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1440 EventRootType Probe[main.testReturnsIntAndFloat]Return
-          InjectionPoints: [{PC: "0x80a174", Frameless: false}]
+          Type: 1441 EventRootType Probe[main.testReturnsIntAndFloat]Return
+          InjectionPoints: [{PC: "0x80a274", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2941,15 +2980,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 98}
       events:
         - Kind: Entry
-          Type: 1437 EventRootType Probe[main.testReturnsIntPointer]
-          InjectionPoints: [{PC: "0x80a048", Frameless: false}]
+          Type: 1438 EventRootType Probe[main.testReturnsIntPointer]
+          InjectionPoints: [{PC: "0x80a148", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1438 EventRootType Probe[main.testReturnsIntPointer]Return
-          InjectionPoints: [{PC: "0x80a0a4", Frameless: false}]
+          Type: 1439 EventRootType Probe[main.testReturnsIntPointer]Return
+          InjectionPoints: [{PC: "0x80a1a4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2966,18 +3005,18 @@ Probes:
       template: '{v}'
       segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1447 EventRootType Probe[main.testReturnsInterface]
-          InjectionPoints: [{PC: "0x80a588", Frameless: false}]
+          Type: 1448 EventRootType Probe[main.testReturnsInterface]
+          InjectionPoints: [{PC: "0x80a688", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1448 EventRootType Probe[main.testReturnsInterface]Return
+          Type: 1449 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
-            - PC: "0x80a640"
+            - PC: "0x80a740"
               Frameless: false
-            - PC: "0x80a654"
+            - PC: "0x80a754"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2994,15 +3033,15 @@ Probes:
       template: testReturnsLargeStruct
       segments: [testReturnsLargeStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 110}
       events:
         - Kind: Entry
-          Type: 1471 EventRootType Probe[main.testReturnsLargeStruct]
-          InjectionPoints: [{PC: "0x80aab0", Frameless: false}]
+          Type: 1472 EventRootType Probe[main.testReturnsLargeStruct]
+          InjectionPoints: [{PC: "0x80abb0", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1472 EventRootType Probe[main.testReturnsLargeStruct]Return
-          InjectionPoints: [{PC: "0x80ab2c", Frameless: false}]
+          Type: 1473 EventRootType Probe[main.testReturnsLargeStruct]Return
+          InjectionPoints: [{PC: "0x80ac2c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsLargeStruct
@@ -3014,15 +3053,15 @@ Probes:
       template: testReturnsManyFloats
       segments: [testReturnsManyFloats]
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 108}
       events:
         - Kind: Entry
-          Type: 1467 EventRootType Probe[main.testReturnsManyFloats]
-          InjectionPoints: [{PC: "0x80a978", Frameless: false}]
+          Type: 1468 EventRootType Probe[main.testReturnsManyFloats]
+          InjectionPoints: [{PC: "0x80aa78", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1468 EventRootType Probe[main.testReturnsManyFloats]Return
-          InjectionPoints: [{PC: "0x80a9f8", Frameless: false}]
+          Type: 1469 EventRootType Probe[main.testReturnsManyFloats]Return
+          InjectionPoints: [{PC: "0x80aaf8", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsManyFloats
@@ -3034,15 +3073,15 @@ Probes:
       template: testReturnsMixed
       segments: [testReturnsMixed]
       captureSnapshot: true
-      subprogram: {subprogram: 116}
+      subprogram: {subprogram: 117}
       events:
         - Kind: Entry
-          Type: 1485 EventRootType Probe[main.testReturnsMixed]
-          InjectionPoints: [{PC: "0x80aea8", Frameless: false}]
+          Type: 1486 EventRootType Probe[main.testReturnsMixed]
+          InjectionPoints: [{PC: "0x80afa8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1486 EventRootType Probe[main.testReturnsMixed]Return
-          InjectionPoints: [{PC: "0x80aefc", Frameless: false}]
+          Type: 1487 EventRootType Probe[main.testReturnsMixed]Return
+          InjectionPoints: [{PC: "0x80affc", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsMixed
@@ -3054,15 +3093,15 @@ Probes:
       template: testReturnsMixedStruct
       segments: [testReturnsMixedStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 114}
       events:
         - Kind: Entry
-          Type: 1479 EventRootType Probe[main.testReturnsMixedStruct]
-          InjectionPoints: [{PC: "0x80acc8", Frameless: false}]
+          Type: 1480 EventRootType Probe[main.testReturnsMixedStruct]
+          InjectionPoints: [{PC: "0x80adc8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1480 EventRootType Probe[main.testReturnsMixedStruct]Return
-          InjectionPoints: [{PC: "0x80ad0c", Frameless: false}]
+          Type: 1481 EventRootType Probe[main.testReturnsMixedStruct]Return
+          InjectionPoints: [{PC: "0x80ae0c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsMixedStruct
@@ -3074,15 +3113,15 @@ Probes:
       template: testReturnsMultipleFloats
       segments: [testReturnsMultipleFloats]
       captureSnapshot: true
-      subprogram: {subprogram: 119}
+      subprogram: {subprogram: 120}
       events:
         - Kind: Entry
-          Type: 1491 EventRootType Probe[main.testReturnsMultipleFloats]
-          InjectionPoints: [{PC: "0x80b028", Frameless: false}]
+          Type: 1492 EventRootType Probe[main.testReturnsMultipleFloats]
+          InjectionPoints: [{PC: "0x80b128", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1492 EventRootType Probe[main.testReturnsMultipleFloats]Return
-          InjectionPoints: [{PC: "0x80b068", Frameless: false}]
+          Type: 1493 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          InjectionPoints: [{PC: "0x80b168", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsMultipleFloats
@@ -3094,15 +3133,15 @@ Probes:
       template: testReturnsOnlyFloat
       segments: [testReturnsOnlyFloat]
       captureSnapshot: true
-      subprogram: {subprogram: 118}
+      subprogram: {subprogram: 119}
       events:
         - Kind: Entry
-          Type: 1489 EventRootType Probe[main.testReturnsOnlyFloat]
-          InjectionPoints: [{PC: "0x80afb8", Frameless: false}]
+          Type: 1490 EventRootType Probe[main.testReturnsOnlyFloat]
+          InjectionPoints: [{PC: "0x80b0b8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1490 EventRootType Probe[main.testReturnsOnlyFloat]Return
-          InjectionPoints: [{PC: "0x80aff4", Frameless: false}]
+          Type: 1491 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          InjectionPoints: [{PC: "0x80b0f4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsOnlyFloat
@@ -3114,15 +3153,15 @@ Probes:
       template: testReturnsPrimitives
       segments: [testReturnsPrimitives]
       captureSnapshot: true
-      subprogram: {subprogram: 106}
+      subprogram: {subprogram: 107}
       events:
         - Kind: Entry
-          Type: 1465 EventRootType Probe[main.testReturnsPrimitives]
-          InjectionPoints: [{PC: "0x80a8e8", Frameless: false}]
+          Type: 1466 EventRootType Probe[main.testReturnsPrimitives]
+          InjectionPoints: [{PC: "0x80a9e8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1466 EventRootType Probe[main.testReturnsPrimitives]Return
-          InjectionPoints: [{PC: "0x80a93c", Frameless: false}]
+          Type: 1467 EventRootType Probe[main.testReturnsPrimitives]Return
+          InjectionPoints: [{PC: "0x80aa3c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsPrimitives
@@ -3134,15 +3173,15 @@ Probes:
       template: testReturnsStructWithArray
       segments: [testReturnsStructWithArray]
       captureSnapshot: true
-      subprogram: {subprogram: 117}
+      subprogram: {subprogram: 118}
       events:
         - Kind: Entry
-          Type: 1487 EventRootType Probe[main.testReturnsStructWithArray]
-          InjectionPoints: [{PC: "0x80af3c", Frameless: false}]
+          Type: 1488 EventRootType Probe[main.testReturnsStructWithArray]
+          InjectionPoints: [{PC: "0x80b03c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1488 EventRootType Probe[main.testReturnsStructWithArray]Return
-          InjectionPoints: [{PC: "0x80af88", Frameless: false}]
+          Type: 1489 EventRootType Probe[main.testReturnsStructWithArray]Return
+          InjectionPoints: [{PC: "0x80b088", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsStructWithArray
@@ -3154,15 +3193,15 @@ Probes:
       template: testReturnsWideStruct
       segments: [testReturnsWideStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 115}
+      subprogram: {subprogram: 116}
       events:
         - Kind: Entry
-          Type: 1483 EventRootType Probe[main.testReturnsWideStruct]
-          InjectionPoints: [{PC: "0x80ade0", Frameless: false}]
+          Type: 1484 EventRootType Probe[main.testReturnsWideStruct]
+          InjectionPoints: [{PC: "0x80aee0", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1484 EventRootType Probe[main.testReturnsWideStruct]Return
-          InjectionPoints: [{PC: "0x80ae6c", Frameless: false}]
+          Type: 1485 EventRootType Probe[main.testReturnsWideStruct]Return
+          InjectionPoints: [{PC: "0x80af6c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsWideStruct
@@ -3209,15 +3248,15 @@ Probes:
         - json: {ref: result}
           dsl: result
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1455 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0x80a768", Frameless: false}]
+          Type: 1456 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x80a868", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1456 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0x80a7e8", Frameless: false}]
+          Type: 1457 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x80a8e8", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -3485,11 +3524,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 143}
+      subprogram: {subprogram: 144}
       events:
         - Kind: Entry
-          Type: 1528 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0x80c3d0", Frameless: true}]
+          Type: 1529 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0x80c4d0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -3611,11 +3650,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 140}
+      subprogram: {subprogram: 141}
       events:
         - Kind: Entry
-          Type: 1524 EventRootType Probe[main.testSliceEmptyStructs]
-          InjectionPoints: [{PC: "0x80c070", Frameless: true}]
+          Type: 1525 EventRootType Probe[main.testSliceEmptyStructs]
+          InjectionPoints: [{PC: "0x80c170", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -3632,11 +3671,11 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 132}
+      subprogram: {subprogram: 133}
       events:
         - Kind: Entry
-          Type: 1515 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0x80bff0", Frameless: true}]
+          Type: 1516 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0x80c0f0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{u}'
@@ -3653,11 +3692,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 65}
+      subprogram: {subprogram: 66}
       events:
         - Kind: Entry
-          Type: 1401 EventRootType Probe[main.testSmallMap]
-          InjectionPoints: [{PC: "0x808270", Frameless: true}]
+          Type: 1402 EventRootType Probe[main.testSmallMap]
+          InjectionPoints: [{PC: "0x808370", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -3673,15 +3712,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 105}
+      subprogram: {subprogram: 106}
       events:
         - Kind: Entry
-          Type: 1463 EventRootType Probe[main.testSomeNamedReturn]
-          InjectionPoints: [{PC: "0x80a828", Frameless: false}]
+          Type: 1464 EventRootType Probe[main.testSomeNamedReturn]
+          InjectionPoints: [{PC: "0x80a928", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1464 EventRootType Probe[main.testSomeNamedReturn]Return
-          InjectionPoints: [{PC: "0x80a8ac", Frameless: false}]
+          Type: 1465 EventRootType Probe[main.testSomeNamedReturn]Return
+          InjectionPoints: [{PC: "0x80a9ac", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -3697,15 +3736,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 126}
+      subprogram: {subprogram: 127}
       events:
         - Kind: Entry
-          Type: 1505 EventRootType Probe[main.testStackArgRegReturns]
-          InjectionPoints: [{PC: "0x80b8f8", Frameless: false}]
+          Type: 1506 EventRootType Probe[main.testStackArgRegReturns]
+          InjectionPoints: [{PC: "0x80b9f8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1506 EventRootType Probe[main.testStackArgRegReturns]Return
-          InjectionPoints: [{PC: "0x80b950", Frameless: false}]
+          Type: 1507 EventRootType Probe[main.testStackArgRegReturns]Return
+          InjectionPoints: [{PC: "0x80ba50", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -3743,11 +3782,11 @@ Probes:
       template: '{z}'
       segments: [{json: {ref: z}, dsl: z}]
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 94}
       events:
         - Kind: Entry
-          Type: 1432 EventRootType Probe[main.testStringPointer]
-          InjectionPoints: [{PC: "0x809c60", Frameless: true}]
+          Type: 1433 EventRootType Probe[main.testStringPointer]
+          InjectionPoints: [{PC: "0x809d60", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{z}'
@@ -3764,11 +3803,11 @@ Probes:
       template: '{s}'
       segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
-      subprogram: {subprogram: 136}
+      subprogram: {subprogram: 137}
       events:
         - Kind: Entry
-          Type: 1519 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0x80c030", Frameless: true}]
+          Type: 1520 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0x80c130", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{s}'
@@ -3785,11 +3824,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 44}
+      subprogram: {subprogram: 45}
       events:
         - Kind: Entry
-          Type: 1367 EventRootType Probe[main.testStringType1]
-          InjectionPoints: [{PC: "0x806cb0", Frameless: true}]
+          Type: 1368 EventRootType Probe[main.testStringType1]
+          InjectionPoints: [{PC: "0x806db0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3806,11 +3845,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 45}
+      subprogram: {subprogram: 46}
       events:
         - Kind: Entry
-          Type: 1368 EventRootType Probe[main.testStringType2]
-          InjectionPoints: [{PC: "0x806cc0", Frameless: true}]
+          Type: 1369 EventRootType Probe[main.testStringType2]
+          InjectionPoints: [{PC: "0x806dc0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3827,15 +3866,15 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1547 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0x80c670", Frameless: true}]
+          Type: 1548 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0x80c770", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1548 EventRootType Probe[main.testStruct]Return
-          InjectionPoints: [{PC: "0x80c680", Frameless: true}]
+          Type: 1549 EventRootType Probe[main.testStruct]Return
+          InjectionPoints: [{PC: "0x80c780", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -3857,11 +3896,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 133}
+      subprogram: {subprogram: 134}
       events:
         - Kind: Entry
-          Type: 1516 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0x80c000", Frameless: true}]
+          Type: 1517 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0x80c100", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}, {a}'
@@ -3883,11 +3922,11 @@ Probes:
       template: '{s}'
       segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
-      subprogram: {subprogram: 59}
+      subprogram: {subprogram: 60}
       events:
         - Kind: Entry
-          Type: 1395 EventRootType Probe[main.testStructWithAny]
-          InjectionPoints: [{PC: "0x807cd0", Frameless: true}]
+          Type: 1396 EventRootType Probe[main.testStructWithAny]
+          InjectionPoints: [{PC: "0x807dd0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{s}'
@@ -3903,15 +3942,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 128}
+      subprogram: {subprogram: 129}
       events:
         - Kind: Entry
-          Type: 1509 EventRootType Probe[main.testStructWithArrayArg]
-          InjectionPoints: [{PC: "0x80ba5c", Frameless: false}]
+          Type: 1510 EventRootType Probe[main.testStructWithArrayArg]
+          InjectionPoints: [{PC: "0x80bb5c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1510 EventRootType Probe[main.testStructWithArrayArg]Return
-          InjectionPoints: [{PC: "0x80bae0", Frameless: false}]
+          Type: 1511 EventRootType Probe[main.testStructWithArrayArg]Return
+          InjectionPoints: [{PC: "0x80bbe0", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -3928,15 +3967,15 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 153}
+      subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1543 EventRootType Probe[main.testStructWithCyclicMaps]
-          InjectionPoints: [{PC: "0x80c5c0", Frameless: true}]
+          Type: 1544 EventRootType Probe[main.testStructWithCyclicMaps]
+          InjectionPoints: [{PC: "0x80c6c0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1544 EventRootType Probe[main.testStructWithCyclicMaps]Return
-          InjectionPoints: [{PC: "0x80c5cc", Frameless: true}]
+          Type: 1545 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          InjectionPoints: [{PC: "0x80c6cc", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3952,11 +3991,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 152}
+      subprogram: {subprogram: 153}
       events:
         - Kind: Entry
-          Type: 1542 EventRootType Probe[main.testStructWithCyclicSlices]
-          InjectionPoints: [{PC: "0x80c5b0", Frameless: true}]
+          Type: 1543 EventRootType Probe[main.testStructWithCyclicSlices]
+          InjectionPoints: [{PC: "0x80c6b0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3978,11 +4017,11 @@ Probes:
         - json: {ref: '@duration'}
           dsl: '@duration'
       captureSnapshot: true
-      subprogram: {subprogram: 60}
+      subprogram: {subprogram: 61}
       events:
         - Kind: Entry
-          Type: 1396 EventRootType Probe[main.testStructWithMap]
-          InjectionPoints: [{PC: "0x808220", Frameless: true}]
+          Type: 1397 EventRootType Probe[main.testStructWithMap]
+          InjectionPoints: [{PC: "0x808320", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{s} {@duration}'
@@ -4009,11 +4048,11 @@ Probes:
         - json: {ref: cs}
           dsl: cs
       captureSnapshot: true
-      subprogram: {subprogram: 141}
+      subprogram: {subprogram: 142}
       events:
         - Kind: Entry
-          Type: 1525 EventRootType Probe[main.testSubslices]
-          InjectionPoints: [{PC: "0x80c080", Frameless: true}]
+          Type: 1526 EventRootType Probe[main.testSubslices]
+          InjectionPoints: [{PC: "0x80c180", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{as}, {bs}, {cs}'
@@ -4048,11 +4087,11 @@ Probes:
         - json: {ref: c}
           dsl: c
       captureSnapshot: true
-      subprogram: {subprogram: 151}
+      subprogram: {subprogram: 152}
       events:
         - Kind: Entry
-          Type: 1541 EventRootType Probe[main.testSubstrings]
-          InjectionPoints: [{PC: "0x80c450", Frameless: true}]
+          Type: 1542 EventRootType Probe[main.testSubstrings]
+          InjectionPoints: [{PC: "0x80c550", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}'
@@ -4080,15 +4119,15 @@ Probes:
         - json: {ref: nonexistentVariable}
           dsl: nonexistentVariable
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1457 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0x80a768", Frameless: false}]
+          Type: 1458 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x80a868", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1458 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0x80a7e8", Frameless: false}]
+          Type: 1459 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x80a8e8", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{nonexistentVariable}'
@@ -4104,15 +4143,15 @@ Probes:
         - json: {foobar: unsupportedExpression}
           dsl: unsupportedExpression
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1459 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0x80a768", Frameless: false}]
+          Type: 1460 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x80a868", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1460 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0x80a7e8", Frameless: false}]
+          Type: 1461 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x80a8e8", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{unsupportedExpression}'
@@ -4130,15 +4169,15 @@ Probes:
           dsl: '@duration'
         - ms
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1461 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0x80a768", Frameless: false}]
+          Type: 1462 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x80a868", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1462 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0x80a7e8", Frameless: false}]
+          Type: 1463 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x80a8e8", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -4162,11 +4201,11 @@ Probes:
         - json: {ref: z}
           dsl: z
       captureSnapshot: true
-      subprogram: {subprogram: 144}
+      subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1529 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0x80c3e0", Frameless: true}]
+          Type: 1530 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0x80c4e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}, {y}, {z}'
@@ -4193,15 +4232,15 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 145}
+      subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1530 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0x80c3f0", Frameless: true}]
+          Type: 1531 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0x80c4f0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1531 EventRootType Probe[main.testThreeStringsInStruct]Return
-          InjectionPoints: [{PC: "0x80c3fc", Frameless: true}]
+          Type: 1532 EventRootType Probe[main.testThreeStringsInStruct]Return
+          InjectionPoints: [{PC: "0x80c4fc", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -4226,15 +4265,15 @@ Probes:
         - json: {getmember: [{ref: a}, c]}
           dsl: t.c
       captureSnapshot: false
-      subprogram: {subprogram: 145}
+      subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1532 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0x80c3f0", Frameless: true}]
+          Type: 1533 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0x80c4f0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1533 EventRootType Probe[main.testThreeStringsInStruct]Return
-          InjectionPoints: [{PC: "0x80c3fc", Frameless: true}]
+          Type: 1534 EventRootType Probe[main.testThreeStringsInStruct]Return
+          InjectionPoints: [{PC: "0x80c4fc", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a.a} {a.b} {a.c}'
@@ -4261,11 +4300,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 146}
+      subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1534 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0x80c400", Frameless: true}]
+          Type: 1535 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0x80c500", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -4290,11 +4329,11 @@ Probes:
         - json: {getmember: [{ref: a}, c]}
           dsl: a.c
       captureSnapshot: false
-      subprogram: {subprogram: 146}
+      subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1535 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0x80c400", Frameless: true}]
+          Type: 1536 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0x80c500", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a.a} {a.b} {a.c}'
@@ -4447,11 +4486,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 93}
       events:
         - Kind: Entry
-          Type: 1431 EventRootType Probe[main.testUintPointer]
-          InjectionPoints: [{PC: "0x809bf0", Frameless: true}]
+          Type: 1432 EventRootType Probe[main.testUintPointer]
+          InjectionPoints: [{PC: "0x809cf0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4468,11 +4507,11 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 130}
+      subprogram: {subprogram: 131}
       events:
         - Kind: Entry
-          Type: 1513 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0x80bfd0", Frameless: true}]
+          Type: 1514 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0x80c0d0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{u}'
@@ -4489,11 +4528,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 149}
+      subprogram: {subprogram: 150}
       events:
         - Kind: Entry
-          Type: 1539 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0x80c430", Frameless: true}]
+          Type: 1540 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0x80c530", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4510,11 +4549,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 92}
       events:
         - Kind: Entry
-          Type: 1430 EventRootType Probe[main.testUnsafePointer]
-          InjectionPoints: [{PC: "0x809bd0", Frameless: true}]
+          Type: 1431 EventRootType Probe[main.testUnsafePointer]
+          InjectionPoints: [{PC: "0x809cd0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4552,11 +4591,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 139}
+      subprogram: {subprogram: 140}
       events:
         - Kind: Entry
-          Type: 1522 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0x80c060", Frameless: true}]
+          Type: 1523 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0x80c160", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -4573,11 +4612,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 139}
+      subprogram: {subprogram: 140}
       events:
         - Kind: Entry
-          Type: 1523 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0x80c060", Frameless: true}]
+          Type: 1524 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0x80c160", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -4593,19 +4632,19 @@ Probes:
       template: testWhollyInlinedSubroutine
       segments: [testWhollyInlinedSubroutine]
       captureSnapshot: true
-      subprogram: {subprogram: 164}
+      subprogram: {subprogram: 165}
       events:
         - Kind: Entry
-          Type: 1568 EventRootType Probe[main.firstBehavior.DoSomething]
+          Type: 1569 EventRootType Probe[main.firstBehavior.DoSomething]
           InjectionPoints:
-            - PC: "0x807b38"
+            - PC: "0x807c38"
               Frameless: false
-            - PC: "0x80d2d8"
+            - PC: "0x80d3d8"
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1569 EventRootType Probe[main.firstBehavior.DoSomething]Return
-          InjectionPoints: [{PC: "0x807b60", Frameless: false}]
+          Type: 1570 EventRootType Probe[main.firstBehavior.DoSomething]Return
+          InjectionPoints: [{PC: "0x807c60", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testWhollyInlinedSubroutine
@@ -4622,15 +4661,15 @@ Probes:
         - json: {ref: b}
           dsl: b
       captureSnapshot: true
-      subprogram: {subprogram: 129}
+      subprogram: {subprogram: 130}
       events:
         - Kind: Entry
-          Type: 1511 EventRootType Probe[main.testZeroSizeArgAndReturn]
-          InjectionPoints: [{PC: "0x80bb18", Frameless: false}]
+          Type: 1512 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          InjectionPoints: [{PC: "0x80bc18", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1512 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-          InjectionPoints: [{PC: "0x80bb78", Frameless: false}]
+          Type: 1513 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          InjectionPoints: [{PC: "0x80bc78", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}'
@@ -5065,36 +5104,81 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
     - ID: 38
+      Name: main.testErrorAtLine
+      OutOfLinePCRanges: [0x806920..0x806a20]
+      InlinePCRanges: []
+      Variables:
+        - Name: shouldErr
+          Type: 4 BaseType bool
+          Locations:
+            - Range: 0x806920..0x806940
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+        - Name: ~r0
+          Type: 7 BaseType int
+          Locations: [{Range: 0x806920..0x806a20, Pieces: []}]
+          Role: Return
+        - Name: x
+          Type: 7 BaseType int
+          Locations: [{Range: 0x806920..0x806a20, Pieces: []}]
+          Role: Local
+        - Name: err
+          Type: 14 GoInterfaceType error
+          Locations:
+            - Range: 0x806938..0x806974
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+            - Range: 0x806974..0x80697c
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+            - Range: 0x80697c..0x8069c8
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: -64}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x8069c8..0x8069d0
+              Pieces: [{Size: 8, Op: {CfaOffset: -64}}, {Size: 8, Op: null}]
+            - Range: 0x8069d0..0x806a20
+              Pieces: [{Size: 8, Op: {CfaOffset: -64}}, {Size: 8, Op: null}]
+          Role: Local
+    - ID: 39
       Name: main.testDeepPtr1
-      OutOfLinePCRanges: [0x8069b0..0x8069c0]
+      OutOfLinePCRanges: [0x806ab0..0x806ac0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 132 StructureType main.deepPtr1
           Locations:
-            - Range: 0x8069b0..0x8069c0
+            - Range: 0x806ab0..0x806ac0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 39
+    - ID: 40
       Name: main.testDeepPtr7
-      OutOfLinePCRanges: [0x8069c0..0x8069d0]
+      OutOfLinePCRanges: [0x806ac0..0x806ad0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 135 PointerType *main.deepPtr7
           Locations:
-            - Range: 0x8069c0..0x8069d0
+            - Range: 0x806ac0..0x806ad0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 40
+    - ID: 41
       Name: main.testDeepSlice1
-      OutOfLinePCRanges: [0x806b30..0x806b40]
+      OutOfLinePCRanges: [0x806c30..0x806c40]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 137 StructureType main.deepSlice1
           Locations:
-            - Range: 0x806b30..0x806b40
+            - Range: 0x806c30..0x806c40
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -5103,117 +5187,117 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 41
+    - ID: 42
       Name: main.testDeepSlice7
-      OutOfLinePCRanges: [0x806b40..0x806b50]
+      OutOfLinePCRanges: [0x806c40..0x806c50]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 141 PointerType *main.deepSlice7
           Locations:
-            - Range: 0x806b40..0x806b50
+            - Range: 0x806c40..0x806c50
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 42
+    - ID: 43
       Name: main.testDeepMap1
-      OutOfLinePCRanges: [0x806c90..0x806ca0]
+      OutOfLinePCRanges: [0x806d90..0x806da0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 143 StructureType main.deepMap1
           Locations:
-            - Range: 0x806c90..0x806ca0
+            - Range: 0x806d90..0x806da0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 43
+    - ID: 44
       Name: main.testDeepMap7
-      OutOfLinePCRanges: [0x806ca0..0x806cb0]
+      OutOfLinePCRanges: [0x806da0..0x806db0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 149 PointerType *main.deepMap7
           Locations:
-            - Range: 0x806ca0..0x806cb0
+            - Range: 0x806da0..0x806db0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 44
+    - ID: 45
       Name: main.testStringType1
-      OutOfLinePCRanges: [0x806cb0..0x806cc0]
+      OutOfLinePCRanges: [0x806db0..0x806dc0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 151 PointerType *main.stringType1
           Locations:
-            - Range: 0x806cb0..0x806cc0
+            - Range: 0x806db0..0x806dc0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 45
+    - ID: 46
       Name: main.testStringType2
-      OutOfLinePCRanges: [0x806cc0..0x806cd0]
+      OutOfLinePCRanges: [0x806dc0..0x806dd0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 153 PointerType **main.stringType2
           Locations:
-            - Range: 0x806cc0..0x806cd0
+            - Range: 0x806dc0..0x806dd0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 46
+    - ID: 47
       Name: main.testLongFunctionWithChangingState
-      OutOfLinePCRanges: [0x806cd0..0x806eb0]
+      OutOfLinePCRanges: [0x806dd0..0x806fb0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 7 BaseType int
           Locations:
-            - Range: 0x806d88..0x806d98
+            - Range: 0x806e88..0x806e98
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x806e28..0x806e38
+            - Range: 0x806f28..0x806f38
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
         - Name: aPerArch
           Type: 7 BaseType int
           Locations:
-            - Range: 0x806d70..0x806d74
+            - Range: 0x806e70..0x806e74
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x806d74..0x806d98
+            - Range: 0x806e74..0x806e98
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x806d98..0x806e1c
+            - Range: 0x806e98..0x806f1c
               Pieces: [{Size: 8, Op: {CfaOffset: -160}}]
-            - Range: 0x806e1c..0x806e24
+            - Range: 0x806f1c..0x806f24
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0x806e24..0x806eb0
+            - Range: 0x806f24..0x806fb0
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
           Role: Local
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x806d68..0x806d74
+            - Range: 0x806e68..0x806e74
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x806d74..0x806d74
+            - Range: 0x806e74..0x806e74
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x806d74..0x806d98
+            - Range: 0x806e74..0x806e98
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x806d98..0x806e1c
+            - Range: 0x806e98..0x806f1c
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0x806e1c..0x806e20
+            - Range: 0x806f1c..0x806f20
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0x806e20..0x806e24
+            - Range: 0x806f20..0x806f24
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0x806e24..0x806e38
+            - Range: 0x806f24..0x806f38
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0x806e38..0x806eb0
+            - Range: 0x806f38..0x806fb0
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
           Role: Local
-    - ID: 47
+    - ID: 48
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0x8071e0..0x8072a0]
+      OutOfLinePCRanges: [0x8072e0..0x8073a0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 155 StructureType main.esotericStack
           Locations:
-            - Range: 0x8071e0..0x807218
+            - Range: 0x8072e0..0x807318
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -5233,7 +5317,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x807218..0x80721c
+            - Range: 0x807318..0x80731c
               Pieces:
                 - Size: 4
                   Op: null
@@ -5253,7 +5337,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x80721c..0x807220
+            - Range: 0x80731c..0x807320
               Pieces:
                 - Size: 4
                   Op: null
@@ -5274,157 +5358,157 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 48
+    - ID: 49
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0x8072a0..0x807310]
+      OutOfLinePCRanges: [0x8073a0..0x807410]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 159 PointerType *main.esotericHeap
           Locations:
-            - Range: 0x8072a0..0x8072d4
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-    - ID: 49
-      Name: main.testInlinedBA
-      OutOfLinePCRanges: [0x8076b0..0x807740]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x8076b0..0x8076e8
+            - Range: 0x8073a0..0x8073d4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 50
-      Name: main.testInlinedBB
-      OutOfLinePCRanges: [0x807740..0x807800]
+      Name: main.testInlinedBA
+      OutOfLinePCRanges: [0x8077b0..0x807840]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807740..0x80775c
+            - Range: 0x8077b0..0x8077e8
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+    - ID: 51
+      Name: main.testInlinedBB
+      OutOfLinePCRanges: [0x807840..0x807900]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x807840..0x80785c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: y
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807740..0x80776c
+            - Range: 0x807840..0x80786c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
         - Name: z
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80775c..0x80776c
+            - Range: 0x80785c..0x80786c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80776c..0x807800
+            - Range: 0x80786c..0x807900
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Local
-    - ID: 51
+    - ID: 52
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0x807800..0x807870]
+      OutOfLinePCRanges: [0x807900..0x807970]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807800..0x807824
+            - Range: 0x807900..0x807924
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 52
+    - ID: 53
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0x807870..0x807980]
+      OutOfLinePCRanges: [0x807970..0x807a80]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80788c..0x8078f8
+            - Range: 0x80798c..0x8079f8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8078f8..0x807900
+            - Range: 0x8079f8..0x807a00
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80788c..0x8078f8
+            - Range: 0x80798c..0x8079f8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8078f8..0x8078fc
+            - Range: 0x8079f8..0x8079fc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 53
+    - ID: 54
       Name: main.testFrameless
-      OutOfLinePCRanges: [0x807980..0x807990]
+      OutOfLinePCRanges: [0x807a80..0x807a90]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807980..0x807988
+            - Range: 0x807a80..0x807a88
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807980..0x807988
+            - Range: 0x807a80..0x807a88
               Pieces: []
-            - Range: 0x807988..0x807989
+            - Range: 0x807a88..0x807a89
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x807989..0x807990
+            - Range: 0x807a89..0x807a90
               Pieces: []
           Role: Return
-    - ID: 54
+    - ID: 55
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0x807990..0x8079e0]
+      OutOfLinePCRanges: [0x807a90..0x807ae0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 161 ArrayType [5]int
           Locations:
-            - Range: 0x807990..0x8079e0
+            - Range: 0x807a90..0x807ae0
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807990..0x8079d0
+            - Range: 0x807a90..0x807ad0
               Pieces: []
-            - Range: 0x8079d0..0x8079d1
+            - Range: 0x807ad0..0x807ad1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8079d1..0x8079e0
+            - Range: 0x807ad1..0x807ae0
               Pieces: []
           Role: Return
-    - ID: 55
+    - ID: 56
       Name: main.testInterface
-      OutOfLinePCRanges: [0x807bf0..0x807c00]
+      OutOfLinePCRanges: [0x807cf0..0x807d00]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 162 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x807bf0..0x807c00
+            - Range: 0x807cf0..0x807d00
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 56
+    - ID: 57
       Name: main.testAny
-      OutOfLinePCRanges: [0x807c00..0x807c60]
+      OutOfLinePCRanges: [0x807d00..0x807d60]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x807c00..0x807c2c
+            - Range: 0x807d00..0x807d2c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x807c2c..0x807c30
+            - Range: 0x807d2c..0x807d30
               Pieces:
                 - Size: 8
                   Op: null
@@ -5434,363 +5518,363 @@ Subprograms:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x807c00..0x807c40
+            - Range: 0x807d00..0x807d40
               Pieces: []
-            - Range: 0x807c40..0x807c41
+            - Range: 0x807d40..0x807d41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x807c41..0x807c60
+            - Range: 0x807d41..0x807d60
               Pieces: []
           Role: Return
-    - ID: 57
+    - ID: 58
       Name: main.testError
-      OutOfLinePCRanges: [0x807c60..0x807c70]
+      OutOfLinePCRanges: [0x807d60..0x807d70]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 14 GoInterfaceType error
           Locations:
-            - Range: 0x807c60..0x807c70
+            - Range: 0x807d60..0x807d70
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 58
+    - ID: 59
       Name: main.testAnyPtr
-      OutOfLinePCRanges: [0x807c70..0x807cd0]
+      OutOfLinePCRanges: [0x807d70..0x807dd0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 163 PointerType *interface {}
           Locations:
-            - Range: 0x807c70..0x807c9c
+            - Range: 0x807d70..0x807d9c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x807c70..0x807cb0
+            - Range: 0x807d70..0x807db0
               Pieces: []
-            - Range: 0x807cb0..0x807cb1
+            - Range: 0x807db0..0x807db1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x807cb1..0x807cd0
+            - Range: 0x807db1..0x807dd0
               Pieces: []
           Role: Return
-    - ID: 59
+    - ID: 60
       Name: main.testStructWithAny
-      OutOfLinePCRanges: [0x807cd0..0x807ce0]
+      OutOfLinePCRanges: [0x807dd0..0x807de0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 164 StructureType main.structWithAny
           Locations:
-            - Range: 0x807cd0..0x807ce0
+            - Range: 0x807dd0..0x807de0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 60
+    - ID: 61
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0x808220..0x808230]
+      OutOfLinePCRanges: [0x808320..0x808330]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 165 StructureType main.structWithMap
           Locations:
-            - Range: 0x808220..0x808230
+            - Range: 0x808320..0x808330
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 61
+    - ID: 62
       Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0x808230..0x808240]
+      OutOfLinePCRanges: [0x808330..0x808340]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 171 GoMapType map[string]main.nestedStruct
           Locations:
-            - Range: 0x808230..0x808240
+            - Range: 0x808330..0x808340
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 62
+    - ID: 63
       Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0x808240..0x808250]
+      OutOfLinePCRanges: [0x808340..0x808350]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 176 GoMapType map[string]int
           Locations:
-            - Range: 0x808240..0x808250
+            - Range: 0x808340..0x808350
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 63
+    - ID: 64
       Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0x808250..0x808260]
+      OutOfLinePCRanges: [0x808350..0x808360]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 181 GoMapType map[string][]string
           Locations:
-            - Range: 0x808250..0x808260
+            - Range: 0x808350..0x808360
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 64
+    - ID: 65
       Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0x808260..0x808270]
+      OutOfLinePCRanges: [0x808360..0x808370]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 186 GoMapType map[[4]string][2]int
           Locations:
-            - Range: 0x808260..0x808270
+            - Range: 0x808360..0x808370
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 65
+    - ID: 66
       Name: main.testSmallMap
-      OutOfLinePCRanges: [0x808270..0x808280]
+      OutOfLinePCRanges: [0x808370..0x808380]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 176 GoMapType map[string]int
           Locations:
-            - Range: 0x808270..0x808280
+            - Range: 0x808370..0x808380
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 66
+    - ID: 67
       Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0x808280..0x808290]
+      OutOfLinePCRanges: [0x808380..0x808390]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 191 ArrayType [2]map[string]int
           Locations:
-            - Range: 0x808280..0x808290
+            - Range: 0x808380..0x808390
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
-    - ID: 67
+    - ID: 68
       Name: main.testPointerToMap
-      OutOfLinePCRanges: [0x808290..0x8082a0]
+      OutOfLinePCRanges: [0x808390..0x8083a0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 192 PointerType *map[string]int
           Locations:
-            - Range: 0x808290..0x8082a0
+            - Range: 0x808390..0x8083a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 68
+    - ID: 69
       Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0x8082a0..0x8082b0]
+      OutOfLinePCRanges: [0x8083a0..0x8083b0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 166 GoMapType map[int]int
           Locations:
-            - Range: 0x8082a0..0x8082b0
+            - Range: 0x8083a0..0x8083b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 69
+    - ID: 70
       Name: main.testMapMassive
-      OutOfLinePCRanges: [0x8082b0..0x8082c0]
+      OutOfLinePCRanges: [0x8083b0..0x8083c0]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 193 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0x8082b0..0x8082c0
+            - Range: 0x8083b0..0x8083c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 70
+    - ID: 71
       Name: main.testMapEmbeddedMaps
-      OutOfLinePCRanges: [0x8082c0..0x8082d0]
+      OutOfLinePCRanges: [0x8083c0..0x8083d0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 193 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0x8082c0..0x8082d0
+            - Range: 0x8083c0..0x8083d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 71
+    - ID: 72
       Name: main.testMapWithLinkedList
-      OutOfLinePCRanges: [0x8082d0..0x8082e0]
+      OutOfLinePCRanges: [0x8083d0..0x8083e0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 198 GoMapType map[bool]main.node
           Locations:
-            - Range: 0x8082d0..0x8082e0
+            - Range: 0x8083d0..0x8083e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 72
+    - ID: 73
       Name: main.testMapWithSmallValue
-      OutOfLinePCRanges: [0x8082e0..0x8082f0]
+      OutOfLinePCRanges: [0x8083e0..0x8083f0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 203 GoMapType map[int]uint8
           Locations:
-            - Range: 0x8082e0..0x8082f0
+            - Range: 0x8083e0..0x8083f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 73
+    - ID: 74
       Name: main.testMapWithSmallValueMassive
-      OutOfLinePCRanges: [0x8082f0..0x808300]
+      OutOfLinePCRanges: [0x8083f0..0x808400]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 203 GoMapType map[int]uint8
           Locations:
-            - Range: 0x8082f0..0x808300
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-    - ID: 74
-      Name: main.testMapWithSmallKeyAndValue
-      OutOfLinePCRanges: [0x808300..0x808310]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 208 GoMapType map[uint8]uint8
-          Locations:
-            - Range: 0x808300..0x808310
+            - Range: 0x8083f0..0x808400
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 75
-      Name: main.testMapWithSmallKeyAndValueMassive
-      OutOfLinePCRanges: [0x808310..0x808320]
+      Name: main.testMapWithSmallKeyAndValue
+      OutOfLinePCRanges: [0x808400..0x808410]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 208 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0x808310..0x808320
+            - Range: 0x808400..0x808410
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 76
-      Name: main.testMapSmallKeySmallValue
-      OutOfLinePCRanges: [0x808320..0x808330]
+      Name: main.testMapWithSmallKeyAndValueMassive
+      OutOfLinePCRanges: [0x808410..0x808420]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 208 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0x808320..0x808330
+            - Range: 0x808410..0x808420
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 77
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0x808420..0x808430]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 208 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0x808420..0x808430
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+    - ID: 78
       Name: main.testMapSmallKeyLargeValue
-      OutOfLinePCRanges: [0x808330..0x808340]
+      OutOfLinePCRanges: [0x808430..0x808440]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 213 GoMapType map[uint8][4]int
           Locations:
-            - Range: 0x808330..0x808340
+            - Range: 0x808430..0x808440
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 78
+    - ID: 79
       Name: main.testMapLargeKeySmallValue
-      OutOfLinePCRanges: [0x808340..0x808350]
+      OutOfLinePCRanges: [0x808440..0x808450]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 218 GoMapType map[[4]int]uint8
           Locations:
-            - Range: 0x808340..0x808350
+            - Range: 0x808440..0x808450
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 79
+    - ID: 80
       Name: main.testMapLargeKeyLargeValue
-      OutOfLinePCRanges: [0x808350..0x808360]
+      OutOfLinePCRanges: [0x808450..0x808460]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 223 GoMapType map[[4]int][4]int
           Locations:
-            - Range: 0x808350..0x808360
+            - Range: 0x808450..0x808460
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 80
+    - ID: 81
       Name: main.testMapEmptyKey
-      OutOfLinePCRanges: [0x808360..0x808370]
+      OutOfLinePCRanges: [0x808460..0x808470]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 228 GoMapType map[struct {}]int
           Locations:
-            - Range: 0x808360..0x808370
+            - Range: 0x808460..0x808470
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 81
+    - ID: 82
       Name: main.testMapEmptyValue
-      OutOfLinePCRanges: [0x808370..0x808380]
+      OutOfLinePCRanges: [0x808470..0x808480]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 233 GoMapType map[int]struct {}
           Locations:
-            - Range: 0x808370..0x808380
+            - Range: 0x808470..0x808480
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 82
+    - ID: 83
       Name: main.testMapEmptyKeyAndValue
-      OutOfLinePCRanges: [0x808380..0x808390]
+      OutOfLinePCRanges: [0x808480..0x808490]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 238 GoMapType map[struct {}]struct {}
           Locations:
-            - Range: 0x808380..0x808390
+            - Range: 0x808480..0x808490
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 83
+    - ID: 84
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0x809750..0x809760]
+      OutOfLinePCRanges: [0x809850..0x809860]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x809750..0x809760
+            - Range: 0x809850..0x809860
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x809750..0x809760
+            - Range: 0x809850..0x809860
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
         - Name: y
           Type: 18 BaseType float32
           Locations:
-            - Range: 0x809750..0x809760
+            - Range: 0x809850..0x809860
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
-    - ID: 84
+    - ID: 85
       Name: main.testCombinedString
-      OutOfLinePCRanges: [0x809770..0x809780]
+      OutOfLinePCRanges: [0x809870..0x809880]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x809770..0x809780
+            - Range: 0x809870..0x809880
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x809770..0x809780
+            - Range: 0x809870..0x809880
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -5800,339 +5884,339 @@ Subprograms:
         - Name: y
           Type: 18 BaseType float32
           Locations:
-            - Range: 0x809770..0x809780
+            - Range: 0x809870..0x809880
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
-    - ID: 85
+    - ID: 86
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0x809830..0x809840]
+      OutOfLinePCRanges: [0x809930..0x809940]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x809830..0x809840
+            - Range: 0x809930..0x809940
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: b
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x809830..0x809840
+            - Range: 0x809930..0x809940
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
         - Name: c
           Type: 12 BaseType int32
           Locations:
-            - Range: 0x809830..0x809840
+            - Range: 0x809930..0x809940
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
         - Name: d
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x809830..0x809840
+            - Range: 0x809930..0x809940
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
         - Name: e
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x809830..0x809840
+            - Range: 0x809930..0x809940
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
-    - ID: 86
+    - ID: 87
       Name: main.testAtomicAdd
-      OutOfLinePCRanges: [0x8099d0..0x809a10]
+      OutOfLinePCRanges: [0x809ad0..0x809b10]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0x8099d0..0x809a0c
+            - Range: 0x809ad0..0x809b0c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0x8099d0..0x809a0c
+            - Range: 0x809ad0..0x809b0c
               Pieces: []
-            - Range: 0x809a0c..0x809a0d
+            - Range: 0x809b0c..0x809b0d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x809a0d..0x809a10
+            - Range: 0x809b0d..0x809b10
               Pieces: []
           Role: Return
-    - ID: 87
+    - ID: 88
       Name: main.testChannel
-      OutOfLinePCRanges: [0x809a10..0x809a20]
+      OutOfLinePCRanges: [0x809b10..0x809b20]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 243 GoChannelType chan bool
           Locations:
-            - Range: 0x809a10..0x809a20
+            - Range: 0x809b10..0x809b20
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 88
+    - ID: 89
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0x809ba0..0x809bb0]
+      OutOfLinePCRanges: [0x809ca0..0x809cb0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 244 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0x809ba0..0x809bb0
+            - Range: 0x809ca0..0x809cb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 89
+    - ID: 90
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0x809bb0..0x809bc0]
+      OutOfLinePCRanges: [0x809cb0..0x809cc0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 246 StructureType main.node
           Locations:
-            - Range: 0x809bb0..0x809bc0
+            - Range: 0x809cb0..0x809cc0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 90
+    - ID: 91
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0x809bc0..0x809bd0]
+      OutOfLinePCRanges: [0x809cc0..0x809cd0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 247 PointerType *main.node
           Locations:
-            - Range: 0x809bc0..0x809bd0
+            - Range: 0x809cc0..0x809cd0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 91
+    - ID: 92
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0x809bd0..0x809be0]
+      OutOfLinePCRanges: [0x809cd0..0x809ce0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 15 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0x809bd0..0x809be0
+            - Range: 0x809cd0..0x809ce0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 92
+    - ID: 93
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0x809bf0..0x809c00]
+      OutOfLinePCRanges: [0x809cf0..0x809d00]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 107 PointerType *uint
           Locations:
-            - Range: 0x809bf0..0x809c00
+            - Range: 0x809cf0..0x809d00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 93
+    - ID: 94
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0x809c60..0x809c70]
+      OutOfLinePCRanges: [0x809d60..0x809d70]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 95 PointerType *string
           Locations:
-            - Range: 0x809c60..0x809c70
+            - Range: 0x809d60..0x809d70
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 94
+    - ID: 95
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0x809c80..0x809c90]
+      OutOfLinePCRanges: [0x809d80..0x809d90]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 11 PointerType *bool
           Locations:
-            - Range: 0x809c80..0x809c90
+            - Range: 0x809d80..0x809d90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: a
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x809c80..0x809c90
+            - Range: 0x809d80..0x809d90
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
-    - ID: 95
+    - ID: 96
       Name: main.testCycle
-      OutOfLinePCRanges: [0x809ca0..0x809cb0]
+      OutOfLinePCRanges: [0x809da0..0x809db0]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 248 PointerType *main.t
           Locations:
-            - Range: 0x809ca0..0x809cb0
+            - Range: 0x809da0..0x809db0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 96
+    - ID: 97
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0x809fb0..0x80a030]
+      OutOfLinePCRanges: [0x80a0b0..0x80a130]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809fb0..0x809fcc
+            - Range: 0x80a0b0..0x80a0cc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809fb0..0x80a008
+            - Range: 0x80a0b0..0x80a108
               Pieces: []
-            - Range: 0x80a008..0x80a009
+            - Range: 0x80a108..0x80a109
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a009..0x80a030
+            - Range: 0x80a109..0x80a130
               Pieces: []
           Role: Return
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809fcc..0x809fd8
+            - Range: 0x80a0cc..0x80a0d8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x809fd8..0x80a030
+            - Range: 0x80a0d8..0x80a130
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
-    - ID: 97
+    - ID: 98
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0x80a030..0x80a0d0]
+      OutOfLinePCRanges: [0x80a130..0x80a1d0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a030..0x80a054
+            - Range: 0x80a130..0x80a154
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a054..0x80a0d0
+            - Range: 0x80a154..0x80a1d0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 100 PointerType *int
           Locations:
-            - Range: 0x80a030..0x80a0a4
+            - Range: 0x80a130..0x80a1a4
               Pieces: []
-            - Range: 0x80a0a4..0x80a0a5
+            - Range: 0x80a1a4..0x80a1a5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a0a5..0x80a0d0
+            - Range: 0x80a1a5..0x80a1d0
               Pieces: []
           Role: Return
         - Name: '&result'
           Type: 100 PointerType *int
           Locations:
-            - Range: 0x80a058..0x80a070
+            - Range: 0x80a158..0x80a170
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a070..0x80a0d0
+            - Range: 0x80a170..0x80a1d0
               Pieces: [{Size: 8, Op: {CfaOffset: -16}}]
           Role: Local
-    - ID: 98
+    - ID: 99
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0x80a0d0..0x80a1a0]
+      OutOfLinePCRanges: [0x80a1d0..0x80a2a0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a0d0..0x80a124
+            - Range: 0x80a1d0..0x80a224
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a0d0..0x80a174
+            - Range: 0x80a1d0..0x80a274
               Pieces: []
-            - Range: 0x80a174..0x80a175
+            - Range: 0x80a274..0x80a275
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a175..0x80a1a0
+            - Range: 0x80a275..0x80a2a0
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80a0d0..0x80a1a0, Pieces: []}]
+          Locations: [{Range: 0x80a1d0..0x80a2a0, Pieces: []}]
           Role: Return
         - Name: resultInt
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a0ec..0x80a128
+            - Range: 0x80a1ec..0x80a228
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80a128..0x80a1a0
+            - Range: 0x80a228..0x80a2a0
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
         - Name: resultFloat
           Type: 16 BaseType float64
           Locations:
-            - Range: 0x80a0fc..0x80a128
+            - Range: 0x80a1fc..0x80a228
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
-            - Range: 0x80a128..0x80a1a0
+            - Range: 0x80a228..0x80a2a0
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
           Role: Local
-    - ID: 99
+    - ID: 100
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0x80a1a0..0x80a220]
+      OutOfLinePCRanges: [0x80a2a0..0x80a320]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x80a1a0..0x80a1c4
+            - Range: 0x80a2a0..0x80a2c4
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 14 GoInterfaceType error
           Locations:
-            - Range: 0x80a1a0..0x80a1e4
+            - Range: 0x80a2a0..0x80a2e4
               Pieces: []
-            - Range: 0x80a1e4..0x80a1e5
+            - Range: 0x80a2e4..0x80a2e5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a1e5..0x80a1f8
+            - Range: 0x80a2e5..0x80a2f8
               Pieces: []
-            - Range: 0x80a1f8..0x80a1f9
+            - Range: 0x80a2f8..0x80a2f9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a1f9..0x80a220
+            - Range: 0x80a2f9..0x80a320
               Pieces: []
           Role: Return
-    - ID: 100
+    - ID: 101
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0x80a220..0x80a390]
+      OutOfLinePCRanges: [0x80a320..0x80a490]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80a220..0x80a270
+            - Range: 0x80a320..0x80a370
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a270..0x80a274
+            - Range: 0x80a370..0x80a374
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: null
-            - Range: 0x80a2fc..0x80a300
+            - Range: 0x80a3fc..0x80a400
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a33c..0x80a340
+            - Range: 0x80a43c..0x80a440
               Pieces:
                 - Size: 8
                   Op: null
@@ -6142,112 +6226,112 @@ Subprograms:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x80a220..0x80a264
+            - Range: 0x80a320..0x80a364
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80a220..0x80a28c
+            - Range: 0x80a320..0x80a38c
               Pieces: []
-            - Range: 0x80a28c..0x80a28d
+            - Range: 0x80a38c..0x80a38d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a28d..0x80a2e8
+            - Range: 0x80a38d..0x80a3e8
               Pieces: []
-            - Range: 0x80a2e8..0x80a2e9
+            - Range: 0x80a3e8..0x80a3e9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a2e9..0x80a328
+            - Range: 0x80a3e9..0x80a428
               Pieces: []
-            - Range: 0x80a328..0x80a329
+            - Range: 0x80a428..0x80a429
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a329..0x80a364
+            - Range: 0x80a429..0x80a464
               Pieces: []
-            - Range: 0x80a364..0x80a365
+            - Range: 0x80a464..0x80a465
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a365..0x80a390
+            - Range: 0x80a465..0x80a490
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 14 GoInterfaceType error
           Locations:
-            - Range: 0x80a220..0x80a28c
+            - Range: 0x80a320..0x80a38c
               Pieces: []
-            - Range: 0x80a28c..0x80a28d
+            - Range: 0x80a38c..0x80a38d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80a28d..0x80a2e8
+            - Range: 0x80a38d..0x80a3e8
               Pieces: []
-            - Range: 0x80a2e8..0x80a2e9
+            - Range: 0x80a3e8..0x80a3e9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80a2e9..0x80a328
+            - Range: 0x80a3e9..0x80a428
               Pieces: []
-            - Range: 0x80a328..0x80a329
+            - Range: 0x80a428..0x80a429
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80a329..0x80a364
+            - Range: 0x80a429..0x80a464
               Pieces: []
-            - Range: 0x80a364..0x80a365
+            - Range: 0x80a464..0x80a465
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80a365..0x80a390
+            - Range: 0x80a465..0x80a490
               Pieces: []
           Role: Return
         - Name: val
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a270..0x80a278
+            - Range: 0x80a370..0x80a378
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
-    - ID: 101
+    - ID: 102
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0x80a390..0x80a570]
+      OutOfLinePCRanges: [0x80a490..0x80a670]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80a390..0x80a3d0
+            - Range: 0x80a490..0x80a4d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a3d0..0x80a3d8
+            - Range: 0x80a4d0..0x80a4d8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80a3d8..0x80a570
+            - Range: 0x80a4d8..0x80a670
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -6257,429 +6341,429 @@ Subprograms:
         - Name: ~r0
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80a390..0x80a430
+            - Range: 0x80a490..0x80a530
               Pieces: []
-            - Range: 0x80a430..0x80a431
+            - Range: 0x80a530..0x80a531
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a431..0x80a484
+            - Range: 0x80a531..0x80a584
               Pieces: []
-            - Range: 0x80a484..0x80a485
+            - Range: 0x80a584..0x80a585
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a485..0x80a534
+            - Range: 0x80a585..0x80a634
               Pieces: []
-            - Range: 0x80a534..0x80a535
+            - Range: 0x80a634..0x80a635
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a535..0x80a548
+            - Range: 0x80a635..0x80a648
               Pieces: []
-            - Range: 0x80a548..0x80a549
+            - Range: 0x80a648..0x80a649
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a549..0x80a570
+            - Range: 0x80a649..0x80a670
               Pieces: []
           Role: Return
         - Name: val
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a41c..0x80a424
+            - Range: 0x80a51c..0x80a524
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
         - Name: '&result'
           Type: 100 PointerType *int
           Locations:
-            - Range: 0x80a468..0x80a484
+            - Range: 0x80a568..0x80a584
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 102
+    - ID: 103
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0x80a570..0x80a6c0]
+      OutOfLinePCRanges: [0x80a670..0x80a7c0]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80a570..0x80a5ac
+            - Range: 0x80a670..0x80a6ac
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a5ac..0x80a5ec
+            - Range: 0x80a6ac..0x80a6ec
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x80a5ec..0x80a660
+            - Range: 0x80a6ec..0x80a760
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x80a660..0x80a688
+            - Range: 0x80a760..0x80a788
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80a688..0x80a68c
+            - Range: 0x80a788..0x80a78c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80a68c..0x80a6c0
+            - Range: 0x80a78c..0x80a7c0
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
         - Name: ~r0
           Type: 162 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x80a570..0x80a640
+            - Range: 0x80a670..0x80a740
               Pieces: []
-            - Range: 0x80a640..0x80a641
+            - Range: 0x80a740..0x80a741
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a641..0x80a654
+            - Range: 0x80a741..0x80a754
               Pieces: []
-            - Range: 0x80a654..0x80a655
+            - Range: 0x80a754..0x80a755
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a655..0x80a6c0
+            - Range: 0x80a755..0x80a7c0
               Pieces: []
           Role: Return
         - Name: b
           Type: 162 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x80a570..0x80a5ac
+            - Range: 0x80a670..0x80a6ac
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a5ac..0x80a5ec
+            - Range: 0x80a6ac..0x80a6ec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80a5ec..0x80a5f4
+            - Range: 0x80a6ec..0x80a6f4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80a5f4..0x80a64c
+            - Range: 0x80a6f4..0x80a74c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80a64c..0x80a650
+            - Range: 0x80a74c..0x80a750
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80a650..0x80a654
+            - Range: 0x80a750..0x80a754
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x80a654..0x80a6c0
+            - Range: 0x80a754..0x80a7c0
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Local
-    - ID: 103
+    - ID: 104
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0x80a6c0..0x80a750]
+      OutOfLinePCRanges: [0x80a7c0..0x80a850]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a6c0..0x80a6dc
+            - Range: 0x80a7c0..0x80a7dc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a6c0..0x80a730
+            - Range: 0x80a7c0..0x80a830
               Pieces: []
-            - Range: 0x80a730..0x80a731
+            - Range: 0x80a830..0x80a831
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a731..0x80a750
+            - Range: 0x80a831..0x80a850
               Pieces: []
           Role: Return
-    - ID: 104
+    - ID: 105
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0x80a750..0x80a810]
+      OutOfLinePCRanges: [0x80a850..0x80a910]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a750..0x80a79c
+            - Range: 0x80a850..0x80a89c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a750..0x80a7e8
+            - Range: 0x80a850..0x80a8e8
               Pieces: []
-            - Range: 0x80a7e8..0x80a7e9
+            - Range: 0x80a8e8..0x80a8e9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a7e9..0x80a810
+            - Range: 0x80a8e9..0x80a910
               Pieces: []
           Role: Return
         - Name: result2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a750..0x80a7e8
+            - Range: 0x80a850..0x80a8e8
               Pieces: []
-            - Range: 0x80a7e8..0x80a7e9
+            - Range: 0x80a8e8..0x80a8e9
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80a7e9..0x80a810
+            - Range: 0x80a8e9..0x80a910
               Pieces: []
           Role: Return
-    - ID: 105
+    - ID: 106
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0x80a810..0x80a8d0]
+      OutOfLinePCRanges: [0x80a910..0x80a9d0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a810..0x80a84c
+            - Range: 0x80a910..0x80a94c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a84c..0x80a8d0
+            - Range: 0x80a94c..0x80a9d0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a810..0x80a8ac
+            - Range: 0x80a910..0x80a9ac
               Pieces: []
-            - Range: 0x80a8ac..0x80a8ad
+            - Range: 0x80a9ac..0x80a9ad
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a8ad..0x80a8d0
+            - Range: 0x80a9ad..0x80a9d0
               Pieces: []
           Role: Return
         - Name: result2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a810..0x80a8ac
+            - Range: 0x80a910..0x80a9ac
               Pieces: []
-            - Range: 0x80a8ac..0x80a8ad
+            - Range: 0x80a9ac..0x80a9ad
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80a8ad..0x80a8d0
+            - Range: 0x80a9ad..0x80a9d0
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a810..0x80a8ac
+            - Range: 0x80a910..0x80a9ac
               Pieces: []
-            - Range: 0x80a8ac..0x80a8ad
+            - Range: 0x80a9ac..0x80a9ad
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80a8ad..0x80a8d0
+            - Range: 0x80a9ad..0x80a9d0
               Pieces: []
           Role: Return
-    - ID: 106
+    - ID: 107
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0x80a8d0..0x80a960]
+      OutOfLinePCRanges: [0x80a9d0..0x80aa60]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType int8
           Locations:
-            - Range: 0x80a8d0..0x80a93c
+            - Range: 0x80a9d0..0x80aa3c
               Pieces: []
-            - Range: 0x80a93c..0x80a93d
+            - Range: 0x80aa3c..0x80aa3d
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a93d..0x80a960
+            - Range: 0x80aa3d..0x80aa60
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 96 BaseType int16
           Locations:
-            - Range: 0x80a8d0..0x80a93c
+            - Range: 0x80a9d0..0x80aa3c
               Pieces: []
-            - Range: 0x80a93c..0x80a93d
+            - Range: 0x80aa3c..0x80aa3d
               Pieces: [{Size: 2, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80a93d..0x80a960
+            - Range: 0x80aa3d..0x80aa60
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 12 BaseType int32
           Locations:
-            - Range: 0x80a8d0..0x80a93c
+            - Range: 0x80a9d0..0x80aa3c
               Pieces: []
-            - Range: 0x80a93c..0x80a93d
+            - Range: 0x80aa3c..0x80aa3d
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80a93d..0x80a960
+            - Range: 0x80aa3d..0x80aa60
               Pieces: []
           Role: Return
         - Name: ~r3
           Type: 13 BaseType int64
           Locations:
-            - Range: 0x80a8d0..0x80a93c
+            - Range: 0x80a9d0..0x80aa3c
               Pieces: []
-            - Range: 0x80a93c..0x80a93d
+            - Range: 0x80aa3c..0x80aa3d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x80a93d..0x80a960
+            - Range: 0x80aa3d..0x80aa60
               Pieces: []
           Role: Return
         - Name: ~r4
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x80a8d0..0x80a93c
+            - Range: 0x80a9d0..0x80aa3c
               Pieces: []
-            - Range: 0x80a93c..0x80a93d
+            - Range: 0x80aa3c..0x80aa3d
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80a93d..0x80a960
+            - Range: 0x80aa3d..0x80aa60
               Pieces: []
           Role: Return
         - Name: ~r5
           Type: 6 BaseType uint16
           Locations:
-            - Range: 0x80a8d0..0x80a93c
+            - Range: 0x80a9d0..0x80aa3c
               Pieces: []
-            - Range: 0x80a93c..0x80a93d
+            - Range: 0x80aa3c..0x80aa3d
               Pieces: [{Size: 2, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x80a93d..0x80a960
+            - Range: 0x80aa3d..0x80aa60
               Pieces: []
           Role: Return
         - Name: ~r6
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0x80a8d0..0x80a93c
+            - Range: 0x80a9d0..0x80aa3c
               Pieces: []
-            - Range: 0x80a93c..0x80a93d
+            - Range: 0x80aa3c..0x80aa3d
               Pieces: [{Size: 4, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x80a93d..0x80a960
+            - Range: 0x80aa3d..0x80aa60
               Pieces: []
           Role: Return
         - Name: ~r7
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0x80a8d0..0x80a93c
+            - Range: 0x80a9d0..0x80aa3c
               Pieces: []
-            - Range: 0x80a93c..0x80a93d
+            - Range: 0x80aa3c..0x80aa3d
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x80a93d..0x80a960
+            - Range: 0x80aa3d..0x80aa60
               Pieces: []
           Role: Return
-    - ID: 107
+    - ID: 108
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0x80a960..0x80aa10]
+      OutOfLinePCRanges: [0x80aa60..0x80ab10]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80a960..0x80aa10, Pieces: []}]
+          Locations: [{Range: 0x80aa60..0x80ab10, Pieces: []}]
           Role: Return
         - Name: ~r1
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80a960..0x80aa10, Pieces: []}]
+          Locations: [{Range: 0x80aa60..0x80ab10, Pieces: []}]
           Role: Return
         - Name: ~r2
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80a960..0x80aa10, Pieces: []}]
+          Locations: [{Range: 0x80aa60..0x80ab10, Pieces: []}]
           Role: Return
         - Name: ~r3
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80a960..0x80aa10, Pieces: []}]
+          Locations: [{Range: 0x80aa60..0x80ab10, Pieces: []}]
           Role: Return
         - Name: ~r4
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80a960..0x80aa10, Pieces: []}]
+          Locations: [{Range: 0x80aa60..0x80ab10, Pieces: []}]
           Role: Return
         - Name: ~r5
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80a960..0x80aa10, Pieces: []}]
+          Locations: [{Range: 0x80aa60..0x80ab10, Pieces: []}]
           Role: Return
         - Name: ~r6
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80a960..0x80aa10, Pieces: []}]
+          Locations: [{Range: 0x80aa60..0x80ab10, Pieces: []}]
           Role: Return
         - Name: ~r7
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80a960..0x80aa10, Pieces: []}]
+          Locations: [{Range: 0x80aa60..0x80ab10, Pieces: []}]
           Role: Return
         - Name: ~r8
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80a960..0x80aa10, Pieces: []}]
+          Locations: [{Range: 0x80aa60..0x80ab10, Pieces: []}]
           Role: Return
         - Name: ~r9
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80a960..0x80aa10, Pieces: []}]
+          Locations: [{Range: 0x80aa60..0x80ab10, Pieces: []}]
           Role: Return
         - Name: ~r10
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80a960..0x80aa10, Pieces: []}]
+          Locations: [{Range: 0x80aa60..0x80ab10, Pieces: []}]
           Role: Return
         - Name: ~r11
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80a960..0x80aa10, Pieces: []}]
+          Locations: [{Range: 0x80aa60..0x80ab10, Pieces: []}]
           Role: Return
         - Name: ~r12
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80a960..0x80aa10, Pieces: []}]
+          Locations: [{Range: 0x80aa60..0x80ab10, Pieces: []}]
           Role: Return
         - Name: ~r13
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80a960..0x80aa10, Pieces: []}]
+          Locations: [{Range: 0x80aa60..0x80ab10, Pieces: []}]
           Role: Return
         - Name: ~r14
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80a960..0x80aa10, Pieces: []}]
+          Locations: [{Range: 0x80aa60..0x80ab10, Pieces: []}]
           Role: Return
         - Name: onlyOnAmd64_16
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80a960..0x80aa10, Pieces: []}]
+          Locations: [{Range: 0x80aa60..0x80ab10, Pieces: []}]
           Role: Return
         - Name: bothArmAndAmd64
           Type: 16 BaseType float64
           Locations:
-            - Range: 0x80a960..0x80a9f8
+            - Range: 0x80aa60..0x80aaf8
               Pieces: []
-            - Range: 0x80a9f8..0x80a9f9
+            - Range: 0x80aaf8..0x80aaf9
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x80a9f9..0x80aa10
+            - Range: 0x80aaf9..0x80ab10
               Pieces: []
           Role: Return
-    - ID: 108
+    - ID: 109
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0x80aa10..0x80aa90]
+      OutOfLinePCRanges: [0x80ab10..0x80ab90]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 97 BaseType complex64
-          Locations: [{Range: 0x80aa10..0x80aa90, Pieces: []}]
+          Locations: [{Range: 0x80ab10..0x80ab90, Pieces: []}]
           Role: Return
         - Name: ~r1
           Type: 98 BaseType complex128
-          Locations: [{Range: 0x80aa10..0x80aa90, Pieces: []}]
+          Locations: [{Range: 0x80ab10..0x80ab90, Pieces: []}]
           Role: Return
-    - ID: 109
+    - ID: 110
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0x80aa90..0x80ab50]
+      OutOfLinePCRanges: [0x80ab90..0x80ac50]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0x80aa90..0x80ab2c
+            - Range: 0x80ab90..0x80ac2c
               Pieces: []
-            - Range: 0x80ab2c..0x80ab2d
+            - Range: 0x80ac2c..0x80ac2d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6701,173 +6785,173 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80ab2d..0x80ab50
+            - Range: 0x80ac2d..0x80ac50
               Pieces: []
           Role: Return
-    - ID: 110
+    - ID: 111
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0x80ab50..0x80abd0]
+      OutOfLinePCRanges: [0x80ac50..0x80acd0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0x80ab50..0x80abb8
+            - Range: 0x80ac50..0x80acb8
               Pieces: []
-            - Range: 0x80abb8..0x80abb9
+            - Range: 0x80acb8..0x80acb9
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x80abb9..0x80abd0
+            - Range: 0x80acb9..0x80acd0
               Pieces: []
           Role: Return
-    - ID: 111
+    - ID: 112
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0x80abd0..0x80ac40]
+      OutOfLinePCRanges: [0x80acd0..0x80ad40]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 252 ArrayType [1]int
           Locations:
-            - Range: 0x80abd0..0x80ac20
+            - Range: 0x80acd0..0x80ad20
               Pieces: []
-            - Range: 0x80ac20..0x80ac21
+            - Range: 0x80ad20..0x80ad21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80ac21..0x80ac40
+            - Range: 0x80ad21..0x80ad40
               Pieces: []
           Role: Return
-    - ID: 112
+    - ID: 113
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0x80ac40..0x80acb0]
+      OutOfLinePCRanges: [0x80ad40..0x80adb0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 253 ArrayType [0]int
           Locations:
-            - Range: 0x80ac40..0x80ac8c
+            - Range: 0x80ad40..0x80ad8c
               Pieces: []
-            - Range: 0x80ac8c..0x80ac8d
+            - Range: 0x80ad8c..0x80ad8d
               Pieces: []
-            - Range: 0x80ac8d..0x80acb0
+            - Range: 0x80ad8d..0x80adb0
               Pieces: []
           Role: Return
-    - ID: 113
+    - ID: 114
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0x80acb0..0x80ad30]
+      OutOfLinePCRanges: [0x80adb0..0x80ae30]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 254 StructureType main.mixedStruct
-          Locations: [{Range: 0x80acb0..0x80ad30, Pieces: []}]
+          Locations: [{Range: 0x80adb0..0x80ae30, Pieces: []}]
           Role: Return
-    - ID: 114
+    - ID: 115
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0x80ad30..0x80adc0]
+      OutOfLinePCRanges: [0x80ae30..0x80aec0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80ad30..0x80ada8
+            - Range: 0x80ae30..0x80aea8
               Pieces: []
-            - Range: 0x80ada8..0x80ada9
+            - Range: 0x80aea8..0x80aea9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80ada9..0x80adc0
+            - Range: 0x80aea9..0x80aec0
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80ad30..0x80ada8
+            - Range: 0x80ae30..0x80aea8
               Pieces: []
-            - Range: 0x80ada8..0x80ada9
+            - Range: 0x80aea8..0x80aea9
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80ada9..0x80adc0
+            - Range: 0x80aea9..0x80aec0
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80ad30..0x80ada8
+            - Range: 0x80ae30..0x80aea8
               Pieces: []
-            - Range: 0x80ada8..0x80ada9
+            - Range: 0x80aea8..0x80aea9
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80ada9..0x80adc0
+            - Range: 0x80aea9..0x80aec0
               Pieces: []
           Role: Return
         - Name: ~r3
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80ad30..0x80ada8
+            - Range: 0x80ae30..0x80aea8
               Pieces: []
-            - Range: 0x80ada8..0x80ada9
+            - Range: 0x80aea8..0x80aea9
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x80ada9..0x80adc0
+            - Range: 0x80aea9..0x80aec0
               Pieces: []
           Role: Return
         - Name: ~r4
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80ad30..0x80ada8
+            - Range: 0x80ae30..0x80aea8
               Pieces: []
-            - Range: 0x80ada8..0x80ada9
+            - Range: 0x80aea8..0x80aea9
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80ada9..0x80adc0
+            - Range: 0x80aea9..0x80aec0
               Pieces: []
           Role: Return
         - Name: ~r5
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80ad30..0x80ada8
+            - Range: 0x80ae30..0x80aea8
               Pieces: []
-            - Range: 0x80ada8..0x80ada9
+            - Range: 0x80aea8..0x80aea9
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x80ada9..0x80adc0
+            - Range: 0x80aea9..0x80aec0
               Pieces: []
           Role: Return
         - Name: ~r6
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80ad30..0x80ada8
+            - Range: 0x80ae30..0x80aea8
               Pieces: []
-            - Range: 0x80ada8..0x80ada9
+            - Range: 0x80aea8..0x80aea9
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x80ada9..0x80adc0
+            - Range: 0x80aea9..0x80aec0
               Pieces: []
           Role: Return
         - Name: ~r7
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80ad30..0x80ada8
+            - Range: 0x80ae30..0x80aea8
               Pieces: []
-            - Range: 0x80ada8..0x80ada9
+            - Range: 0x80aea8..0x80aea9
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x80ada9..0x80adc0
+            - Range: 0x80aea9..0x80aec0
               Pieces: []
           Role: Return
         - Name: ~r8
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80ad30..0x80ada8
+            - Range: 0x80ae30..0x80aea8
               Pieces: []
-            - Range: 0x80ada8..0x80ada9
+            - Range: 0x80aea8..0x80aea9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80ada9..0x80adc0
+            - Range: 0x80aea9..0x80aec0
               Pieces: []
           Role: Return
-    - ID: 115
+    - ID: 116
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0x80adc0..0x80ae90]
+      OutOfLinePCRanges: [0x80aec0..0x80af90]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 255 StructureType main.wideStruct
           Locations:
-            - Range: 0x80adc0..0x80ae6c
+            - Range: 0x80aec0..0x80af6c
               Pieces: []
-            - Range: 0x80ae6c..0x80ae6d
+            - Range: 0x80af6c..0x80af6d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6891,127 +6975,127 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0x80ae6d..0x80ae90
+            - Range: 0x80af6d..0x80af90
               Pieces: []
           Role: Return
-    - ID: 116
+    - ID: 117
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0x80ae90..0x80af20]
+      OutOfLinePCRanges: [0x80af90..0x80b020]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80ae90..0x80aefc
+            - Range: 0x80af90..0x80affc
               Pieces: []
-            - Range: 0x80aefc..0x80aefd
+            - Range: 0x80affc..0x80affd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80aefd..0x80af20
+            - Range: 0x80affd..0x80b020
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80ae90..0x80af20, Pieces: []}]
+          Locations: [{Range: 0x80af90..0x80b020, Pieces: []}]
           Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80ae90..0x80aefc
+            - Range: 0x80af90..0x80affc
               Pieces: []
-            - Range: 0x80aefc..0x80aefd
+            - Range: 0x80affc..0x80affd
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80aefd..0x80af20
+            - Range: 0x80affd..0x80b020
               Pieces: []
           Role: Return
         - Name: ~r3
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80ae90..0x80af20, Pieces: []}]
+          Locations: [{Range: 0x80af90..0x80b020, Pieces: []}]
           Role: Return
         - Name: ~r4
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80ae90..0x80aefc
+            - Range: 0x80af90..0x80affc
               Pieces: []
-            - Range: 0x80aefc..0x80aefd
+            - Range: 0x80affc..0x80affd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80aefd..0x80af20
+            - Range: 0x80affd..0x80b020
               Pieces: []
           Role: Return
-    - ID: 117
+    - ID: 118
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0x80af20..0x80afa0]
+      OutOfLinePCRanges: [0x80b020..0x80b0a0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 256 StructureType main.structWithArray
           Locations:
-            - Range: 0x80af20..0x80af88
+            - Range: 0x80b020..0x80b088
               Pieces: []
-            - Range: 0x80af88..0x80af89
+            - Range: 0x80b088..0x80b089
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x80af89..0x80afa0
+            - Range: 0x80b089..0x80b0a0
               Pieces: []
           Role: Return
-    - ID: 118
+    - ID: 119
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0x80afa0..0x80b010]
+      OutOfLinePCRanges: [0x80b0a0..0x80b110]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80afa0..0x80b010, Pieces: []}]
+          Locations: [{Range: 0x80b0a0..0x80b110, Pieces: []}]
           Role: Return
-    - ID: 119
+    - ID: 120
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0x80b010..0x80b080]
+      OutOfLinePCRanges: [0x80b110..0x80b180]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 18 BaseType float32
-          Locations: [{Range: 0x80b010..0x80b080, Pieces: []}]
+          Locations: [{Range: 0x80b110..0x80b180, Pieces: []}]
           Role: Return
         - Name: ~r1
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80b010..0x80b080, Pieces: []}]
+          Locations: [{Range: 0x80b110..0x80b180, Pieces: []}]
           Role: Return
-    - ID: 120
+    - ID: 121
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0x80b080..0x80b0f0]
+      OutOfLinePCRanges: [0x80b180..0x80b1f0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x80b080..0x80b0d4
+            - Range: 0x80b180..0x80b1d4
               Pieces: []
-            - Range: 0x80b0d4..0x80b0d5
+            - Range: 0x80b1d4..0x80b1d5
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80b0d5..0x80b0f0
+            - Range: 0x80b1d5..0x80b1f0
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 1 BaseType uintptr
           Locations:
-            - Range: 0x80b080..0x80b0d4
+            - Range: 0x80b180..0x80b1d4
               Pieces: []
-            - Range: 0x80b0d4..0x80b0d5
+            - Range: 0x80b1d4..0x80b1d5
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80b0d5..0x80b0f0
+            - Range: 0x80b1d5..0x80b1f0
               Pieces: []
           Role: Return
-    - ID: 121
+    - ID: 122
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0x80b0f0..0x80b280]
+      OutOfLinePCRanges: [0x80b1f0..0x80b380]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0x80b0f0..0x80b148
+            - Range: 0x80b1f0..0x80b248
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7033,7 +7117,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80b148..0x80b150
+            - Range: 0x80b248..0x80b250
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7055,7 +7139,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80b150..0x80b158
+            - Range: 0x80b250..0x80b258
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7077,7 +7161,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80b158..0x80b15c
+            - Range: 0x80b258..0x80b25c
               Pieces:
                 - Size: 8
                   Op: null
@@ -7103,9 +7187,9 @@ Subprograms:
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0x80b0f0..0x80b238
+            - Range: 0x80b1f0..0x80b338
               Pieces: []
-            - Range: 0x80b238..0x80b239
+            - Range: 0x80b338..0x80b339
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7127,39 +7211,39 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80b239..0x80b280
+            - Range: 0x80b339..0x80b380
               Pieces: []
           Role: Return
-    - ID: 122
+    - ID: 123
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0x80b280..0x80b340]
+      OutOfLinePCRanges: [0x80b380..0x80b440]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0x80b280..0x80b340
+            - Range: 0x80b380..0x80b440
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0x80b280..0x80b328
+            - Range: 0x80b380..0x80b428
               Pieces: []
-            - Range: 0x80b328..0x80b329
+            - Range: 0x80b428..0x80b429
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x80b329..0x80b340
+            - Range: 0x80b429..0x80b440
               Pieces: []
           Role: Return
-    - ID: 123
+    - ID: 124
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0x80b340..0x80b550]
+      OutOfLinePCRanges: [0x80b440..0x80b650]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0x80b340..0x80b39c
+            - Range: 0x80b440..0x80b49c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7181,7 +7265,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80b39c..0x80b3a4
+            - Range: 0x80b49c..0x80b4a4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7203,7 +7287,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80b3a4..0x80b3ac
+            - Range: 0x80b4a4..0x80b4ac
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7225,7 +7309,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80b3ac..0x80b3b0
+            - Range: 0x80b4ac..0x80b4b0
               Pieces:
                 - Size: 8
                   Op: null
@@ -7251,15 +7335,15 @@ Subprograms:
         - Name: s2
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0x80b340..0x80b550
+            - Range: 0x80b440..0x80b650
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0x80b340..0x80b504
+            - Range: 0x80b440..0x80b604
               Pieces: []
-            - Range: 0x80b504..0x80b505
+            - Range: 0x80b604..0x80b605
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7281,175 +7365,175 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80b505..0x80b550
+            - Range: 0x80b605..0x80b650
               Pieces: []
           Role: Return
-    - ID: 124
+    - ID: 125
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0x80b550..0x80b6f0]
+      OutOfLinePCRanges: [0x80b650..0x80b7f0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80b550..0x80b5c4
+            - Range: 0x80b650..0x80b6c4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80b5c4..0x80b6f0
+            - Range: 0x80b6c4..0x80b7f0
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80b550..0x80b5b4
+            - Range: 0x80b650..0x80b6b4
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80b5b4..0x80b6f0
+            - Range: 0x80b6b4..0x80b7f0
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80b550..0x80b5bc
+            - Range: 0x80b650..0x80b6bc
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80b5bc..0x80b6f0
+            - Range: 0x80b6bc..0x80b7f0
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80b550..0x80b5c4
+            - Range: 0x80b650..0x80b6c4
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x80b5c4..0x80b6f0
+            - Range: 0x80b6c4..0x80b7f0
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80b550..0x80b5c4
+            - Range: 0x80b650..0x80b6c4
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80b5c4..0x80b6f0
+            - Range: 0x80b6c4..0x80b7f0
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80b550..0x80b5c4
+            - Range: 0x80b650..0x80b6c4
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x80b5c4..0x80b6f0
+            - Range: 0x80b6c4..0x80b7f0
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80b550..0x80b5c4
+            - Range: 0x80b650..0x80b6c4
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x80b5c4..0x80b6f0
+            - Range: 0x80b6c4..0x80b7f0
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80b550..0x80b5c4
+            - Range: 0x80b650..0x80b6c4
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x80b5c4..0x80b6f0
+            - Range: 0x80b6c4..0x80b7f0
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80b550..0x80b5c4
+            - Range: 0x80b650..0x80b6c4
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0x80b5c4..0x80b6f0
+            - Range: 0x80b6c4..0x80b7f0
               Pieces: [{Size: 8, Op: {CfaOffset: 88}}]
           Role: Parameter
         - Name: ~r0
           Type: 113 ArrayType [2]int
           Locations:
-            - Range: 0x80b550..0x80b6ac
+            - Range: 0x80b650..0x80b7ac
               Pieces: []
-            - Range: 0x80b6ac..0x80b6ad
+            - Range: 0x80b7ac..0x80b7ad
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-            - Range: 0x80b6ad..0x80b6f0
+            - Range: 0x80b7ad..0x80b7f0
               Pieces: []
           Role: Return
-    - ID: 125
+    - ID: 126
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0x80b6f0..0x80b8e0]
+      OutOfLinePCRanges: [0x80b7f0..0x80b9e0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80b6f0..0x80b774
+            - Range: 0x80b7f0..0x80b874
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80b774..0x80b8e0
+            - Range: 0x80b874..0x80b9e0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80b6f0..0x80b764
+            - Range: 0x80b7f0..0x80b864
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80b764..0x80b8e0
+            - Range: 0x80b864..0x80b9e0
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80b6f0..0x80b76c
+            - Range: 0x80b7f0..0x80b86c
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80b76c..0x80b8e0
+            - Range: 0x80b86c..0x80b9e0
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80b6f0..0x80b774
+            - Range: 0x80b7f0..0x80b874
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x80b774..0x80b8e0
+            - Range: 0x80b874..0x80b9e0
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80b6f0..0x80b774
+            - Range: 0x80b7f0..0x80b874
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80b774..0x80b8e0
+            - Range: 0x80b874..0x80b9e0
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80b6f0..0x80b774
+            - Range: 0x80b7f0..0x80b874
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x80b774..0x80b8e0
+            - Range: 0x80b874..0x80b9e0
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80b6f0..0x80b774
+            - Range: 0x80b7f0..0x80b874
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x80b774..0x80b8e0
+            - Range: 0x80b874..0x80b9e0
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80b6f0..0x80b774
+            - Range: 0x80b7f0..0x80b874
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x80b774..0x80b8e0
+            - Range: 0x80b874..0x80b9e0
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80b6f0..0x80b774
+            - Range: 0x80b7f0..0x80b874
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80b774..0x80b8e0
+            - Range: 0x80b874..0x80b9e0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 72}
@@ -7459,9 +7543,9 @@ Subprograms:
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0x80b6f0..0x80b898
+            - Range: 0x80b7f0..0x80b998
               Pieces: []
-            - Range: 0x80b898..0x80b899
+            - Range: 0x80b998..0x80b999
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7483,191 +7567,174 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80b899..0x80b8e0
+            - Range: 0x80b999..0x80b9e0
               Pieces: []
           Role: Return
-    - ID: 126
+    - ID: 127
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0x80b8e0..0x80b970]
+      OutOfLinePCRanges: [0x80b9e0..0x80ba70]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 161 ArrayType [5]int
           Locations:
-            - Range: 0x80b8e0..0x80b970
+            - Range: 0x80b9e0..0x80ba70
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80b8e0..0x80b950
+            - Range: 0x80b9e0..0x80ba50
               Pieces: []
-            - Range: 0x80b950..0x80b951
+            - Range: 0x80ba50..0x80ba51
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80b951..0x80b970
+            - Range: 0x80ba51..0x80ba70
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80b8e0..0x80b950
+            - Range: 0x80b9e0..0x80ba50
               Pieces: []
-            - Range: 0x80b950..0x80b951
+            - Range: 0x80ba50..0x80ba51
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80b951..0x80b970
+            - Range: 0x80ba51..0x80ba70
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80b8e0..0x80b950
+            - Range: 0x80b9e0..0x80ba50
               Pieces: []
-            - Range: 0x80b950..0x80b951
+            - Range: 0x80ba50..0x80ba51
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80b951..0x80b970
+            - Range: 0x80ba51..0x80ba70
               Pieces: []
           Role: Return
-    - ID: 127
+    - ID: 128
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0x80b970..0x80ba40]
+      OutOfLinePCRanges: [0x80ba70..0x80bb40]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 113 ArrayType [2]int
           Locations:
-            - Range: 0x80b970..0x80ba40
+            - Range: 0x80ba70..0x80bb40
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: b
           Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0x80b970..0x80ba40
+            - Range: 0x80ba70..0x80bb40
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80b970..0x80ba24
+            - Range: 0x80ba70..0x80bb24
               Pieces: []
-            - Range: 0x80ba24..0x80ba25
+            - Range: 0x80bb24..0x80bb25
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80ba25..0x80ba40
+            - Range: 0x80bb25..0x80bb40
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 113 ArrayType [2]int
           Locations:
-            - Range: 0x80b970..0x80ba24
+            - Range: 0x80ba70..0x80bb24
               Pieces: []
-            - Range: 0x80ba24..0x80ba25
+            - Range: 0x80bb24..0x80bb25
               Pieces: [{Size: 16, Op: {CfaOffset: 48}}]
-            - Range: 0x80ba25..0x80ba40
+            - Range: 0x80bb25..0x80bb40
               Pieces: []
           Role: Return
-    - ID: 128
+    - ID: 129
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0x80ba40..0x80bb00]
+      OutOfLinePCRanges: [0x80bb40..0x80bc00]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 256 StructureType main.structWithArray
           Locations:
-            - Range: 0x80ba40..0x80bb00
+            - Range: 0x80bb40..0x80bc00
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80ba40..0x80bae0
+            - Range: 0x80bb40..0x80bbe0
               Pieces: []
-            - Range: 0x80bae0..0x80bae1
+            - Range: 0x80bbe0..0x80bbe1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80bae1..0x80bb00
+            - Range: 0x80bbe1..0x80bc00
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 256 StructureType main.structWithArray
           Locations:
-            - Range: 0x80ba40..0x80bae0
+            - Range: 0x80bb40..0x80bbe0
               Pieces: []
-            - Range: 0x80bae0..0x80bae1
+            - Range: 0x80bbe0..0x80bbe1
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x80bae1..0x80bb00
+            - Range: 0x80bbe1..0x80bc00
               Pieces: []
           Role: Return
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80bab8..0x80bb00
+            - Range: 0x80bbb8..0x80bc00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 129
+    - ID: 130
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0x80bb00..0x80bba0]
+      OutOfLinePCRanges: [0x80bc00..0x80bca0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 253 ArrayType [0]int
-          Locations: [{Range: 0x80bb00..0x80bba0, Pieces: []}]
+          Locations: [{Range: 0x80bc00..0x80bca0, Pieces: []}]
           Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80bb00..0x80bb3c
+            - Range: 0x80bc00..0x80bc3c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80bb3c..0x80bb54
+            - Range: 0x80bc3c..0x80bc54
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x80bb54..0x80bb5c
+            - Range: 0x80bc54..0x80bc5c
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x80bb5c..0x80bba0
+            - Range: 0x80bc5c..0x80bca0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80bb00..0x80bb78
+            - Range: 0x80bc00..0x80bc78
               Pieces: []
-            - Range: 0x80bb78..0x80bb79
+            - Range: 0x80bc78..0x80bc79
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80bb79..0x80bba0
+            - Range: 0x80bc79..0x80bca0
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 253 ArrayType [0]int
           Locations:
-            - Range: 0x80bb00..0x80bb78
+            - Range: 0x80bc00..0x80bc78
               Pieces: []
-            - Range: 0x80bb78..0x80bb79
+            - Range: 0x80bc78..0x80bc79
               Pieces: []
-            - Range: 0x80bb79..0x80bba0
+            - Range: 0x80bc79..0x80bca0
               Pieces: []
           Role: Return
-    - ID: 130
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0x80bfd0..0x80bfe0]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 257 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x80bfd0..0x80bfe0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
     - ID: 131
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0x80bfe0..0x80bff0]
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0x80c0d0..0x80c0e0]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80bfe0..0x80bff0
+            - Range: 0x80c0d0..0x80c0e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7677,14 +7744,14 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
     - ID: 132
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0x80bff0..0x80c000]
+      Name: main.testEmptySlice
+      OutOfLinePCRanges: [0x80c0e0..0x80c0f0]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 258 GoSliceHeaderType [][]uint
+          Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80bff0..0x80c000
+            - Range: 0x80c0e0..0x80c0f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7694,14 +7761,14 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
     - ID: 133
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0x80c000..0x80c010]
+      Name: main.testSliceOfSlices
+      OutOfLinePCRanges: [0x80c0f0..0x80c100]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 260 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 258 GoSliceHeaderType [][]uint
           Locations:
-            - Range: 0x80c000..0x80c010
+            - Range: 0x80c0f0..0x80c100
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7709,22 +7776,16 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x80c000..0x80c010
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
     - ID: 134
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0x80c010..0x80c020]
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0x80c100..0x80c110]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 260 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x80c010..0x80c020
+            - Range: 0x80c100..0x80c110
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7736,18 +7797,18 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80c010..0x80c020
+            - Range: 0x80c100..0x80c110
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
     - ID: 135
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0x80c020..0x80c030]
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0x80c110..0x80c120]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 260 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x80c020..0x80c030
+            - Range: 0x80c110..0x80c120
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7759,18 +7820,41 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80c020..0x80c030
+            - Range: 0x80c110..0x80c120
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
     - ID: 136
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0x80c120..0x80c130]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 260 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x80c120..0x80c130
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80c120..0x80c130
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          Role: Parameter
+    - ID: 137
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0x80c030..0x80c040]
+      OutOfLinePCRanges: [0x80c130..0x80c140]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 263 GoSliceHeaderType []string
           Locations:
-            - Range: 0x80c030..0x80c040
+            - Range: 0x80c130..0x80c140
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7779,21 +7863,21 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 137
+    - ID: 138
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0x80c040..0x80c050]
+      OutOfLinePCRanges: [0x80c140..0x80c150]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 17 BaseType int8
           Locations:
-            - Range: 0x80c040..0x80c050
+            - Range: 0x80c140..0x80c150
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: s
           Type: 264 GoSliceHeaderType []bool
           Locations:
-            - Range: 0x80c040..0x80c050
+            - Range: 0x80c140..0x80c150
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -7805,35 +7889,18 @@ Subprograms:
         - Name: x
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x80c040..0x80c050
+            - Range: 0x80c140..0x80c150
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
-    - ID: 138
+    - ID: 139
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0x80c050..0x80c060]
+      OutOfLinePCRanges: [0x80c150..0x80c160]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 265 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0x80c050..0x80c060
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-    - ID: 139
-      Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0x80c060..0x80c070]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 257 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x80c060..0x80c070
+            - Range: 0x80c150..0x80c160
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7843,14 +7910,14 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
     - ID: 140
-      Name: main.testSliceEmptyStructs
-      OutOfLinePCRanges: [0x80c070..0x80c080]
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0x80c160..0x80c170]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 266 GoSliceHeaderType []struct {}
+          Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80c070..0x80c080
+            - Range: 0x80c160..0x80c170
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7860,14 +7927,31 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
     - ID: 141
+      Name: main.testSliceEmptyStructs
+      OutOfLinePCRanges: [0x80c170..0x80c180]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 266 GoSliceHeaderType []struct {}
+          Locations:
+            - Range: 0x80c170..0x80c180
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+    - ID: 142
       Name: main.testSubslices
-      OutOfLinePCRanges: [0x80c080..0x80c090]
+      OutOfLinePCRanges: [0x80c180..0x80c190]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80c080..0x80c090
+            - Range: 0x80c180..0x80c190
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7879,7 +7963,7 @@ Subprograms:
         - Name: bs
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80c080..0x80c090
+            - Range: 0x80c180..0x80c190
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -7891,7 +7975,7 @@ Subprograms:
         - Name: cs
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80c080..0x80c090
+            - Range: 0x80c180..0x80c190
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -7900,49 +7984,49 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 142
+    - ID: 143
       Name: main.stackC
-      OutOfLinePCRanges: [0x80c370..0x80c3d0]
+      OutOfLinePCRanges: [0x80c470..0x80c4d0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80c370..0x80c3b8
+            - Range: 0x80c470..0x80c4b8
               Pieces: []
-            - Range: 0x80c3b8..0x80c3b9
+            - Range: 0x80c4b8..0x80c4b9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80c3b9..0x80c3d0
+            - Range: 0x80c4b9..0x80c4d0
               Pieces: []
           Role: Return
-    - ID: 143
+    - ID: 144
       Name: main.testSingleString
-      OutOfLinePCRanges: [0x80c3d0..0x80c3e0]
+      OutOfLinePCRanges: [0x80c4d0..0x80c4e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80c3d0..0x80c3e0
+            - Range: 0x80c4d0..0x80c4e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 144
+    - ID: 145
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0x80c3e0..0x80c3f0]
+      OutOfLinePCRanges: [0x80c4e0..0x80c4f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80c3e0..0x80c3f0
+            - Range: 0x80c4e0..0x80c4f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7952,7 +8036,7 @@ Subprograms:
         - Name: y
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80c3e0..0x80c3f0
+            - Range: 0x80c4e0..0x80c4f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -7962,22 +8046,22 @@ Subprograms:
         - Name: z
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80c3e0..0x80c3f0
+            - Range: 0x80c4e0..0x80c4f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
-    - ID: 145
+    - ID: 146
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x80c3f0..0x80c400]
+      OutOfLinePCRanges: [0x80c4f0..0x80c500]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 268 StructureType main.threeStringStruct
           Locations:
-            - Range: 0x80c3f0..0x80c400
+            - Range: 0x80c4f0..0x80c500
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7992,52 +8076,37 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
-    - ID: 146
+    - ID: 147
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x80c400..0x80c410]
+      OutOfLinePCRanges: [0x80c500..0x80c510]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 269 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0x80c400..0x80c410
+            - Range: 0x80c500..0x80c510
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 147
+    - ID: 148
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0x80c410..0x80c420]
+      OutOfLinePCRanges: [0x80c510..0x80c520]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 270 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0x80c410..0x80c420
+            - Range: 0x80c510..0x80c520
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 148
-      Name: main.testMassiveString
-      OutOfLinePCRanges: [0x80c420..0x80c430]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0x80c420..0x80c430
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          Role: Parameter
     - ID: 149
-      Name: main.testUnitializedString
-      OutOfLinePCRanges: [0x80c430..0x80c440]
+      Name: main.testMassiveString
+      OutOfLinePCRanges: [0x80c520..0x80c530]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80c430..0x80c440
+            - Range: 0x80c520..0x80c530
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8045,14 +8114,14 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
     - ID: 150
-      Name: main.testEmptyString
-      OutOfLinePCRanges: [0x80c440..0x80c450]
+      Name: main.testUnitializedString
+      OutOfLinePCRanges: [0x80c530..0x80c540]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80c440..0x80c450
+            - Range: 0x80c530..0x80c540
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8060,14 +8129,29 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
     - ID: 151
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0x80c540..0x80c550]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x80c540..0x80c550
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          Role: Parameter
+    - ID: 152
       Name: main.testSubstrings
-      OutOfLinePCRanges: [0x80c450..0x80c460]
+      OutOfLinePCRanges: [0x80c550..0x80c560]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80c450..0x80c460
+            - Range: 0x80c550..0x80c560
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8077,7 +8161,7 @@ Subprograms:
         - Name: b
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80c450..0x80c460
+            - Range: 0x80c550..0x80c560
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -8087,33 +8171,33 @@ Subprograms:
         - Name: c
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80c450..0x80c460
+            - Range: 0x80c550..0x80c560
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
-    - ID: 152
+    - ID: 153
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0x80c5b0..0x80c5c0]
+      OutOfLinePCRanges: [0x80c6b0..0x80c6c0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 272 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0x80c5b0..0x80c5c0
+            - Range: 0x80c6b0..0x80c6c0
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
-    - ID: 153
+    - ID: 154
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0x80c5c0..0x80c5d0]
+      OutOfLinePCRanges: [0x80c6c0..0x80c6d0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 285 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0x80c5c0..0x80c5d0
+            - Range: 0x80c6c0..0x80c6d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8128,15 +8212,15 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
-    - ID: 154
+    - ID: 155
       Name: main.testStruct
-      OutOfLinePCRanges: [0x80c670..0x80c690]
+      OutOfLinePCRanges: [0x80c770..0x80c790]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 316 StructureType main.aStruct
           Locations:
-            - Range: 0x80c670..0x80c690
+            - Range: 0x80c770..0x80c790
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -8153,128 +8237,128 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
           Role: Parameter
-    - ID: 155
+    - ID: 156
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0x80c700..0x80c710]
+      OutOfLinePCRanges: [0x80c800..0x80c810]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 317 PointerType *main.anotherStruct
           Locations:
-            - Range: 0x80c700..0x80c710
+            - Range: 0x80c800..0x80c810
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 156
+    - ID: 157
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x80c740..0x80c750]
+      OutOfLinePCRanges: [0x80c840..0x80c850]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 319 StructureType main.emptyStruct
-          Locations: [{Range: 0x80c740..0x80c750, Pieces: []}]
+          Locations: [{Range: 0x80c840..0x80c850, Pieces: []}]
           Role: Parameter
-    - ID: 157
+    - ID: 158
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x80c750..0x80c760]
+      OutOfLinePCRanges: [0x80c850..0x80c860]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 320 PointerType *main.emptyStruct
           Locations:
-            - Range: 0x80c750..0x80c760
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-    - ID: 158
-      Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0x807520..0x807590]
-      InlinePCRanges:
-        - Ranges: [0x8075ac..0x8075e0]
-          RootRanges: [0x807590..0x807600]
-        - Ranges: [0x8076e8..0x80771c]
-          RootRanges: [0x8076b0..0x807740]
-        - Ranges: [0x807764..0x807798]
-          RootRanges: [0x807740..0x807800]
-        - Ranges: [0x80781c..0x807850]
-          RootRanges: [0x807800..0x807870]
-      Variables:
-        - Name: x
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x807520..0x807540
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8075ac..0x8075b4
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8076e8..0x8076f0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80775c..0x80776c
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80776c..0x807800
-              Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x807800..0x807824
+            - Range: 0x80c850..0x80c860
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 159
-      Name: main.testInlinedBBB
-      OutOfLinePCRanges: []
+      Name: main.testInlinedPrint
+      OutOfLinePCRanges: [0x807620..0x807690]
       InlinePCRanges:
-        - Ranges: [0x8077a4..0x8077d8]
-          RootRanges: [0x807740..0x807800]
-      Variables: []
-    - ID: 160
-      Name: main.testInlinedBCA
-      OutOfLinePCRanges: []
-      InlinePCRanges:
-        - Ranges: [0x80788c..0x8078c0, 0x8078c8..0x8078cc]
-          RootRanges: [0x807870..0x807980]
-      Variables: []
-    - ID: 161
-      Name: main.testInlinedBCB
-      OutOfLinePCRanges: []
-      InlinePCRanges:
-        - Ranges: [0x807930..0x807964]
-          RootRanges: [0x807870..0x807980]
-      Variables: []
-    - ID: 162
-      Name: main.testInlinedSq
-      OutOfLinePCRanges: []
-      InlinePCRanges:
-        - Ranges: [0x807984..0x807988]
-          RootRanges: [0x807980..0x807990]
+        - Ranges: [0x8076ac..0x8076e0]
+          RootRanges: [0x807690..0x807700]
+        - Ranges: [0x8077e8..0x80781c]
+          RootRanges: [0x8077b0..0x807840]
+        - Ranges: [0x807864..0x807898]
+          RootRanges: [0x807840..0x807900]
+        - Ranges: [0x80791c..0x807950]
+          RootRanges: [0x807900..0x807970]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807980..0x807988
+            - Range: 0x807620..0x807640
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x8076ac..0x8076b4
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x8077e8..0x8077f0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x80785c..0x80786c
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x80786c..0x807900
+              Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
+            - Range: 0x807900..0x807924
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
+    - ID: 160
+      Name: main.testInlinedBBB
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0x8078a4..0x8078d8]
+          RootRanges: [0x807840..0x807900]
+      Variables: []
+    - ID: 161
+      Name: main.testInlinedBCA
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0x80798c..0x8079c0, 0x8079c8..0x8079cc]
+          RootRanges: [0x807970..0x807a80]
+      Variables: []
+    - ID: 162
+      Name: main.testInlinedBCB
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0x807a30..0x807a64]
+          RootRanges: [0x807970..0x807a80]
+      Variables: []
     - ID: 163
+      Name: main.testInlinedSq
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0x807a84..0x807a88]
+          RootRanges: [0x807a80..0x807a90]
+      Variables:
+        - Name: x
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x807a80..0x807a88
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+    - ID: 164
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x8079b4..0x8079d0]
-          RootRanges: [0x807990..0x8079e0]
-        - Ranges: [0x807a3c..0x807a5c]
-          RootRanges: [0x8079e0..0x807b20]
+        - Ranges: [0x807ab4..0x807ad0]
+          RootRanges: [0x807a90..0x807ae0]
+        - Ranges: [0x807b3c..0x807b5c]
+          RootRanges: [0x807ae0..0x807c20]
       Variables:
         - Name: a
           Type: 161 ArrayType [5]int
           Locations:
-            - Range: 0x8079a0..0x8079e0
+            - Range: 0x807aa0..0x807ae0
               Pieces: [{Size: 40, Op: {CfaOffset: -48}}]
-            - Range: 0x807a28..0x807b20
+            - Range: 0x807b28..0x807c20
               Pieces: [{Size: 40, Op: {CfaOffset: -120}}]
           Role: Parameter
-    - ID: 164
+    - ID: 165
       Name: main.firstBehavior.DoSomething
-      OutOfLinePCRanges: [0x807b20..0x807b80]
+      OutOfLinePCRanges: [0x807c20..0x807c80]
       InlinePCRanges:
-        - Ranges: [0x80d2d8..0x80d2fc]
-          RootRanges: [0x80d2b0..0x80d340]
+        - Ranges: [0x80d3d8..0x80d3fc]
+          RootRanges: [0x80d3b0..0x80d440]
       Variables:
         - Name: b
           Type: 321 StructureType main.firstBehavior
           Locations:
-            - Range: 0x807b20..0x807b44
+            - Range: 0x807c20..0x807c44
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8284,23 +8368,23 @@ Subprograms:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x807b20..0x807b60
+            - Range: 0x807c20..0x807c60
               Pieces: []
-            - Range: 0x807b60..0x807b61
+            - Range: 0x807c60..0x807c61
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x807b61..0x807b80
+            - Range: 0x807c61..0x807c80
               Pieces: []
           Role: Return
-    - ID: 165
+    - ID: 166
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x808158..0x808164, 0x808168..0x808170]
-          RootRanges: [0x808040..0x8081b0]
+        - Ranges: [0x808258..0x808264, 0x808268..0x808270]
+          RootRanges: [0x808140..0x8082b0]
         - Ranges: [0x805df8..0x805dfc, 0x805e00..0x805e08]
           RootRanges: [0x805df0..0x805e10]
       Variables: []
@@ -11629,10 +11713,10 @@ Types:
       GoKind: 22
       Pointee: 824 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1570
+      ID: 1571
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
     - __kind: EventRootType
-      ID: 1568
+      ID: 1569
       Name: Probe[main.firstBehavior.DoSomething]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11644,11 +11728,11 @@ Types:
             Type: 321 StructureType main.firstBehavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 0, name: b}
+                  Variable: {subprogram: 165, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1569
+      ID: 1570
       Name: Probe[main.firstBehavior.DoSomething]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11660,14 +11744,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 1, name: ~r0}
+                  Variable: {subprogram: 165, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1526
+      ID: 1527
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1527
+      ID: 1528
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11679,11 +11763,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: ~r0}
+                  Variable: {subprogram: 143, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1393
+      ID: 1394
       Name: Probe[main.testAnyPtr]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11695,7 +11779,7 @@ Types:
             Type: 163 PointerType *interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: a}
+                  Variable: {subprogram: 59, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -11705,11 +11789,11 @@ Types:
             Type: 163 PointerType *interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: a}
+                  Variable: {subprogram: 59, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1394
+      ID: 1395
       Name: Probe[main.testAnyPtr]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11721,11 +11805,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 1, name: ~r0}
+                  Variable: {subprogram: 59, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1390
+      ID: 1391
       Name: Probe[main.testAny]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11737,7 +11821,7 @@ Types:
             Type: 157 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: a}
+                  Variable: {subprogram: 57, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -11747,11 +11831,11 @@ Types:
             Type: 157 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: a}
+                  Variable: {subprogram: 57, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1391
+      ID: 1392
       Name: Probe[main.testAny]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11763,11 +11847,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 1, name: ~r0}
+                  Variable: {subprogram: 57, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1497
+      ID: 1498
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11779,7 +11863,7 @@ Types:
             Type: 251 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: arg}
+                  Variable: {subprogram: 123, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
         - Name: arg
@@ -11789,11 +11873,11 @@ Types:
             Type: 251 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: arg}
+                  Variable: {subprogram: 123, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1498
+      ID: 1499
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11805,7 +11889,7 @@ Types:
             Type: 251 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 1, name: ~r0}
+                  Variable: {subprogram: 123, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -11887,7 +11971,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1402
+      ID: 1403
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11899,7 +11983,7 @@ Types:
             Type: 191 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: m}
+                  Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
         - Name: m
@@ -11909,7 +11993,7 @@ Types:
             Type: 191 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: m}
+                  Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -11965,7 +12049,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1424
+      ID: 1425
       Name: Probe[main.testAtomicAdd]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11977,7 +12061,7 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: x}
+                  Variable: {subprogram: 87, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -11987,11 +12071,11 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: x}
+                  Variable: {subprogram: 87, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1425
+      ID: 1426
       Name: Probe[main.testAtomicAdd]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12003,7 +12087,7 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 1, name: ~r0}
+                  Variable: {subprogram: 87, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -12088,7 +12172,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1426
+      ID: 1427
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -12100,7 +12184,7 @@ Types:
             Type: 243 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: c}
+                  Variable: {subprogram: 88, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
         - Name: c
@@ -12110,11 +12194,11 @@ Types:
             Type: 243 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: c}
+                  Variable: {subprogram: 88, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1420
+      ID: 1421
       Name: Probe[main.testCombinedByte]
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -12126,7 +12210,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: w}
+                  Variable: {subprogram: 84, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: w
@@ -12136,7 +12220,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: w}
+                  Variable: {subprogram: 84, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: x
@@ -12146,7 +12230,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 1, name: x}
+                  Variable: {subprogram: 84, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: x
@@ -12156,7 +12240,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 1, name: x}
+                  Variable: {subprogram: 84, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: y
@@ -12166,7 +12250,7 @@ Types:
             Type: 18 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 2, name: y}
+                  Variable: {subprogram: 84, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
         - Name: y
@@ -12176,11 +12260,11 @@ Types:
             Type: 18 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 2, name: y}
+                  Variable: {subprogram: 84, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1421
+      ID: 1422
       Name: Probe[main.testCombinedString]
       ByteSize: 18
       PresenceBitsetSize: 1
@@ -12192,7 +12276,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 1, name: x}
+                  Variable: {subprogram: 85, index: 1, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: w_val
@@ -12202,11 +12286,11 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: w}
+                  Variable: {subprogram: 85, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1422
+      ID: 1423
       Name: Probe[main.testCombinedString]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -12218,7 +12302,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 1, name: x}
+                  Variable: {subprogram: 85, index: 1, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x_val
@@ -12228,7 +12312,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 1, name: x}
+                  Variable: {subprogram: 85, index: 1, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: w_val
@@ -12238,11 +12322,11 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: w}
+                  Variable: {subprogram: 85, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1434
+      ID: 1435
       Name: Probe[main.testCycle]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12254,7 +12338,7 @@ Types:
             Type: 248 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: t}
+                  Variable: {subprogram: 96, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
         - Name: t
@@ -12264,11 +12348,11 @@ Types:
             Type: 248 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: t}
+                  Variable: {subprogram: 96, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1365
+      ID: 1366
       Name: Probe[main.testDeepMap1]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12280,7 +12364,7 @@ Types:
             Type: 143 StructureType main.deepMap1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: a}
+                  Variable: {subprogram: 43, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12290,11 +12374,11 @@ Types:
             Type: 143 StructureType main.deepMap1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: a}
+                  Variable: {subprogram: 43, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1366
+      ID: 1367
       Name: Probe[main.testDeepMap7]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12306,7 +12390,7 @@ Types:
             Type: 149 PointerType *main.deepMap7
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 0, name: a}
+                  Variable: {subprogram: 44, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12316,11 +12400,11 @@ Types:
             Type: 149 PointerType *main.deepMap7
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 0, name: a}
+                  Variable: {subprogram: 44, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1361
+      ID: 1362
       Name: Probe[main.testDeepPtr1]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12332,7 +12416,7 @@ Types:
             Type: 132 StructureType main.deepPtr1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: a}
+                  Variable: {subprogram: 39, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12342,11 +12426,11 @@ Types:
             Type: 132 StructureType main.deepPtr1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: a}
+                  Variable: {subprogram: 39, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1362
+      ID: 1363
       Name: Probe[main.testDeepPtr7]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12358,7 +12442,7 @@ Types:
             Type: 135 PointerType *main.deepPtr7
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: a}
+                  Variable: {subprogram: 40, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12368,11 +12452,11 @@ Types:
             Type: 135 PointerType *main.deepPtr7
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: a}
+                  Variable: {subprogram: 40, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1363
+      ID: 1364
       Name: Probe[main.testDeepSlice1]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12384,7 +12468,7 @@ Types:
             Type: 137 StructureType main.deepSlice1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: a}
+                  Variable: {subprogram: 41, index: 0, name: a}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -12394,11 +12478,11 @@ Types:
             Type: 137 StructureType main.deepSlice1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: a}
+                  Variable: {subprogram: 41, index: 0, name: a}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1364
+      ID: 1365
       Name: Probe[main.testDeepSlice7]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12410,7 +12494,7 @@ Types:
             Type: 141 PointerType *main.deepSlice7
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: a}
+                  Variable: {subprogram: 42, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12420,11 +12504,11 @@ Types:
             Type: 141 PointerType *main.deepSlice7
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: a}
+                  Variable: {subprogram: 42, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1517
+      ID: 1518
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -12436,7 +12520,7 @@ Types:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: xs}
+                  Variable: {subprogram: 135, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -12446,7 +12530,7 @@ Types:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: xs}
+                  Variable: {subprogram: 135, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -12456,7 +12540,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 1, name: a}
+                  Variable: {subprogram: 135, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12466,11 +12550,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 1, name: a}
+                  Variable: {subprogram: 135, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1514
+      ID: 1515
       Name: Probe[main.testEmptySlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12482,7 +12566,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: u}
+                  Variable: {subprogram: 132, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -12492,11 +12576,11 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: u}
+                  Variable: {subprogram: 132, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1540
+      ID: 1541
       Name: Probe[main.testEmptyString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12508,7 +12592,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: x}
+                  Variable: {subprogram: 151, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -12518,11 +12602,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: x}
+                  Variable: {subprogram: 151, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1554
+      ID: 1555
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12534,7 +12618,7 @@ Types:
             Type: 320 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: e}
+                  Variable: {subprogram: 158, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -12544,11 +12628,11 @@ Types:
             Type: 320 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: e}
+                  Variable: {subprogram: 158, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1553
+      ID: 1554
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -12560,7 +12644,7 @@ Types:
             Type: 319 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: e}
+                  Variable: {subprogram: 157, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
         - Name: e
@@ -12570,11 +12654,77 @@ Types:
             Type: 319 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: e}
+                  Variable: {subprogram: 157, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1392
+      ID: 1361
+      Name: Probe[main.testErrorAtLine]Line
+      ByteSize: 58
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: shouldErr
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 0, name: shouldErr}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: ~r0
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 10
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 2, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 18
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 2, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: err
+          Offset: 26
+          Kind: local
+          Expression:
+            Type: 14 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 3, name: err}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: err
+          Offset: 42
+          Kind: template_segment
+          Expression:
+            Type: 14 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 3, name: err}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1393
       Name: Probe[main.testError]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12586,7 +12736,7 @@ Types:
             Type: 14 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: e}
+                  Variable: {subprogram: 58, index: 0, name: e}
                   Offset: 0
                   ByteSize: 16
         - Name: e
@@ -12596,11 +12746,11 @@ Types:
             Type: 14 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: e}
+                  Variable: {subprogram: 58, index: 0, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1374
+      ID: 1375
       Name: Probe[main.testEsotericHeap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12612,7 +12762,7 @@ Types:
             Type: 159 PointerType *main.esotericHeap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 48, index: 0, name: e}
+                  Variable: {subprogram: 49, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -12622,14 +12772,14 @@ Types:
             Type: 159 PointerType *main.esotericHeap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 48, index: 0, name: e}
+                  Variable: {subprogram: 49, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1375
+      ID: 1376
       Name: Probe[main.testEsotericHeap]Return
     - __kind: EventRootType
-      ID: 1372
+      ID: 1373
       Name: Probe[main.testEsotericStack]
       ByteSize: 129
       PresenceBitsetSize: 1
@@ -12641,7 +12791,7 @@ Types:
             Type: 155 StructureType main.esotericStack
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 0, name: e}
+                  Variable: {subprogram: 48, index: 0, name: e}
                   Offset: 0
                   ByteSize: 64
         - Name: e
@@ -12651,14 +12801,14 @@ Types:
             Type: 155 StructureType main.esotericStack
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 0, name: e}
+                  Variable: {subprogram: 48, index: 0, name: e}
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1373
+      ID: 1374
       Name: Probe[main.testEsotericStack]Return
     - __kind: EventRootType
-      ID: 1386
+      ID: 1387
       Name: Probe[main.testFramelessArray]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12670,7 +12820,7 @@ Types:
             Type: 161 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: a}
+                  Variable: {subprogram: 55, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: a
@@ -12680,11 +12830,11 @@ Types:
             Type: 161 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: a}
+                  Variable: {subprogram: 55, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1388
+      ID: 1389
       Name: Probe[main.testFramelessArray]Line
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -12696,7 +12846,7 @@ Types:
             Type: 161 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: a}
+                  Variable: {subprogram: 55, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: a
@@ -12706,7 +12856,7 @@ Types:
             Type: 161 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: a}
+                  Variable: {subprogram: 55, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: ~r0
@@ -12716,11 +12866,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 1, name: ~r0}
+                  Variable: {subprogram: 55, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1387
+      ID: 1388
       Name: Probe[main.testFramelessArray]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12732,11 +12882,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 1, name: ~r0}
+                  Variable: {subprogram: 55, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1384
+      ID: 1385
       Name: Probe[main.testFrameless]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12748,7 +12898,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: x}
+                  Variable: {subprogram: 54, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12758,11 +12908,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: x}
+                  Variable: {subprogram: 54, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1385
+      ID: 1386
       Name: Probe[main.testFrameless]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12774,11 +12924,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 1, name: ~r0}
+                  Variable: {subprogram: 54, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1376
+      ID: 1377
       Name: Probe[main.testInlinedBA]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12790,7 +12940,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: x}
+                  Variable: {subprogram: 50, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12800,14 +12950,14 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: x}
+                  Variable: {subprogram: 50, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1377
+      ID: 1378
       Name: Probe[main.testInlinedBA]Return
     - __kind: EventRootType
-      ID: 1380
+      ID: 1381
       Name: Probe[main.testInlinedBBA]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12819,7 +12969,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: x}
+                  Variable: {subprogram: 52, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12829,17 +12979,17 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: x}
+                  Variable: {subprogram: 52, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1381
+      ID: 1382
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1560
+      ID: 1561
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 1378
+      ID: 1379
       Name: Probe[main.testInlinedBB]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12851,7 +13001,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: x}
+                  Variable: {subprogram: 51, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12861,7 +13011,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: x}
+                  Variable: {subprogram: 51, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: y
@@ -12871,7 +13021,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 1, name: y}
+                  Variable: {subprogram: 51, index: 1, name: y}
                   Offset: 0
                   ByteSize: 8
         - Name: y
@@ -12881,32 +13031,32 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 1, name: y}
+                  Variable: {subprogram: 51, index: 1, name: y}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1379
+      ID: 1380
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1561
+      ID: 1562
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1562
+      ID: 1563
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1563
+      ID: 1564
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1564
+      ID: 1565
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
-      ID: 1382
+      ID: 1383
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 1383
+      ID: 1384
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1557
+      ID: 1558
       Name: Probe[main.testInlinedPrint]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12918,7 +13068,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12928,11 +13078,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1555
+      ID: 1556
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12944,11 +13094,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1556
+      ID: 1557
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12960,7 +13110,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x_val
@@ -12970,11 +13120,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1559
+      ID: 1560
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12986,7 +13136,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12996,14 +13146,14 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1558
+      ID: 1559
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1565
+      ID: 1566
       Name: Probe[main.testInlinedSq]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13015,7 +13165,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -13025,11 +13175,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1566
+      ID: 1567
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13041,7 +13191,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -13051,11 +13201,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1567
+      ID: 1568
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13067,7 +13217,7 @@ Types:
             Type: 161 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: a}
+                  Variable: {subprogram: 164, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: a
@@ -13077,7 +13227,7 @@ Types:
             Type: 161 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: a}
+                  Variable: {subprogram: 164, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
@@ -13211,7 +13361,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1389
+      ID: 1390
       Name: Probe[main.testInterface]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13223,7 +13373,7 @@ Types:
             Type: 162 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: b}
+                  Variable: {subprogram: 56, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -13233,11 +13383,11 @@ Types:
             Type: 162 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: b}
+                  Variable: {subprogram: 56, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1495
+      ID: 1496
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 161
       PresenceBitsetSize: 1
@@ -13249,7 +13399,7 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: arg}
+                  Variable: {subprogram: 122, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
         - Name: arg
@@ -13259,11 +13409,11 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: arg}
+                  Variable: {subprogram: 122, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1496
+      ID: 1497
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13275,11 +13425,11 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 1, name: ~r0}
+                  Variable: {subprogram: 122, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1428
+      ID: 1429
       Name: Probe[main.testLinkedList]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13291,7 +13441,7 @@ Types:
             Type: 246 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: a}
+                  Variable: {subprogram: 90, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -13301,38 +13451,12 @@ Types:
             Type: 246 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: a}
+                  Variable: {subprogram: 90, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1369
-      Name: Probe[main.testLongFunctionWithChangingState]Line
-    - __kind: EventRootType
       ID: 1370
       Name: Probe[main.testLongFunctionWithChangingState]Line
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: aPerArch
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 1, name: aPerArch}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: b
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 2, name: b}
-                  Offset: 0
-                  ByteSize: 8
     - __kind: EventRootType
       ID: 1371
       Name: Probe[main.testLongFunctionWithChangingState]Line
@@ -13346,7 +13470,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 1, name: aPerArch}
+                  Variable: {subprogram: 47, index: 1, name: aPerArch}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13356,11 +13480,37 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 2, name: b}
+                  Variable: {subprogram: 47, index: 2, name: b}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1501
+      ID: 1372
+      Name: Probe[main.testLongFunctionWithChangingState]Line
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: aPerArch
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 47, index: 1, name: aPerArch}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 47, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1502
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 147
       PresenceBitsetSize: 3
@@ -13372,7 +13522,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: a}
+                  Variable: {subprogram: 125, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -13382,7 +13532,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: a}
+                  Variable: {subprogram: 125, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13392,7 +13542,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 1, name: b}
+                  Variable: {subprogram: 125, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13402,7 +13552,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 1, name: b}
+                  Variable: {subprogram: 125, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13412,7 +13562,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 2, name: c}
+                  Variable: {subprogram: 125, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13422,7 +13572,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 2, name: c}
+                  Variable: {subprogram: 125, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13432,7 +13582,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 3, name: d}
+                  Variable: {subprogram: 125, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13442,7 +13592,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 3, name: d}
+                  Variable: {subprogram: 125, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13452,7 +13602,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 4, name: e}
+                  Variable: {subprogram: 125, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13462,7 +13612,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 4, name: e}
+                  Variable: {subprogram: 125, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13472,7 +13622,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 5, name: f}
+                  Variable: {subprogram: 125, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13482,7 +13632,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 5, name: f}
+                  Variable: {subprogram: 125, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13492,7 +13642,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 6, name: g}
+                  Variable: {subprogram: 125, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13502,7 +13652,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 6, name: g}
+                  Variable: {subprogram: 125, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13512,7 +13662,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 7, name: h}
+                  Variable: {subprogram: 125, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13522,7 +13672,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 7, name: h}
+                  Variable: {subprogram: 125, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13532,7 +13682,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 8, name: i}
+                  Variable: {subprogram: 125, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13542,11 +13692,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 8, name: i}
+                  Variable: {subprogram: 125, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1502
+      ID: 1503
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13558,11 +13708,11 @@ Types:
             Type: 113 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 9, name: ~r0}
+                  Variable: {subprogram: 125, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1400
+      ID: 1401
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13574,7 +13724,7 @@ Types:
             Type: 186 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13584,11 +13734,11 @@ Types:
             Type: 186 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1407
+      ID: 1408
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13600,7 +13750,7 @@ Types:
             Type: 193 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: m}
+                  Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13610,11 +13760,11 @@ Types:
             Type: 193 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: m}
+                  Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1419
+      ID: 1420
       Name: Probe[main.testMapEmptyKeyAndValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13626,7 +13776,7 @@ Types:
             Type: 238 GoMapType map[struct {}]struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: m}
+                  Variable: {subprogram: 83, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13636,11 +13786,11 @@ Types:
             Type: 238 GoMapType map[struct {}]struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: m}
+                  Variable: {subprogram: 83, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1417
+      ID: 1418
       Name: Probe[main.testMapEmptyKey]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13652,7 +13802,7 @@ Types:
             Type: 228 GoMapType map[struct {}]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: m}
+                  Variable: {subprogram: 81, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13662,11 +13812,11 @@ Types:
             Type: 228 GoMapType map[struct {}]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: m}
+                  Variable: {subprogram: 81, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1418
+      ID: 1419
       Name: Probe[main.testMapEmptyValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13678,7 +13828,7 @@ Types:
             Type: 233 GoMapType map[int]struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: m}
+                  Variable: {subprogram: 82, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13688,11 +13838,11 @@ Types:
             Type: 233 GoMapType map[int]struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: m}
+                  Variable: {subprogram: 82, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1404
+      ID: 1405
       Name: Probe[main.testMapIntToInt]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13704,7 +13854,7 @@ Types:
             Type: 166 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
+                  Variable: {subprogram: 69, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13714,11 +13864,11 @@ Types:
             Type: 166 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
+                  Variable: {subprogram: 69, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1416
+      ID: 1417
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13730,7 +13880,7 @@ Types:
             Type: 223 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: m}
+                  Variable: {subprogram: 80, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13740,11 +13890,11 @@ Types:
             Type: 223 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: m}
+                  Variable: {subprogram: 80, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1415
+      ID: 1416
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13756,7 +13906,7 @@ Types:
             Type: 218 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: m}
+                  Variable: {subprogram: 79, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13766,33 +13916,7 @@ Types:
             Type: 218 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1405
-      Name: Probe[main.testMapMassive]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: redactMyEntries
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 193 GoMapType map[string][]main.structWithMap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: redactMyEntries
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 193 GoMapType map[string][]main.structWithMap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 79, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -13808,7 +13932,7 @@ Types:
             Type: 193 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 70, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
         - Name: redactMyEntries
@@ -13818,11 +13942,37 @@ Types:
             Type: 193 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 70, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1414
+      ID: 1407
+      Name: Probe[main.testMapMassive]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: redactMyEntries
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 193 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 70, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: redactMyEntries
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 193 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 70, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1415
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13834,7 +13984,7 @@ Types:
             Type: 213 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: m}
+                  Variable: {subprogram: 78, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13844,11 +13994,11 @@ Types:
             Type: 213 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: m}
+                  Variable: {subprogram: 78, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1413
+      ID: 1414
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13860,6 +14010,136 @@ Types:
             Type: 208 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
+                  Variable: {subprogram: 77, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 208 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 77, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1399
+      Name: Probe[main.testMapStringToInt]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 176 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 63, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 176 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 63, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1400
+      Name: Probe[main.testMapStringToSlice]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 181 GoMapType map[string][]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 64, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 181 GoMapType map[string][]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 64, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1398
+      Name: Probe[main.testMapStringToStruct]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 171 GoMapType map[string]main.nestedStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 62, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 171 GoMapType map[string]main.nestedStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 62, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1409
+      Name: Probe[main.testMapWithLinkedList]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 198 GoMapType map[bool]main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 72, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 198 GoMapType map[bool]main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 72, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1413
+      Name: Probe[main.testMapWithSmallKeyAndValueMassive]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 208 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
                   Variable: {subprogram: 76, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
@@ -13874,112 +14154,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1398
-      Name: Probe[main.testMapStringToInt]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 176 GoMapType map[string]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: m
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 176 GoMapType map[string]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1399
-      Name: Probe[main.testMapStringToSlice]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 181 GoMapType map[string][]string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: m
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 181 GoMapType map[string][]string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1397
-      Name: Probe[main.testMapStringToStruct]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 171 GoMapType map[string]main.nestedStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: m
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 171 GoMapType map[string]main.nestedStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1408
-      Name: Probe[main.testMapWithLinkedList]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 198 GoMapType map[bool]main.node
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: m
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 198 GoMapType map[bool]main.node
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
       ID: 1412
-      Name: Probe[main.testMapWithSmallKeyAndValueMassive]
+      Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
@@ -14005,32 +14181,6 @@ Types:
                   ByteSize: 8
     - __kind: EventRootType
       ID: 1411
-      Name: Probe[main.testMapWithSmallKeyAndValue]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 208 GoMapType map[uint8]uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: m
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 208 GoMapType map[uint8]uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1410
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14042,7 +14192,7 @@ Types:
             Type: 203 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 74, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
         - Name: redactMyEntries
@@ -14052,11 +14202,11 @@ Types:
             Type: 203 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 74, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1409
+      ID: 1410
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14068,7 +14218,7 @@ Types:
             Type: 203 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: m}
+                  Variable: {subprogram: 73, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -14078,35 +14228,9 @@ Types:
             Type: 203 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: m}
+                  Variable: {subprogram: 73, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
-    - __kind: EventRootType
-      ID: 1537
-      Name: Probe[main.testMassiveString]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: x
-          Offset: 17
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
     - __kind: EventRootType
       ID: 1538
       Name: Probe[main.testMassiveString]
@@ -14120,7 +14244,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
+                  Variable: {subprogram: 149, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -14130,11 +14254,37 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
+                  Variable: {subprogram: 149, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1503
+      ID: 1539
+      Name: Probe[main.testMassiveString]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 149, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 149, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1504
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 163
       PresenceBitsetSize: 3
@@ -14146,7 +14296,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: a}
+                  Variable: {subprogram: 126, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14156,7 +14306,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: a}
+                  Variable: {subprogram: 126, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -14166,7 +14316,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: b}
+                  Variable: {subprogram: 126, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -14176,7 +14326,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: b}
+                  Variable: {subprogram: 126, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -14186,7 +14336,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: c}
+                  Variable: {subprogram: 126, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -14196,7 +14346,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: c}
+                  Variable: {subprogram: 126, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -14206,7 +14356,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 3, name: d}
+                  Variable: {subprogram: 126, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -14216,7 +14366,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 3, name: d}
+                  Variable: {subprogram: 126, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -14226,7 +14376,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 4, name: e}
+                  Variable: {subprogram: 126, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -14236,7 +14386,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 4, name: e}
+                  Variable: {subprogram: 126, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -14246,7 +14396,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 5, name: f}
+                  Variable: {subprogram: 126, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -14256,7 +14406,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 5, name: f}
+                  Variable: {subprogram: 126, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -14266,7 +14416,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 6, name: g}
+                  Variable: {subprogram: 126, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -14276,7 +14426,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 6, name: g}
+                  Variable: {subprogram: 126, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -14286,7 +14436,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 7, name: h}
+                  Variable: {subprogram: 126, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -14296,7 +14446,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 7, name: h}
+                  Variable: {subprogram: 126, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: s
@@ -14306,7 +14456,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 8, name: s}
+                  Variable: {subprogram: 126, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
         - Name: s
@@ -14316,11 +14466,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 8, name: s}
+                  Variable: {subprogram: 126, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1504
+      ID: 1505
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -14332,11 +14482,11 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 9, name: ~r0}
+                  Variable: {subprogram: 126, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1507
+      ID: 1508
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -14348,7 +14498,7 @@ Types:
             Type: 113 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -14358,7 +14508,7 @@ Types:
             Type: 113 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -14368,7 +14518,7 @@ Types:
             Type: 251 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: b}
+                  Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
         - Name: b
@@ -14378,11 +14528,11 @@ Types:
             Type: 251 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: b}
+                  Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1508
+      ID: 1509
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -14394,7 +14544,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 2, name: ~r0}
+                  Variable: {subprogram: 128, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -14404,11 +14554,11 @@ Types:
             Type: 113 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 3, name: ~r1}
+                  Variable: {subprogram: 128, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1499
+      ID: 1500
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 321
       PresenceBitsetSize: 1
@@ -14420,7 +14570,7 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: s1}
+                  Variable: {subprogram: 124, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
         - Name: s1
@@ -14430,7 +14580,7 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: s1}
+                  Variable: {subprogram: 124, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
         - Name: s2
@@ -14440,7 +14590,7 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: s2}
+                  Variable: {subprogram: 124, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
         - Name: s2
@@ -14450,11 +14600,11 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: s2}
+                  Variable: {subprogram: 124, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1500
+      ID: 1501
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -14466,11 +14616,11 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 2, name: ~r0}
+                  Variable: {subprogram: 124, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1453
+      ID: 1454
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14482,7 +14632,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14492,11 +14642,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1455
+      ID: 1456
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14508,7 +14658,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14518,7 +14668,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14528,7 +14678,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14538,11 +14688,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1457
+      ID: 1458
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14554,11 +14704,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1459
+      ID: 1460
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14570,11 +14720,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1461
+      ID: 1462
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14586,11 +14736,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1454
+      ID: 1455
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14602,7 +14752,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14612,11 +14762,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1456
+      ID: 1457
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -14628,7 +14778,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14638,7 +14788,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14648,7 +14798,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14658,7 +14808,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14668,7 +14818,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14678,11 +14828,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1458
+      ID: 1459
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14694,7 +14844,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14704,11 +14854,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1460
+      ID: 1461
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14720,7 +14870,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14730,11 +14880,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1462
+      ID: 1463
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14746,7 +14896,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14756,11 +14906,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1423
+      ID: 1424
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 62
       PresenceBitsetSize: 2
@@ -14772,7 +14922,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: a}
+                  Variable: {subprogram: 86, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: a
@@ -14782,7 +14932,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: a}
+                  Variable: {subprogram: 86, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -14792,7 +14942,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 1, name: b}
+                  Variable: {subprogram: 86, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -14802,7 +14952,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 1, name: b}
+                  Variable: {subprogram: 86, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: c
@@ -14812,7 +14962,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 2, name: c}
+                  Variable: {subprogram: 86, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: c
@@ -14822,7 +14972,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 2, name: c}
+                  Variable: {subprogram: 86, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: d
@@ -14832,7 +14982,7 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 3, name: d}
+                  Variable: {subprogram: 86, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -14842,7 +14992,7 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 3, name: d}
+                  Variable: {subprogram: 86, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -14852,7 +15002,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 4, name: e}
+                  Variable: {subprogram: 86, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
         - Name: e
@@ -14862,11 +15012,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 4, name: e}
+                  Variable: {subprogram: 86, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1449
+      ID: 1450
       Name: Probe[main.testNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14878,7 +15028,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14888,37 +15038,37 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1452
+      Name: Probe[main.testNamedReturn]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
       ID: 1451
-      Name: Probe[main.testNamedReturn]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1450
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14930,11 +15080,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1452
+      ID: 1453
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14946,7 +15096,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14956,11 +15106,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1549
+      ID: 1550
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14972,7 +15122,7 @@ Types:
             Type: 317 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: x}
+                  Variable: {subprogram: 156, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -14982,11 +15132,11 @@ Types:
             Type: 317 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: x}
+                  Variable: {subprogram: 156, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1550
+      ID: 1551
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14998,7 +15148,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: x}
+                  Variable: {subprogram: 156, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -15008,10 +15158,10 @@ Types:
                   Bias: 8
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1551
+      ID: 1552
       Name: Probe[main.testNestedPointer]
     - __kind: EventRootType
-      ID: 1552
+      ID: 1553
       Name: Probe[main.testNestedPointer]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15023,7 +15173,7 @@ Types:
             Type: 123 StructureType main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: x}
+                  Variable: {subprogram: 156, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -15033,7 +15183,7 @@ Types:
                   Bias: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1433
+      ID: 1434
       Name: Probe[main.testNilPointer]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15045,7 +15195,7 @@ Types:
             Type: 11 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: z}
+                  Variable: {subprogram: 95, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: z
@@ -15055,7 +15205,7 @@ Types:
             Type: 11 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: z}
+                  Variable: {subprogram: 95, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -15065,7 +15215,7 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 1, name: a}
+                  Variable: {subprogram: 95, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -15075,11 +15225,11 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 1, name: a}
+                  Variable: {subprogram: 95, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1518
+      ID: 1519
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -15091,7 +15241,7 @@ Types:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: xs}
+                  Variable: {subprogram: 136, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -15101,7 +15251,7 @@ Types:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: xs}
+                  Variable: {subprogram: 136, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -15111,7 +15261,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 1, name: a}
+                  Variable: {subprogram: 136, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -15121,11 +15271,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 1, name: a}
+                  Variable: {subprogram: 136, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1520
+      ID: 1521
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 67
       PresenceBitsetSize: 1
@@ -15137,7 +15287,7 @@ Types:
             Type: 17 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: a}
+                  Variable: {subprogram: 138, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: a
@@ -15147,7 +15297,7 @@ Types:
             Type: 17 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: a}
+                  Variable: {subprogram: 138, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
@@ -15157,7 +15307,7 @@ Types:
             Type: 264 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 1, name: s}
+                  Variable: {subprogram: 138, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: s
@@ -15167,7 +15317,7 @@ Types:
             Type: 264 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 1, name: s}
+                  Variable: {subprogram: 138, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -15177,7 +15327,7 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 2, name: x}
+                  Variable: {subprogram: 138, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -15187,11 +15337,11 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 2, name: x}
+                  Variable: {subprogram: 138, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1521
+      ID: 1522
       Name: Probe[main.testNilSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -15203,7 +15353,7 @@ Types:
             Type: 265 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -15213,11 +15363,11 @@ Types:
             Type: 265 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1536
+      ID: 1537
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15229,7 +15379,7 @@ Types:
             Type: 270 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -15239,11 +15389,11 @@ Types:
             Type: 270 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1429
+      ID: 1430
       Name: Probe[main.testPointerLoop]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15255,7 +15405,7 @@ Types:
             Type: 247 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: a}
+                  Variable: {subprogram: 91, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -15265,11 +15415,11 @@ Types:
             Type: 247 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: a}
+                  Variable: {subprogram: 91, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1403
+      ID: 1404
       Name: Probe[main.testPointerToMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15281,7 +15431,7 @@ Types:
             Type: 192 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: m}
+                  Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -15291,11 +15441,11 @@ Types:
             Type: 192 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: m}
+                  Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1427
+      ID: 1428
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15307,7 +15457,7 @@ Types:
             Type: 244 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: a}
+                  Variable: {subprogram: 89, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -15317,11 +15467,11 @@ Types:
             Type: 244 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: a}
+                  Variable: {subprogram: 89, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1443
+      ID: 1444
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 35
       PresenceBitsetSize: 1
@@ -15333,7 +15483,7 @@ Types:
             Type: 157 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: v}
+                  Variable: {subprogram: 101, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: v
@@ -15343,7 +15493,7 @@ Types:
             Type: 157 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: v}
+                  Variable: {subprogram: 101, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: failed
@@ -15353,7 +15503,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 1, name: failed}
+                  Variable: {subprogram: 101, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
         - Name: failed
@@ -15363,11 +15513,11 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 1, name: failed}
+                  Variable: {subprogram: 101, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1444
+      ID: 1445
       Name: Probe[main.testReturnsAnyAndError]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15379,7 +15529,7 @@ Types:
             Type: 157 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 2, name: ~r0}
+                  Variable: {subprogram: 101, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
         - Name: ~r1
@@ -15389,11 +15539,11 @@ Types:
             Type: 14 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 3, name: ~r1}
+                  Variable: {subprogram: 101, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1445
+      ID: 1446
       Name: Probe[main.testReturnsAny]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15405,7 +15555,7 @@ Types:
             Type: 157 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: v}
+                  Variable: {subprogram: 102, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: v
@@ -15415,11 +15565,11 @@ Types:
             Type: 157 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: v}
+                  Variable: {subprogram: 102, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1446
+      ID: 1447
       Name: Probe[main.testReturnsAny]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15431,14 +15581,14 @@ Types:
             Type: 157 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 1, name: ~r0}
+                  Variable: {subprogram: 102, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1475
+      ID: 1476
       Name: Probe[main.testReturnsArrayOne]
     - __kind: EventRootType
-      ID: 1476
+      ID: 1477
       Name: Probe[main.testReturnsArrayOne]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15450,14 +15600,14 @@ Types:
             Type: 252 ArrayType [1]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 0, name: ~r0}
+                  Variable: {subprogram: 112, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1477
+      ID: 1478
       Name: Probe[main.testReturnsArrayZero]
     - __kind: EventRootType
-      ID: 1478
+      ID: 1479
       Name: Probe[main.testReturnsArrayZero]Return
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -15469,14 +15619,14 @@ Types:
             Type: 253 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 0, name: ~r0}
+                  Variable: {subprogram: 113, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1473
+      ID: 1474
       Name: Probe[main.testReturnsArray]
     - __kind: EventRootType
-      ID: 1474
+      ID: 1475
       Name: Probe[main.testReturnsArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15488,14 +15638,14 @@ Types:
             Type: 251 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 0, name: ~r0}
+                  Variable: {subprogram: 111, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1481
+      ID: 1482
       Name: Probe[main.testReturnsBacktrackInt]
     - __kind: EventRootType
-      ID: 1482
+      ID: 1483
       Name: Probe[main.testReturnsBacktrackInt]Return
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -15507,7 +15657,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: ~r0}
+                  Variable: {subprogram: 115, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15517,7 +15667,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 1, name: ~r1}
+                  Variable: {subprogram: 115, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15527,7 +15677,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 2, name: ~r2}
+                  Variable: {subprogram: 115, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -15537,7 +15687,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 3, name: ~r3}
+                  Variable: {subprogram: 115, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15547,7 +15697,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 4, name: ~r4}
+                  Variable: {subprogram: 115, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r5
@@ -15557,7 +15707,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 5, name: ~r5}
+                  Variable: {subprogram: 115, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r6
@@ -15567,7 +15717,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 6, name: ~r6}
+                  Variable: {subprogram: 115, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r7
@@ -15577,7 +15727,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 7, name: ~r7}
+                  Variable: {subprogram: 115, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r8
@@ -15587,14 +15737,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 8, name: ~r8}
+                  Variable: {subprogram: 115, index: 8, name: ~r8}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1493
+      ID: 1494
       Name: Probe[main.testReturnsBoolAndUintptr]
     - __kind: EventRootType
-      ID: 1494
+      ID: 1495
       Name: Probe[main.testReturnsBoolAndUintptr]Return
       ByteSize: 10
       PresenceBitsetSize: 1
@@ -15606,7 +15756,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: ~r0}
+                  Variable: {subprogram: 121, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r1
@@ -15616,14 +15766,14 @@ Types:
             Type: 1 BaseType uintptr
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 1, name: ~r1}
+                  Variable: {subprogram: 121, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1469
+      ID: 1470
       Name: Probe[main.testReturnsComplex]
     - __kind: EventRootType
-      ID: 1470
+      ID: 1471
       Name: Probe[main.testReturnsComplex]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15635,7 +15785,7 @@ Types:
             Type: 97 BaseType complex64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: ~r0}
+                  Variable: {subprogram: 109, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15645,11 +15795,11 @@ Types:
             Type: 98 BaseType complex128
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: ~r1}
+                  Variable: {subprogram: 109, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1441
+      ID: 1442
       Name: Probe[main.testReturnsError]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -15661,7 +15811,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: failed}
+                  Variable: {subprogram: 100, index: 0, name: failed}
                   Offset: 0
                   ByteSize: 1
         - Name: failed
@@ -15671,11 +15821,11 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: failed}
+                  Variable: {subprogram: 100, index: 0, name: failed}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1442
+      ID: 1443
       Name: Probe[main.testReturnsError]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15687,11 +15837,11 @@ Types:
             Type: 14 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 1, name: ~r0}
+                  Variable: {subprogram: 100, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1439
+      ID: 1440
       Name: Probe[main.testReturnsIntAndFloat]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15703,7 +15853,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: i}
+                  Variable: {subprogram: 99, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -15713,11 +15863,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: i}
+                  Variable: {subprogram: 99, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1440
+      ID: 1441
       Name: Probe[main.testReturnsIntAndFloat]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15729,7 +15879,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 1, name: ~r0}
+                  Variable: {subprogram: 99, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15739,11 +15889,11 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 2, name: ~r1}
+                  Variable: {subprogram: 99, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1437
+      ID: 1438
       Name: Probe[main.testReturnsIntPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15755,7 +15905,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: i}
+                  Variable: {subprogram: 98, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -15765,11 +15915,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: i}
+                  Variable: {subprogram: 98, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1438
+      ID: 1439
       Name: Probe[main.testReturnsIntPointer]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15781,11 +15931,11 @@ Types:
             Type: 100 PointerType *int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 1, name: ~r0}
+                  Variable: {subprogram: 98, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1435
+      ID: 1436
       Name: Probe[main.testReturnsInt]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15797,7 +15947,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: i}
+                  Variable: {subprogram: 97, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -15807,11 +15957,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: i}
+                  Variable: {subprogram: 97, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1436
+      ID: 1437
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15823,11 +15973,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 1, name: ~r0}
+                  Variable: {subprogram: 97, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1447
+      ID: 1448
       Name: Probe[main.testReturnsInterface]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15839,7 +15989,7 @@ Types:
             Type: 157 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: v}
+                  Variable: {subprogram: 103, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: v
@@ -15849,11 +15999,11 @@ Types:
             Type: 157 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: v}
+                  Variable: {subprogram: 103, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1448
+      ID: 1449
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15865,14 +16015,14 @@ Types:
             Type: 162 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: ~r0}
+                  Variable: {subprogram: 103, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1471
+      ID: 1472
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1472
+      ID: 1473
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -15884,14 +16034,14 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: ~r0}
+                  Variable: {subprogram: 110, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1467
+      ID: 1468
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1468
+      ID: 1469
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 139
       PresenceBitsetSize: 3
@@ -15903,7 +16053,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: ~r0}
+                  Variable: {subprogram: 108, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15913,7 +16063,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 1, name: ~r1}
+                  Variable: {subprogram: 108, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15923,7 +16073,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 2, name: ~r2}
+                  Variable: {subprogram: 108, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -15933,7 +16083,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 3, name: ~r3}
+                  Variable: {subprogram: 108, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15943,7 +16093,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 4, name: ~r4}
+                  Variable: {subprogram: 108, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r5
@@ -15953,7 +16103,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 5, name: ~r5}
+                  Variable: {subprogram: 108, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r6
@@ -15963,7 +16113,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 6, name: ~r6}
+                  Variable: {subprogram: 108, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r7
@@ -15973,7 +16123,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 7, name: ~r7}
+                  Variable: {subprogram: 108, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r8
@@ -15983,7 +16133,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 8, name: ~r8}
+                  Variable: {subprogram: 108, index: 8, name: ~r8}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r9
@@ -15993,7 +16143,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 9, name: ~r9}
+                  Variable: {subprogram: 108, index: 9, name: ~r9}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r10
@@ -16003,7 +16153,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 10, name: ~r10}
+                  Variable: {subprogram: 108, index: 10, name: ~r10}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r11
@@ -16013,7 +16163,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 11, name: ~r11}
+                  Variable: {subprogram: 108, index: 11, name: ~r11}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r12
@@ -16023,7 +16173,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 12, name: ~r12}
+                  Variable: {subprogram: 108, index: 12, name: ~r12}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r13
@@ -16033,7 +16183,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 13, name: ~r13}
+                  Variable: {subprogram: 108, index: 13, name: ~r13}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r14
@@ -16043,7 +16193,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 14, name: ~r14}
+                  Variable: {subprogram: 108, index: 14, name: ~r14}
                   Offset: 0
                   ByteSize: 8
         - Name: onlyOnAmd64_16
@@ -16053,7 +16203,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 15, name: onlyOnAmd64_16}
+                  Variable: {subprogram: 108, index: 15, name: onlyOnAmd64_16}
                   Offset: 0
                   ByteSize: 8
         - Name: bothArmAndAmd64
@@ -16063,14 +16213,14 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 16, name: bothArmAndAmd64}
+                  Variable: {subprogram: 108, index: 16, name: bothArmAndAmd64}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1479
+      ID: 1480
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1480
+      ID: 1481
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16082,14 +16232,14 @@ Types:
             Type: 254 StructureType main.mixedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: ~r0}
+                  Variable: {subprogram: 114, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1485
+      ID: 1486
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1486
+      ID: 1487
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16101,7 +16251,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 0, name: ~r0}
+                  Variable: {subprogram: 117, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -16111,7 +16261,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 1, name: ~r1}
+                  Variable: {subprogram: 117, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -16121,7 +16271,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 2, name: ~r2}
+                  Variable: {subprogram: 117, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -16131,7 +16281,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 3, name: ~r3}
+                  Variable: {subprogram: 117, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -16141,14 +16291,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 4, name: ~r4}
+                  Variable: {subprogram: 117, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1491
+      ID: 1492
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1492
+      ID: 1493
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -16160,7 +16310,7 @@ Types:
             Type: 18 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: ~r0}
+                  Variable: {subprogram: 120, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r1
@@ -16170,14 +16320,14 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 1, name: ~r1}
+                  Variable: {subprogram: 120, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1489
+      ID: 1490
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1490
+      ID: 1491
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -16189,14 +16339,14 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 0, name: ~r0}
+                  Variable: {subprogram: 119, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1465
+      ID: 1466
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1466
+      ID: 1467
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -16208,7 +16358,7 @@ Types:
             Type: 17 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 0, name: ~r0}
+                  Variable: {subprogram: 107, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r1
@@ -16218,7 +16368,7 @@ Types:
             Type: 96 BaseType int16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 1, name: ~r1}
+                  Variable: {subprogram: 107, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 2
         - Name: ~r2
@@ -16228,7 +16378,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 2, name: ~r2}
+                  Variable: {subprogram: 107, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r3
@@ -16238,7 +16388,7 @@ Types:
             Type: 13 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 3, name: ~r3}
+                  Variable: {subprogram: 107, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -16248,7 +16398,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 4, name: ~r4}
+                  Variable: {subprogram: 107, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r5
@@ -16258,7 +16408,7 @@ Types:
             Type: 6 BaseType uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 5, name: ~r5}
+                  Variable: {subprogram: 107, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 2
         - Name: ~r6
@@ -16268,7 +16418,7 @@ Types:
             Type: 2 BaseType uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 6, name: ~r6}
+                  Variable: {subprogram: 107, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r7
@@ -16278,14 +16428,14 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 7, name: ~r7}
+                  Variable: {subprogram: 107, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1487
+      ID: 1488
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1488
+      ID: 1489
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16297,14 +16447,14 @@ Types:
             Type: 256 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 0, name: ~r0}
+                  Variable: {subprogram: 118, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1483
+      ID: 1484
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1484
+      ID: 1485
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -16316,7 +16466,7 @@ Types:
             Type: 255 StructureType main.wideStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 0, name: ~r0}
+                  Variable: {subprogram: 116, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 88
     - __kind: EventRootType
@@ -16626,7 +16776,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1528
+      ID: 1529
       Name: Probe[main.testSingleString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16638,7 +16788,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: x}
+                  Variable: {subprogram: 144, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -16648,7 +16798,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: x}
+                  Variable: {subprogram: 144, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -16782,7 +16932,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1524
+      ID: 1525
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16794,7 +16944,7 @@ Types:
             Type: 266 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: xs}
+                  Variable: {subprogram: 141, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -16804,11 +16954,11 @@ Types:
             Type: 266 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: xs}
+                  Variable: {subprogram: 141, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1515
+      ID: 1516
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16820,7 +16970,7 @@ Types:
             Type: 258 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: u}
+                  Variable: {subprogram: 133, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -16830,11 +16980,11 @@ Types:
             Type: 258 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: u}
+                  Variable: {subprogram: 133, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1401
+      ID: 1402
       Name: Probe[main.testSmallMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16846,7 +16996,7 @@ Types:
             Type: 176 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -16856,11 +17006,11 @@ Types:
             Type: 176 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1463
+      ID: 1464
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16872,7 +17022,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: i}
+                  Variable: {subprogram: 106, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -16882,11 +17032,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: i}
+                  Variable: {subprogram: 106, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1464
+      ID: 1465
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16898,7 +17048,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 1, name: ~r0}
+                  Variable: {subprogram: 106, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -16908,7 +17058,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 2, name: result2}
+                  Variable: {subprogram: 106, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -16918,11 +17068,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 3, name: ~r2}
+                  Variable: {subprogram: 106, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1505
+      ID: 1506
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -16934,7 +17084,7 @@ Types:
             Type: 161 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: arg}
+                  Variable: {subprogram: 127, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
         - Name: arg
@@ -16944,11 +17094,11 @@ Types:
             Type: 161 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: arg}
+                  Variable: {subprogram: 127, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1506
+      ID: 1507
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16960,7 +17110,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: ~r0}
+                  Variable: {subprogram: 127, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -16970,7 +17120,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: ~r1}
+                  Variable: {subprogram: 127, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -16980,7 +17130,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 3, name: ~r2}
+                  Variable: {subprogram: 127, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -17010,7 +17160,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1432
+      ID: 1433
       Name: Probe[main.testStringPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17022,7 +17172,7 @@ Types:
             Type: 95 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: z}
+                  Variable: {subprogram: 94, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: z
@@ -17032,11 +17182,11 @@ Types:
             Type: 95 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: z}
+                  Variable: {subprogram: 94, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1519
+      ID: 1520
       Name: Probe[main.testStringSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17048,7 +17198,7 @@ Types:
             Type: 263 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: s}
+                  Variable: {subprogram: 137, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: s
@@ -17058,11 +17208,11 @@ Types:
             Type: 263 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: s}
+                  Variable: {subprogram: 137, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1367
+      ID: 1368
       Name: Probe[main.testStringType1]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17074,7 +17224,7 @@ Types:
             Type: 151 PointerType *main.stringType1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 0, name: a}
+                  Variable: {subprogram: 45, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -17084,11 +17234,11 @@ Types:
             Type: 151 PointerType *main.stringType1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 0, name: a}
+                  Variable: {subprogram: 45, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1368
+      ID: 1369
       Name: Probe[main.testStringType2]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17100,7 +17250,7 @@ Types:
             Type: 153 PointerType **main.stringType2
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: a}
+                  Variable: {subprogram: 46, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -17110,11 +17260,11 @@ Types:
             Type: 153 PointerType **main.stringType2
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: a}
+                  Variable: {subprogram: 46, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1516
+      ID: 1517
       Name: Probe[main.testStructSlice]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -17126,7 +17276,7 @@ Types:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Variable: {subprogram: 134, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -17136,7 +17286,7 @@ Types:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Variable: {subprogram: 134, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -17146,7 +17296,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 1, name: a}
+                  Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -17156,11 +17306,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 1, name: a}
+                  Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1395
+      ID: 1396
       Name: Probe[main.testStructWithAny]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17172,7 +17322,7 @@ Types:
             Type: 164 StructureType main.structWithAny
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: s}
+                  Variable: {subprogram: 60, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
         - Name: s
@@ -17182,11 +17332,11 @@ Types:
             Type: 164 StructureType main.structWithAny
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: s}
+                  Variable: {subprogram: 60, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1509
+      ID: 1510
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17198,7 +17348,7 @@ Types:
             Type: 256 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: arg}
+                  Variable: {subprogram: 129, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
         - Name: arg
@@ -17208,11 +17358,11 @@ Types:
             Type: 256 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: arg}
+                  Variable: {subprogram: 129, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1510
+      ID: 1511
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17224,7 +17374,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 1, name: ~r0}
+                  Variable: {subprogram: 129, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -17234,11 +17384,11 @@ Types:
             Type: 256 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 2, name: ~r1}
+                  Variable: {subprogram: 129, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1543
+      ID: 1544
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17250,7 +17400,7 @@ Types:
             Type: 285 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: a}
+                  Variable: {subprogram: 154, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
         - Name: a
@@ -17260,14 +17410,14 @@ Types:
             Type: 285 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: a}
+                  Variable: {subprogram: 154, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1544
+      ID: 1545
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1542
+      ID: 1543
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 289
       PresenceBitsetSize: 1
@@ -17279,7 +17429,7 @@ Types:
             Type: 272 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: a}
+                  Variable: {subprogram: 153, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
         - Name: a
@@ -17289,11 +17439,11 @@ Types:
             Type: 272 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: a}
+                  Variable: {subprogram: 153, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
     - __kind: EventRootType
-      ID: 1396
+      ID: 1397
       Name: Probe[main.testStructWithMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17305,7 +17455,7 @@ Types:
             Type: 165 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: s}
+                  Variable: {subprogram: 61, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
         - Name: s
@@ -17315,11 +17465,11 @@ Types:
             Type: 165 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: s}
+                  Variable: {subprogram: 61, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1545
+      ID: 1546
       Name: Probe[main.testStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17331,11 +17481,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 8
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1547
+      ID: 1548
       Name: Probe[main.testStruct]
       ByteSize: 113
       PresenceBitsetSize: 1
@@ -17347,7 +17497,7 @@ Types:
             Type: 316 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
         - Name: x
@@ -17357,17 +17507,17 @@ Types:
             Type: 316 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1546
+      ID: 1547
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1548
+      ID: 1549
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1525
+      ID: 1526
       Name: Probe[main.testSubslices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -17379,7 +17529,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: as}
+                  Variable: {subprogram: 142, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
         - Name: as
@@ -17389,7 +17539,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: as}
+                  Variable: {subprogram: 142, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
         - Name: bs
@@ -17399,7 +17549,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 1, name: bs}
+                  Variable: {subprogram: 142, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
         - Name: bs
@@ -17409,7 +17559,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 1, name: bs}
+                  Variable: {subprogram: 142, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
         - Name: cs
@@ -17419,7 +17569,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 2, name: cs}
+                  Variable: {subprogram: 142, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
         - Name: cs
@@ -17429,11 +17579,11 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 2, name: cs}
+                  Variable: {subprogram: 142, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1541
+      ID: 1542
       Name: Probe[main.testSubstrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17445,7 +17595,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: a}
+                  Variable: {subprogram: 152, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -17455,7 +17605,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: a}
+                  Variable: {subprogram: 152, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -17465,7 +17615,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 1, name: b}
+                  Variable: {subprogram: 152, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -17475,7 +17625,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 1, name: b}
+                  Variable: {subprogram: 152, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: c
@@ -17485,7 +17635,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 2, name: c}
+                  Variable: {subprogram: 152, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
         - Name: c
@@ -17495,11 +17645,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 2, name: c}
+                  Variable: {subprogram: 152, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1534
+      ID: 1535
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17511,7 +17661,7 @@ Types:
             Type: 269 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -17521,11 +17671,11 @@ Types:
             Type: 269 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1535
+      ID: 1536
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17537,7 +17687,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -17550,7 +17700,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -17563,14 +17713,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
                   Bias: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1530
+      ID: 1531
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17582,7 +17732,7 @@ Types:
             Type: 268 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
         - Name: a
@@ -17592,11 +17742,11 @@ Types:
             Type: 268 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1532
+      ID: 1533
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17608,7 +17758,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: t.b
@@ -17618,7 +17768,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 16
                   ByteSize: 16
         - Name: t.c
@@ -17628,17 +17778,17 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1531
+      ID: 1532
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1533
+      ID: 1534
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1529
+      ID: 1530
       Name: Probe[main.testThreeStrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17650,7 +17800,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: x}
+                  Variable: {subprogram: 145, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -17660,7 +17810,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: x}
+                  Variable: {subprogram: 145, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -17670,7 +17820,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 1, name: y}
+                  Variable: {subprogram: 145, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -17680,7 +17830,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 1, name: y}
+                  Variable: {subprogram: 145, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -17690,7 +17840,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 2, name: z}
+                  Variable: {subprogram: 145, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -17700,7 +17850,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 2, name: z}
+                  Variable: {subprogram: 145, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -17860,7 +18010,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1431
+      ID: 1432
       Name: Probe[main.testUintPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17872,7 +18022,7 @@ Types:
             Type: 107 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: x}
+                  Variable: {subprogram: 93, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -17882,11 +18032,11 @@ Types:
             Type: 107 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: x}
+                  Variable: {subprogram: 93, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1513
+      ID: 1514
       Name: Probe[main.testUintSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17898,7 +18048,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: u}
+                  Variable: {subprogram: 131, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -17908,11 +18058,11 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: u}
+                  Variable: {subprogram: 131, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1539
+      ID: 1540
       Name: Probe[main.testUnitializedString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17924,7 +18074,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: x}
+                  Variable: {subprogram: 150, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -17934,11 +18084,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: x}
+                  Variable: {subprogram: 150, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1430
+      ID: 1431
       Name: Probe[main.testUnsafePointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17950,7 +18100,7 @@ Types:
             Type: 15 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: x}
+                  Variable: {subprogram: 92, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -17960,7 +18110,7 @@ Types:
             Type: 15 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: x}
+                  Variable: {subprogram: 92, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -17990,32 +18140,6 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1522
-      Name: Probe[main.testVeryLargeSlice]
-      ByteSize: 49
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: xs
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 257 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: xs
-          Offset: 25
-          Kind: template_segment
-          Expression:
-            Type: 257 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
       ID: 1523
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
@@ -18028,7 +18152,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: xs}
+                  Variable: {subprogram: 140, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -18038,11 +18162,37 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: xs}
+                  Variable: {subprogram: 140, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1511
+      ID: 1524
+      Name: Probe[main.testVeryLargeSlice]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 257 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 140, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: xs
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 257 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 140, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1512
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -18054,7 +18204,7 @@ Types:
             Type: 253 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: a}
+                  Variable: {subprogram: 130, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
         - Name: a
@@ -18064,7 +18214,7 @@ Types:
             Type: 253 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: a}
+                  Variable: {subprogram: 130, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
         - Name: b
@@ -18074,7 +18224,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 1, name: b}
+                  Variable: {subprogram: 130, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -18084,11 +18234,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 1, name: b}
+                  Variable: {subprogram: 130, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1512
+      ID: 1513
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -18100,7 +18250,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 2, name: ~r0}
+                  Variable: {subprogram: 130, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -18110,7 +18260,7 @@ Types:
             Type: 253 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 3, name: ~r1}
+                  Variable: {subprogram: 130, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 0
     - __kind: ArrayType
@@ -26778,7 +26928,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 994240
       GoKind: 5
-MaxTypeID: 1570
+MaxTypeID: 1571
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x12ed500", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.26rc1.yaml
@@ -8,15 +8,15 @@ Probes:
       template: stackC
       segments: [stackC]
       captureSnapshot: true
-      subprogram: {subprogram: 142}
+      subprogram: {subprogram: 143}
       events:
         - Kind: Entry
-          Type: 1526 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0x808ad8", Frameless: false}]
+          Type: 1527 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0x808be8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1527 EventRootType Probe[main.stackC]Return
-          InjectionPoints: [{PC: "0x808b08", Frameless: false}]
+          Type: 1528 EventRootType Probe[main.stackC]Return
+          InjectionPoints: [{PC: "0x808c18", Frameless: false}]
           Condition: null
       probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -27,15 +27,15 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 56}
+      subprogram: {subprogram: 57}
       events:
         - Kind: Entry
-          Type: 1390 EventRootType Probe[main.testAny]
-          InjectionPoints: [{PC: "0x804358", Frameless: false}]
+          Type: 1391 EventRootType Probe[main.testAny]
+          InjectionPoints: [{PC: "0x804468", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1391 EventRootType Probe[main.testAny]Return
-          InjectionPoints: [{PC: "0x804380", Frameless: false}]
+          Type: 1392 EventRootType Probe[main.testAny]Return
+          InjectionPoints: [{PC: "0x804490", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -52,15 +52,15 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 58}
+      subprogram: {subprogram: 59}
       events:
         - Kind: Entry
-          Type: 1393 EventRootType Probe[main.testAnyPtr]
-          InjectionPoints: [{PC: "0x8043c8", Frameless: false}]
+          Type: 1394 EventRootType Probe[main.testAnyPtr]
+          InjectionPoints: [{PC: "0x8044d8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1394 EventRootType Probe[main.testAnyPtr]Return
-          InjectionPoints: [{PC: "0x8043f0", Frameless: false}]
+          Type: 1395 EventRootType Probe[main.testAnyPtr]Return
+          InjectionPoints: [{PC: "0x804500", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -76,15 +76,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 122}
+      subprogram: {subprogram: 123}
       events:
         - Kind: Entry
-          Type: 1497 EventRootType Probe[main.testArrayArgAndReturn]
-          InjectionPoints: [{PC: "0x8079dc", Frameless: false}]
+          Type: 1498 EventRootType Probe[main.testArrayArgAndReturn]
+          InjectionPoints: [{PC: "0x807aec", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1498 EventRootType Probe[main.testArrayArgAndReturn]Return
-          InjectionPoints: [{PC: "0x807a70", Frameless: false}]
+          Type: 1499 EventRootType Probe[main.testArrayArgAndReturn]Return
+          InjectionPoints: [{PC: "0x807b80", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -164,11 +164,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 66}
+      subprogram: {subprogram: 67}
       events:
         - Kind: Entry
-          Type: 1402 EventRootType Probe[main.testArrayOfMaps]
-          InjectionPoints: [{PC: "0x804a00", Frameless: true}]
+          Type: 1403 EventRootType Probe[main.testArrayOfMaps]
+          InjectionPoints: [{PC: "0x804b10", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -226,15 +226,15 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 87}
       events:
         - Kind: Entry
-          Type: 1424 EventRootType Probe[main.testAtomicAdd]
-          InjectionPoints: [{PC: "0x8060f0", Frameless: true}]
+          Type: 1425 EventRootType Probe[main.testAtomicAdd]
+          InjectionPoints: [{PC: "0x806200", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1425 EventRootType Probe[main.testAtomicAdd]Return
-          InjectionPoints: [{PC: "0x80612c", Frameless: true}]
+          Type: 1426 EventRootType Probe[main.testAtomicAdd]Return
+          InjectionPoints: [{PC: "0x80623c", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -319,11 +319,11 @@ Probes:
           expr:
             dsl: x.aString
             json: {getmember: [{ref: x}, aString]}
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1542 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0x808da0", Frameless: true}]
+          Type: 1543 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0x808eb0", Frameless: true}]
           Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -337,20 +337,20 @@ Probes:
       segments: []
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1550 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1551 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
-            - PC: "0x803c78"
+            - PC: "0x803d88"
               Frameless: false
-            - PC: "0x803cec"
+            - PC: "0x803dfc"
               Frameless: false
-            - PC: "0x803e20"
+            - PC: "0x803f30"
               Frameless: false
-            - PC: "0x803ea4"
+            - PC: "0x803fb4"
               Frameless: false
-            - PC: "0x803f5c"
+            - PC: "0x80406c"
               Frameless: false
           Condition: null
     - id: testCaptureExprLineWithTemplate
@@ -365,20 +365,20 @@ Probes:
       segments: [x=, {json: {ref: x}, dsl: x}]
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1551 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1552 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
-            - PC: "0x803c78"
+            - PC: "0x803d88"
               Frameless: false
-            - PC: "0x803cec"
+            - PC: "0x803dfc"
               Frameless: false
-            - PC: "0x803e20"
+            - PC: "0x803f30"
               Frameless: false
-            - PC: "0x803ea4"
+            - PC: "0x803fb4"
               Frameless: false
-            - PC: "0x803f5c"
+            - PC: "0x80406c"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -401,11 +401,11 @@ Probes:
           expr: {dsl: x, json: {ref: x}}
         - name: w_val
           expr: {dsl: w, json: {ref: w}}
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 85}
       events:
         - Kind: Entry
-          Type: 1421 EventRootType Probe[main.testCombinedString]
-          InjectionPoints: [{PC: "0x805e90", Frameless: true}]
+          Type: 1422 EventRootType Probe[main.testCombinedString]
+          InjectionPoints: [{PC: "0x805fa0", Frameless: true}]
           Condition: null
     - id: testCaptureExprWithTemplate
       version: 0
@@ -419,11 +419,11 @@ Probes:
           expr: {dsl: x, json: {ref: x}}
         - name: w_val
           expr: {dsl: w, json: {ref: w}}
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 85}
       events:
         - Kind: Entry
-          Type: 1422 EventRootType Probe[main.testCombinedString]
-          InjectionPoints: [{PC: "0x805e90", Frameless: true}]
+          Type: 1423 EventRootType Probe[main.testCombinedString]
+          InjectionPoints: [{PC: "0x805fa0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: x={x}
@@ -441,11 +441,11 @@ Probes:
       template: '{c}'
       segments: [{json: {ref: c}, dsl: c}]
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 88}
       events:
         - Kind: Entry
-          Type: 1426 EventRootType Probe[main.testChannel]
-          InjectionPoints: [{PC: "0x806130", Frameless: true}]
+          Type: 1427 EventRootType Probe[main.testChannel]
+          InjectionPoints: [{PC: "0x806240", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{c}'
@@ -470,11 +470,11 @@ Probes:
         - json: {ref: y}
           dsl: y
       captureSnapshot: true
-      subprogram: {subprogram: 83}
+      subprogram: {subprogram: 84}
       events:
         - Kind: Entry
-          Type: 1420 EventRootType Probe[main.testCombinedByte]
-          InjectionPoints: [{PC: "0x805e70", Frameless: true}]
+          Type: 1421 EventRootType Probe[main.testCombinedByte]
+          InjectionPoints: [{PC: "0x805f80", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{w}, {x}, {y}'
@@ -501,11 +501,11 @@ Probes:
       template: '{t}'
       segments: [{json: {ref: t}, dsl: t}]
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 96}
       events:
         - Kind: Entry
-          Type: 1434 EventRootType Probe[main.testCycle]
-          InjectionPoints: [{PC: "0x8063b0", Frameless: true}]
+          Type: 1435 EventRootType Probe[main.testCycle]
+          InjectionPoints: [{PC: "0x8064c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{t}'
@@ -522,11 +522,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 42}
+      subprogram: {subprogram: 43}
       events:
         - Kind: Entry
-          Type: 1365 EventRootType Probe[main.testDeepMap1]
-          InjectionPoints: [{PC: "0x8033e0", Frameless: true}]
+          Type: 1366 EventRootType Probe[main.testDeepMap1]
+          InjectionPoints: [{PC: "0x8034f0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -543,11 +543,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 43}
+      subprogram: {subprogram: 44}
       events:
         - Kind: Entry
-          Type: 1366 EventRootType Probe[main.testDeepMap7]
-          InjectionPoints: [{PC: "0x8033f0", Frameless: true}]
+          Type: 1367 EventRootType Probe[main.testDeepMap7]
+          InjectionPoints: [{PC: "0x803500", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -564,11 +564,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 38}
+      subprogram: {subprogram: 39}
       events:
         - Kind: Entry
-          Type: 1361 EventRootType Probe[main.testDeepPtr1]
-          InjectionPoints: [{PC: "0x803150", Frameless: true}]
+          Type: 1362 EventRootType Probe[main.testDeepPtr1]
+          InjectionPoints: [{PC: "0x803260", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -585,11 +585,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 39}
+      subprogram: {subprogram: 40}
       events:
         - Kind: Entry
-          Type: 1362 EventRootType Probe[main.testDeepPtr7]
-          InjectionPoints: [{PC: "0x803160", Frameless: true}]
+          Type: 1363 EventRootType Probe[main.testDeepPtr7]
+          InjectionPoints: [{PC: "0x803270", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -606,11 +606,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 40}
+      subprogram: {subprogram: 41}
       events:
         - Kind: Entry
-          Type: 1363 EventRootType Probe[main.testDeepSlice1]
-          InjectionPoints: [{PC: "0x803280", Frameless: true}]
+          Type: 1364 EventRootType Probe[main.testDeepSlice1]
+          InjectionPoints: [{PC: "0x803390", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -627,11 +627,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 41}
+      subprogram: {subprogram: 42}
       events:
         - Kind: Entry
-          Type: 1364 EventRootType Probe[main.testDeepSlice7]
-          InjectionPoints: [{PC: "0x803290", Frameless: true}]
+          Type: 1365 EventRootType Probe[main.testDeepSlice7]
+          InjectionPoints: [{PC: "0x8033a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -648,11 +648,11 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 131}
+      subprogram: {subprogram: 132}
       events:
         - Kind: Entry
-          Type: 1514 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0x808750", Frameless: true}]
+          Type: 1515 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0x808860", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{u}'
@@ -674,11 +674,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 134}
+      subprogram: {subprogram: 135}
       events:
         - Kind: Entry
-          Type: 1517 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0x808780", Frameless: true}]
+          Type: 1518 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0x808890", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}, {a}'
@@ -701,11 +701,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 150}
+      subprogram: {subprogram: 151}
       events:
         - Kind: Entry
-          Type: 1538 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0x808b90", Frameless: true}]
+          Type: 1539 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0x808ca0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -722,11 +722,11 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 156}
+      subprogram: {subprogram: 157}
       events:
         - Kind: Entry
-          Type: 1548 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0x808e40", Frameless: true}]
+          Type: 1549 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0x808f50", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -742,11 +742,11 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 157}
+      subprogram: {subprogram: 158}
       events:
         - Kind: Entry
-          Type: 1549 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0x808e50", Frameless: true}]
+          Type: 1550 EventRootType Probe[main.testEmptyStructPointer]
+          InjectionPoints: [{PC: "0x808f60", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -763,11 +763,11 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 57}
+      subprogram: {subprogram: 58}
       events:
         - Kind: Entry
-          Type: 1392 EventRootType Probe[main.testError]
-          InjectionPoints: [{PC: "0x8043a0", Frameless: true}]
+          Type: 1393 EventRootType Probe[main.testError]
+          InjectionPoints: [{PC: "0x8044b0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -776,6 +776,45 @@ Probes:
               DSL: e
               EventKind: Entry
               EventExpressionIndex: 1
+    - id: testErrorAtLine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testErrorAtLine
+        sourceFile: complex.go
+        lines: ["108"]
+      tags:
+        - config_diff:arch=amd64,toolchain=go1.26rc1
+        - skip_integration:arch=arm64,toolchain=go1.25.0
+      sampling: {snapshotsPerSecond: 100}
+      template: x={x}, err={err}
+      segments:
+        - x=
+        - json: {ref: x}
+          dsl: x
+        - ', err='
+        - json: {ref: err}
+          dsl: err
+      captureSnapshot: true
+      subprogram: {subprogram: 38}
+      events:
+        - Kind: Line
+          Type: 1361 EventRootType Probe[main.testErrorAtLine]Line
+          InjectionPoints: [{PC: "0x803120", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: x={x}, err={err}
+        Segments:
+            - x=
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Line
+              EventExpressionIndex: 2
+            - ', err='
+            - JSON: {Ref: err}
+              DSL: err
+              EventKind: Line
+              EventExpressionIndex: 4
     - id: testEsotericHeap
       version: 0
       type: LOG_PROBE
@@ -784,15 +823,15 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 48}
+      subprogram: {subprogram: 49}
       events:
         - Kind: Entry
-          Type: 1374 EventRootType Probe[main.testEsotericHeap]
-          InjectionPoints: [{PC: "0x8039e8", Frameless: false}]
+          Type: 1375 EventRootType Probe[main.testEsotericHeap]
+          InjectionPoints: [{PC: "0x803af8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1375 EventRootType Probe[main.testEsotericHeap]Return
-          InjectionPoints: [{PC: "0x803a20", Frameless: false}]
+          Type: 1376 EventRootType Probe[main.testEsotericHeap]Return
+          InjectionPoints: [{PC: "0x803b30", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -809,15 +848,15 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 47}
+      subprogram: {subprogram: 48}
       events:
         - Kind: Entry
-          Type: 1372 EventRootType Probe[main.testEsotericStack]
-          InjectionPoints: [{PC: "0x80392c", Frameless: false}]
+          Type: 1373 EventRootType Probe[main.testEsotericStack]
+          InjectionPoints: [{PC: "0x803a3c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1373 EventRootType Probe[main.testEsotericStack]Return
-          InjectionPoints: [{PC: "0x803988", Frameless: false}]
+          Type: 1374 EventRootType Probe[main.testEsotericStack]Return
+          InjectionPoints: [{PC: "0x803a98", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -834,15 +873,15 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 53}
+      subprogram: {subprogram: 54}
       events:
         - Kind: Entry
-          Type: 1384 EventRootType Probe[main.testFrameless]
-          InjectionPoints: [{PC: "0x8040c0", Frameless: true}]
+          Type: 1385 EventRootType Probe[main.testFrameless]
+          InjectionPoints: [{PC: "0x8041d0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1385 EventRootType Probe[main.testFrameless]Return
-          InjectionPoints: [{PC: "0x8040c8", Frameless: true}]
+          Type: 1386 EventRootType Probe[main.testFrameless]Return
+          InjectionPoints: [{PC: "0x8041d8", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -859,15 +898,15 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 54}
+      subprogram: {subprogram: 55}
       events:
         - Kind: Entry
-          Type: 1386 EventRootType Probe[main.testFramelessArray]
-          InjectionPoints: [{PC: "0x8040dc", Frameless: false}]
+          Type: 1387 EventRootType Probe[main.testFramelessArray]
+          InjectionPoints: [{PC: "0x8041ec", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1387 EventRootType Probe[main.testFramelessArray]Return
-          InjectionPoints: [{PC: "0x804110", Frameless: false}]
+          Type: 1388 EventRootType Probe[main.testFramelessArray]Return
+          InjectionPoints: [{PC: "0x804220", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -887,11 +926,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 54}
+      subprogram: {subprogram: 55}
       events:
         - Kind: Line
-          Type: 1388 EventRootType Probe[main.testFramelessArray]Line
-          InjectionPoints: [{PC: "0x8040dc", Frameless: false}]
+          Type: 1389 EventRootType Probe[main.testFramelessArray]Line
+          InjectionPoints: [{PC: "0x8041ec", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -908,15 +947,15 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 49}
+      subprogram: {subprogram: 50}
       events:
         - Kind: Entry
-          Type: 1376 EventRootType Probe[main.testInlinedBA]
-          InjectionPoints: [{PC: "0x803e08", Frameless: false}]
+          Type: 1377 EventRootType Probe[main.testInlinedBA]
+          InjectionPoints: [{PC: "0x803f18", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1377 EventRootType Probe[main.testInlinedBA]Return
-          InjectionPoints: [{PC: "0x803e54", Frameless: false}]
+          Type: 1378 EventRootType Probe[main.testInlinedBA]Return
+          InjectionPoints: [{PC: "0x803f64", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -938,15 +977,15 @@ Probes:
         - json: {ref: y}
           dsl: y
       captureSnapshot: true
-      subprogram: {subprogram: 50}
+      subprogram: {subprogram: 51}
       events:
         - Kind: Entry
-          Type: 1378 EventRootType Probe[main.testInlinedBB]
-          InjectionPoints: [{PC: "0x803e98", Frameless: false}]
+          Type: 1379 EventRootType Probe[main.testInlinedBB]
+          InjectionPoints: [{PC: "0x803fa8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1379 EventRootType Probe[main.testInlinedBB]Return
-          InjectionPoints: [{PC: "0x803f18", Frameless: false}]
+          Type: 1380 EventRootType Probe[main.testInlinedBB]Return
+          InjectionPoints: [{PC: "0x804028", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}, {y}'
@@ -968,15 +1007,15 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 51}
+      subprogram: {subprogram: 52}
       events:
         - Kind: Entry
-          Type: 1380 EventRootType Probe[main.testInlinedBBA]
-          InjectionPoints: [{PC: "0x803f58", Frameless: false}]
+          Type: 1381 EventRootType Probe[main.testInlinedBBA]
+          InjectionPoints: [{PC: "0x804068", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1381 EventRootType Probe[main.testInlinedBBA]Return
-          InjectionPoints: [{PC: "0x803f90", Frameless: false}]
+          Type: 1382 EventRootType Probe[main.testInlinedBBA]Return
+          InjectionPoints: [{PC: "0x8040a0", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -993,11 +1032,11 @@ Probes:
       template: testInlinedBBB
       segments: [testInlinedBBB]
       captureSnapshot: true
-      subprogram: {subprogram: 159}
+      subprogram: {subprogram: 160}
       events:
         - Kind: Entry
-          Type: 1555 EventRootType Probe[main.testInlinedBBB]
-          InjectionPoints: [{PC: "0x803ee4", Frameless: false}]
+          Type: 1556 EventRootType Probe[main.testInlinedBBB]
+          InjectionPoints: [{PC: "0x803ff4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBBB
@@ -1010,15 +1049,15 @@ Probes:
       template: testInlinedBC
       segments: [testInlinedBC]
       captureSnapshot: true
-      subprogram: {subprogram: 52}
+      subprogram: {subprogram: 53}
       events:
         - Kind: Entry
-          Type: 1382 EventRootType Probe[main.testInlinedBC]
-          InjectionPoints: [{PC: "0x803fc8", Frameless: false}]
+          Type: 1383 EventRootType Probe[main.testInlinedBC]
+          InjectionPoints: [{PC: "0x8040d8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1383 EventRootType Probe[main.testInlinedBC]Return
-          InjectionPoints: [{PC: "0x8040a4", Frameless: false}]
+          Type: 1384 EventRootType Probe[main.testInlinedBC]Return
+          InjectionPoints: [{PC: "0x8041b4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBC
@@ -1031,11 +1070,11 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Entry
-          Type: 1556 EventRootType Probe[main.testInlinedBCA]
-          InjectionPoints: [{PC: "0x803fcc", Frameless: false}]
+          Type: 1557 EventRootType Probe[main.testInlinedBCA]
+          InjectionPoints: [{PC: "0x8040dc", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBCA
@@ -1051,11 +1090,11 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Line
-          Type: 1557 EventRootType Probe[main.testInlinedBCA]Line
-          InjectionPoints: [{PC: "0x803fcc", Frameless: false}]
+          Type: 1558 EventRootType Probe[main.testInlinedBCA]Line
+          InjectionPoints: [{PC: "0x8040dc", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBCA
@@ -1068,11 +1107,11 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Entry
-          Type: 1558 EventRootType Probe[main.testInlinedBCB]
-          InjectionPoints: [{PC: "0x804070", Frameless: false}]
+          Type: 1559 EventRootType Probe[main.testInlinedBCB]
+          InjectionPoints: [{PC: "0x804180", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBCB
@@ -1088,11 +1127,11 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Line
-          Type: 1559 EventRootType Probe[main.testInlinedBCB]Line
-          InjectionPoints: [{PC: "0x804070", Frameless: false}]
+          Type: 1560 EventRootType Probe[main.testInlinedBCB]Line
+          InjectionPoints: [{PC: "0x804180", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBCB
@@ -1105,14 +1144,14 @@ Probes:
       template: testInlinedFuncFromOtherPackage
       segments: [testInlinedFuncFromOtherPackage]
       captureSnapshot: true
-      subprogram: {subprogram: 165}
+      subprogram: {subprogram: 166}
       events:
         - Kind: Entry
-          Type: 1565 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
+          Type: 1566 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
           InjectionPoints:
             - PC: "0x802568"
               Frameless: true
-            - PC: "0x8048e0"
+            - PC: "0x8049f0"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -1127,25 +1166,25 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Entry
-          Type: 1552 EventRootType Probe[main.testInlinedPrint]
+          Type: 1553 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
-            - PC: "0x803c78"
+            - PC: "0x803d88"
               Frameless: false
-            - PC: "0x803cec"
+            - PC: "0x803dfc"
               Frameless: false
-            - PC: "0x803e20"
+            - PC: "0x803f30"
               Frameless: false
-            - PC: "0x803ea4"
+            - PC: "0x803fb4"
               Frameless: false
-            - PC: "0x803f5c"
+            - PC: "0x80406c"
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1553 EventRootType Probe[main.testInlinedPrint]Return
-          InjectionPoints: [{PC: "0x803cac", Frameless: false}]
+          Type: 1554 EventRootType Probe[main.testInlinedPrint]Return
+          InjectionPoints: [{PC: "0x803dbc", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1165,20 +1204,20 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1554 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1555 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
-            - PC: "0x803c78"
+            - PC: "0x803d88"
               Frameless: false
-            - PC: "0x803cec"
+            - PC: "0x803dfc"
               Frameless: false
-            - PC: "0x803e20"
+            - PC: "0x803f30"
               Frameless: false
-            - PC: "0x803ea4"
+            - PC: "0x803fb4"
               Frameless: false
-            - PC: "0x803f5c"
+            - PC: "0x80406c"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -1196,11 +1235,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 162}
+      subprogram: {subprogram: 163}
       events:
         - Kind: Entry
-          Type: 1560 EventRootType Probe[main.testInlinedSq]
-          InjectionPoints: [{PC: "0x8040c4", Frameless: true}]
+          Type: 1561 EventRootType Probe[main.testInlinedSq]
+          InjectionPoints: [{PC: "0x8041d4", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1220,11 +1259,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 162}
+      subprogram: {subprogram: 163}
       events:
         - Kind: Line
-          Type: 1561 EventRootType Probe[main.testInlinedSq]Line
-          InjectionPoints: [{PC: "0x8040c4", Frameless: true}]
+          Type: 1562 EventRootType Probe[main.testInlinedSq]Line
+          InjectionPoints: [{PC: "0x8041d4", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1242,14 +1281,14 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 163}
+      subprogram: {subprogram: 164}
       events:
         - Kind: Entry
-          Type: 1562 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1563 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
-            - PC: "0x8040f4"
+            - PC: "0x804204"
               Frameless: false
-            - PC: "0x80417c"
+            - PC: "0x80428c"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -1372,11 +1411,11 @@ Probes:
       template: '{b}'
       segments: [{json: {ref: b}, dsl: b}]
       captureSnapshot: true
-      subprogram: {subprogram: 55}
+      subprogram: {subprogram: 56}
       events:
         - Kind: Entry
-          Type: 1389 EventRootType Probe[main.testInterface]
-          InjectionPoints: [{PC: "0x804330", Frameless: true}]
+          Type: 1390 EventRootType Probe[main.testInterface]
+          InjectionPoints: [{PC: "0x804440", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{b}'
@@ -1392,15 +1431,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 121}
+      subprogram: {subprogram: 122}
       events:
         - Kind: Entry
-          Type: 1495 EventRootType Probe[main.testLargeArgAndReturn]
-          InjectionPoints: [{PC: "0x807850", Frameless: false}]
+          Type: 1496 EventRootType Probe[main.testLargeArgAndReturn]
+          InjectionPoints: [{PC: "0x807960", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1496 EventRootType Probe[main.testLargeArgAndReturn]Return
-          InjectionPoints: [{PC: "0x807980", Frameless: false}]
+          Type: 1497 EventRootType Probe[main.testLargeArgAndReturn]Return
+          InjectionPoints: [{PC: "0x807a90", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -1417,11 +1456,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 90}
       events:
         - Kind: Entry
-          Type: 1428 EventRootType Probe[main.testLinkedList]
-          InjectionPoints: [{PC: "0x8062c0", Frameless: true}]
+          Type: 1429 EventRootType Probe[main.testLinkedList]
+          InjectionPoints: [{PC: "0x8063d0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -1436,16 +1475,16 @@ Probes:
       where:
         methodName: main.testLongFunctionWithChangingState
         sourceFile: complex.go
-        lines: ["211"]
+        lines: ["230"]
       sampling: {snapshotsPerSecond: 100}
       template: testLongFunctionWithChangingState
       segments: [testLongFunctionWithChangingState]
       captureSnapshot: true
-      subprogram: {subprogram: 46}
+      subprogram: {subprogram: 47}
       events:
         - Kind: Line
-          Type: 1369 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-          InjectionPoints: [{PC: "0x80343c", Frameless: false}]
+          Type: 1370 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          InjectionPoints: [{PC: "0x80354c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testLongFunctionWithChangingState
@@ -1456,17 +1495,17 @@ Probes:
       where:
         methodName: main.testLongFunctionWithChangingState
         sourceFile: complex.go
-        lines: ["218"]
+        lines: ["237"]
       tags: ['version_diff:go1.26rc1']
       sampling: {snapshotsPerSecond: 100}
       template: testLongFunctionWithChangingState
       segments: [testLongFunctionWithChangingState]
       captureSnapshot: true
-      subprogram: {subprogram: 46}
+      subprogram: {subprogram: 47}
       events:
         - Kind: Line
-          Type: 1370 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-          InjectionPoints: [{PC: "0x8034dc", Frameless: false}]
+          Type: 1371 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          InjectionPoints: [{PC: "0x8035ec", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testLongFunctionWithChangingState
@@ -1477,17 +1516,17 @@ Probes:
       where:
         methodName: main.testLongFunctionWithChangingState
         sourceFile: complex.go
-        lines: ["223"]
+        lines: ["242"]
       tags: ['version_diff:go1.26rc1']
       sampling: {snapshotsPerSecond: 100}
       template: testLongFunctionWithChangingState
       segments: [testLongFunctionWithChangingState]
       captureSnapshot: true
-      subprogram: {subprogram: 46}
+      subprogram: {subprogram: 47}
       events:
         - Kind: Line
-          Type: 1371 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-          InjectionPoints: [{PC: "0x803580", Frameless: false}]
+          Type: 1372 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          InjectionPoints: [{PC: "0x803690", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testLongFunctionWithChangingState
@@ -1525,15 +1564,15 @@ Probes:
         - json: {ref: i}
           dsl: i
       captureSnapshot: true
-      subprogram: {subprogram: 124}
+      subprogram: {subprogram: 125}
       events:
         - Kind: Entry
-          Type: 1501 EventRootType Probe[main.testManyArgsArrayReturn]
-          InjectionPoints: [{PC: "0x807cbc", Frameless: false}]
+          Type: 1502 EventRootType Probe[main.testManyArgsArrayReturn]
+          InjectionPoints: [{PC: "0x807dcc", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1502 EventRootType Probe[main.testManyArgsArrayReturn]Return
-          InjectionPoints: [{PC: "0x807e10", Frameless: false}]
+          Type: 1503 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          InjectionPoints: [{PC: "0x807f20", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -1590,11 +1629,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 64}
+      subprogram: {subprogram: 65}
       events:
         - Kind: Entry
-          Type: 1400 EventRootType Probe[main.testMapArrayToArray]
-          InjectionPoints: [{PC: "0x8049e0", Frameless: true}]
+          Type: 1401 EventRootType Probe[main.testMapArrayToArray]
+          InjectionPoints: [{PC: "0x804af0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1611,11 +1650,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 70}
+      subprogram: {subprogram: 71}
       events:
         - Kind: Entry
-          Type: 1407 EventRootType Probe[main.testMapEmbeddedMaps]
-          InjectionPoints: [{PC: "0x804a40", Frameless: true}]
+          Type: 1408 EventRootType Probe[main.testMapEmbeddedMaps]
+          InjectionPoints: [{PC: "0x804b50", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1632,11 +1671,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 80}
+      subprogram: {subprogram: 81}
       events:
         - Kind: Entry
-          Type: 1417 EventRootType Probe[main.testMapEmptyKey]
-          InjectionPoints: [{PC: "0x804ae0", Frameless: true}]
+          Type: 1418 EventRootType Probe[main.testMapEmptyKey]
+          InjectionPoints: [{PC: "0x804bf0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1653,11 +1692,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 82}
+      subprogram: {subprogram: 83}
       events:
         - Kind: Entry
-          Type: 1419 EventRootType Probe[main.testMapEmptyKeyAndValue]
-          InjectionPoints: [{PC: "0x804b00", Frameless: true}]
+          Type: 1420 EventRootType Probe[main.testMapEmptyKeyAndValue]
+          InjectionPoints: [{PC: "0x804c10", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1674,11 +1713,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 81}
+      subprogram: {subprogram: 82}
       events:
         - Kind: Entry
-          Type: 1418 EventRootType Probe[main.testMapEmptyValue]
-          InjectionPoints: [{PC: "0x804af0", Frameless: true}]
+          Type: 1419 EventRootType Probe[main.testMapEmptyValue]
+          InjectionPoints: [{PC: "0x804c00", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1695,11 +1734,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 68}
+      subprogram: {subprogram: 69}
       events:
         - Kind: Entry
-          Type: 1404 EventRootType Probe[main.testMapIntToInt]
-          InjectionPoints: [{PC: "0x804a20", Frameless: true}]
+          Type: 1405 EventRootType Probe[main.testMapIntToInt]
+          InjectionPoints: [{PC: "0x804b30", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1716,11 +1755,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 79}
+      subprogram: {subprogram: 80}
       events:
         - Kind: Entry
-          Type: 1416 EventRootType Probe[main.testMapLargeKeyLargeValue]
-          InjectionPoints: [{PC: "0x804ad0", Frameless: true}]
+          Type: 1417 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          InjectionPoints: [{PC: "0x804be0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1737,11 +1776,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 78}
+      subprogram: {subprogram: 79}
       events:
         - Kind: Entry
-          Type: 1415 EventRootType Probe[main.testMapLargeKeySmallValue]
-          InjectionPoints: [{PC: "0x804ac0", Frameless: true}]
+          Type: 1416 EventRootType Probe[main.testMapLargeKeySmallValue]
+          InjectionPoints: [{PC: "0x804bd0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1760,11 +1799,11 @@ Probes:
         - json: {ref: redactMyEntries}
           dsl: redactMyEntries
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 70}
       events:
         - Kind: Entry
-          Type: 1405 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0x804a30", Frameless: true}]
+          Type: 1406 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0x804b40", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{redactMyEntries}'
@@ -1783,11 +1822,11 @@ Probes:
         - json: {ref: redactMyEntries}
           dsl: redactMyEntries
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 70}
       events:
         - Kind: Entry
-          Type: 1406 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0x804a30", Frameless: true}]
+          Type: 1407 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0x804b40", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{redactMyEntries}'
@@ -1804,11 +1843,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 77}
+      subprogram: {subprogram: 78}
       events:
         - Kind: Entry
-          Type: 1414 EventRootType Probe[main.testMapSmallKeyLargeValue]
-          InjectionPoints: [{PC: "0x804ab0", Frameless: true}]
+          Type: 1415 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          InjectionPoints: [{PC: "0x804bc0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1825,11 +1864,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 76}
+      subprogram: {subprogram: 77}
       events:
         - Kind: Entry
-          Type: 1413 EventRootType Probe[main.testMapSmallKeySmallValue]
-          InjectionPoints: [{PC: "0x804aa0", Frameless: true}]
+          Type: 1414 EventRootType Probe[main.testMapSmallKeySmallValue]
+          InjectionPoints: [{PC: "0x804bb0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1846,11 +1885,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 62}
+      subprogram: {subprogram: 63}
       events:
         - Kind: Entry
-          Type: 1398 EventRootType Probe[main.testMapStringToInt]
-          InjectionPoints: [{PC: "0x8049c0", Frameless: true}]
+          Type: 1399 EventRootType Probe[main.testMapStringToInt]
+          InjectionPoints: [{PC: "0x804ad0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1867,11 +1906,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 63}
+      subprogram: {subprogram: 64}
       events:
         - Kind: Entry
-          Type: 1399 EventRootType Probe[main.testMapStringToSlice]
-          InjectionPoints: [{PC: "0x8049d0", Frameless: true}]
+          Type: 1400 EventRootType Probe[main.testMapStringToSlice]
+          InjectionPoints: [{PC: "0x804ae0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1888,11 +1927,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 61}
+      subprogram: {subprogram: 62}
       events:
         - Kind: Entry
-          Type: 1397 EventRootType Probe[main.testMapStringToStruct]
-          InjectionPoints: [{PC: "0x8049b0", Frameless: true}]
+          Type: 1398 EventRootType Probe[main.testMapStringToStruct]
+          InjectionPoints: [{PC: "0x804ac0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1909,11 +1948,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 71}
+      subprogram: {subprogram: 72}
       events:
         - Kind: Entry
-          Type: 1408 EventRootType Probe[main.testMapWithLinkedList]
-          InjectionPoints: [{PC: "0x804a50", Frameless: true}]
+          Type: 1409 EventRootType Probe[main.testMapWithLinkedList]
+          InjectionPoints: [{PC: "0x804b60", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1930,11 +1969,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 74}
+      subprogram: {subprogram: 75}
       events:
         - Kind: Entry
-          Type: 1411 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-          InjectionPoints: [{PC: "0x804a80", Frameless: true}]
+          Type: 1412 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          InjectionPoints: [{PC: "0x804b90", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1951,11 +1990,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 75}
+      subprogram: {subprogram: 76}
       events:
         - Kind: Entry
-          Type: 1412 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-          InjectionPoints: [{PC: "0x804a90", Frameless: true}]
+          Type: 1413 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          InjectionPoints: [{PC: "0x804ba0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1972,11 +2011,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 72}
+      subprogram: {subprogram: 73}
       events:
         - Kind: Entry
-          Type: 1409 EventRootType Probe[main.testMapWithSmallValue]
-          InjectionPoints: [{PC: "0x804a60", Frameless: true}]
+          Type: 1410 EventRootType Probe[main.testMapWithSmallValue]
+          InjectionPoints: [{PC: "0x804b70", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1995,11 +2034,11 @@ Probes:
         - json: {ref: redactMyEntries}
           dsl: redactMyEntries
       captureSnapshot: true
-      subprogram: {subprogram: 73}
+      subprogram: {subprogram: 74}
       events:
         - Kind: Entry
-          Type: 1410 EventRootType Probe[main.testMapWithSmallValueMassive]
-          InjectionPoints: [{PC: "0x804a70", Frameless: true}]
+          Type: 1411 EventRootType Probe[main.testMapWithSmallValueMassive]
+          InjectionPoints: [{PC: "0x804b80", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{redactMyEntries}'
@@ -2016,11 +2055,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 148}
+      subprogram: {subprogram: 149}
       events:
         - Kind: Entry
-          Type: 1535 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0x808b70", Frameless: true}]
+          Type: 1536 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0x808c80", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -2038,11 +2077,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 148}
+      subprogram: {subprogram: 149}
       events:
         - Kind: Entry
-          Type: 1536 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0x808b70", Frameless: true}]
+          Type: 1537 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0x808c80", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -2084,15 +2123,15 @@ Probes:
         - json: {ref: s}
           dsl: s
       captureSnapshot: true
-      subprogram: {subprogram: 125}
+      subprogram: {subprogram: 126}
       events:
         - Kind: Entry
-          Type: 1503 EventRootType Probe[main.testMixedArgsStackReturn]
-          InjectionPoints: [{PC: "0x807e70", Frameless: false}]
+          Type: 1504 EventRootType Probe[main.testMixedArgsStackReturn]
+          InjectionPoints: [{PC: "0x807f80", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1504 EventRootType Probe[main.testMixedArgsStackReturn]Return
-          InjectionPoints: [{PC: "0x807ffc", Frameless: false}]
+          Type: 1505 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          InjectionPoints: [{PC: "0x80810c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -2153,15 +2192,15 @@ Probes:
         - json: {ref: b}
           dsl: b
       captureSnapshot: true
-      subprogram: {subprogram: 127}
+      subprogram: {subprogram: 128}
       events:
         - Kind: Entry
-          Type: 1507 EventRootType Probe[main.testMultipleArrayArgs]
-          InjectionPoints: [{PC: "0x8080ec", Frameless: false}]
+          Type: 1508 EventRootType Probe[main.testMultipleArrayArgs]
+          InjectionPoints: [{PC: "0x8081fc", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1508 EventRootType Probe[main.testMultipleArrayArgs]Return
-          InjectionPoints: [{PC: "0x808188", Frameless: false}]
+          Type: 1509 EventRootType Probe[main.testMultipleArrayArgs]Return
+          InjectionPoints: [{PC: "0x808298", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}'
@@ -2187,15 +2226,15 @@ Probes:
         - json: {ref: s2}
           dsl: s2
       captureSnapshot: true
-      subprogram: {subprogram: 123}
+      subprogram: {subprogram: 124}
       events:
         - Kind: Entry
-          Type: 1499 EventRootType Probe[main.testMultipleLargeArgs]
-          InjectionPoints: [{PC: "0x807ab0", Frameless: false}]
+          Type: 1500 EventRootType Probe[main.testMultipleLargeArgs]
+          InjectionPoints: [{PC: "0x807bc0", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1500 EventRootType Probe[main.testMultipleLargeArgs]Return
-          InjectionPoints: [{PC: "0x807c58", Frameless: false}]
+          Type: 1501 EventRootType Probe[main.testMultipleLargeArgs]Return
+          InjectionPoints: [{PC: "0x807d68", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{s1}, {s2}'
@@ -2216,15 +2255,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1453 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0x806e88", Frameless: false}]
+          Type: 1454 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x806f98", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1454 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0x806f0c", Frameless: false}]
+          Type: 1455 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x80701c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2255,11 +2294,11 @@ Probes:
         - json: {ref: e}
           dsl: e
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 86}
       events:
         - Kind: Entry
-          Type: 1423 EventRootType Probe[main.testMultipleSimpleParams]
-          InjectionPoints: [{PC: "0x805f50", Frameless: true}]
+          Type: 1424 EventRootType Probe[main.testMultipleSimpleParams]
+          InjectionPoints: [{PC: "0x806060", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}, {d}, {e}'
@@ -2295,15 +2334,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1449 EventRootType Probe[main.testNamedReturn]
-          InjectionPoints: [{PC: "0x806de8", Frameless: false}]
+          Type: 1450 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0x806ef8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1450 EventRootType Probe[main.testNamedReturn]Return
-          InjectionPoints: [{PC: "0x806e44", Frameless: false}]
+          Type: 1451 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0x806f54", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2325,15 +2364,15 @@ Probes:
         - json: {ref: result}
           dsl: result
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1451 EventRootType Probe[main.testNamedReturn]
-          InjectionPoints: [{PC: "0x806de8", Frameless: false}]
+          Type: 1452 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0x806ef8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1452 EventRootType Probe[main.testNamedReturn]Return
-          InjectionPoints: [{PC: "0x806e44", Frameless: false}]
+          Type: 1453 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0x806f54", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: Parameter {i} * 2 = result {result}
@@ -2356,11 +2395,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 155}
+      subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1544 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0x808e00", Frameless: true}]
+          Type: 1545 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0x808f10", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -2380,11 +2419,11 @@ Probes:
             getmember: [{getmember: [{ref: x}, nested]}, anotherString]
           dsl: x.nested.anotherString
       captureSnapshot: false
-      subprogram: {subprogram: 155}
+      subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1545 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0x808e00", Frameless: true}]
+          Type: 1546 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0x808f10", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x.nested.anotherString}'
@@ -2410,11 +2449,11 @@ Probes:
         - json: {getmember: [{ref: x}, notAMember]}
           dsl: x.notAMember
       captureSnapshot: false
-      subprogram: {subprogram: 155}
+      subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1546 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0x808e00", Frameless: true}]
+          Type: 1547 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0x808f10", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -2434,11 +2473,11 @@ Probes:
         - json: {getmember: [{ref: x}, nested]}
           dsl: x.nested
       captureSnapshot: false
-      subprogram: {subprogram: 155}
+      subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1547 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0x808e00", Frameless: true}]
+          Type: 1548 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0x808f10", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x.nested}'
@@ -2460,11 +2499,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 95}
       events:
         - Kind: Entry
-          Type: 1433 EventRootType Probe[main.testNilPointer]
-          InjectionPoints: [{PC: "0x806390", Frameless: true}]
+          Type: 1434 EventRootType Probe[main.testNilPointer]
+          InjectionPoints: [{PC: "0x8064a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{z}, {a}'
@@ -2486,11 +2525,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 138}
+      subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1521 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0x8087c0", Frameless: true}]
+          Type: 1522 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0x8088d0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -2512,11 +2551,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 135}
+      subprogram: {subprogram: 136}
       events:
         - Kind: Entry
-          Type: 1518 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0x808790", Frameless: true}]
+          Type: 1519 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0x8088a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}, {a}'
@@ -2546,11 +2585,11 @@ Probes:
         - json: {ref: x}
           dsl: x
       captureSnapshot: true
-      subprogram: {subprogram: 137}
+      subprogram: {subprogram: 138}
       events:
         - Kind: Entry
-          Type: 1520 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0x8087b0", Frameless: true}]
+          Type: 1521 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0x8088c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {s}, {x}'
@@ -2577,11 +2616,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 147}
+      subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1534 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0x808b60", Frameless: true}]
+          Type: 1535 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0x808c70", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -2598,11 +2637,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 91}
       events:
         - Kind: Entry
-          Type: 1429 EventRootType Probe[main.testPointerLoop]
-          InjectionPoints: [{PC: "0x8062d0", Frameless: true}]
+          Type: 1430 EventRootType Probe[main.testPointerLoop]
+          InjectionPoints: [{PC: "0x8063e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -2619,11 +2658,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 67}
+      subprogram: {subprogram: 68}
       events:
         - Kind: Entry
-          Type: 1403 EventRootType Probe[main.testPointerToMap]
-          InjectionPoints: [{PC: "0x804a10", Frameless: true}]
+          Type: 1404 EventRootType Probe[main.testPointerToMap]
+          InjectionPoints: [{PC: "0x804b20", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -2640,11 +2679,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 89}
       events:
         - Kind: Entry
-          Type: 1427 EventRootType Probe[main.testPointerToSimpleStruct]
-          InjectionPoints: [{PC: "0x8062b0", Frameless: true}]
+          Type: 1428 EventRootType Probe[main.testPointerToSimpleStruct]
+          InjectionPoints: [{PC: "0x8063c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -2661,22 +2700,22 @@ Probes:
       template: '{v}'
       segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
         - Kind: Entry
-          Type: 1445 EventRootType Probe[main.testReturnsAny]
-          InjectionPoints: [{PC: "0x806ab8", Frameless: false}]
+          Type: 1446 EventRootType Probe[main.testReturnsAny]
+          InjectionPoints: [{PC: "0x806bc8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1446 EventRootType Probe[main.testReturnsAny]Return
+          Type: 1447 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints:
-            - PC: "0x806b40"
+            - PC: "0x806c50"
               Frameless: false
-            - PC: "0x806b94"
+            - PC: "0x806ca4"
               Frameless: false
-            - PC: "0x806c4c"
+            - PC: "0x806d5c"
               Frameless: false
-            - PC: "0x806c60"
+            - PC: "0x806d70"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2699,22 +2738,22 @@ Probes:
         - json: {ref: failed}
           dsl: failed
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 101}
       events:
         - Kind: Entry
-          Type: 1443 EventRootType Probe[main.testReturnsAnyAndError]
-          InjectionPoints: [{PC: "0x806938", Frameless: false}]
+          Type: 1444 EventRootType Probe[main.testReturnsAnyAndError]
+          InjectionPoints: [{PC: "0x806a48", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1444 EventRootType Probe[main.testReturnsAnyAndError]Return
+          Type: 1445 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
-            - PC: "0x80698c"
+            - PC: "0x806a9c"
               Frameless: false
-            - PC: "0x8069e8"
+            - PC: "0x806af8"
               Frameless: false
-            - PC: "0x806a30"
+            - PC: "0x806b40"
               Frameless: false
-            - PC: "0x806a74"
+            - PC: "0x806b84"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2736,15 +2775,15 @@ Probes:
       template: testReturnsArray
       segments: [testReturnsArray]
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 111}
       events:
         - Kind: Entry
-          Type: 1473 EventRootType Probe[main.testReturnsArray]
-          InjectionPoints: [{PC: "0x80728c", Frameless: false}]
+          Type: 1474 EventRootType Probe[main.testReturnsArray]
+          InjectionPoints: [{PC: "0x80739c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1474 EventRootType Probe[main.testReturnsArray]Return
-          InjectionPoints: [{PC: "0x8072dc", Frameless: false}]
+          Type: 1475 EventRootType Probe[main.testReturnsArray]Return
+          InjectionPoints: [{PC: "0x8073ec", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsArray
@@ -2756,15 +2795,15 @@ Probes:
       template: testReturnsArrayOne
       segments: [testReturnsArrayOne]
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 112}
       events:
         - Kind: Entry
-          Type: 1475 EventRootType Probe[main.testReturnsArrayOne]
-          InjectionPoints: [{PC: "0x807318", Frameless: false}]
+          Type: 1476 EventRootType Probe[main.testReturnsArrayOne]
+          InjectionPoints: [{PC: "0x807428", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1476 EventRootType Probe[main.testReturnsArrayOne]Return
-          InjectionPoints: [{PC: "0x807350", Frameless: false}]
+          Type: 1477 EventRootType Probe[main.testReturnsArrayOne]Return
+          InjectionPoints: [{PC: "0x807460", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsArrayOne
@@ -2776,15 +2815,15 @@ Probes:
       template: testReturnsArrayZero
       segments: [testReturnsArrayZero]
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 113}
       events:
         - Kind: Entry
-          Type: 1477 EventRootType Probe[main.testReturnsArrayZero]
-          InjectionPoints: [{PC: "0x807388", Frameless: false}]
+          Type: 1478 EventRootType Probe[main.testReturnsArrayZero]
+          InjectionPoints: [{PC: "0x807498", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1478 EventRootType Probe[main.testReturnsArrayZero]Return
-          InjectionPoints: [{PC: "0x8073bc", Frameless: false}]
+          Type: 1479 EventRootType Probe[main.testReturnsArrayZero]Return
+          InjectionPoints: [{PC: "0x8074cc", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsArrayZero
@@ -2796,15 +2835,15 @@ Probes:
       template: testReturnsBacktrackInt
       segments: [testReturnsBacktrackInt]
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 115}
       events:
         - Kind: Entry
-          Type: 1481 EventRootType Probe[main.testReturnsBacktrackInt]
-          InjectionPoints: [{PC: "0x807478", Frameless: false}]
+          Type: 1482 EventRootType Probe[main.testReturnsBacktrackInt]
+          InjectionPoints: [{PC: "0x807588", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1482 EventRootType Probe[main.testReturnsBacktrackInt]Return
-          InjectionPoints: [{PC: "0x8074d8", Frameless: false}]
+          Type: 1483 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          InjectionPoints: [{PC: "0x8075e8", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsBacktrackInt
@@ -2816,15 +2855,15 @@ Probes:
       template: testReturnsBoolAndUintptr
       segments: [testReturnsBoolAndUintptr]
       captureSnapshot: true
-      subprogram: {subprogram: 120}
+      subprogram: {subprogram: 121}
       events:
         - Kind: Entry
-          Type: 1493 EventRootType Probe[main.testReturnsBoolAndUintptr]
-          InjectionPoints: [{PC: "0x8077d8", Frameless: false}]
+          Type: 1494 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          InjectionPoints: [{PC: "0x8078e8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1494 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-          InjectionPoints: [{PC: "0x807814", Frameless: false}]
+          Type: 1495 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          InjectionPoints: [{PC: "0x807924", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsBoolAndUintptr
@@ -2836,15 +2875,15 @@ Probes:
       template: testReturnsComplex
       segments: [testReturnsComplex]
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 109}
       events:
         - Kind: Entry
-          Type: 1469 EventRootType Probe[main.testReturnsComplex]
-          InjectionPoints: [{PC: "0x807148", Frameless: false}]
+          Type: 1470 EventRootType Probe[main.testReturnsComplex]
+          InjectionPoints: [{PC: "0x807258", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1470 EventRootType Probe[main.testReturnsComplex]Return
-          InjectionPoints: [{PC: "0x807190", Frameless: false}]
+          Type: 1471 EventRootType Probe[main.testReturnsComplex]Return
+          InjectionPoints: [{PC: "0x8072a0", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsComplex
@@ -2857,18 +2896,18 @@ Probes:
       template: '{failed}'
       segments: [{json: {ref: failed}, dsl: failed}]
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 100}
       events:
         - Kind: Entry
-          Type: 1441 EventRootType Probe[main.testReturnsError]
-          InjectionPoints: [{PC: "0x8068b8", Frameless: false}]
+          Type: 1442 EventRootType Probe[main.testReturnsError]
+          InjectionPoints: [{PC: "0x8069c8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1442 EventRootType Probe[main.testReturnsError]Return
+          Type: 1443 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
-            - PC: "0x8068ec"
+            - PC: "0x8069fc"
               Frameless: false
-            - PC: "0x806900"
+            - PC: "0x806a10"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2885,15 +2924,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 97}
       events:
         - Kind: Entry
-          Type: 1435 EventRootType Probe[main.testReturnsInt]
-          InjectionPoints: [{PC: "0x8066c8", Frameless: false}]
+          Type: 1436 EventRootType Probe[main.testReturnsInt]
+          InjectionPoints: [{PC: "0x8067d8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1436 EventRootType Probe[main.testReturnsInt]Return
-          InjectionPoints: [{PC: "0x806708", Frameless: false}]
+          Type: 1437 EventRootType Probe[main.testReturnsInt]Return
+          InjectionPoints: [{PC: "0x806818", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2909,15 +2948,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 99}
       events:
         - Kind: Entry
-          Type: 1439 EventRootType Probe[main.testReturnsIntAndFloat]
-          InjectionPoints: [{PC: "0x8067e8", Frameless: false}]
+          Type: 1440 EventRootType Probe[main.testReturnsIntAndFloat]
+          InjectionPoints: [{PC: "0x8068f8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1440 EventRootType Probe[main.testReturnsIntAndFloat]Return
-          InjectionPoints: [{PC: "0x806878", Frameless: false}]
+          Type: 1441 EventRootType Probe[main.testReturnsIntAndFloat]Return
+          InjectionPoints: [{PC: "0x806988", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2933,15 +2972,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 98}
       events:
         - Kind: Entry
-          Type: 1437 EventRootType Probe[main.testReturnsIntPointer]
-          InjectionPoints: [{PC: "0x806748", Frameless: false}]
+          Type: 1438 EventRootType Probe[main.testReturnsIntPointer]
+          InjectionPoints: [{PC: "0x806858", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1438 EventRootType Probe[main.testReturnsIntPointer]Return
-          InjectionPoints: [{PC: "0x8067a4", Frameless: false}]
+          Type: 1439 EventRootType Probe[main.testReturnsIntPointer]Return
+          InjectionPoints: [{PC: "0x8068b4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2958,18 +2997,18 @@ Probes:
       template: '{v}'
       segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1447 EventRootType Probe[main.testReturnsInterface]
-          InjectionPoints: [{PC: "0x806c98", Frameless: false}]
+          Type: 1448 EventRootType Probe[main.testReturnsInterface]
+          InjectionPoints: [{PC: "0x806da8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1448 EventRootType Probe[main.testReturnsInterface]Return
+          Type: 1449 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
-            - PC: "0x806d50"
+            - PC: "0x806e60"
               Frameless: false
-            - PC: "0x806d64"
+            - PC: "0x806e74"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2986,15 +3025,15 @@ Probes:
       template: testReturnsLargeStruct
       segments: [testReturnsLargeStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 110}
       events:
         - Kind: Entry
-          Type: 1471 EventRootType Probe[main.testReturnsLargeStruct]
-          InjectionPoints: [{PC: "0x8071d0", Frameless: false}]
+          Type: 1472 EventRootType Probe[main.testReturnsLargeStruct]
+          InjectionPoints: [{PC: "0x8072e0", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1472 EventRootType Probe[main.testReturnsLargeStruct]Return
-          InjectionPoints: [{PC: "0x807250", Frameless: false}]
+          Type: 1473 EventRootType Probe[main.testReturnsLargeStruct]Return
+          InjectionPoints: [{PC: "0x807360", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsLargeStruct
@@ -3006,15 +3045,15 @@ Probes:
       template: testReturnsManyFloats
       segments: [testReturnsManyFloats]
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 108}
       events:
         - Kind: Entry
-          Type: 1467 EventRootType Probe[main.testReturnsManyFloats]
-          InjectionPoints: [{PC: "0x807098", Frameless: false}]
+          Type: 1468 EventRootType Probe[main.testReturnsManyFloats]
+          InjectionPoints: [{PC: "0x8071a8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1468 EventRootType Probe[main.testReturnsManyFloats]Return
-          InjectionPoints: [{PC: "0x807118", Frameless: false}]
+          Type: 1469 EventRootType Probe[main.testReturnsManyFloats]Return
+          InjectionPoints: [{PC: "0x807228", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsManyFloats
@@ -3026,15 +3065,15 @@ Probes:
       template: testReturnsMixed
       segments: [testReturnsMixed]
       captureSnapshot: true
-      subprogram: {subprogram: 116}
+      subprogram: {subprogram: 117}
       events:
         - Kind: Entry
-          Type: 1485 EventRootType Probe[main.testReturnsMixed]
-          InjectionPoints: [{PC: "0x8075d8", Frameless: false}]
+          Type: 1486 EventRootType Probe[main.testReturnsMixed]
+          InjectionPoints: [{PC: "0x8076e8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1486 EventRootType Probe[main.testReturnsMixed]Return
-          InjectionPoints: [{PC: "0x80762c", Frameless: false}]
+          Type: 1487 EventRootType Probe[main.testReturnsMixed]Return
+          InjectionPoints: [{PC: "0x80773c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsMixed
@@ -3046,15 +3085,15 @@ Probes:
       template: testReturnsMixedStruct
       segments: [testReturnsMixedStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 114}
       events:
         - Kind: Entry
-          Type: 1479 EventRootType Probe[main.testReturnsMixedStruct]
-          InjectionPoints: [{PC: "0x8073f8", Frameless: false}]
+          Type: 1480 EventRootType Probe[main.testReturnsMixedStruct]
+          InjectionPoints: [{PC: "0x807508", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1480 EventRootType Probe[main.testReturnsMixedStruct]Return
-          InjectionPoints: [{PC: "0x80743c", Frameless: false}]
+          Type: 1481 EventRootType Probe[main.testReturnsMixedStruct]Return
+          InjectionPoints: [{PC: "0x80754c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsMixedStruct
@@ -3066,15 +3105,15 @@ Probes:
       template: testReturnsMultipleFloats
       segments: [testReturnsMultipleFloats]
       captureSnapshot: true
-      subprogram: {subprogram: 119}
+      subprogram: {subprogram: 120}
       events:
         - Kind: Entry
-          Type: 1491 EventRootType Probe[main.testReturnsMultipleFloats]
-          InjectionPoints: [{PC: "0x807768", Frameless: false}]
+          Type: 1492 EventRootType Probe[main.testReturnsMultipleFloats]
+          InjectionPoints: [{PC: "0x807878", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1492 EventRootType Probe[main.testReturnsMultipleFloats]Return
-          InjectionPoints: [{PC: "0x8077a8", Frameless: false}]
+          Type: 1493 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          InjectionPoints: [{PC: "0x8078b8", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsMultipleFloats
@@ -3086,15 +3125,15 @@ Probes:
       template: testReturnsOnlyFloat
       segments: [testReturnsOnlyFloat]
       captureSnapshot: true
-      subprogram: {subprogram: 118}
+      subprogram: {subprogram: 119}
       events:
         - Kind: Entry
-          Type: 1489 EventRootType Probe[main.testReturnsOnlyFloat]
-          InjectionPoints: [{PC: "0x8076f8", Frameless: false}]
+          Type: 1490 EventRootType Probe[main.testReturnsOnlyFloat]
+          InjectionPoints: [{PC: "0x807808", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1490 EventRootType Probe[main.testReturnsOnlyFloat]Return
-          InjectionPoints: [{PC: "0x807734", Frameless: false}]
+          Type: 1491 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          InjectionPoints: [{PC: "0x807844", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsOnlyFloat
@@ -3106,15 +3145,15 @@ Probes:
       template: testReturnsPrimitives
       segments: [testReturnsPrimitives]
       captureSnapshot: true
-      subprogram: {subprogram: 106}
+      subprogram: {subprogram: 107}
       events:
         - Kind: Entry
-          Type: 1465 EventRootType Probe[main.testReturnsPrimitives]
-          InjectionPoints: [{PC: "0x807008", Frameless: false}]
+          Type: 1466 EventRootType Probe[main.testReturnsPrimitives]
+          InjectionPoints: [{PC: "0x807118", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1466 EventRootType Probe[main.testReturnsPrimitives]Return
-          InjectionPoints: [{PC: "0x80705c", Frameless: false}]
+          Type: 1467 EventRootType Probe[main.testReturnsPrimitives]Return
+          InjectionPoints: [{PC: "0x80716c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsPrimitives
@@ -3126,15 +3165,15 @@ Probes:
       template: testReturnsStructWithArray
       segments: [testReturnsStructWithArray]
       captureSnapshot: true
-      subprogram: {subprogram: 117}
+      subprogram: {subprogram: 118}
       events:
         - Kind: Entry
-          Type: 1487 EventRootType Probe[main.testReturnsStructWithArray]
-          InjectionPoints: [{PC: "0x80766c", Frameless: false}]
+          Type: 1488 EventRootType Probe[main.testReturnsStructWithArray]
+          InjectionPoints: [{PC: "0x80777c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1488 EventRootType Probe[main.testReturnsStructWithArray]Return
-          InjectionPoints: [{PC: "0x8076bc", Frameless: false}]
+          Type: 1489 EventRootType Probe[main.testReturnsStructWithArray]Return
+          InjectionPoints: [{PC: "0x8077cc", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsStructWithArray
@@ -3146,15 +3185,15 @@ Probes:
       template: testReturnsWideStruct
       segments: [testReturnsWideStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 115}
+      subprogram: {subprogram: 116}
       events:
         - Kind: Entry
-          Type: 1483 EventRootType Probe[main.testReturnsWideStruct]
-          InjectionPoints: [{PC: "0x807510", Frameless: false}]
+          Type: 1484 EventRootType Probe[main.testReturnsWideStruct]
+          InjectionPoints: [{PC: "0x807620", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1484 EventRootType Probe[main.testReturnsWideStruct]Return
-          InjectionPoints: [{PC: "0x8075a0", Frameless: false}]
+          Type: 1485 EventRootType Probe[main.testReturnsWideStruct]Return
+          InjectionPoints: [{PC: "0x8076b0", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsWideStruct
@@ -3201,15 +3240,15 @@ Probes:
         - json: {ref: result}
           dsl: result
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1455 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0x806e88", Frameless: false}]
+          Type: 1456 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x806f98", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1456 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0x806f0c", Frameless: false}]
+          Type: 1457 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x80701c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -3477,11 +3516,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 143}
+      subprogram: {subprogram: 144}
       events:
         - Kind: Entry
-          Type: 1528 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0x808b20", Frameless: true}]
+          Type: 1529 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0x808c30", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -3603,11 +3642,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 140}
+      subprogram: {subprogram: 141}
       events:
         - Kind: Entry
-          Type: 1524 EventRootType Probe[main.testSliceEmptyStructs]
-          InjectionPoints: [{PC: "0x8087e0", Frameless: true}]
+          Type: 1525 EventRootType Probe[main.testSliceEmptyStructs]
+          InjectionPoints: [{PC: "0x8088f0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -3624,11 +3663,11 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 132}
+      subprogram: {subprogram: 133}
       events:
         - Kind: Entry
-          Type: 1515 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0x808760", Frameless: true}]
+          Type: 1516 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0x808870", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{u}'
@@ -3645,11 +3684,11 @@ Probes:
       template: '{m}'
       segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
-      subprogram: {subprogram: 65}
+      subprogram: {subprogram: 66}
       events:
         - Kind: Entry
-          Type: 1401 EventRootType Probe[main.testSmallMap]
-          InjectionPoints: [{PC: "0x8049f0", Frameless: true}]
+          Type: 1402 EventRootType Probe[main.testSmallMap]
+          InjectionPoints: [{PC: "0x804b00", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -3665,15 +3704,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 105}
+      subprogram: {subprogram: 106}
       events:
         - Kind: Entry
-          Type: 1463 EventRootType Probe[main.testSomeNamedReturn]
-          InjectionPoints: [{PC: "0x806f48", Frameless: false}]
+          Type: 1464 EventRootType Probe[main.testSomeNamedReturn]
+          InjectionPoints: [{PC: "0x807058", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1464 EventRootType Probe[main.testSomeNamedReturn]Return
-          InjectionPoints: [{PC: "0x806fd0", Frameless: false}]
+          Type: 1465 EventRootType Probe[main.testSomeNamedReturn]Return
+          InjectionPoints: [{PC: "0x8070e0", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -3689,15 +3728,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 126}
+      subprogram: {subprogram: 127}
       events:
         - Kind: Entry
-          Type: 1505 EventRootType Probe[main.testStackArgRegReturns]
-          InjectionPoints: [{PC: "0x808058", Frameless: false}]
+          Type: 1506 EventRootType Probe[main.testStackArgRegReturns]
+          InjectionPoints: [{PC: "0x808168", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1506 EventRootType Probe[main.testStackArgRegReturns]Return
-          InjectionPoints: [{PC: "0x8080b4", Frameless: false}]
+          Type: 1507 EventRootType Probe[main.testStackArgRegReturns]Return
+          InjectionPoints: [{PC: "0x8081c4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -3735,11 +3774,11 @@ Probes:
       template: '{z}'
       segments: [{json: {ref: z}, dsl: z}]
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 94}
       events:
         - Kind: Entry
-          Type: 1432 EventRootType Probe[main.testStringPointer]
-          InjectionPoints: [{PC: "0x806370", Frameless: true}]
+          Type: 1433 EventRootType Probe[main.testStringPointer]
+          InjectionPoints: [{PC: "0x806480", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{z}'
@@ -3756,11 +3795,11 @@ Probes:
       template: '{s}'
       segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
-      subprogram: {subprogram: 136}
+      subprogram: {subprogram: 137}
       events:
         - Kind: Entry
-          Type: 1519 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0x8087a0", Frameless: true}]
+          Type: 1520 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0x8088b0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{s}'
@@ -3777,11 +3816,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 44}
+      subprogram: {subprogram: 45}
       events:
         - Kind: Entry
-          Type: 1367 EventRootType Probe[main.testStringType1]
-          InjectionPoints: [{PC: "0x803400", Frameless: true}]
+          Type: 1368 EventRootType Probe[main.testStringType1]
+          InjectionPoints: [{PC: "0x803510", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3798,11 +3837,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 45}
+      subprogram: {subprogram: 46}
       events:
         - Kind: Entry
-          Type: 1368 EventRootType Probe[main.testStringType2]
-          InjectionPoints: [{PC: "0x803410", Frameless: true}]
+          Type: 1369 EventRootType Probe[main.testStringType2]
+          InjectionPoints: [{PC: "0x803520", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3819,11 +3858,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1543 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0x808da0", Frameless: true}]
+          Type: 1544 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0x808eb0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -3845,11 +3884,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 133}
+      subprogram: {subprogram: 134}
       events:
         - Kind: Entry
-          Type: 1516 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0x808770", Frameless: true}]
+          Type: 1517 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0x808880", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}, {a}'
@@ -3871,11 +3910,11 @@ Probes:
       template: '{s}'
       segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
-      subprogram: {subprogram: 59}
+      subprogram: {subprogram: 60}
       events:
         - Kind: Entry
-          Type: 1395 EventRootType Probe[main.testStructWithAny]
-          InjectionPoints: [{PC: "0x804410", Frameless: true}]
+          Type: 1396 EventRootType Probe[main.testStructWithAny]
+          InjectionPoints: [{PC: "0x804520", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{s}'
@@ -3891,15 +3930,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 128}
+      subprogram: {subprogram: 129}
       events:
         - Kind: Entry
-          Type: 1509 EventRootType Probe[main.testStructWithArrayArg]
-          InjectionPoints: [{PC: "0x8081bc", Frameless: false}]
+          Type: 1510 EventRootType Probe[main.testStructWithArrayArg]
+          InjectionPoints: [{PC: "0x8082cc", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1510 EventRootType Probe[main.testStructWithArrayArg]Return
-          InjectionPoints: [{PC: "0x808244", Frameless: false}]
+          Type: 1511 EventRootType Probe[main.testStructWithArrayArg]Return
+          InjectionPoints: [{PC: "0x808354", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -3916,11 +3955,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 153}
+      subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1541 EventRootType Probe[main.testStructWithCyclicMaps]
-          InjectionPoints: [{PC: "0x808d00", Frameless: true}]
+          Type: 1542 EventRootType Probe[main.testStructWithCyclicMaps]
+          InjectionPoints: [{PC: "0x808e10", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3936,11 +3975,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 152}
+      subprogram: {subprogram: 153}
       events:
         - Kind: Entry
-          Type: 1540 EventRootType Probe[main.testStructWithCyclicSlices]
-          InjectionPoints: [{PC: "0x808cf0", Frameless: true}]
+          Type: 1541 EventRootType Probe[main.testStructWithCyclicSlices]
+          InjectionPoints: [{PC: "0x808e00", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3962,11 +4001,11 @@ Probes:
         - json: {ref: '@duration'}
           dsl: '@duration'
       captureSnapshot: true
-      subprogram: {subprogram: 60}
+      subprogram: {subprogram: 61}
       events:
         - Kind: Entry
-          Type: 1396 EventRootType Probe[main.testStructWithMap]
-          InjectionPoints: [{PC: "0x8049a0", Frameless: true}]
+          Type: 1397 EventRootType Probe[main.testStructWithMap]
+          InjectionPoints: [{PC: "0x804ab0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{s} {@duration}'
@@ -3993,11 +4032,11 @@ Probes:
         - json: {ref: cs}
           dsl: cs
       captureSnapshot: true
-      subprogram: {subprogram: 141}
+      subprogram: {subprogram: 142}
       events:
         - Kind: Entry
-          Type: 1525 EventRootType Probe[main.testSubslices]
-          InjectionPoints: [{PC: "0x8087f0", Frameless: true}]
+          Type: 1526 EventRootType Probe[main.testSubslices]
+          InjectionPoints: [{PC: "0x808900", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{as}, {bs}, {cs}'
@@ -4032,11 +4071,11 @@ Probes:
         - json: {ref: c}
           dsl: c
       captureSnapshot: true
-      subprogram: {subprogram: 151}
+      subprogram: {subprogram: 152}
       events:
         - Kind: Entry
-          Type: 1539 EventRootType Probe[main.testSubstrings]
-          InjectionPoints: [{PC: "0x808ba0", Frameless: true}]
+          Type: 1540 EventRootType Probe[main.testSubstrings]
+          InjectionPoints: [{PC: "0x808cb0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}'
@@ -4064,15 +4103,15 @@ Probes:
         - json: {ref: nonexistentVariable}
           dsl: nonexistentVariable
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1457 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0x806e88", Frameless: false}]
+          Type: 1458 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x806f98", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1458 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0x806f0c", Frameless: false}]
+          Type: 1459 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x80701c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{nonexistentVariable}'
@@ -4088,15 +4127,15 @@ Probes:
         - json: {foobar: unsupportedExpression}
           dsl: unsupportedExpression
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1459 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0x806e88", Frameless: false}]
+          Type: 1460 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x806f98", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1460 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0x806f0c", Frameless: false}]
+          Type: 1461 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x80701c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{unsupportedExpression}'
@@ -4114,15 +4153,15 @@ Probes:
           dsl: '@duration'
         - ms
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1461 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0x806e88", Frameless: false}]
+          Type: 1462 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x806f98", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1462 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0x806f0c", Frameless: false}]
+          Type: 1463 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x80701c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -4146,11 +4185,11 @@ Probes:
         - json: {ref: z}
           dsl: z
       captureSnapshot: true
-      subprogram: {subprogram: 144}
+      subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1529 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0x808b30", Frameless: true}]
+          Type: 1530 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0x808c40", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}, {y}, {z}'
@@ -4177,11 +4216,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 145}
+      subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1530 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0x808b40", Frameless: true}]
+          Type: 1531 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0x808c50", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -4206,11 +4245,11 @@ Probes:
         - json: {getmember: [{ref: a}, c]}
           dsl: t.c
       captureSnapshot: false
-      subprogram: {subprogram: 145}
+      subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1531 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0x808b40", Frameless: true}]
+          Type: 1532 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0x808c50", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a.a} {a.b} {a.c}'
@@ -4237,11 +4276,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 146}
+      subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1532 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0x808b50", Frameless: true}]
+          Type: 1533 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0x808c60", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -4266,11 +4305,11 @@ Probes:
         - json: {getmember: [{ref: a}, c]}
           dsl: a.c
       captureSnapshot: false
-      subprogram: {subprogram: 146}
+      subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1533 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0x808b50", Frameless: true}]
+          Type: 1534 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0x808c60", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a.a} {a.b} {a.c}'
@@ -4423,11 +4462,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 93}
       events:
         - Kind: Entry
-          Type: 1431 EventRootType Probe[main.testUintPointer]
-          InjectionPoints: [{PC: "0x806300", Frameless: true}]
+          Type: 1432 EventRootType Probe[main.testUintPointer]
+          InjectionPoints: [{PC: "0x806410", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4444,11 +4483,11 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 130}
+      subprogram: {subprogram: 131}
       events:
         - Kind: Entry
-          Type: 1513 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0x808740", Frameless: true}]
+          Type: 1514 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0x808850", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{u}'
@@ -4465,11 +4504,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 149}
+      subprogram: {subprogram: 150}
       events:
         - Kind: Entry
-          Type: 1537 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0x808b80", Frameless: true}]
+          Type: 1538 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0x808c90", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4486,11 +4525,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 92}
       events:
         - Kind: Entry
-          Type: 1430 EventRootType Probe[main.testUnsafePointer]
-          InjectionPoints: [{PC: "0x8062e0", Frameless: true}]
+          Type: 1431 EventRootType Probe[main.testUnsafePointer]
+          InjectionPoints: [{PC: "0x8063f0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4528,11 +4567,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 139}
+      subprogram: {subprogram: 140}
       events:
         - Kind: Entry
-          Type: 1522 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0x8087d0", Frameless: true}]
+          Type: 1523 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0x8088e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -4549,11 +4588,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 139}
+      subprogram: {subprogram: 140}
       events:
         - Kind: Entry
-          Type: 1523 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0x8087d0", Frameless: true}]
+          Type: 1524 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0x8088e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -4569,19 +4608,19 @@ Probes:
       template: testWhollyInlinedSubroutine
       segments: [testWhollyInlinedSubroutine]
       captureSnapshot: true
-      subprogram: {subprogram: 164}
+      subprogram: {subprogram: 165}
       events:
         - Kind: Entry
-          Type: 1563 EventRootType Probe[main.firstBehavior.DoSomething]
+          Type: 1564 EventRootType Probe[main.firstBehavior.DoSomething]
           InjectionPoints:
-            - PC: "0x804278"
+            - PC: "0x804388"
               Frameless: false
-            - PC: "0x809950"
+            - PC: "0x809a60"
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1564 EventRootType Probe[main.firstBehavior.DoSomething]Return
-          InjectionPoints: [{PC: "0x8042a0", Frameless: false}]
+          Type: 1565 EventRootType Probe[main.firstBehavior.DoSomething]Return
+          InjectionPoints: [{PC: "0x8043b0", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testWhollyInlinedSubroutine
@@ -4598,15 +4637,15 @@ Probes:
         - json: {ref: b}
           dsl: b
       captureSnapshot: true
-      subprogram: {subprogram: 129}
+      subprogram: {subprogram: 130}
       events:
         - Kind: Entry
-          Type: 1511 EventRootType Probe[main.testZeroSizeArgAndReturn]
-          InjectionPoints: [{PC: "0x808278", Frameless: false}]
+          Type: 1512 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          InjectionPoints: [{PC: "0x808388", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1512 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-          InjectionPoints: [{PC: "0x8082dc", Frameless: false}]
+          Type: 1513 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          InjectionPoints: [{PC: "0x8083ec", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}'
@@ -5041,36 +5080,77 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
     - ID: 38
+      Name: main.testErrorAtLine
+      OutOfLinePCRanges: [0x8030c0..0x8031d0]
+      InlinePCRanges: []
+      Variables:
+        - Name: shouldErr
+          Type: 4 BaseType bool
+          Locations:
+            - Range: 0x8030c0..0x8030e0
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+        - Name: ~r0
+          Type: 7 BaseType int
+          Locations: [{Range: 0x8030c0..0x8031d0, Pieces: []}]
+          Role: Return
+        - Name: x
+          Type: 7 BaseType int
+          Locations: [{Range: 0x8030c0..0x8031d0, Pieces: []}]
+          Role: Local
+        - Name: err
+          Type: 15 GoInterfaceType error
+          Locations:
+            - Range: 0x8030d8..0x80311c
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+            - Range: 0x80311c..0x80317c
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+            - Range: 0x80317c..0x8031d0
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: -64}
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+          Role: Local
+    - ID: 39
       Name: main.testDeepPtr1
-      OutOfLinePCRanges: [0x803150..0x803160]
+      OutOfLinePCRanges: [0x803260..0x803270]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 138 StructureType main.deepPtr1
           Locations:
-            - Range: 0x803150..0x803160
+            - Range: 0x803260..0x803270
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 39
+    - ID: 40
       Name: main.testDeepPtr7
-      OutOfLinePCRanges: [0x803160..0x803170]
+      OutOfLinePCRanges: [0x803270..0x803280]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 141 PointerType *main.deepPtr7
           Locations:
-            - Range: 0x803160..0x803170
+            - Range: 0x803270..0x803280
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 40
+    - ID: 41
       Name: main.testDeepSlice1
-      OutOfLinePCRanges: [0x803280..0x803290]
+      OutOfLinePCRanges: [0x803390..0x8033a0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 143 StructureType main.deepSlice1
           Locations:
-            - Range: 0x803280..0x803290
+            - Range: 0x803390..0x8033a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -5079,109 +5159,109 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 41
+    - ID: 42
       Name: main.testDeepSlice7
-      OutOfLinePCRanges: [0x803290..0x8032a0]
+      OutOfLinePCRanges: [0x8033a0..0x8033b0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 147 PointerType *main.deepSlice7
           Locations:
-            - Range: 0x803290..0x8032a0
+            - Range: 0x8033a0..0x8033b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 42
+    - ID: 43
       Name: main.testDeepMap1
-      OutOfLinePCRanges: [0x8033e0..0x8033f0]
+      OutOfLinePCRanges: [0x8034f0..0x803500]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 149 StructureType main.deepMap1
           Locations:
-            - Range: 0x8033e0..0x8033f0
+            - Range: 0x8034f0..0x803500
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 43
+    - ID: 44
       Name: main.testDeepMap7
-      OutOfLinePCRanges: [0x8033f0..0x803400]
+      OutOfLinePCRanges: [0x803500..0x803510]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 155 PointerType *main.deepMap7
           Locations:
-            - Range: 0x8033f0..0x803400
+            - Range: 0x803500..0x803510
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 44
+    - ID: 45
       Name: main.testStringType1
-      OutOfLinePCRanges: [0x803400..0x803410]
+      OutOfLinePCRanges: [0x803510..0x803520]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 157 PointerType *main.stringType1
           Locations:
-            - Range: 0x803400..0x803410
+            - Range: 0x803510..0x803520
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 45
+    - ID: 46
       Name: main.testStringType2
-      OutOfLinePCRanges: [0x803410..0x803420]
+      OutOfLinePCRanges: [0x803520..0x803530]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 159 PointerType **main.stringType2
           Locations:
-            - Range: 0x803410..0x803420
+            - Range: 0x803520..0x803530
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 46
+    - ID: 47
       Name: main.testLongFunctionWithChangingState
-      OutOfLinePCRanges: [0x803420..0x803600]
+      OutOfLinePCRanges: [0x803530..0x803710]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8034dc..0x8034f0
+            - Range: 0x8035ec..0x803600
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x803580..0x803594
+            - Range: 0x803690..0x8036a4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
         - Name: aPerArch
           Type: 7 BaseType int
           Locations:
-            - Range: 0x803440..0x803600
+            - Range: 0x803550..0x803710
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8034bc..0x8034c8
+            - Range: 0x8035cc..0x8035d8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8034c8..0x8034c8
+            - Range: 0x8035d8..0x8035d8
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x8034c8..0x8034dc
+            - Range: 0x8035d8..0x8035ec
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8034dc..0x803574
+            - Range: 0x8035ec..0x803684
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0x803574..0x803578
+            - Range: 0x803684..0x803688
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0x803578..0x80357c
+            - Range: 0x803688..0x80368c
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0x80357c..0x803594
+            - Range: 0x80368c..0x8036a4
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0x803594..0x803600
+            - Range: 0x8036a4..0x803710
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
           Role: Local
-    - ID: 47
+    - ID: 48
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0x803910..0x8039d0]
+      OutOfLinePCRanges: [0x803a20..0x803ae0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 161 StructureType main.esotericStack
           Locations:
-            - Range: 0x803910..0x803948
+            - Range: 0x803a20..0x803a58
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -5201,7 +5281,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x803948..0x80394c
+            - Range: 0x803a58..0x803a5c
               Pieces:
                 - Size: 4
                   Op: null
@@ -5221,7 +5301,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x80394c..0x803950
+            - Range: 0x803a5c..0x803a60
               Pieces:
                 - Size: 4
                   Op: null
@@ -5242,157 +5322,157 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 48
+    - ID: 49
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0x8039d0..0x803a40]
+      OutOfLinePCRanges: [0x803ae0..0x803b50]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 165 PointerType *main.esotericHeap
           Locations:
-            - Range: 0x8039d0..0x803a04
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-    - ID: 49
-      Name: main.testInlinedBA
-      OutOfLinePCRanges: [0x803df0..0x803e80]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x803df0..0x803e20
+            - Range: 0x803ae0..0x803b14
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 50
-      Name: main.testInlinedBB
-      OutOfLinePCRanges: [0x803e80..0x803f40]
+      Name: main.testInlinedBA
+      OutOfLinePCRanges: [0x803f00..0x803f90]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x803e80..0x803e9c
+            - Range: 0x803f00..0x803f30
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+    - ID: 51
+      Name: main.testInlinedBB
+      OutOfLinePCRanges: [0x803f90..0x804050]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x803f90..0x803fac
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: y
           Type: 7 BaseType int
           Locations:
-            - Range: 0x803e80..0x803eac
+            - Range: 0x803f90..0x803fbc
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
         - Name: z
           Type: 7 BaseType int
           Locations:
-            - Range: 0x803e9c..0x803eac
+            - Range: 0x803fac..0x803fbc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x803eac..0x803f40
+            - Range: 0x803fbc..0x804050
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Local
-    - ID: 51
+    - ID: 52
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0x803f40..0x803fb0]
+      OutOfLinePCRanges: [0x804050..0x8040c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x803f40..0x803f64
+            - Range: 0x804050..0x804074
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 52
+    - ID: 53
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0x803fb0..0x8040c0]
+      OutOfLinePCRanges: [0x8040c0..0x8041d0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 7 BaseType int
           Locations:
-            - Range: 0x803fcc..0x804038
+            - Range: 0x8040dc..0x804148
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x804038..0x804040
+            - Range: 0x804148..0x804150
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x803fcc..0x804038
+            - Range: 0x8040dc..0x804148
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x804038..0x80403c
+            - Range: 0x804148..0x80414c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 53
+    - ID: 54
       Name: main.testFrameless
-      OutOfLinePCRanges: [0x8040c0..0x8040d0]
+      OutOfLinePCRanges: [0x8041d0..0x8041e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8040c0..0x8040c8
+            - Range: 0x8041d0..0x8041d8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8040c0..0x8040c8
+            - Range: 0x8041d0..0x8041d8
               Pieces: []
-            - Range: 0x8040c8..0x8040c9
+            - Range: 0x8041d8..0x8041d9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8040c9..0x8040d0
+            - Range: 0x8041d9..0x8041e0
               Pieces: []
           Role: Return
-    - ID: 54
+    - ID: 55
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0x8040d0..0x804120]
+      OutOfLinePCRanges: [0x8041e0..0x804230]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 167 ArrayType [5]int
           Locations:
-            - Range: 0x8040d0..0x804120
+            - Range: 0x8041e0..0x804230
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8040d0..0x804110
+            - Range: 0x8041e0..0x804220
               Pieces: []
-            - Range: 0x804110..0x804111
+            - Range: 0x804220..0x804221
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x804111..0x804120
+            - Range: 0x804221..0x804230
               Pieces: []
           Role: Return
-    - ID: 55
+    - ID: 56
       Name: main.testInterface
-      OutOfLinePCRanges: [0x804330..0x804340]
+      OutOfLinePCRanges: [0x804440..0x804450]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 168 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x804330..0x804340
+            - Range: 0x804440..0x804450
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 56
+    - ID: 57
       Name: main.testAny
-      OutOfLinePCRanges: [0x804340..0x8043a0]
+      OutOfLinePCRanges: [0x804450..0x8044b0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 163 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x804340..0x80436c
+            - Range: 0x804450..0x80447c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80436c..0x804370
+            - Range: 0x80447c..0x804480
               Pieces:
                 - Size: 8
                   Op: null
@@ -5402,363 +5482,363 @@ Subprograms:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x804340..0x804380
+            - Range: 0x804450..0x804490
               Pieces: []
-            - Range: 0x804380..0x804381
+            - Range: 0x804490..0x804491
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x804381..0x8043a0
+            - Range: 0x804491..0x8044b0
               Pieces: []
           Role: Return
-    - ID: 57
+    - ID: 58
       Name: main.testError
-      OutOfLinePCRanges: [0x8043a0..0x8043b0]
+      OutOfLinePCRanges: [0x8044b0..0x8044c0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 15 GoInterfaceType error
           Locations:
-            - Range: 0x8043a0..0x8043b0
+            - Range: 0x8044b0..0x8044c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 58
+    - ID: 59
       Name: main.testAnyPtr
-      OutOfLinePCRanges: [0x8043b0..0x804410]
+      OutOfLinePCRanges: [0x8044c0..0x804520]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 169 PointerType *interface {}
           Locations:
-            - Range: 0x8043b0..0x8043dc
+            - Range: 0x8044c0..0x8044ec
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x8043b0..0x8043f0
+            - Range: 0x8044c0..0x804500
               Pieces: []
-            - Range: 0x8043f0..0x8043f1
+            - Range: 0x804500..0x804501
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8043f1..0x804410
+            - Range: 0x804501..0x804520
               Pieces: []
           Role: Return
-    - ID: 59
+    - ID: 60
       Name: main.testStructWithAny
-      OutOfLinePCRanges: [0x804410..0x804420]
+      OutOfLinePCRanges: [0x804520..0x804530]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 170 StructureType main.structWithAny
           Locations:
-            - Range: 0x804410..0x804420
+            - Range: 0x804520..0x804530
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 60
+    - ID: 61
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0x8049a0..0x8049b0]
+      OutOfLinePCRanges: [0x804ab0..0x804ac0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 171 StructureType main.structWithMap
           Locations:
-            - Range: 0x8049a0..0x8049b0
+            - Range: 0x804ab0..0x804ac0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 61
+    - ID: 62
       Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0x8049b0..0x8049c0]
+      OutOfLinePCRanges: [0x804ac0..0x804ad0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 177 GoMapType map[string]main.nestedStruct
           Locations:
-            - Range: 0x8049b0..0x8049c0
+            - Range: 0x804ac0..0x804ad0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 62
+    - ID: 63
       Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0x8049c0..0x8049d0]
+      OutOfLinePCRanges: [0x804ad0..0x804ae0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 182 GoMapType map[string]int
           Locations:
-            - Range: 0x8049c0..0x8049d0
+            - Range: 0x804ad0..0x804ae0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 63
+    - ID: 64
       Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0x8049d0..0x8049e0]
+      OutOfLinePCRanges: [0x804ae0..0x804af0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 187 GoMapType map[string][]string
           Locations:
-            - Range: 0x8049d0..0x8049e0
+            - Range: 0x804ae0..0x804af0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 64
+    - ID: 65
       Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0x8049e0..0x8049f0]
+      OutOfLinePCRanges: [0x804af0..0x804b00]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 192 GoMapType map[[4]string][2]int
           Locations:
-            - Range: 0x8049e0..0x8049f0
+            - Range: 0x804af0..0x804b00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 65
+    - ID: 66
       Name: main.testSmallMap
-      OutOfLinePCRanges: [0x8049f0..0x804a00]
+      OutOfLinePCRanges: [0x804b00..0x804b10]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 182 GoMapType map[string]int
           Locations:
-            - Range: 0x8049f0..0x804a00
+            - Range: 0x804b00..0x804b10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 66
+    - ID: 67
       Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0x804a00..0x804a10]
+      OutOfLinePCRanges: [0x804b10..0x804b20]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 197 ArrayType [2]map[string]int
           Locations:
-            - Range: 0x804a00..0x804a10
+            - Range: 0x804b10..0x804b20
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
-    - ID: 67
+    - ID: 68
       Name: main.testPointerToMap
-      OutOfLinePCRanges: [0x804a10..0x804a20]
+      OutOfLinePCRanges: [0x804b20..0x804b30]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 198 PointerType *map[string]int
           Locations:
-            - Range: 0x804a10..0x804a20
+            - Range: 0x804b20..0x804b30
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 68
+    - ID: 69
       Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0x804a20..0x804a30]
+      OutOfLinePCRanges: [0x804b30..0x804b40]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 172 GoMapType map[int]int
           Locations:
-            - Range: 0x804a20..0x804a30
+            - Range: 0x804b30..0x804b40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 69
+    - ID: 70
       Name: main.testMapMassive
-      OutOfLinePCRanges: [0x804a30..0x804a40]
+      OutOfLinePCRanges: [0x804b40..0x804b50]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 199 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0x804a30..0x804a40
+            - Range: 0x804b40..0x804b50
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 70
+    - ID: 71
       Name: main.testMapEmbeddedMaps
-      OutOfLinePCRanges: [0x804a40..0x804a50]
+      OutOfLinePCRanges: [0x804b50..0x804b60]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 199 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0x804a40..0x804a50
+            - Range: 0x804b50..0x804b60
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 71
+    - ID: 72
       Name: main.testMapWithLinkedList
-      OutOfLinePCRanges: [0x804a50..0x804a60]
+      OutOfLinePCRanges: [0x804b60..0x804b70]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 204 GoMapType map[bool]main.node
           Locations:
-            - Range: 0x804a50..0x804a60
+            - Range: 0x804b60..0x804b70
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 72
+    - ID: 73
       Name: main.testMapWithSmallValue
-      OutOfLinePCRanges: [0x804a60..0x804a70]
+      OutOfLinePCRanges: [0x804b70..0x804b80]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 209 GoMapType map[int]uint8
           Locations:
-            - Range: 0x804a60..0x804a70
+            - Range: 0x804b70..0x804b80
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 73
+    - ID: 74
       Name: main.testMapWithSmallValueMassive
-      OutOfLinePCRanges: [0x804a70..0x804a80]
+      OutOfLinePCRanges: [0x804b80..0x804b90]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 209 GoMapType map[int]uint8
           Locations:
-            - Range: 0x804a70..0x804a80
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-    - ID: 74
-      Name: main.testMapWithSmallKeyAndValue
-      OutOfLinePCRanges: [0x804a80..0x804a90]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 214 GoMapType map[uint8]uint8
-          Locations:
-            - Range: 0x804a80..0x804a90
+            - Range: 0x804b80..0x804b90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 75
-      Name: main.testMapWithSmallKeyAndValueMassive
-      OutOfLinePCRanges: [0x804a90..0x804aa0]
+      Name: main.testMapWithSmallKeyAndValue
+      OutOfLinePCRanges: [0x804b90..0x804ba0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 214 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0x804a90..0x804aa0
+            - Range: 0x804b90..0x804ba0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 76
-      Name: main.testMapSmallKeySmallValue
-      OutOfLinePCRanges: [0x804aa0..0x804ab0]
+      Name: main.testMapWithSmallKeyAndValueMassive
+      OutOfLinePCRanges: [0x804ba0..0x804bb0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 214 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0x804aa0..0x804ab0
+            - Range: 0x804ba0..0x804bb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 77
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0x804bb0..0x804bc0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 214 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0x804bb0..0x804bc0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+    - ID: 78
       Name: main.testMapSmallKeyLargeValue
-      OutOfLinePCRanges: [0x804ab0..0x804ac0]
+      OutOfLinePCRanges: [0x804bc0..0x804bd0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 219 GoMapType map[uint8][4]int
           Locations:
-            - Range: 0x804ab0..0x804ac0
+            - Range: 0x804bc0..0x804bd0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 78
+    - ID: 79
       Name: main.testMapLargeKeySmallValue
-      OutOfLinePCRanges: [0x804ac0..0x804ad0]
+      OutOfLinePCRanges: [0x804bd0..0x804be0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 224 GoMapType map[[4]int]uint8
           Locations:
-            - Range: 0x804ac0..0x804ad0
+            - Range: 0x804bd0..0x804be0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 79
+    - ID: 80
       Name: main.testMapLargeKeyLargeValue
-      OutOfLinePCRanges: [0x804ad0..0x804ae0]
+      OutOfLinePCRanges: [0x804be0..0x804bf0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 229 GoMapType map[[4]int][4]int
           Locations:
-            - Range: 0x804ad0..0x804ae0
+            - Range: 0x804be0..0x804bf0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 80
+    - ID: 81
       Name: main.testMapEmptyKey
-      OutOfLinePCRanges: [0x804ae0..0x804af0]
+      OutOfLinePCRanges: [0x804bf0..0x804c00]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 234 GoMapType map[struct {}]int
           Locations:
-            - Range: 0x804ae0..0x804af0
+            - Range: 0x804bf0..0x804c00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 81
+    - ID: 82
       Name: main.testMapEmptyValue
-      OutOfLinePCRanges: [0x804af0..0x804b00]
+      OutOfLinePCRanges: [0x804c00..0x804c10]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 239 GoMapType map[int]struct {}
           Locations:
-            - Range: 0x804af0..0x804b00
+            - Range: 0x804c00..0x804c10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 82
+    - ID: 83
       Name: main.testMapEmptyKeyAndValue
-      OutOfLinePCRanges: [0x804b00..0x804b10]
+      OutOfLinePCRanges: [0x804c10..0x804c20]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 244 GoMapType map[struct {}]struct {}
           Locations:
-            - Range: 0x804b00..0x804b10
+            - Range: 0x804c10..0x804c20
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 83
+    - ID: 84
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0x805e70..0x805e80]
+      OutOfLinePCRanges: [0x805f80..0x805f90]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x805e70..0x805e80
+            - Range: 0x805f80..0x805f90
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x805e70..0x805e80
+            - Range: 0x805f80..0x805f90
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
         - Name: y
           Type: 17 BaseType float32
           Locations:
-            - Range: 0x805e70..0x805e80
+            - Range: 0x805f80..0x805f90
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
-    - ID: 84
+    - ID: 85
       Name: main.testCombinedString
-      OutOfLinePCRanges: [0x805e90..0x805ea0]
+      OutOfLinePCRanges: [0x805fa0..0x805fb0]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x805e90..0x805ea0
+            - Range: 0x805fa0..0x805fb0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x805e90..0x805ea0
+            - Range: 0x805fa0..0x805fb0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -5768,339 +5848,339 @@ Subprograms:
         - Name: y
           Type: 17 BaseType float32
           Locations:
-            - Range: 0x805e90..0x805ea0
+            - Range: 0x805fa0..0x805fb0
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
-    - ID: 85
+    - ID: 86
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0x805f50..0x805f60]
+      OutOfLinePCRanges: [0x806060..0x806070]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x805f50..0x805f60
+            - Range: 0x806060..0x806070
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: b
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x805f50..0x805f60
+            - Range: 0x806060..0x806070
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
         - Name: c
           Type: 12 BaseType int32
           Locations:
-            - Range: 0x805f50..0x805f60
+            - Range: 0x806060..0x806070
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
         - Name: d
           Type: 11 BaseType uint
           Locations:
-            - Range: 0x805f50..0x805f60
+            - Range: 0x806060..0x806070
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
         - Name: e
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x805f50..0x805f60
+            - Range: 0x806060..0x806070
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
-    - ID: 86
+    - ID: 87
       Name: main.testAtomicAdd
-      OutOfLinePCRanges: [0x8060f0..0x806130]
+      OutOfLinePCRanges: [0x806200..0x806240]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0x8060f0..0x80612c
+            - Range: 0x806200..0x80623c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0x8060f0..0x80612c
+            - Range: 0x806200..0x80623c
               Pieces: []
-            - Range: 0x80612c..0x80612d
+            - Range: 0x80623c..0x80623d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80612d..0x806130
+            - Range: 0x80623d..0x806240
               Pieces: []
           Role: Return
-    - ID: 87
+    - ID: 88
       Name: main.testChannel
-      OutOfLinePCRanges: [0x806130..0x806140]
+      OutOfLinePCRanges: [0x806240..0x806250]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 249 GoChannelType chan bool
           Locations:
-            - Range: 0x806130..0x806140
+            - Range: 0x806240..0x806250
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 88
+    - ID: 89
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0x8062b0..0x8062c0]
+      OutOfLinePCRanges: [0x8063c0..0x8063d0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 250 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0x8062b0..0x8062c0
+            - Range: 0x8063c0..0x8063d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 89
+    - ID: 90
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0x8062c0..0x8062d0]
+      OutOfLinePCRanges: [0x8063d0..0x8063e0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 252 StructureType main.node
           Locations:
-            - Range: 0x8062c0..0x8062d0
+            - Range: 0x8063d0..0x8063e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 90
+    - ID: 91
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0x8062d0..0x8062e0]
+      OutOfLinePCRanges: [0x8063e0..0x8063f0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 253 PointerType *main.node
           Locations:
-            - Range: 0x8062d0..0x8062e0
+            - Range: 0x8063e0..0x8063f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 91
+    - ID: 92
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0x8062e0..0x8062f0]
+      OutOfLinePCRanges: [0x8063f0..0x806400]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 16 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0x8062e0..0x8062f0
+            - Range: 0x8063f0..0x806400
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 92
+    - ID: 93
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0x806300..0x806310]
+      OutOfLinePCRanges: [0x806410..0x806420]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 112 PointerType *uint
           Locations:
-            - Range: 0x806300..0x806310
+            - Range: 0x806410..0x806420
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 93
+    - ID: 94
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0x806370..0x806380]
+      OutOfLinePCRanges: [0x806480..0x806490]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 101 PointerType *string
           Locations:
-            - Range: 0x806370..0x806380
+            - Range: 0x806480..0x806490
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 94
+    - ID: 95
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0x806390..0x8063a0]
+      OutOfLinePCRanges: [0x8064a0..0x8064b0]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 10 PointerType *bool
           Locations:
-            - Range: 0x806390..0x8063a0
+            - Range: 0x8064a0..0x8064b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: a
           Type: 11 BaseType uint
           Locations:
-            - Range: 0x806390..0x8063a0
+            - Range: 0x8064a0..0x8064b0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
-    - ID: 95
+    - ID: 96
       Name: main.testCycle
-      OutOfLinePCRanges: [0x8063b0..0x8063c0]
+      OutOfLinePCRanges: [0x8064c0..0x8064d0]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 254 PointerType *main.t
           Locations:
-            - Range: 0x8063b0..0x8063c0
+            - Range: 0x8064c0..0x8064d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 96
+    - ID: 97
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0x8066b0..0x806730]
+      OutOfLinePCRanges: [0x8067c0..0x806840]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8066b0..0x8066cc
+            - Range: 0x8067c0..0x8067dc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8066b0..0x806708
+            - Range: 0x8067c0..0x806818
               Pieces: []
-            - Range: 0x806708..0x806709
+            - Range: 0x806818..0x806819
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x806709..0x806730
+            - Range: 0x806819..0x806840
               Pieces: []
           Role: Return
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8066cc..0x8066d8
+            - Range: 0x8067dc..0x8067e8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8066d8..0x806730
+            - Range: 0x8067e8..0x806840
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
-    - ID: 97
+    - ID: 98
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0x806730..0x8067d0]
+      OutOfLinePCRanges: [0x806840..0x8068e0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x806730..0x806754
+            - Range: 0x806840..0x806864
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x806754..0x8067d0
+            - Range: 0x806864..0x8068e0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 105 PointerType *int
           Locations:
-            - Range: 0x806730..0x8067a4
+            - Range: 0x806840..0x8068b4
               Pieces: []
-            - Range: 0x8067a4..0x8067a5
+            - Range: 0x8068b4..0x8068b5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8067a5..0x8067d0
+            - Range: 0x8068b5..0x8068e0
               Pieces: []
           Role: Return
         - Name: '&result'
           Type: 105 PointerType *int
           Locations:
-            - Range: 0x806758..0x806770
+            - Range: 0x806868..0x806880
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x806770..0x8067d0
+            - Range: 0x806880..0x8068e0
               Pieces: [{Size: 8, Op: {CfaOffset: -16}}]
           Role: Local
-    - ID: 98
+    - ID: 99
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0x8067d0..0x8068a0]
+      OutOfLinePCRanges: [0x8068e0..0x8069b0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8067d0..0x806828
+            - Range: 0x8068e0..0x806938
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8067d0..0x806878
+            - Range: 0x8068e0..0x806988
               Pieces: []
-            - Range: 0x806878..0x806879
+            - Range: 0x806988..0x806989
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x806879..0x8068a0
+            - Range: 0x806989..0x8069b0
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 14 BaseType float64
-          Locations: [{Range: 0x8067d0..0x8068a0, Pieces: []}]
+          Locations: [{Range: 0x8068e0..0x8069b0, Pieces: []}]
           Role: Return
         - Name: resultInt
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8067ec..0x80682c
+            - Range: 0x8068fc..0x80693c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80682c..0x8068a0
+            - Range: 0x80693c..0x8069b0
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
         - Name: resultFloat
           Type: 14 BaseType float64
           Locations:
-            - Range: 0x8067fc..0x80682c
+            - Range: 0x80690c..0x80693c
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
-            - Range: 0x80682c..0x8068a0
+            - Range: 0x80693c..0x8069b0
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
           Role: Local
-    - ID: 99
+    - ID: 100
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0x8068a0..0x806920]
+      OutOfLinePCRanges: [0x8069b0..0x806a30]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x8068a0..0x8068c0
+            - Range: 0x8069b0..0x8069d0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 15 GoInterfaceType error
           Locations:
-            - Range: 0x8068a0..0x8068ec
+            - Range: 0x8069b0..0x8069fc
               Pieces: []
-            - Range: 0x8068ec..0x8068ed
+            - Range: 0x8069fc..0x8069fd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8068ed..0x806900
+            - Range: 0x8069fd..0x806a10
               Pieces: []
-            - Range: 0x806900..0x806901
+            - Range: 0x806a10..0x806a11
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x806901..0x806920
+            - Range: 0x806a11..0x806a30
               Pieces: []
           Role: Return
-    - ID: 100
+    - ID: 101
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0x806920..0x806aa0]
+      OutOfLinePCRanges: [0x806a30..0x806bb0]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 163 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x806920..0x806970
+            - Range: 0x806a30..0x806a80
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x806970..0x806974
+            - Range: 0x806a80..0x806a84
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: null
-            - Range: 0x8069f8..0x806a00
+            - Range: 0x806b08..0x806b10
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x806a40..0x806a48
+            - Range: 0x806b50..0x806b58
               Pieces:
                 - Size: 8
                   Op: null
@@ -6110,122 +6190,29 @@ Subprograms:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x806920..0x806978
+            - Range: 0x806a30..0x806a88
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 163 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x806920..0x80698c
+            - Range: 0x806a30..0x806a9c
               Pieces: []
-            - Range: 0x80698c..0x80698d
+            - Range: 0x806a9c..0x806a9d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80698d..0x8069e8
+            - Range: 0x806a9d..0x806af8
               Pieces: []
-            - Range: 0x8069e8..0x8069e9
+            - Range: 0x806af8..0x806af9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8069e9..0x806a30
-              Pieces: []
-            - Range: 0x806a30..0x806a31
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x806a31..0x806a74
-              Pieces: []
-            - Range: 0x806a74..0x806a75
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x806a75..0x806aa0
-              Pieces: []
-          Role: Return
-        - Name: ~r1
-          Type: 15 GoInterfaceType error
-          Locations:
-            - Range: 0x806920..0x80698c
-              Pieces: []
-            - Range: 0x80698c..0x80698d
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80698d..0x8069e8
-              Pieces: []
-            - Range: 0x8069e8..0x8069e9
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8069e9..0x806a30
-              Pieces: []
-            - Range: 0x806a30..0x806a31
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0x806a31..0x806a74
-              Pieces: []
-            - Range: 0x806a74..0x806a75
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0x806a75..0x806aa0
-              Pieces: []
-          Role: Return
-        - Name: val
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x806970..0x806978
-              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          Role: Local
-    - ID: 101
-      Name: main.testReturnsAny
-      OutOfLinePCRanges: [0x806aa0..0x806c80]
-      InlinePCRanges: []
-      Variables:
-        - Name: v
-          Type: 163 GoEmptyInterfaceType interface {}
-          Locations:
-            - Range: 0x806aa0..0x806ae0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x806ae0..0x806ae8
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 8}
-                - Size: 8
-                  Op: {CfaOffset: 16}
-            - Range: 0x806ae8..0x806c80
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 8}
-                - Size: 8
-                  Op: {CfaOffset: 16}
-          Role: Parameter
-        - Name: ~r0
-          Type: 163 GoEmptyInterfaceType interface {}
-          Locations:
-            - Range: 0x806aa0..0x806b40
+            - Range: 0x806af9..0x806b40
               Pieces: []
             - Range: 0x806b40..0x806b41
               Pieces:
@@ -6233,421 +6220,514 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x806b41..0x806b94
+            - Range: 0x806b41..0x806b84
               Pieces: []
-            - Range: 0x806b94..0x806b95
+            - Range: 0x806b84..0x806b85
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x806b95..0x806c4c
+            - Range: 0x806b85..0x806bb0
               Pieces: []
-            - Range: 0x806c4c..0x806c4d
+          Role: Return
+        - Name: ~r1
+          Type: 15 GoInterfaceType error
+          Locations:
+            - Range: 0x806a30..0x806a9c
+              Pieces: []
+            - Range: 0x806a9c..0x806a9d
               Pieces:
                 - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
+                  Op: {RegNo: 2, Shift: 0}
                 - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x806c4d..0x806c60
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x806a9d..0x806af8
               Pieces: []
-            - Range: 0x806c60..0x806c61
+            - Range: 0x806af8..0x806af9
               Pieces:
                 - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
+                  Op: {RegNo: 2, Shift: 0}
                 - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x806c61..0x806c80
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x806af9..0x806b40
+              Pieces: []
+            - Range: 0x806b40..0x806b41
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x806b41..0x806b84
+              Pieces: []
+            - Range: 0x806b84..0x806b85
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x806b85..0x806bb0
               Pieces: []
           Role: Return
         - Name: val
           Type: 7 BaseType int
           Locations:
-            - Range: 0x806b2c..0x806b34
+            - Range: 0x806a80..0x806a88
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
-        - Name: '&result'
-          Type: 105 PointerType *int
-          Locations:
-            - Range: 0x806b78..0x806b94
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Local
     - ID: 102
-      Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0x806c80..0x806dd0]
+      Name: main.testReturnsAny
+      OutOfLinePCRanges: [0x806bb0..0x806d90]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 163 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x806c80..0x806cbc
+            - Range: 0x806bb0..0x806bf0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x806cbc..0x806d00
+            - Range: 0x806bf0..0x806bf8
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0x806bf8..0x806d90
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+          Role: Parameter
+        - Name: ~r0
+          Type: 163 GoEmptyInterfaceType interface {}
+          Locations:
+            - Range: 0x806bb0..0x806c50
+              Pieces: []
+            - Range: 0x806c50..0x806c51
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x806c51..0x806ca4
+              Pieces: []
+            - Range: 0x806ca4..0x806ca5
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x806ca5..0x806d5c
+              Pieces: []
+            - Range: 0x806d5c..0x806d5d
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x806d5d..0x806d70
+              Pieces: []
+            - Range: 0x806d70..0x806d71
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x806d71..0x806d90
+              Pieces: []
+          Role: Return
+        - Name: val
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x806c3c..0x806c44
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          Role: Local
+        - Name: '&result'
+          Type: 105 PointerType *int
+          Locations:
+            - Range: 0x806c88..0x806ca4
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Local
+    - ID: 103
+      Name: main.testReturnsInterface
+      OutOfLinePCRanges: [0x806d90..0x806ee0]
+      InlinePCRanges: []
+      Variables:
+        - Name: v
+          Type: 163 GoEmptyInterfaceType interface {}
+          Locations:
+            - Range: 0x806d90..0x806dcc
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x806dcc..0x806e10
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x806d00..0x806d70
+            - Range: 0x806e10..0x806e80
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x806d70..0x806d98
+            - Range: 0x806e80..0x806ea8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x806d98..0x806d9c
+            - Range: 0x806ea8..0x806eac
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x806d9c..0x806dd0
+            - Range: 0x806eac..0x806ee0
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
         - Name: ~r0
           Type: 168 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x806c80..0x806d50
+            - Range: 0x806d90..0x806e60
               Pieces: []
-            - Range: 0x806d50..0x806d51
+            - Range: 0x806e60..0x806e61
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x806d51..0x806d64
+            - Range: 0x806e61..0x806e74
               Pieces: []
-            - Range: 0x806d64..0x806d65
+            - Range: 0x806e74..0x806e75
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x806d65..0x806dd0
+            - Range: 0x806e75..0x806ee0
               Pieces: []
           Role: Return
         - Name: b
           Type: 168 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x806c80..0x806cbc
+            - Range: 0x806d90..0x806dcc
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x806cbc..0x806d00
+            - Range: 0x806dcc..0x806e10
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x806d00..0x806d08
+            - Range: 0x806e10..0x806e18
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x806d08..0x806d5c
+            - Range: 0x806e18..0x806e6c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x806d5c..0x806d60
+            - Range: 0x806e6c..0x806e70
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x806d60..0x806d64
+            - Range: 0x806e70..0x806e74
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x806d64..0x806dd0
+            - Range: 0x806e74..0x806ee0
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Local
-    - ID: 103
+    - ID: 104
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0x806dd0..0x806e70]
+      OutOfLinePCRanges: [0x806ee0..0x806f80]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x806dd0..0x806dec
+            - Range: 0x806ee0..0x806efc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0x806dd0..0x806e44
+            - Range: 0x806ee0..0x806f54
               Pieces: []
-            - Range: 0x806e44..0x806e45
+            - Range: 0x806f54..0x806f55
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x806e45..0x806e70
+            - Range: 0x806f55..0x806f80
               Pieces: []
           Role: Return
-    - ID: 104
+    - ID: 105
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0x806e70..0x806f30]
+      OutOfLinePCRanges: [0x806f80..0x807040]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x806e70..0x806ec0
+            - Range: 0x806f80..0x806fd0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0x806e70..0x806f0c
+            - Range: 0x806f80..0x80701c
               Pieces: []
-            - Range: 0x806f0c..0x806f0d
+            - Range: 0x80701c..0x80701d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x806f0d..0x806f30
+            - Range: 0x80701d..0x807040
               Pieces: []
           Role: Return
         - Name: result2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x806e70..0x806f0c
+            - Range: 0x806f80..0x80701c
               Pieces: []
-            - Range: 0x806f0c..0x806f0d
+            - Range: 0x80701c..0x80701d
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x806f0d..0x806f30
+            - Range: 0x80701d..0x807040
               Pieces: []
           Role: Return
-    - ID: 105
+    - ID: 106
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0x806f30..0x806ff0]
+      OutOfLinePCRanges: [0x807040..0x807100]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x806f30..0x806f70
+            - Range: 0x807040..0x807080
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x806f70..0x806ff0
+            - Range: 0x807080..0x807100
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x806f30..0x806fd0
+            - Range: 0x807040..0x8070e0
               Pieces: []
-            - Range: 0x806fd0..0x806fd1
+            - Range: 0x8070e0..0x8070e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x806fd1..0x806ff0
+            - Range: 0x8070e1..0x807100
               Pieces: []
           Role: Return
         - Name: result2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x806f30..0x806fd0
+            - Range: 0x807040..0x8070e0
               Pieces: []
-            - Range: 0x806fd0..0x806fd1
+            - Range: 0x8070e0..0x8070e1
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x806fd1..0x806ff0
+            - Range: 0x8070e1..0x807100
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x806f30..0x806fd0
+            - Range: 0x807040..0x8070e0
               Pieces: []
-            - Range: 0x806fd0..0x806fd1
+            - Range: 0x8070e0..0x8070e1
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x806fd1..0x806ff0
+            - Range: 0x8070e1..0x807100
               Pieces: []
           Role: Return
-    - ID: 106
+    - ID: 107
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0x806ff0..0x807080]
+      OutOfLinePCRanges: [0x807100..0x807190]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 19 BaseType int8
           Locations:
-            - Range: 0x806ff0..0x80705c
+            - Range: 0x807100..0x80716c
               Pieces: []
-            - Range: 0x80705c..0x80705d
+            - Range: 0x80716c..0x80716d
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80705d..0x807080
+            - Range: 0x80716d..0x807190
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 102 BaseType int16
           Locations:
-            - Range: 0x806ff0..0x80705c
+            - Range: 0x807100..0x80716c
               Pieces: []
-            - Range: 0x80705c..0x80705d
+            - Range: 0x80716c..0x80716d
               Pieces: [{Size: 2, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80705d..0x807080
+            - Range: 0x80716d..0x807190
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 12 BaseType int32
           Locations:
-            - Range: 0x806ff0..0x80705c
+            - Range: 0x807100..0x80716c
               Pieces: []
-            - Range: 0x80705c..0x80705d
+            - Range: 0x80716c..0x80716d
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80705d..0x807080
+            - Range: 0x80716d..0x807190
               Pieces: []
           Role: Return
         - Name: ~r3
           Type: 13 BaseType int64
           Locations:
-            - Range: 0x806ff0..0x80705c
+            - Range: 0x807100..0x80716c
               Pieces: []
-            - Range: 0x80705c..0x80705d
+            - Range: 0x80716c..0x80716d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x80705d..0x807080
+            - Range: 0x80716d..0x807190
               Pieces: []
           Role: Return
         - Name: ~r4
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x806ff0..0x80705c
+            - Range: 0x807100..0x80716c
               Pieces: []
-            - Range: 0x80705c..0x80705d
+            - Range: 0x80716c..0x80716d
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80705d..0x807080
+            - Range: 0x80716d..0x807190
               Pieces: []
           Role: Return
         - Name: ~r5
           Type: 6 BaseType uint16
           Locations:
-            - Range: 0x806ff0..0x80705c
+            - Range: 0x807100..0x80716c
               Pieces: []
-            - Range: 0x80705c..0x80705d
+            - Range: 0x80716c..0x80716d
               Pieces: [{Size: 2, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x80705d..0x807080
+            - Range: 0x80716d..0x807190
               Pieces: []
           Role: Return
         - Name: ~r6
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0x806ff0..0x80705c
+            - Range: 0x807100..0x80716c
               Pieces: []
-            - Range: 0x80705c..0x80705d
+            - Range: 0x80716c..0x80716d
               Pieces: [{Size: 4, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x80705d..0x807080
+            - Range: 0x80716d..0x807190
               Pieces: []
           Role: Return
         - Name: ~r7
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0x806ff0..0x80705c
+            - Range: 0x807100..0x80716c
               Pieces: []
-            - Range: 0x80705c..0x80705d
+            - Range: 0x80716c..0x80716d
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x80705d..0x807080
+            - Range: 0x80716d..0x807190
               Pieces: []
           Role: Return
-    - ID: 107
+    - ID: 108
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0x807080..0x807130]
+      OutOfLinePCRanges: [0x807190..0x807240]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 14 BaseType float64
-          Locations: [{Range: 0x807080..0x807130, Pieces: []}]
+          Locations: [{Range: 0x807190..0x807240, Pieces: []}]
           Role: Return
         - Name: ~r1
           Type: 14 BaseType float64
-          Locations: [{Range: 0x807080..0x807130, Pieces: []}]
+          Locations: [{Range: 0x807190..0x807240, Pieces: []}]
           Role: Return
         - Name: ~r2
           Type: 14 BaseType float64
-          Locations: [{Range: 0x807080..0x807130, Pieces: []}]
+          Locations: [{Range: 0x807190..0x807240, Pieces: []}]
           Role: Return
         - Name: ~r3
           Type: 14 BaseType float64
-          Locations: [{Range: 0x807080..0x807130, Pieces: []}]
+          Locations: [{Range: 0x807190..0x807240, Pieces: []}]
           Role: Return
         - Name: ~r4
           Type: 14 BaseType float64
-          Locations: [{Range: 0x807080..0x807130, Pieces: []}]
+          Locations: [{Range: 0x807190..0x807240, Pieces: []}]
           Role: Return
         - Name: ~r5
           Type: 14 BaseType float64
-          Locations: [{Range: 0x807080..0x807130, Pieces: []}]
+          Locations: [{Range: 0x807190..0x807240, Pieces: []}]
           Role: Return
         - Name: ~r6
           Type: 14 BaseType float64
-          Locations: [{Range: 0x807080..0x807130, Pieces: []}]
+          Locations: [{Range: 0x807190..0x807240, Pieces: []}]
           Role: Return
         - Name: ~r7
           Type: 14 BaseType float64
-          Locations: [{Range: 0x807080..0x807130, Pieces: []}]
+          Locations: [{Range: 0x807190..0x807240, Pieces: []}]
           Role: Return
         - Name: ~r8
           Type: 14 BaseType float64
-          Locations: [{Range: 0x807080..0x807130, Pieces: []}]
+          Locations: [{Range: 0x807190..0x807240, Pieces: []}]
           Role: Return
         - Name: ~r9
           Type: 14 BaseType float64
-          Locations: [{Range: 0x807080..0x807130, Pieces: []}]
+          Locations: [{Range: 0x807190..0x807240, Pieces: []}]
           Role: Return
         - Name: ~r10
           Type: 14 BaseType float64
-          Locations: [{Range: 0x807080..0x807130, Pieces: []}]
+          Locations: [{Range: 0x807190..0x807240, Pieces: []}]
           Role: Return
         - Name: ~r11
           Type: 14 BaseType float64
-          Locations: [{Range: 0x807080..0x807130, Pieces: []}]
+          Locations: [{Range: 0x807190..0x807240, Pieces: []}]
           Role: Return
         - Name: ~r12
           Type: 14 BaseType float64
-          Locations: [{Range: 0x807080..0x807130, Pieces: []}]
+          Locations: [{Range: 0x807190..0x807240, Pieces: []}]
           Role: Return
         - Name: ~r13
           Type: 14 BaseType float64
-          Locations: [{Range: 0x807080..0x807130, Pieces: []}]
+          Locations: [{Range: 0x807190..0x807240, Pieces: []}]
           Role: Return
         - Name: ~r14
           Type: 14 BaseType float64
-          Locations: [{Range: 0x807080..0x807130, Pieces: []}]
+          Locations: [{Range: 0x807190..0x807240, Pieces: []}]
           Role: Return
         - Name: onlyOnAmd64_16
           Type: 14 BaseType float64
-          Locations: [{Range: 0x807080..0x807130, Pieces: []}]
+          Locations: [{Range: 0x807190..0x807240, Pieces: []}]
           Role: Return
         - Name: bothArmAndAmd64
           Type: 14 BaseType float64
           Locations:
-            - Range: 0x807080..0x807118
+            - Range: 0x807190..0x807228
               Pieces: []
-            - Range: 0x807118..0x807119
+            - Range: 0x807228..0x807229
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x807119..0x807130
+            - Range: 0x807229..0x807240
               Pieces: []
           Role: Return
-    - ID: 108
+    - ID: 109
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0x807130..0x8071b0]
+      OutOfLinePCRanges: [0x807240..0x8072c0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 103 BaseType complex64
-          Locations: [{Range: 0x807130..0x8071b0, Pieces: []}]
+          Locations: [{Range: 0x807240..0x8072c0, Pieces: []}]
           Role: Return
         - Name: ~r1
           Type: 18 BaseType complex128
-          Locations: [{Range: 0x807130..0x8071b0, Pieces: []}]
+          Locations: [{Range: 0x807240..0x8072c0, Pieces: []}]
           Role: Return
-    - ID: 109
+    - ID: 110
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0x8071b0..0x807270]
+      OutOfLinePCRanges: [0x8072c0..0x807380]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0x8071b0..0x807250
+            - Range: 0x8072c0..0x807360
               Pieces: []
-            - Range: 0x807250..0x807251
+            - Range: 0x807360..0x807361
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6669,173 +6749,173 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x807251..0x807270
+            - Range: 0x807361..0x807380
               Pieces: []
           Role: Return
-    - ID: 110
+    - ID: 111
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0x807270..0x807300]
+      OutOfLinePCRanges: [0x807380..0x807410]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 257 ArrayType [3]int
           Locations:
-            - Range: 0x807270..0x8072dc
+            - Range: 0x807380..0x8073ec
               Pieces: []
-            - Range: 0x8072dc..0x8072dd
+            - Range: 0x8073ec..0x8073ed
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x8072dd..0x807300
+            - Range: 0x8073ed..0x807410
               Pieces: []
           Role: Return
-    - ID: 111
+    - ID: 112
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0x807300..0x807370]
+      OutOfLinePCRanges: [0x807410..0x807480]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 258 ArrayType [1]int
           Locations:
-            - Range: 0x807300..0x807350
+            - Range: 0x807410..0x807460
               Pieces: []
-            - Range: 0x807350..0x807351
+            - Range: 0x807460..0x807461
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x807351..0x807370
+            - Range: 0x807461..0x807480
               Pieces: []
           Role: Return
-    - ID: 112
+    - ID: 113
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0x807370..0x8073e0]
+      OutOfLinePCRanges: [0x807480..0x8074f0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 259 ArrayType [0]int
           Locations:
-            - Range: 0x807370..0x8073bc
+            - Range: 0x807480..0x8074cc
               Pieces: []
-            - Range: 0x8073bc..0x8073bd
+            - Range: 0x8074cc..0x8074cd
               Pieces: []
-            - Range: 0x8073bd..0x8073e0
+            - Range: 0x8074cd..0x8074f0
               Pieces: []
           Role: Return
-    - ID: 113
+    - ID: 114
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0x8073e0..0x807460]
+      OutOfLinePCRanges: [0x8074f0..0x807570]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 260 StructureType main.mixedStruct
-          Locations: [{Range: 0x8073e0..0x807460, Pieces: []}]
+          Locations: [{Range: 0x8074f0..0x807570, Pieces: []}]
           Role: Return
-    - ID: 114
+    - ID: 115
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0x807460..0x8074f0]
+      OutOfLinePCRanges: [0x807570..0x807600]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807460..0x8074d8
+            - Range: 0x807570..0x8075e8
               Pieces: []
-            - Range: 0x8074d8..0x8074d9
+            - Range: 0x8075e8..0x8075e9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8074d9..0x8074f0
+            - Range: 0x8075e9..0x807600
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807460..0x8074d8
+            - Range: 0x807570..0x8075e8
               Pieces: []
-            - Range: 0x8074d8..0x8074d9
+            - Range: 0x8075e8..0x8075e9
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x8074d9..0x8074f0
+            - Range: 0x8075e9..0x807600
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807460..0x8074d8
+            - Range: 0x807570..0x8075e8
               Pieces: []
-            - Range: 0x8074d8..0x8074d9
+            - Range: 0x8075e8..0x8075e9
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x8074d9..0x8074f0
+            - Range: 0x8075e9..0x807600
               Pieces: []
           Role: Return
         - Name: ~r3
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807460..0x8074d8
+            - Range: 0x807570..0x8075e8
               Pieces: []
-            - Range: 0x8074d8..0x8074d9
+            - Range: 0x8075e8..0x8075e9
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x8074d9..0x8074f0
+            - Range: 0x8075e9..0x807600
               Pieces: []
           Role: Return
         - Name: ~r4
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807460..0x8074d8
+            - Range: 0x807570..0x8075e8
               Pieces: []
-            - Range: 0x8074d8..0x8074d9
+            - Range: 0x8075e8..0x8075e9
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x8074d9..0x8074f0
+            - Range: 0x8075e9..0x807600
               Pieces: []
           Role: Return
         - Name: ~r5
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807460..0x8074d8
+            - Range: 0x807570..0x8075e8
               Pieces: []
-            - Range: 0x8074d8..0x8074d9
+            - Range: 0x8075e8..0x8075e9
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x8074d9..0x8074f0
+            - Range: 0x8075e9..0x807600
               Pieces: []
           Role: Return
         - Name: ~r6
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807460..0x8074d8
+            - Range: 0x807570..0x8075e8
               Pieces: []
-            - Range: 0x8074d8..0x8074d9
+            - Range: 0x8075e8..0x8075e9
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x8074d9..0x8074f0
+            - Range: 0x8075e9..0x807600
               Pieces: []
           Role: Return
         - Name: ~r7
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807460..0x8074d8
+            - Range: 0x807570..0x8075e8
               Pieces: []
-            - Range: 0x8074d8..0x8074d9
+            - Range: 0x8075e8..0x8075e9
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x8074d9..0x8074f0
+            - Range: 0x8075e9..0x807600
               Pieces: []
           Role: Return
         - Name: ~r8
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x807460..0x8074d8
+            - Range: 0x807570..0x8075e8
               Pieces: []
-            - Range: 0x8074d8..0x8074d9
+            - Range: 0x8075e8..0x8075e9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8074d9..0x8074f0
+            - Range: 0x8075e9..0x807600
               Pieces: []
           Role: Return
-    - ID: 115
+    - ID: 116
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0x8074f0..0x8075c0]
+      OutOfLinePCRanges: [0x807600..0x8076d0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 261 StructureType main.wideStruct
           Locations:
-            - Range: 0x8074f0..0x8075a0
+            - Range: 0x807600..0x8076b0
               Pieces: []
-            - Range: 0x8075a0..0x8075a1
+            - Range: 0x8076b0..0x8076b1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6859,127 +6939,127 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0x8075a1..0x8075c0
+            - Range: 0x8076b1..0x8076d0
               Pieces: []
           Role: Return
-    - ID: 116
+    - ID: 117
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0x8075c0..0x807650]
+      OutOfLinePCRanges: [0x8076d0..0x807760]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8075c0..0x80762c
+            - Range: 0x8076d0..0x80773c
               Pieces: []
-            - Range: 0x80762c..0x80762d
+            - Range: 0x80773c..0x80773d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80762d..0x807650
+            - Range: 0x80773d..0x807760
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 14 BaseType float64
-          Locations: [{Range: 0x8075c0..0x807650, Pieces: []}]
+          Locations: [{Range: 0x8076d0..0x807760, Pieces: []}]
           Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8075c0..0x80762c
+            - Range: 0x8076d0..0x80773c
               Pieces: []
-            - Range: 0x80762c..0x80762d
+            - Range: 0x80773c..0x80773d
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80762d..0x807650
+            - Range: 0x80773d..0x807760
               Pieces: []
           Role: Return
         - Name: ~r3
           Type: 14 BaseType float64
-          Locations: [{Range: 0x8075c0..0x807650, Pieces: []}]
+          Locations: [{Range: 0x8076d0..0x807760, Pieces: []}]
           Role: Return
         - Name: ~r4
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x8075c0..0x80762c
+            - Range: 0x8076d0..0x80773c
               Pieces: []
-            - Range: 0x80762c..0x80762d
+            - Range: 0x80773c..0x80773d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80762d..0x807650
+            - Range: 0x80773d..0x807760
               Pieces: []
           Role: Return
-    - ID: 117
+    - ID: 118
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0x807650..0x8076e0]
+      OutOfLinePCRanges: [0x807760..0x8077f0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 262 StructureType main.structWithArray
           Locations:
-            - Range: 0x807650..0x8076bc
+            - Range: 0x807760..0x8077cc
               Pieces: []
-            - Range: 0x8076bc..0x8076bd
+            - Range: 0x8077cc..0x8077cd
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x8076bd..0x8076e0
+            - Range: 0x8077cd..0x8077f0
               Pieces: []
           Role: Return
-    - ID: 118
+    - ID: 119
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0x8076e0..0x807750]
+      OutOfLinePCRanges: [0x8077f0..0x807860]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 14 BaseType float64
-          Locations: [{Range: 0x8076e0..0x807750, Pieces: []}]
+          Locations: [{Range: 0x8077f0..0x807860, Pieces: []}]
           Role: Return
-    - ID: 119
+    - ID: 120
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0x807750..0x8077c0]
+      OutOfLinePCRanges: [0x807860..0x8078d0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType float32
-          Locations: [{Range: 0x807750..0x8077c0, Pieces: []}]
+          Locations: [{Range: 0x807860..0x8078d0, Pieces: []}]
           Role: Return
         - Name: ~r1
           Type: 14 BaseType float64
-          Locations: [{Range: 0x807750..0x8077c0, Pieces: []}]
+          Locations: [{Range: 0x807860..0x8078d0, Pieces: []}]
           Role: Return
-    - ID: 120
+    - ID: 121
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0x8077c0..0x807830]
+      OutOfLinePCRanges: [0x8078d0..0x807940]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x8077c0..0x807814
+            - Range: 0x8078d0..0x807924
               Pieces: []
-            - Range: 0x807814..0x807815
+            - Range: 0x807924..0x807925
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x807815..0x807830
+            - Range: 0x807925..0x807940
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 1 BaseType uintptr
           Locations:
-            - Range: 0x8077c0..0x807814
+            - Range: 0x8078d0..0x807924
               Pieces: []
-            - Range: 0x807814..0x807815
+            - Range: 0x807924..0x807925
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x807815..0x807830
+            - Range: 0x807925..0x807940
               Pieces: []
           Role: Return
-    - ID: 121
+    - ID: 122
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0x807830..0x8079c0]
+      OutOfLinePCRanges: [0x807940..0x807ad0]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0x807830..0x807864
+            - Range: 0x807940..0x807974
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7001,7 +7081,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x807864..0x807894
+            - Range: 0x807974..0x8079a4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7023,7 +7103,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x807894..0x80789c
+            - Range: 0x8079a4..0x8079ac
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7045,7 +7125,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80789c..0x8078a0
+            - Range: 0x8079ac..0x8079b0
               Pieces:
                 - Size: 8
                   Op: null
@@ -7071,9 +7151,9 @@ Subprograms:
         - Name: ~r0
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0x807830..0x807980
+            - Range: 0x807940..0x807a90
               Pieces: []
-            - Range: 0x807980..0x807981
+            - Range: 0x807a90..0x807a91
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7095,39 +7175,39 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x807981..0x8079c0
+            - Range: 0x807a91..0x807ad0
               Pieces: []
           Role: Return
-    - ID: 122
+    - ID: 123
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0x8079c0..0x807a90]
+      OutOfLinePCRanges: [0x807ad0..0x807ba0]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 257 ArrayType [3]int
           Locations:
-            - Range: 0x8079c0..0x807a90
+            - Range: 0x807ad0..0x807ba0
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 257 ArrayType [3]int
           Locations:
-            - Range: 0x8079c0..0x807a70
+            - Range: 0x807ad0..0x807b80
               Pieces: []
-            - Range: 0x807a70..0x807a71
+            - Range: 0x807b80..0x807b81
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x807a71..0x807a90
+            - Range: 0x807b81..0x807ba0
               Pieces: []
           Role: Return
-    - ID: 123
+    - ID: 124
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0x807a90..0x807ca0]
+      OutOfLinePCRanges: [0x807ba0..0x807db0]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0x807a90..0x807ac4
+            - Range: 0x807ba0..0x807bd4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7149,7 +7229,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x807ac4..0x807af8
+            - Range: 0x807bd4..0x807c08
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7171,7 +7251,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x807af8..0x807b00
+            - Range: 0x807c08..0x807c10
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7193,7 +7273,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x807b00..0x807b04
+            - Range: 0x807c10..0x807c14
               Pieces:
                 - Size: 8
                   Op: null
@@ -7219,15 +7299,15 @@ Subprograms:
         - Name: s2
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0x807a90..0x807ca0
+            - Range: 0x807ba0..0x807db0
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0x807a90..0x807c58
+            - Range: 0x807ba0..0x807d68
               Pieces: []
-            - Range: 0x807c58..0x807c59
+            - Range: 0x807d68..0x807d69
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7249,175 +7329,175 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x807c59..0x807ca0
+            - Range: 0x807d69..0x807db0
               Pieces: []
           Role: Return
-    - ID: 124
+    - ID: 125
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0x807ca0..0x807e50]
+      OutOfLinePCRanges: [0x807db0..0x807f60]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807ca0..0x807d28
+            - Range: 0x807db0..0x807e38
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x807d28..0x807e50
+            - Range: 0x807e38..0x807f60
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807ca0..0x807ce8
+            - Range: 0x807db0..0x807df8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x807ce8..0x807e50
+            - Range: 0x807df8..0x807f60
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807ca0..0x807d20
+            - Range: 0x807db0..0x807e30
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x807d20..0x807e50
+            - Range: 0x807e30..0x807f60
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807ca0..0x807d28
+            - Range: 0x807db0..0x807e38
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x807d28..0x807e50
+            - Range: 0x807e38..0x807f60
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807ca0..0x807d28
+            - Range: 0x807db0..0x807e38
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x807d28..0x807e50
+            - Range: 0x807e38..0x807f60
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807ca0..0x807d28
+            - Range: 0x807db0..0x807e38
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x807d28..0x807e50
+            - Range: 0x807e38..0x807f60
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807ca0..0x807d28
+            - Range: 0x807db0..0x807e38
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x807d28..0x807e50
+            - Range: 0x807e38..0x807f60
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807ca0..0x807d28
+            - Range: 0x807db0..0x807e38
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x807d28..0x807e50
+            - Range: 0x807e38..0x807f60
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807ca0..0x807d28
+            - Range: 0x807db0..0x807e38
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0x807d28..0x807e50
+            - Range: 0x807e38..0x807f60
               Pieces: [{Size: 8, Op: {CfaOffset: 88}}]
           Role: Parameter
         - Name: ~r0
           Type: 119 ArrayType [2]int
           Locations:
-            - Range: 0x807ca0..0x807e10
+            - Range: 0x807db0..0x807f20
               Pieces: []
-            - Range: 0x807e10..0x807e11
+            - Range: 0x807f20..0x807f21
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-            - Range: 0x807e11..0x807e50
+            - Range: 0x807f21..0x807f60
               Pieces: []
           Role: Return
-    - ID: 125
+    - ID: 126
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0x807e50..0x808040]
+      OutOfLinePCRanges: [0x807f60..0x808150]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807e50..0x807ed8
+            - Range: 0x807f60..0x807fe8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x807ed8..0x808040
+            - Range: 0x807fe8..0x808150
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807e50..0x807e9c
+            - Range: 0x807f60..0x807fac
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x807e9c..0x808040
+            - Range: 0x807fac..0x808150
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807e50..0x807ed0
+            - Range: 0x807f60..0x807fe0
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x807ed0..0x808040
+            - Range: 0x807fe0..0x808150
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807e50..0x807ed8
+            - Range: 0x807f60..0x807fe8
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x807ed8..0x808040
+            - Range: 0x807fe8..0x808150
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807e50..0x807ed8
+            - Range: 0x807f60..0x807fe8
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x807ed8..0x808040
+            - Range: 0x807fe8..0x808150
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807e50..0x807ed8
+            - Range: 0x807f60..0x807fe8
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x807ed8..0x808040
+            - Range: 0x807fe8..0x808150
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807e50..0x807ed8
+            - Range: 0x807f60..0x807fe8
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x807ed8..0x808040
+            - Range: 0x807fe8..0x808150
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807e50..0x807ed8
+            - Range: 0x807f60..0x807fe8
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x807ed8..0x808040
+            - Range: 0x807fe8..0x808150
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x807e50..0x807ed8
+            - Range: 0x807f60..0x807fe8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x807ed8..0x808040
+            - Range: 0x807fe8..0x808150
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 72}
@@ -7427,9 +7507,9 @@ Subprograms:
         - Name: ~r0
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0x807e50..0x807ffc
+            - Range: 0x807f60..0x80810c
               Pieces: []
-            - Range: 0x807ffc..0x807ffd
+            - Range: 0x80810c..0x80810d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7451,191 +7531,174 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x807ffd..0x808040
+            - Range: 0x80810d..0x808150
               Pieces: []
           Role: Return
-    - ID: 126
+    - ID: 127
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0x808040..0x8080d0]
+      OutOfLinePCRanges: [0x808150..0x8081e0]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 167 ArrayType [5]int
           Locations:
-            - Range: 0x808040..0x8080d0
+            - Range: 0x808150..0x8081e0
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x808040..0x8080b4
+            - Range: 0x808150..0x8081c4
               Pieces: []
-            - Range: 0x8080b4..0x8080b5
+            - Range: 0x8081c4..0x8081c5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8080b5..0x8080d0
+            - Range: 0x8081c5..0x8081e0
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0x808040..0x8080b4
+            - Range: 0x808150..0x8081c4
               Pieces: []
-            - Range: 0x8080b4..0x8080b5
+            - Range: 0x8081c4..0x8081c5
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x8080b5..0x8080d0
+            - Range: 0x8081c5..0x8081e0
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x808040..0x8080b4
+            - Range: 0x808150..0x8081c4
               Pieces: []
-            - Range: 0x8080b4..0x8080b5
+            - Range: 0x8081c4..0x8081c5
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x8080b5..0x8080d0
+            - Range: 0x8081c5..0x8081e0
               Pieces: []
           Role: Return
-    - ID: 127
+    - ID: 128
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0x8080d0..0x8081a0]
+      OutOfLinePCRanges: [0x8081e0..0x8082b0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 119 ArrayType [2]int
           Locations:
-            - Range: 0x8080d0..0x8081a0
+            - Range: 0x8081e0..0x8082b0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: b
           Type: 257 ArrayType [3]int
           Locations:
-            - Range: 0x8080d0..0x8081a0
+            - Range: 0x8081e0..0x8082b0
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8080d0..0x808188
+            - Range: 0x8081e0..0x808298
               Pieces: []
-            - Range: 0x808188..0x808189
+            - Range: 0x808298..0x808299
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x808189..0x8081a0
+            - Range: 0x808299..0x8082b0
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 119 ArrayType [2]int
           Locations:
-            - Range: 0x8080d0..0x808188
+            - Range: 0x8081e0..0x808298
               Pieces: []
-            - Range: 0x808188..0x808189
+            - Range: 0x808298..0x808299
               Pieces: [{Size: 16, Op: {CfaOffset: 48}}]
-            - Range: 0x808189..0x8081a0
+            - Range: 0x808299..0x8082b0
               Pieces: []
           Role: Return
-    - ID: 128
+    - ID: 129
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0x8081a0..0x808260]
+      OutOfLinePCRanges: [0x8082b0..0x808370]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 262 StructureType main.structWithArray
           Locations:
-            - Range: 0x8081a0..0x808260
+            - Range: 0x8082b0..0x808370
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8081a0..0x808244
+            - Range: 0x8082b0..0x808354
               Pieces: []
-            - Range: 0x808244..0x808245
+            - Range: 0x808354..0x808355
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x808245..0x808260
+            - Range: 0x808355..0x808370
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 262 StructureType main.structWithArray
           Locations:
-            - Range: 0x8081a0..0x808244
+            - Range: 0x8082b0..0x808354
               Pieces: []
-            - Range: 0x808244..0x808245
+            - Range: 0x808354..0x808355
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x808245..0x808260
+            - Range: 0x808355..0x808370
               Pieces: []
           Role: Return
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x808220..0x808260
+            - Range: 0x808330..0x808370
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 129
+    - ID: 130
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0x808260..0x808300]
+      OutOfLinePCRanges: [0x808370..0x808410]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 259 ArrayType [0]int
-          Locations: [{Range: 0x808260..0x808300, Pieces: []}]
+          Locations: [{Range: 0x808370..0x808410, Pieces: []}]
           Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x808260..0x8082a0
+            - Range: 0x808370..0x8083b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8082a0..0x8082b8
+            - Range: 0x8083b0..0x8083c8
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x8082b8..0x8082c0
+            - Range: 0x8083c8..0x8083d0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x8082c0..0x808300
+            - Range: 0x8083d0..0x808410
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x808260..0x8082dc
+            - Range: 0x808370..0x8083ec
               Pieces: []
-            - Range: 0x8082dc..0x8082dd
+            - Range: 0x8083ec..0x8083ed
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8082dd..0x808300
+            - Range: 0x8083ed..0x808410
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 259 ArrayType [0]int
           Locations:
-            - Range: 0x808260..0x8082dc
+            - Range: 0x808370..0x8083ec
               Pieces: []
-            - Range: 0x8082dc..0x8082dd
+            - Range: 0x8083ec..0x8083ed
               Pieces: []
-            - Range: 0x8082dd..0x808300
+            - Range: 0x8083ed..0x808410
               Pieces: []
           Role: Return
-    - ID: 130
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0x808740..0x808750]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 263 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x808740..0x808750
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
     - ID: 131
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0x808750..0x808760]
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0x808850..0x808860]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 263 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x808750..0x808760
+            - Range: 0x808850..0x808860
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7645,14 +7708,14 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
     - ID: 132
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0x808760..0x808770]
+      Name: main.testEmptySlice
+      OutOfLinePCRanges: [0x808860..0x808870]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 264 GoSliceHeaderType [][]uint
+          Type: 263 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x808760..0x808770
+            - Range: 0x808860..0x808870
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7662,14 +7725,14 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
     - ID: 133
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0x808770..0x808780]
+      Name: main.testSliceOfSlices
+      OutOfLinePCRanges: [0x808870..0x808880]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 266 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 264 GoSliceHeaderType [][]uint
           Locations:
-            - Range: 0x808770..0x808780
+            - Range: 0x808870..0x808880
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7677,22 +7740,16 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x808770..0x808780
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
     - ID: 134
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0x808780..0x808790]
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0x808880..0x808890]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 266 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x808780..0x808790
+            - Range: 0x808880..0x808890
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7704,18 +7761,18 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x808780..0x808790
+            - Range: 0x808880..0x808890
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
     - ID: 135
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0x808790..0x8087a0]
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0x808890..0x8088a0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 266 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x808790..0x8087a0
+            - Range: 0x808890..0x8088a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7727,18 +7784,41 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x808790..0x8087a0
+            - Range: 0x808890..0x8088a0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
     - ID: 136
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0x8088a0..0x8088b0]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 266 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x8088a0..0x8088b0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x8088a0..0x8088b0
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          Role: Parameter
+    - ID: 137
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0x8087a0..0x8087b0]
+      OutOfLinePCRanges: [0x8088b0..0x8088c0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 269 GoSliceHeaderType []string
           Locations:
-            - Range: 0x8087a0..0x8087b0
+            - Range: 0x8088b0..0x8088c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7747,21 +7827,21 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 137
+    - ID: 138
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0x8087b0..0x8087c0]
+      OutOfLinePCRanges: [0x8088c0..0x8088d0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 19 BaseType int8
           Locations:
-            - Range: 0x8087b0..0x8087c0
+            - Range: 0x8088c0..0x8088d0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: s
           Type: 270 GoSliceHeaderType []bool
           Locations:
-            - Range: 0x8087b0..0x8087c0
+            - Range: 0x8088c0..0x8088d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -7773,35 +7853,18 @@ Subprograms:
         - Name: x
           Type: 11 BaseType uint
           Locations:
-            - Range: 0x8087b0..0x8087c0
+            - Range: 0x8088c0..0x8088d0
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
-    - ID: 138
+    - ID: 139
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0x8087c0..0x8087d0]
+      OutOfLinePCRanges: [0x8088d0..0x8088e0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 271 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0x8087c0..0x8087d0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-    - ID: 139
-      Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0x8087d0..0x8087e0]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 263 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x8087d0..0x8087e0
+            - Range: 0x8088d0..0x8088e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7811,14 +7874,14 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
     - ID: 140
-      Name: main.testSliceEmptyStructs
-      OutOfLinePCRanges: [0x8087e0..0x8087f0]
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0x8088e0..0x8088f0]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 272 GoSliceHeaderType []struct {}
+          Type: 263 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x8087e0..0x8087f0
+            - Range: 0x8088e0..0x8088f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7828,14 +7891,31 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
     - ID: 141
+      Name: main.testSliceEmptyStructs
+      OutOfLinePCRanges: [0x8088f0..0x808900]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 272 GoSliceHeaderType []struct {}
+          Locations:
+            - Range: 0x8088f0..0x808900
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+    - ID: 142
       Name: main.testSubslices
-      OutOfLinePCRanges: [0x8087f0..0x808800]
+      OutOfLinePCRanges: [0x808900..0x808910]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 263 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x8087f0..0x808800
+            - Range: 0x808900..0x808910
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7847,7 +7927,7 @@ Subprograms:
         - Name: bs
           Type: 263 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x8087f0..0x808800
+            - Range: 0x808900..0x808910
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -7859,7 +7939,7 @@ Subprograms:
         - Name: cs
           Type: 263 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x8087f0..0x808800
+            - Range: 0x808900..0x808910
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -7868,49 +7948,49 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 142
+    - ID: 143
       Name: main.stackC
-      OutOfLinePCRanges: [0x808ac0..0x808b20]
+      OutOfLinePCRanges: [0x808bd0..0x808c30]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x808ac0..0x808b08
+            - Range: 0x808bd0..0x808c18
               Pieces: []
-            - Range: 0x808b08..0x808b09
+            - Range: 0x808c18..0x808c19
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x808b09..0x808b20
+            - Range: 0x808c19..0x808c30
               Pieces: []
           Role: Return
-    - ID: 143
+    - ID: 144
       Name: main.testSingleString
-      OutOfLinePCRanges: [0x808b20..0x808b30]
+      OutOfLinePCRanges: [0x808c30..0x808c40]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x808b20..0x808b30
+            - Range: 0x808c30..0x808c40
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 144
+    - ID: 145
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0x808b30..0x808b40]
+      OutOfLinePCRanges: [0x808c40..0x808c50]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x808b30..0x808b40
+            - Range: 0x808c40..0x808c50
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7920,7 +8000,7 @@ Subprograms:
         - Name: y
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x808b30..0x808b40
+            - Range: 0x808c40..0x808c50
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -7930,22 +8010,22 @@ Subprograms:
         - Name: z
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x808b30..0x808b40
+            - Range: 0x808c40..0x808c50
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
-    - ID: 145
+    - ID: 146
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x808b40..0x808b50]
+      OutOfLinePCRanges: [0x808c50..0x808c60]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 274 StructureType main.threeStringStruct
           Locations:
-            - Range: 0x808b40..0x808b50
+            - Range: 0x808c50..0x808c60
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7960,52 +8040,37 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
-    - ID: 146
+    - ID: 147
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x808b50..0x808b60]
+      OutOfLinePCRanges: [0x808c60..0x808c70]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 275 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0x808b50..0x808b60
+            - Range: 0x808c60..0x808c70
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 147
+    - ID: 148
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0x808b60..0x808b70]
+      OutOfLinePCRanges: [0x808c70..0x808c80]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 276 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0x808b60..0x808b70
+            - Range: 0x808c70..0x808c80
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 148
-      Name: main.testMassiveString
-      OutOfLinePCRanges: [0x808b70..0x808b80]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0x808b70..0x808b80
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          Role: Parameter
     - ID: 149
-      Name: main.testUnitializedString
-      OutOfLinePCRanges: [0x808b80..0x808b90]
+      Name: main.testMassiveString
+      OutOfLinePCRanges: [0x808c80..0x808c90]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x808b80..0x808b90
+            - Range: 0x808c80..0x808c90
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8013,14 +8078,14 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
     - ID: 150
-      Name: main.testEmptyString
-      OutOfLinePCRanges: [0x808b90..0x808ba0]
+      Name: main.testUnitializedString
+      OutOfLinePCRanges: [0x808c90..0x808ca0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x808b90..0x808ba0
+            - Range: 0x808c90..0x808ca0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8028,14 +8093,29 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
     - ID: 151
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0x808ca0..0x808cb0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x808ca0..0x808cb0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          Role: Parameter
+    - ID: 152
       Name: main.testSubstrings
-      OutOfLinePCRanges: [0x808ba0..0x808bb0]
+      OutOfLinePCRanges: [0x808cb0..0x808cc0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x808ba0..0x808bb0
+            - Range: 0x808cb0..0x808cc0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8045,7 +8125,7 @@ Subprograms:
         - Name: b
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x808ba0..0x808bb0
+            - Range: 0x808cb0..0x808cc0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -8055,33 +8135,33 @@ Subprograms:
         - Name: c
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x808ba0..0x808bb0
+            - Range: 0x808cb0..0x808cc0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
-    - ID: 152
+    - ID: 153
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0x808cf0..0x808d00]
+      OutOfLinePCRanges: [0x808e00..0x808e10]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 278 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0x808cf0..0x808d00
+            - Range: 0x808e00..0x808e10
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
-    - ID: 153
+    - ID: 154
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0x808d00..0x808d10]
+      OutOfLinePCRanges: [0x808e10..0x808e20]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 291 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0x808d00..0x808d10
+            - Range: 0x808e10..0x808e20
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8096,15 +8176,15 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
-    - ID: 154
+    - ID: 155
       Name: main.testStruct
-      OutOfLinePCRanges: [0x808da0..0x808db0]
+      OutOfLinePCRanges: [0x808eb0..0x808ec0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 322 StructureType main.aStruct
           Locations:
-            - Range: 0x808da0..0x808db0
+            - Range: 0x808eb0..0x808ec0
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -8121,128 +8201,128 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
           Role: Parameter
-    - ID: 155
+    - ID: 156
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0x808e00..0x808e10]
+      OutOfLinePCRanges: [0x808f10..0x808f20]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 323 PointerType *main.anotherStruct
           Locations:
-            - Range: 0x808e00..0x808e10
+            - Range: 0x808f10..0x808f20
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 156
+    - ID: 157
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x808e40..0x808e50]
+      OutOfLinePCRanges: [0x808f50..0x808f60]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 325 StructureType main.emptyStruct
-          Locations: [{Range: 0x808e40..0x808e50, Pieces: []}]
+          Locations: [{Range: 0x808f50..0x808f60, Pieces: []}]
           Role: Parameter
-    - ID: 157
+    - ID: 158
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x808e50..0x808e60]
+      OutOfLinePCRanges: [0x808f60..0x808f70]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 326 PointerType *main.emptyStruct
           Locations:
-            - Range: 0x808e50..0x808e60
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-    - ID: 158
-      Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0x803c60..0x803cd0]
-      InlinePCRanges:
-        - Ranges: [0x803cec..0x803d20]
-          RootRanges: [0x803cd0..0x803d40]
-        - Ranges: [0x803e20..0x803e54]
-          RootRanges: [0x803df0..0x803e80]
-        - Ranges: [0x803ea4..0x803ed8]
-          RootRanges: [0x803e80..0x803f40]
-        - Ranges: [0x803f5c..0x803f90]
-          RootRanges: [0x803f40..0x803fb0]
-      Variables:
-        - Name: x
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x803c60..0x803c80
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x803cec..0x803cf4
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x803e20..0x803e28
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x803e9c..0x803eac
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x803eac..0x803f40
-              Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x803f40..0x803f64
+            - Range: 0x808f60..0x808f70
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 159
-      Name: main.testInlinedBBB
-      OutOfLinePCRanges: []
+      Name: main.testInlinedPrint
+      OutOfLinePCRanges: [0x803d70..0x803de0]
       InlinePCRanges:
-        - Ranges: [0x803ee4..0x803f18]
-          RootRanges: [0x803e80..0x803f40]
-      Variables: []
-    - ID: 160
-      Name: main.testInlinedBCA
-      OutOfLinePCRanges: []
-      InlinePCRanges:
-        - Ranges: [0x803fcc..0x804000, 0x804008..0x80400c]
-          RootRanges: [0x803fb0..0x8040c0]
-      Variables: []
-    - ID: 161
-      Name: main.testInlinedBCB
-      OutOfLinePCRanges: []
-      InlinePCRanges:
-        - Ranges: [0x804070..0x8040a4]
-          RootRanges: [0x803fb0..0x8040c0]
-      Variables: []
-    - ID: 162
-      Name: main.testInlinedSq
-      OutOfLinePCRanges: []
-      InlinePCRanges:
-        - Ranges: [0x8040c4..0x8040c8]
-          RootRanges: [0x8040c0..0x8040d0]
+        - Ranges: [0x803dfc..0x803e30]
+          RootRanges: [0x803de0..0x803e50]
+        - Ranges: [0x803f30..0x803f64]
+          RootRanges: [0x803f00..0x803f90]
+        - Ranges: [0x803fb4..0x803fe8]
+          RootRanges: [0x803f90..0x804050]
+        - Ranges: [0x80406c..0x8040a0]
+          RootRanges: [0x804050..0x8040c0]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8040c0..0x8040c8
+            - Range: 0x803d70..0x803d90
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x803dfc..0x803e04
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x803f30..0x803f38
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x803fac..0x803fbc
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x803fbc..0x804050
+              Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
+            - Range: 0x804050..0x804074
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
+    - ID: 160
+      Name: main.testInlinedBBB
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0x803ff4..0x804028]
+          RootRanges: [0x803f90..0x804050]
+      Variables: []
+    - ID: 161
+      Name: main.testInlinedBCA
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0x8040dc..0x804110, 0x804118..0x80411c]
+          RootRanges: [0x8040c0..0x8041d0]
+      Variables: []
+    - ID: 162
+      Name: main.testInlinedBCB
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0x804180..0x8041b4]
+          RootRanges: [0x8040c0..0x8041d0]
+      Variables: []
     - ID: 163
+      Name: main.testInlinedSq
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0x8041d4..0x8041d8]
+          RootRanges: [0x8041d0..0x8041e0]
+      Variables:
+        - Name: x
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x8041d0..0x8041d8
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+    - ID: 164
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x8040f4..0x804110]
-          RootRanges: [0x8040d0..0x804120]
-        - Ranges: [0x80417c..0x80419c]
-          RootRanges: [0x804120..0x804260]
+        - Ranges: [0x804204..0x804220]
+          RootRanges: [0x8041e0..0x804230]
+        - Ranges: [0x80428c..0x8042ac]
+          RootRanges: [0x804230..0x804370]
       Variables:
         - Name: a
           Type: 167 ArrayType [5]int
           Locations:
-            - Range: 0x8040e0..0x804120
+            - Range: 0x8041f0..0x804230
               Pieces: [{Size: 40, Op: {CfaOffset: -48}}]
-            - Range: 0x804168..0x804260
+            - Range: 0x804278..0x804370
               Pieces: [{Size: 40, Op: {CfaOffset: -120}}]
           Role: Parameter
-    - ID: 164
+    - ID: 165
       Name: main.firstBehavior.DoSomething
-      OutOfLinePCRanges: [0x804260..0x8042c0]
+      OutOfLinePCRanges: [0x804370..0x8043d0]
       InlinePCRanges:
-        - Ranges: [0x809950..0x809974]
-          RootRanges: [0x809930..0x8099a0]
+        - Ranges: [0x809a60..0x809a84]
+          RootRanges: [0x809a40..0x809ab0]
       Variables:
         - Name: b
           Type: 327 StructureType main.firstBehavior
           Locations:
-            - Range: 0x804260..0x804284
+            - Range: 0x804370..0x804394
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8252,23 +8332,23 @@ Subprograms:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x804260..0x8042a0
+            - Range: 0x804370..0x8043b0
               Pieces: []
-            - Range: 0x8042a0..0x8042a1
+            - Range: 0x8043b0..0x8043b1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8042a1..0x8042c0
+            - Range: 0x8043b1..0x8043d0
               Pieces: []
           Role: Return
-    - ID: 165
+    - ID: 166
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x8048e0..0x8048ec, 0x8048f0..0x8048f8]
-          RootRanges: [0x8047c0..0x804930]
+        - Ranges: [0x8049f0..0x8049fc, 0x804a00..0x804a08]
+          RootRanges: [0x8048d0..0x804a40]
         - Ranges: [0x802568..0x80256c, 0x802570..0x802578]
           RootRanges: [0x802560..0x802580]
       Variables: []
@@ -11606,10 +11686,10 @@ Types:
       GoKind: 22
       Pointee: 826 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1565
+      ID: 1566
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
     - __kind: EventRootType
-      ID: 1563
+      ID: 1564
       Name: Probe[main.firstBehavior.DoSomething]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11621,11 +11701,11 @@ Types:
             Type: 327 StructureType main.firstBehavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 0, name: b}
+                  Variable: {subprogram: 165, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1564
+      ID: 1565
       Name: Probe[main.firstBehavior.DoSomething]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11637,14 +11717,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 1, name: ~r0}
+                  Variable: {subprogram: 165, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1526
+      ID: 1527
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1527
+      ID: 1528
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11656,11 +11736,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: ~r0}
+                  Variable: {subprogram: 143, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1393
+      ID: 1394
       Name: Probe[main.testAnyPtr]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11672,7 +11752,7 @@ Types:
             Type: 169 PointerType *interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: a}
+                  Variable: {subprogram: 59, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -11682,11 +11762,11 @@ Types:
             Type: 169 PointerType *interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: a}
+                  Variable: {subprogram: 59, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1394
+      ID: 1395
       Name: Probe[main.testAnyPtr]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11698,11 +11778,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 1, name: ~r0}
+                  Variable: {subprogram: 59, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1390
+      ID: 1391
       Name: Probe[main.testAny]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11714,7 +11794,7 @@ Types:
             Type: 163 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: a}
+                  Variable: {subprogram: 57, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -11724,11 +11804,11 @@ Types:
             Type: 163 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: a}
+                  Variable: {subprogram: 57, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1391
+      ID: 1392
       Name: Probe[main.testAny]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11740,11 +11820,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 1, name: ~r0}
+                  Variable: {subprogram: 57, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1497
+      ID: 1498
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11756,7 +11836,7 @@ Types:
             Type: 257 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: arg}
+                  Variable: {subprogram: 123, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
         - Name: arg
@@ -11766,11 +11846,11 @@ Types:
             Type: 257 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: arg}
+                  Variable: {subprogram: 123, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1498
+      ID: 1499
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11782,7 +11862,7 @@ Types:
             Type: 257 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 1, name: ~r0}
+                  Variable: {subprogram: 123, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -11864,7 +11944,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1402
+      ID: 1403
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11876,7 +11956,7 @@ Types:
             Type: 197 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: m}
+                  Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
         - Name: m
@@ -11886,7 +11966,7 @@ Types:
             Type: 197 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: m}
+                  Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -11942,7 +12022,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1424
+      ID: 1425
       Name: Probe[main.testAtomicAdd]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11954,7 +12034,7 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: x}
+                  Variable: {subprogram: 87, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -11964,11 +12044,11 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: x}
+                  Variable: {subprogram: 87, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1425
+      ID: 1426
       Name: Probe[main.testAtomicAdd]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11980,7 +12060,7 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 1, name: ~r0}
+                  Variable: {subprogram: 87, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -12062,7 +12142,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1426
+      ID: 1427
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -12074,7 +12154,7 @@ Types:
             Type: 249 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: c}
+                  Variable: {subprogram: 88, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
         - Name: c
@@ -12084,11 +12164,11 @@ Types:
             Type: 249 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: c}
+                  Variable: {subprogram: 88, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1420
+      ID: 1421
       Name: Probe[main.testCombinedByte]
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -12100,7 +12180,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: w}
+                  Variable: {subprogram: 84, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: w
@@ -12110,7 +12190,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: w}
+                  Variable: {subprogram: 84, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: x
@@ -12120,7 +12200,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 1, name: x}
+                  Variable: {subprogram: 84, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: x
@@ -12130,7 +12210,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 1, name: x}
+                  Variable: {subprogram: 84, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: y
@@ -12140,7 +12220,7 @@ Types:
             Type: 17 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 2, name: y}
+                  Variable: {subprogram: 84, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
         - Name: y
@@ -12150,11 +12230,11 @@ Types:
             Type: 17 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 2, name: y}
+                  Variable: {subprogram: 84, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1421
+      ID: 1422
       Name: Probe[main.testCombinedString]
       ByteSize: 18
       PresenceBitsetSize: 1
@@ -12166,7 +12246,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 1, name: x}
+                  Variable: {subprogram: 85, index: 1, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: w_val
@@ -12176,11 +12256,11 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: w}
+                  Variable: {subprogram: 85, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1422
+      ID: 1423
       Name: Probe[main.testCombinedString]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -12192,7 +12272,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 1, name: x}
+                  Variable: {subprogram: 85, index: 1, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x_val
@@ -12202,7 +12282,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 1, name: x}
+                  Variable: {subprogram: 85, index: 1, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: w_val
@@ -12212,11 +12292,11 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: w}
+                  Variable: {subprogram: 85, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1434
+      ID: 1435
       Name: Probe[main.testCycle]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12228,7 +12308,7 @@ Types:
             Type: 254 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: t}
+                  Variable: {subprogram: 96, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
         - Name: t
@@ -12238,11 +12318,11 @@ Types:
             Type: 254 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: t}
+                  Variable: {subprogram: 96, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1365
+      ID: 1366
       Name: Probe[main.testDeepMap1]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12254,7 +12334,7 @@ Types:
             Type: 149 StructureType main.deepMap1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: a}
+                  Variable: {subprogram: 43, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12264,11 +12344,11 @@ Types:
             Type: 149 StructureType main.deepMap1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: a}
+                  Variable: {subprogram: 43, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1366
+      ID: 1367
       Name: Probe[main.testDeepMap7]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12280,7 +12360,7 @@ Types:
             Type: 155 PointerType *main.deepMap7
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 0, name: a}
+                  Variable: {subprogram: 44, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12290,11 +12370,11 @@ Types:
             Type: 155 PointerType *main.deepMap7
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 0, name: a}
+                  Variable: {subprogram: 44, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1361
+      ID: 1362
       Name: Probe[main.testDeepPtr1]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12306,7 +12386,7 @@ Types:
             Type: 138 StructureType main.deepPtr1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: a}
+                  Variable: {subprogram: 39, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12316,11 +12396,11 @@ Types:
             Type: 138 StructureType main.deepPtr1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: a}
+                  Variable: {subprogram: 39, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1362
+      ID: 1363
       Name: Probe[main.testDeepPtr7]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12332,7 +12412,7 @@ Types:
             Type: 141 PointerType *main.deepPtr7
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: a}
+                  Variable: {subprogram: 40, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12342,11 +12422,11 @@ Types:
             Type: 141 PointerType *main.deepPtr7
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: a}
+                  Variable: {subprogram: 40, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1363
+      ID: 1364
       Name: Probe[main.testDeepSlice1]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12358,7 +12438,7 @@ Types:
             Type: 143 StructureType main.deepSlice1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: a}
+                  Variable: {subprogram: 41, index: 0, name: a}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -12368,11 +12448,11 @@ Types:
             Type: 143 StructureType main.deepSlice1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: a}
+                  Variable: {subprogram: 41, index: 0, name: a}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1364
+      ID: 1365
       Name: Probe[main.testDeepSlice7]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12384,7 +12464,7 @@ Types:
             Type: 147 PointerType *main.deepSlice7
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: a}
+                  Variable: {subprogram: 42, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12394,11 +12474,11 @@ Types:
             Type: 147 PointerType *main.deepSlice7
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: a}
+                  Variable: {subprogram: 42, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1517
+      ID: 1518
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -12410,7 +12490,7 @@ Types:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: xs}
+                  Variable: {subprogram: 135, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -12420,7 +12500,7 @@ Types:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: xs}
+                  Variable: {subprogram: 135, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -12430,7 +12510,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 1, name: a}
+                  Variable: {subprogram: 135, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12440,11 +12520,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 1, name: a}
+                  Variable: {subprogram: 135, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1514
+      ID: 1515
       Name: Probe[main.testEmptySlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12456,7 +12536,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: u}
+                  Variable: {subprogram: 132, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -12466,11 +12546,11 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: u}
+                  Variable: {subprogram: 132, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1538
+      ID: 1539
       Name: Probe[main.testEmptyString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12482,7 +12562,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: x}
+                  Variable: {subprogram: 151, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -12492,11 +12572,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: x}
+                  Variable: {subprogram: 151, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1549
+      ID: 1550
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12508,7 +12588,7 @@ Types:
             Type: 326 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: e}
+                  Variable: {subprogram: 158, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -12518,11 +12598,11 @@ Types:
             Type: 326 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: e}
+                  Variable: {subprogram: 158, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1548
+      ID: 1549
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -12534,7 +12614,7 @@ Types:
             Type: 325 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: e}
+                  Variable: {subprogram: 157, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
         - Name: e
@@ -12544,11 +12624,67 @@ Types:
             Type: 325 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: e}
+                  Variable: {subprogram: 157, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1392
+      ID: 1361
+      Name: Probe[main.testErrorAtLine]Line
+      ByteSize: 57
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 2, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 2, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: err
+          Offset: 25
+          Kind: local
+          Expression:
+            Type: 15 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 3, name: err}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: err
+          Offset: 41
+          Kind: template_segment
+          Expression:
+            Type: 15 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 3, name: err}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1393
       Name: Probe[main.testError]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12560,7 +12696,7 @@ Types:
             Type: 15 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: e}
+                  Variable: {subprogram: 58, index: 0, name: e}
                   Offset: 0
                   ByteSize: 16
         - Name: e
@@ -12570,11 +12706,11 @@ Types:
             Type: 15 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: e}
+                  Variable: {subprogram: 58, index: 0, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1374
+      ID: 1375
       Name: Probe[main.testEsotericHeap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12586,7 +12722,7 @@ Types:
             Type: 165 PointerType *main.esotericHeap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 48, index: 0, name: e}
+                  Variable: {subprogram: 49, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -12596,14 +12732,14 @@ Types:
             Type: 165 PointerType *main.esotericHeap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 48, index: 0, name: e}
+                  Variable: {subprogram: 49, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1375
+      ID: 1376
       Name: Probe[main.testEsotericHeap]Return
     - __kind: EventRootType
-      ID: 1372
+      ID: 1373
       Name: Probe[main.testEsotericStack]
       ByteSize: 129
       PresenceBitsetSize: 1
@@ -12615,7 +12751,7 @@ Types:
             Type: 161 StructureType main.esotericStack
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 0, name: e}
+                  Variable: {subprogram: 48, index: 0, name: e}
                   Offset: 0
                   ByteSize: 64
         - Name: e
@@ -12625,14 +12761,14 @@ Types:
             Type: 161 StructureType main.esotericStack
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 0, name: e}
+                  Variable: {subprogram: 48, index: 0, name: e}
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1373
+      ID: 1374
       Name: Probe[main.testEsotericStack]Return
     - __kind: EventRootType
-      ID: 1386
+      ID: 1387
       Name: Probe[main.testFramelessArray]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12644,7 +12780,7 @@ Types:
             Type: 167 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: a}
+                  Variable: {subprogram: 55, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: a
@@ -12654,11 +12790,11 @@ Types:
             Type: 167 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: a}
+                  Variable: {subprogram: 55, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1388
+      ID: 1389
       Name: Probe[main.testFramelessArray]Line
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -12670,7 +12806,7 @@ Types:
             Type: 167 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: a}
+                  Variable: {subprogram: 55, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: a
@@ -12680,7 +12816,7 @@ Types:
             Type: 167 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: a}
+                  Variable: {subprogram: 55, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: ~r0
@@ -12690,11 +12826,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 1, name: ~r0}
+                  Variable: {subprogram: 55, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1387
+      ID: 1388
       Name: Probe[main.testFramelessArray]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12706,11 +12842,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 1, name: ~r0}
+                  Variable: {subprogram: 55, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1384
+      ID: 1385
       Name: Probe[main.testFrameless]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12722,7 +12858,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: x}
+                  Variable: {subprogram: 54, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12732,11 +12868,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: x}
+                  Variable: {subprogram: 54, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1385
+      ID: 1386
       Name: Probe[main.testFrameless]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12748,11 +12884,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 1, name: ~r0}
+                  Variable: {subprogram: 54, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1376
+      ID: 1377
       Name: Probe[main.testInlinedBA]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12764,7 +12900,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: x}
+                  Variable: {subprogram: 50, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12774,14 +12910,14 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: x}
+                  Variable: {subprogram: 50, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1377
+      ID: 1378
       Name: Probe[main.testInlinedBA]Return
     - __kind: EventRootType
-      ID: 1380
+      ID: 1381
       Name: Probe[main.testInlinedBBA]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12793,7 +12929,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: x}
+                  Variable: {subprogram: 52, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12803,17 +12939,17 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: x}
+                  Variable: {subprogram: 52, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1381
+      ID: 1382
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1555
+      ID: 1556
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 1378
+      ID: 1379
       Name: Probe[main.testInlinedBB]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12825,7 +12961,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: x}
+                  Variable: {subprogram: 51, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12835,7 +12971,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: x}
+                  Variable: {subprogram: 51, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: y
@@ -12845,7 +12981,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 1, name: y}
+                  Variable: {subprogram: 51, index: 1, name: y}
                   Offset: 0
                   ByteSize: 8
         - Name: y
@@ -12855,32 +12991,32 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 1, name: y}
+                  Variable: {subprogram: 51, index: 1, name: y}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1379
+      ID: 1380
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1556
+      ID: 1557
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1557
+      ID: 1558
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1558
+      ID: 1559
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1559
+      ID: 1560
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
-      ID: 1382
+      ID: 1383
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 1383
+      ID: 1384
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1552
+      ID: 1553
       Name: Probe[main.testInlinedPrint]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12892,7 +13028,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12902,11 +13038,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1550
+      ID: 1551
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12918,11 +13054,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1551
+      ID: 1552
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12934,7 +13070,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x_val
@@ -12944,11 +13080,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1554
+      ID: 1555
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12960,7 +13096,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12970,14 +13106,14 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1553
+      ID: 1554
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1560
+      ID: 1561
       Name: Probe[main.testInlinedSq]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12989,7 +13125,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12999,11 +13135,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1561
+      ID: 1562
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13015,7 +13151,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -13025,11 +13161,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1562
+      ID: 1563
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13041,7 +13177,7 @@ Types:
             Type: 167 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: a}
+                  Variable: {subprogram: 164, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: a
@@ -13051,7 +13187,7 @@ Types:
             Type: 167 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: a}
+                  Variable: {subprogram: 164, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
@@ -13185,7 +13321,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1389
+      ID: 1390
       Name: Probe[main.testInterface]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13197,7 +13333,7 @@ Types:
             Type: 168 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: b}
+                  Variable: {subprogram: 56, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -13207,11 +13343,11 @@ Types:
             Type: 168 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: b}
+                  Variable: {subprogram: 56, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1495
+      ID: 1496
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 161
       PresenceBitsetSize: 1
@@ -13223,7 +13359,7 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: arg}
+                  Variable: {subprogram: 122, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
         - Name: arg
@@ -13233,11 +13369,11 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: arg}
+                  Variable: {subprogram: 122, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1496
+      ID: 1497
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13249,11 +13385,11 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 1, name: ~r0}
+                  Variable: {subprogram: 122, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1428
+      ID: 1429
       Name: Probe[main.testLinkedList]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13265,7 +13401,7 @@ Types:
             Type: 252 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: a}
+                  Variable: {subprogram: 90, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -13275,48 +13411,12 @@ Types:
             Type: 252 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: a}
+                  Variable: {subprogram: 90, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1369
-      Name: Probe[main.testLongFunctionWithChangingState]Line
-    - __kind: EventRootType
       ID: 1370
       Name: Probe[main.testLongFunctionWithChangingState]Line
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: aPerArch
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 1, name: aPerArch}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: b
-          Offset: 17
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 2, name: b}
-                  Offset: 0
-                  ByteSize: 8
     - __kind: EventRootType
       ID: 1371
       Name: Probe[main.testLongFunctionWithChangingState]Line
@@ -13330,7 +13430,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 0, name: s}
+                  Variable: {subprogram: 47, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
         - Name: aPerArch
@@ -13340,7 +13440,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 1, name: aPerArch}
+                  Variable: {subprogram: 47, index: 1, name: aPerArch}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13350,11 +13450,47 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 2, name: b}
+                  Variable: {subprogram: 47, index: 2, name: b}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1501
+      ID: 1372
+      Name: Probe[main.testLongFunctionWithChangingState]Line
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 47, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: aPerArch
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 47, index: 1, name: aPerArch}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 17
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 47, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1502
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 147
       PresenceBitsetSize: 3
@@ -13366,7 +13502,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: a}
+                  Variable: {subprogram: 125, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -13376,7 +13512,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: a}
+                  Variable: {subprogram: 125, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13386,7 +13522,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 1, name: b}
+                  Variable: {subprogram: 125, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13396,7 +13532,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 1, name: b}
+                  Variable: {subprogram: 125, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13406,7 +13542,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 2, name: c}
+                  Variable: {subprogram: 125, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13416,7 +13552,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 2, name: c}
+                  Variable: {subprogram: 125, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13426,7 +13562,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 3, name: d}
+                  Variable: {subprogram: 125, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13436,7 +13572,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 3, name: d}
+                  Variable: {subprogram: 125, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13446,7 +13582,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 4, name: e}
+                  Variable: {subprogram: 125, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13456,7 +13592,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 4, name: e}
+                  Variable: {subprogram: 125, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13466,7 +13602,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 5, name: f}
+                  Variable: {subprogram: 125, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13476,7 +13612,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 5, name: f}
+                  Variable: {subprogram: 125, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13486,7 +13622,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 6, name: g}
+                  Variable: {subprogram: 125, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13496,7 +13632,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 6, name: g}
+                  Variable: {subprogram: 125, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13506,7 +13642,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 7, name: h}
+                  Variable: {subprogram: 125, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13516,7 +13652,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 7, name: h}
+                  Variable: {subprogram: 125, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13526,7 +13662,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 8, name: i}
+                  Variable: {subprogram: 125, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13536,11 +13672,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 8, name: i}
+                  Variable: {subprogram: 125, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1502
+      ID: 1503
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13552,11 +13688,11 @@ Types:
             Type: 119 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 9, name: ~r0}
+                  Variable: {subprogram: 125, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1400
+      ID: 1401
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13568,7 +13704,7 @@ Types:
             Type: 192 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13578,11 +13714,11 @@ Types:
             Type: 192 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1407
+      ID: 1408
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13594,7 +13730,7 @@ Types:
             Type: 199 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: m}
+                  Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13604,11 +13740,11 @@ Types:
             Type: 199 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: m}
+                  Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1419
+      ID: 1420
       Name: Probe[main.testMapEmptyKeyAndValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13620,7 +13756,7 @@ Types:
             Type: 244 GoMapType map[struct {}]struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: m}
+                  Variable: {subprogram: 83, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13630,11 +13766,11 @@ Types:
             Type: 244 GoMapType map[struct {}]struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: m}
+                  Variable: {subprogram: 83, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1417
+      ID: 1418
       Name: Probe[main.testMapEmptyKey]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13646,7 +13782,7 @@ Types:
             Type: 234 GoMapType map[struct {}]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: m}
+                  Variable: {subprogram: 81, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13656,11 +13792,11 @@ Types:
             Type: 234 GoMapType map[struct {}]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: m}
+                  Variable: {subprogram: 81, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1418
+      ID: 1419
       Name: Probe[main.testMapEmptyValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13672,7 +13808,7 @@ Types:
             Type: 239 GoMapType map[int]struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: m}
+                  Variable: {subprogram: 82, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13682,11 +13818,11 @@ Types:
             Type: 239 GoMapType map[int]struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: m}
+                  Variable: {subprogram: 82, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1404
+      ID: 1405
       Name: Probe[main.testMapIntToInt]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13698,7 +13834,7 @@ Types:
             Type: 172 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
+                  Variable: {subprogram: 69, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13708,11 +13844,11 @@ Types:
             Type: 172 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
+                  Variable: {subprogram: 69, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1416
+      ID: 1417
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13724,7 +13860,7 @@ Types:
             Type: 229 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: m}
+                  Variable: {subprogram: 80, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13734,11 +13870,11 @@ Types:
             Type: 229 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: m}
+                  Variable: {subprogram: 80, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1415
+      ID: 1416
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13750,7 +13886,7 @@ Types:
             Type: 224 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: m}
+                  Variable: {subprogram: 79, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13760,33 +13896,7 @@ Types:
             Type: 224 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1405
-      Name: Probe[main.testMapMassive]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: redactMyEntries
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 199 GoMapType map[string][]main.structWithMap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: redactMyEntries
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 199 GoMapType map[string][]main.structWithMap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 79, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -13802,7 +13912,7 @@ Types:
             Type: 199 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 70, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
         - Name: redactMyEntries
@@ -13812,11 +13922,37 @@ Types:
             Type: 199 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 70, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1414
+      ID: 1407
+      Name: Probe[main.testMapMassive]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: redactMyEntries
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 199 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 70, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: redactMyEntries
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 199 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 70, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1415
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13828,7 +13964,7 @@ Types:
             Type: 219 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: m}
+                  Variable: {subprogram: 78, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -13838,11 +13974,11 @@ Types:
             Type: 219 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: m}
+                  Variable: {subprogram: 78, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1413
+      ID: 1414
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13854,6 +13990,136 @@ Types:
             Type: 214 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
+                  Variable: {subprogram: 77, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 214 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 77, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1399
+      Name: Probe[main.testMapStringToInt]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 182 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 63, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 182 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 63, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1400
+      Name: Probe[main.testMapStringToSlice]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 187 GoMapType map[string][]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 64, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 187 GoMapType map[string][]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 64, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1398
+      Name: Probe[main.testMapStringToStruct]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 177 GoMapType map[string]main.nestedStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 62, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 177 GoMapType map[string]main.nestedStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 62, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1409
+      Name: Probe[main.testMapWithLinkedList]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 204 GoMapType map[bool]main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 72, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 204 GoMapType map[bool]main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 72, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1413
+      Name: Probe[main.testMapWithSmallKeyAndValueMassive]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 214 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
                   Variable: {subprogram: 76, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
@@ -13868,112 +14134,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1398
-      Name: Probe[main.testMapStringToInt]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 182 GoMapType map[string]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: m
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 182 GoMapType map[string]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1399
-      Name: Probe[main.testMapStringToSlice]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 187 GoMapType map[string][]string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: m
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 187 GoMapType map[string][]string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1397
-      Name: Probe[main.testMapStringToStruct]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 177 GoMapType map[string]main.nestedStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: m
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 177 GoMapType map[string]main.nestedStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1408
-      Name: Probe[main.testMapWithLinkedList]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 204 GoMapType map[bool]main.node
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: m
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 204 GoMapType map[bool]main.node
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
       ID: 1412
-      Name: Probe[main.testMapWithSmallKeyAndValueMassive]
+      Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
@@ -13999,32 +14161,6 @@ Types:
                   ByteSize: 8
     - __kind: EventRootType
       ID: 1411
-      Name: Probe[main.testMapWithSmallKeyAndValue]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 214 GoMapType map[uint8]uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: m
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 214 GoMapType map[uint8]uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1410
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14036,7 +14172,7 @@ Types:
             Type: 209 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 74, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
         - Name: redactMyEntries
@@ -14046,11 +14182,11 @@ Types:
             Type: 209 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 74, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1409
+      ID: 1410
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14062,7 +14198,7 @@ Types:
             Type: 209 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: m}
+                  Variable: {subprogram: 73, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -14072,35 +14208,9 @@ Types:
             Type: 209 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: m}
+                  Variable: {subprogram: 73, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
-    - __kind: EventRootType
-      ID: 1535
-      Name: Probe[main.testMassiveString]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: x
-          Offset: 17
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
     - __kind: EventRootType
       ID: 1536
       Name: Probe[main.testMassiveString]
@@ -14114,7 +14224,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
+                  Variable: {subprogram: 149, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -14124,11 +14234,37 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
+                  Variable: {subprogram: 149, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1503
+      ID: 1537
+      Name: Probe[main.testMassiveString]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 149, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 149, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1504
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 163
       PresenceBitsetSize: 3
@@ -14140,7 +14276,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: a}
+                  Variable: {subprogram: 126, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14150,7 +14286,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: a}
+                  Variable: {subprogram: 126, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -14160,7 +14296,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: b}
+                  Variable: {subprogram: 126, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -14170,7 +14306,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: b}
+                  Variable: {subprogram: 126, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -14180,7 +14316,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: c}
+                  Variable: {subprogram: 126, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -14190,7 +14326,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: c}
+                  Variable: {subprogram: 126, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -14200,7 +14336,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 3, name: d}
+                  Variable: {subprogram: 126, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -14210,7 +14346,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 3, name: d}
+                  Variable: {subprogram: 126, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -14220,7 +14356,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 4, name: e}
+                  Variable: {subprogram: 126, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -14230,7 +14366,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 4, name: e}
+                  Variable: {subprogram: 126, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -14240,7 +14376,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 5, name: f}
+                  Variable: {subprogram: 126, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -14250,7 +14386,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 5, name: f}
+                  Variable: {subprogram: 126, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -14260,7 +14396,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 6, name: g}
+                  Variable: {subprogram: 126, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -14270,7 +14406,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 6, name: g}
+                  Variable: {subprogram: 126, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -14280,7 +14416,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 7, name: h}
+                  Variable: {subprogram: 126, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -14290,7 +14426,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 7, name: h}
+                  Variable: {subprogram: 126, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: s
@@ -14300,7 +14436,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 8, name: s}
+                  Variable: {subprogram: 126, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
         - Name: s
@@ -14310,11 +14446,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 8, name: s}
+                  Variable: {subprogram: 126, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1504
+      ID: 1505
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -14326,11 +14462,11 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 9, name: ~r0}
+                  Variable: {subprogram: 126, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1507
+      ID: 1508
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -14342,7 +14478,7 @@ Types:
             Type: 119 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -14352,7 +14488,7 @@ Types:
             Type: 119 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -14362,7 +14498,7 @@ Types:
             Type: 257 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: b}
+                  Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
         - Name: b
@@ -14372,11 +14508,11 @@ Types:
             Type: 257 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: b}
+                  Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1508
+      ID: 1509
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -14388,7 +14524,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 2, name: ~r0}
+                  Variable: {subprogram: 128, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -14398,11 +14534,11 @@ Types:
             Type: 119 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 3, name: ~r1}
+                  Variable: {subprogram: 128, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1499
+      ID: 1500
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 321
       PresenceBitsetSize: 1
@@ -14414,7 +14550,7 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: s1}
+                  Variable: {subprogram: 124, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
         - Name: s1
@@ -14424,7 +14560,7 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: s1}
+                  Variable: {subprogram: 124, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
         - Name: s2
@@ -14434,7 +14570,7 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: s2}
+                  Variable: {subprogram: 124, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
         - Name: s2
@@ -14444,11 +14580,11 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: s2}
+                  Variable: {subprogram: 124, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1500
+      ID: 1501
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -14460,11 +14596,11 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 2, name: ~r0}
+                  Variable: {subprogram: 124, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1453
+      ID: 1454
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14476,7 +14612,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14486,11 +14622,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1455
+      ID: 1456
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14502,7 +14638,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14512,7 +14648,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14522,7 +14658,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14532,11 +14668,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1457
+      ID: 1458
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14548,11 +14684,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1459
+      ID: 1460
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14564,11 +14700,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1461
+      ID: 1462
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14580,11 +14716,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1454
+      ID: 1455
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14596,7 +14732,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14606,11 +14742,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1456
+      ID: 1457
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -14622,7 +14758,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14632,7 +14768,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14642,7 +14778,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14652,7 +14788,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14662,7 +14798,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14672,11 +14808,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1458
+      ID: 1459
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14688,7 +14824,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14698,11 +14834,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1460
+      ID: 1461
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14714,7 +14850,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14724,11 +14860,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1462
+      ID: 1463
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14740,7 +14876,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: result}
+                  Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14750,11 +14886,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1423
+      ID: 1424
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 62
       PresenceBitsetSize: 2
@@ -14766,7 +14902,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: a}
+                  Variable: {subprogram: 86, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: a
@@ -14776,7 +14912,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: a}
+                  Variable: {subprogram: 86, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -14786,7 +14922,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 1, name: b}
+                  Variable: {subprogram: 86, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -14796,7 +14932,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 1, name: b}
+                  Variable: {subprogram: 86, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: c
@@ -14806,7 +14942,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 2, name: c}
+                  Variable: {subprogram: 86, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: c
@@ -14816,7 +14952,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 2, name: c}
+                  Variable: {subprogram: 86, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: d
@@ -14826,7 +14962,7 @@ Types:
             Type: 11 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 3, name: d}
+                  Variable: {subprogram: 86, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -14836,7 +14972,7 @@ Types:
             Type: 11 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 3, name: d}
+                  Variable: {subprogram: 86, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -14846,7 +14982,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 4, name: e}
+                  Variable: {subprogram: 86, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
         - Name: e
@@ -14856,11 +14992,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 4, name: e}
+                  Variable: {subprogram: 86, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1449
+      ID: 1450
       Name: Probe[main.testNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14872,7 +15008,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14882,37 +15018,37 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1452
+      Name: Probe[main.testNamedReturn]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
       ID: 1451
-      Name: Probe[main.testNamedReturn]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1450
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14924,11 +15060,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1452
+      ID: 1453
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14940,7 +15076,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14950,11 +15086,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1544
+      ID: 1545
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14966,7 +15102,7 @@ Types:
             Type: 323 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: x}
+                  Variable: {subprogram: 156, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -14976,11 +15112,11 @@ Types:
             Type: 323 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: x}
+                  Variable: {subprogram: 156, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1545
+      ID: 1546
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14992,7 +15128,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: x}
+                  Variable: {subprogram: 156, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -15002,10 +15138,10 @@ Types:
                   Bias: 8
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1546
+      ID: 1547
       Name: Probe[main.testNestedPointer]
     - __kind: EventRootType
-      ID: 1547
+      ID: 1548
       Name: Probe[main.testNestedPointer]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15017,7 +15153,7 @@ Types:
             Type: 129 StructureType main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: x}
+                  Variable: {subprogram: 156, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -15027,7 +15163,7 @@ Types:
                   Bias: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1433
+      ID: 1434
       Name: Probe[main.testNilPointer]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15039,7 +15175,7 @@ Types:
             Type: 10 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: z}
+                  Variable: {subprogram: 95, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: z
@@ -15049,7 +15185,7 @@ Types:
             Type: 10 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: z}
+                  Variable: {subprogram: 95, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -15059,7 +15195,7 @@ Types:
             Type: 11 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 1, name: a}
+                  Variable: {subprogram: 95, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -15069,11 +15205,11 @@ Types:
             Type: 11 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 1, name: a}
+                  Variable: {subprogram: 95, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1518
+      ID: 1519
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -15085,7 +15221,7 @@ Types:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: xs}
+                  Variable: {subprogram: 136, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -15095,7 +15231,7 @@ Types:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: xs}
+                  Variable: {subprogram: 136, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -15105,7 +15241,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 1, name: a}
+                  Variable: {subprogram: 136, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -15115,11 +15251,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 1, name: a}
+                  Variable: {subprogram: 136, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1520
+      ID: 1521
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 67
       PresenceBitsetSize: 1
@@ -15131,7 +15267,7 @@ Types:
             Type: 19 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: a}
+                  Variable: {subprogram: 138, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: a
@@ -15141,7 +15277,7 @@ Types:
             Type: 19 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: a}
+                  Variable: {subprogram: 138, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
@@ -15151,7 +15287,7 @@ Types:
             Type: 270 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 1, name: s}
+                  Variable: {subprogram: 138, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: s
@@ -15161,7 +15297,7 @@ Types:
             Type: 270 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 1, name: s}
+                  Variable: {subprogram: 138, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -15171,7 +15307,7 @@ Types:
             Type: 11 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 2, name: x}
+                  Variable: {subprogram: 138, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -15181,11 +15317,11 @@ Types:
             Type: 11 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 2, name: x}
+                  Variable: {subprogram: 138, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1521
+      ID: 1522
       Name: Probe[main.testNilSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -15197,7 +15333,7 @@ Types:
             Type: 271 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -15207,11 +15343,11 @@ Types:
             Type: 271 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1534
+      ID: 1535
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15223,7 +15359,7 @@ Types:
             Type: 276 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -15233,11 +15369,11 @@ Types:
             Type: 276 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1429
+      ID: 1430
       Name: Probe[main.testPointerLoop]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15249,7 +15385,7 @@ Types:
             Type: 253 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: a}
+                  Variable: {subprogram: 91, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -15259,11 +15395,11 @@ Types:
             Type: 253 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: a}
+                  Variable: {subprogram: 91, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1403
+      ID: 1404
       Name: Probe[main.testPointerToMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15275,7 +15411,7 @@ Types:
             Type: 198 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: m}
+                  Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -15285,11 +15421,11 @@ Types:
             Type: 198 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: m}
+                  Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1427
+      ID: 1428
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15301,7 +15437,7 @@ Types:
             Type: 250 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: a}
+                  Variable: {subprogram: 89, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -15311,11 +15447,11 @@ Types:
             Type: 250 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: a}
+                  Variable: {subprogram: 89, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1443
+      ID: 1444
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 35
       PresenceBitsetSize: 1
@@ -15327,7 +15463,7 @@ Types:
             Type: 163 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: v}
+                  Variable: {subprogram: 101, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: v
@@ -15337,7 +15473,7 @@ Types:
             Type: 163 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: v}
+                  Variable: {subprogram: 101, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: failed
@@ -15347,7 +15483,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 1, name: failed}
+                  Variable: {subprogram: 101, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
         - Name: failed
@@ -15357,11 +15493,11 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 1, name: failed}
+                  Variable: {subprogram: 101, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1444
+      ID: 1445
       Name: Probe[main.testReturnsAnyAndError]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15373,7 +15509,7 @@ Types:
             Type: 163 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 2, name: ~r0}
+                  Variable: {subprogram: 101, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
         - Name: ~r1
@@ -15383,11 +15519,11 @@ Types:
             Type: 15 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 3, name: ~r1}
+                  Variable: {subprogram: 101, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1445
+      ID: 1446
       Name: Probe[main.testReturnsAny]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15399,7 +15535,7 @@ Types:
             Type: 163 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: v}
+                  Variable: {subprogram: 102, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: v
@@ -15409,11 +15545,11 @@ Types:
             Type: 163 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: v}
+                  Variable: {subprogram: 102, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1446
+      ID: 1447
       Name: Probe[main.testReturnsAny]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15425,14 +15561,14 @@ Types:
             Type: 163 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 1, name: ~r0}
+                  Variable: {subprogram: 102, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1475
+      ID: 1476
       Name: Probe[main.testReturnsArrayOne]
     - __kind: EventRootType
-      ID: 1476
+      ID: 1477
       Name: Probe[main.testReturnsArrayOne]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15444,14 +15580,14 @@ Types:
             Type: 258 ArrayType [1]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 0, name: ~r0}
+                  Variable: {subprogram: 112, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1477
+      ID: 1478
       Name: Probe[main.testReturnsArrayZero]
     - __kind: EventRootType
-      ID: 1478
+      ID: 1479
       Name: Probe[main.testReturnsArrayZero]Return
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -15463,14 +15599,14 @@ Types:
             Type: 259 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 0, name: ~r0}
+                  Variable: {subprogram: 113, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1473
+      ID: 1474
       Name: Probe[main.testReturnsArray]
     - __kind: EventRootType
-      ID: 1474
+      ID: 1475
       Name: Probe[main.testReturnsArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15482,14 +15618,14 @@ Types:
             Type: 257 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 0, name: ~r0}
+                  Variable: {subprogram: 111, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1481
+      ID: 1482
       Name: Probe[main.testReturnsBacktrackInt]
     - __kind: EventRootType
-      ID: 1482
+      ID: 1483
       Name: Probe[main.testReturnsBacktrackInt]Return
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -15501,7 +15637,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: ~r0}
+                  Variable: {subprogram: 115, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15511,7 +15647,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 1, name: ~r1}
+                  Variable: {subprogram: 115, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15521,7 +15657,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 2, name: ~r2}
+                  Variable: {subprogram: 115, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -15531,7 +15667,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 3, name: ~r3}
+                  Variable: {subprogram: 115, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15541,7 +15677,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 4, name: ~r4}
+                  Variable: {subprogram: 115, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r5
@@ -15551,7 +15687,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 5, name: ~r5}
+                  Variable: {subprogram: 115, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r6
@@ -15561,7 +15697,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 6, name: ~r6}
+                  Variable: {subprogram: 115, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r7
@@ -15571,7 +15707,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 7, name: ~r7}
+                  Variable: {subprogram: 115, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r8
@@ -15581,14 +15717,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 8, name: ~r8}
+                  Variable: {subprogram: 115, index: 8, name: ~r8}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1493
+      ID: 1494
       Name: Probe[main.testReturnsBoolAndUintptr]
     - __kind: EventRootType
-      ID: 1494
+      ID: 1495
       Name: Probe[main.testReturnsBoolAndUintptr]Return
       ByteSize: 10
       PresenceBitsetSize: 1
@@ -15600,7 +15736,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: ~r0}
+                  Variable: {subprogram: 121, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r1
@@ -15610,14 +15746,14 @@ Types:
             Type: 1 BaseType uintptr
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 1, name: ~r1}
+                  Variable: {subprogram: 121, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1469
+      ID: 1470
       Name: Probe[main.testReturnsComplex]
     - __kind: EventRootType
-      ID: 1470
+      ID: 1471
       Name: Probe[main.testReturnsComplex]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15629,7 +15765,7 @@ Types:
             Type: 103 BaseType complex64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: ~r0}
+                  Variable: {subprogram: 109, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15639,11 +15775,11 @@ Types:
             Type: 18 BaseType complex128
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: ~r1}
+                  Variable: {subprogram: 109, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1441
+      ID: 1442
       Name: Probe[main.testReturnsError]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -15655,7 +15791,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: failed}
+                  Variable: {subprogram: 100, index: 0, name: failed}
                   Offset: 0
                   ByteSize: 1
         - Name: failed
@@ -15665,11 +15801,11 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: failed}
+                  Variable: {subprogram: 100, index: 0, name: failed}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1442
+      ID: 1443
       Name: Probe[main.testReturnsError]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15681,11 +15817,11 @@ Types:
             Type: 15 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 1, name: ~r0}
+                  Variable: {subprogram: 100, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1439
+      ID: 1440
       Name: Probe[main.testReturnsIntAndFloat]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15697,7 +15833,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: i}
+                  Variable: {subprogram: 99, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -15707,11 +15843,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: i}
+                  Variable: {subprogram: 99, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1440
+      ID: 1441
       Name: Probe[main.testReturnsIntAndFloat]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15723,7 +15859,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 1, name: ~r0}
+                  Variable: {subprogram: 99, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15733,11 +15869,11 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 2, name: ~r1}
+                  Variable: {subprogram: 99, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1437
+      ID: 1438
       Name: Probe[main.testReturnsIntPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15749,7 +15885,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: i}
+                  Variable: {subprogram: 98, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -15759,11 +15895,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: i}
+                  Variable: {subprogram: 98, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1438
+      ID: 1439
       Name: Probe[main.testReturnsIntPointer]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15775,11 +15911,11 @@ Types:
             Type: 105 PointerType *int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 1, name: ~r0}
+                  Variable: {subprogram: 98, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1435
+      ID: 1436
       Name: Probe[main.testReturnsInt]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15791,7 +15927,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: i}
+                  Variable: {subprogram: 97, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -15801,11 +15937,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: i}
+                  Variable: {subprogram: 97, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1436
+      ID: 1437
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15817,11 +15953,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 1, name: ~r0}
+                  Variable: {subprogram: 97, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1447
+      ID: 1448
       Name: Probe[main.testReturnsInterface]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15833,7 +15969,7 @@ Types:
             Type: 163 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: v}
+                  Variable: {subprogram: 103, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: v
@@ -15843,11 +15979,11 @@ Types:
             Type: 163 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: v}
+                  Variable: {subprogram: 103, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1448
+      ID: 1449
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15859,14 +15995,14 @@ Types:
             Type: 168 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: ~r0}
+                  Variable: {subprogram: 103, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1471
+      ID: 1472
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1472
+      ID: 1473
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -15878,14 +16014,14 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: ~r0}
+                  Variable: {subprogram: 110, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1467
+      ID: 1468
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1468
+      ID: 1469
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 139
       PresenceBitsetSize: 3
@@ -15897,7 +16033,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: ~r0}
+                  Variable: {subprogram: 108, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15907,7 +16043,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 1, name: ~r1}
+                  Variable: {subprogram: 108, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15917,7 +16053,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 2, name: ~r2}
+                  Variable: {subprogram: 108, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -15927,7 +16063,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 3, name: ~r3}
+                  Variable: {subprogram: 108, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15937,7 +16073,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 4, name: ~r4}
+                  Variable: {subprogram: 108, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r5
@@ -15947,7 +16083,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 5, name: ~r5}
+                  Variable: {subprogram: 108, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r6
@@ -15957,7 +16093,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 6, name: ~r6}
+                  Variable: {subprogram: 108, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r7
@@ -15967,7 +16103,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 7, name: ~r7}
+                  Variable: {subprogram: 108, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r8
@@ -15977,7 +16113,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 8, name: ~r8}
+                  Variable: {subprogram: 108, index: 8, name: ~r8}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r9
@@ -15987,7 +16123,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 9, name: ~r9}
+                  Variable: {subprogram: 108, index: 9, name: ~r9}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r10
@@ -15997,7 +16133,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 10, name: ~r10}
+                  Variable: {subprogram: 108, index: 10, name: ~r10}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r11
@@ -16007,7 +16143,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 11, name: ~r11}
+                  Variable: {subprogram: 108, index: 11, name: ~r11}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r12
@@ -16017,7 +16153,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 12, name: ~r12}
+                  Variable: {subprogram: 108, index: 12, name: ~r12}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r13
@@ -16027,7 +16163,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 13, name: ~r13}
+                  Variable: {subprogram: 108, index: 13, name: ~r13}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r14
@@ -16037,7 +16173,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 14, name: ~r14}
+                  Variable: {subprogram: 108, index: 14, name: ~r14}
                   Offset: 0
                   ByteSize: 8
         - Name: onlyOnAmd64_16
@@ -16047,7 +16183,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 15, name: onlyOnAmd64_16}
+                  Variable: {subprogram: 108, index: 15, name: onlyOnAmd64_16}
                   Offset: 0
                   ByteSize: 8
         - Name: bothArmAndAmd64
@@ -16057,14 +16193,14 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 16, name: bothArmAndAmd64}
+                  Variable: {subprogram: 108, index: 16, name: bothArmAndAmd64}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1479
+      ID: 1480
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1480
+      ID: 1481
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16076,14 +16212,14 @@ Types:
             Type: 260 StructureType main.mixedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: ~r0}
+                  Variable: {subprogram: 114, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1485
+      ID: 1486
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1486
+      ID: 1487
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16095,7 +16231,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 0, name: ~r0}
+                  Variable: {subprogram: 117, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -16105,7 +16241,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 1, name: ~r1}
+                  Variable: {subprogram: 117, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -16115,7 +16251,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 2, name: ~r2}
+                  Variable: {subprogram: 117, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -16125,7 +16261,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 3, name: ~r3}
+                  Variable: {subprogram: 117, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -16135,14 +16271,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 4, name: ~r4}
+                  Variable: {subprogram: 117, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1491
+      ID: 1492
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1492
+      ID: 1493
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -16154,7 +16290,7 @@ Types:
             Type: 17 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: ~r0}
+                  Variable: {subprogram: 120, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r1
@@ -16164,14 +16300,14 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 1, name: ~r1}
+                  Variable: {subprogram: 120, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1489
+      ID: 1490
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1490
+      ID: 1491
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -16183,14 +16319,14 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 0, name: ~r0}
+                  Variable: {subprogram: 119, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1465
+      ID: 1466
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1466
+      ID: 1467
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -16202,7 +16338,7 @@ Types:
             Type: 19 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 0, name: ~r0}
+                  Variable: {subprogram: 107, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r1
@@ -16212,7 +16348,7 @@ Types:
             Type: 102 BaseType int16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 1, name: ~r1}
+                  Variable: {subprogram: 107, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 2
         - Name: ~r2
@@ -16222,7 +16358,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 2, name: ~r2}
+                  Variable: {subprogram: 107, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r3
@@ -16232,7 +16368,7 @@ Types:
             Type: 13 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 3, name: ~r3}
+                  Variable: {subprogram: 107, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -16242,7 +16378,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 4, name: ~r4}
+                  Variable: {subprogram: 107, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r5
@@ -16252,7 +16388,7 @@ Types:
             Type: 6 BaseType uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 5, name: ~r5}
+                  Variable: {subprogram: 107, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 2
         - Name: ~r6
@@ -16262,7 +16398,7 @@ Types:
             Type: 2 BaseType uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 6, name: ~r6}
+                  Variable: {subprogram: 107, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r7
@@ -16272,14 +16408,14 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 7, name: ~r7}
+                  Variable: {subprogram: 107, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1487
+      ID: 1488
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1488
+      ID: 1489
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16291,14 +16427,14 @@ Types:
             Type: 262 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 0, name: ~r0}
+                  Variable: {subprogram: 118, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1483
+      ID: 1484
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1484
+      ID: 1485
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -16310,7 +16446,7 @@ Types:
             Type: 261 StructureType main.wideStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 0, name: ~r0}
+                  Variable: {subprogram: 116, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 88
     - __kind: EventRootType
@@ -16620,7 +16756,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1528
+      ID: 1529
       Name: Probe[main.testSingleString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16632,7 +16768,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: x}
+                  Variable: {subprogram: 144, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -16642,7 +16778,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: x}
+                  Variable: {subprogram: 144, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -16776,7 +16912,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1524
+      ID: 1525
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16788,7 +16924,7 @@ Types:
             Type: 272 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: xs}
+                  Variable: {subprogram: 141, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -16798,11 +16934,11 @@ Types:
             Type: 272 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: xs}
+                  Variable: {subprogram: 141, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1515
+      ID: 1516
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16814,7 +16950,7 @@ Types:
             Type: 264 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: u}
+                  Variable: {subprogram: 133, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -16824,11 +16960,11 @@ Types:
             Type: 264 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: u}
+                  Variable: {subprogram: 133, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1401
+      ID: 1402
       Name: Probe[main.testSmallMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16840,7 +16976,7 @@ Types:
             Type: 182 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
         - Name: m
@@ -16850,11 +16986,11 @@ Types:
             Type: 182 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1463
+      ID: 1464
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16866,7 +17002,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: i}
+                  Variable: {subprogram: 106, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -16876,11 +17012,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: i}
+                  Variable: {subprogram: 106, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1464
+      ID: 1465
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16892,7 +17028,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 1, name: ~r0}
+                  Variable: {subprogram: 106, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -16902,7 +17038,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 2, name: result2}
+                  Variable: {subprogram: 106, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -16912,11 +17048,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 3, name: ~r2}
+                  Variable: {subprogram: 106, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1505
+      ID: 1506
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -16928,7 +17064,7 @@ Types:
             Type: 167 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: arg}
+                  Variable: {subprogram: 127, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
         - Name: arg
@@ -16938,11 +17074,11 @@ Types:
             Type: 167 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: arg}
+                  Variable: {subprogram: 127, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1506
+      ID: 1507
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16954,7 +17090,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: ~r0}
+                  Variable: {subprogram: 127, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -16964,7 +17100,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: ~r1}
+                  Variable: {subprogram: 127, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -16974,7 +17110,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 3, name: ~r2}
+                  Variable: {subprogram: 127, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -17004,7 +17140,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1432
+      ID: 1433
       Name: Probe[main.testStringPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17016,7 +17152,7 @@ Types:
             Type: 101 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: z}
+                  Variable: {subprogram: 94, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: z
@@ -17026,11 +17162,11 @@ Types:
             Type: 101 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: z}
+                  Variable: {subprogram: 94, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1519
+      ID: 1520
       Name: Probe[main.testStringSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17042,7 +17178,7 @@ Types:
             Type: 269 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: s}
+                  Variable: {subprogram: 137, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: s
@@ -17052,11 +17188,11 @@ Types:
             Type: 269 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: s}
+                  Variable: {subprogram: 137, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1367
+      ID: 1368
       Name: Probe[main.testStringType1]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17068,7 +17204,7 @@ Types:
             Type: 157 PointerType *main.stringType1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 0, name: a}
+                  Variable: {subprogram: 45, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -17078,11 +17214,11 @@ Types:
             Type: 157 PointerType *main.stringType1
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 0, name: a}
+                  Variable: {subprogram: 45, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1368
+      ID: 1369
       Name: Probe[main.testStringType2]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17094,7 +17230,7 @@ Types:
             Type: 159 PointerType **main.stringType2
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: a}
+                  Variable: {subprogram: 46, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -17104,11 +17240,11 @@ Types:
             Type: 159 PointerType **main.stringType2
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: a}
+                  Variable: {subprogram: 46, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1516
+      ID: 1517
       Name: Probe[main.testStructSlice]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -17120,7 +17256,7 @@ Types:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Variable: {subprogram: 134, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -17130,7 +17266,7 @@ Types:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Variable: {subprogram: 134, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -17140,7 +17276,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 1, name: a}
+                  Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -17150,11 +17286,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 1, name: a}
+                  Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1395
+      ID: 1396
       Name: Probe[main.testStructWithAny]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17166,7 +17302,7 @@ Types:
             Type: 170 StructureType main.structWithAny
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: s}
+                  Variable: {subprogram: 60, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
         - Name: s
@@ -17176,11 +17312,11 @@ Types:
             Type: 170 StructureType main.structWithAny
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: s}
+                  Variable: {subprogram: 60, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1509
+      ID: 1510
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17192,7 +17328,7 @@ Types:
             Type: 262 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: arg}
+                  Variable: {subprogram: 129, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
         - Name: arg
@@ -17202,11 +17338,11 @@ Types:
             Type: 262 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: arg}
+                  Variable: {subprogram: 129, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1510
+      ID: 1511
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17218,7 +17354,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 1, name: ~r0}
+                  Variable: {subprogram: 129, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -17228,11 +17364,11 @@ Types:
             Type: 262 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 2, name: ~r1}
+                  Variable: {subprogram: 129, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1541
+      ID: 1542
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17244,7 +17380,7 @@ Types:
             Type: 291 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: a}
+                  Variable: {subprogram: 154, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
         - Name: a
@@ -17254,11 +17390,11 @@ Types:
             Type: 291 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: a}
+                  Variable: {subprogram: 154, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1540
+      ID: 1541
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 289
       PresenceBitsetSize: 1
@@ -17270,7 +17406,7 @@ Types:
             Type: 278 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: a}
+                  Variable: {subprogram: 153, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
         - Name: a
@@ -17280,11 +17416,11 @@ Types:
             Type: 278 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: a}
+                  Variable: {subprogram: 153, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
     - __kind: EventRootType
-      ID: 1396
+      ID: 1397
       Name: Probe[main.testStructWithMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17296,7 +17432,7 @@ Types:
             Type: 171 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: s}
+                  Variable: {subprogram: 61, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
         - Name: s
@@ -17306,11 +17442,11 @@ Types:
             Type: 171 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: s}
+                  Variable: {subprogram: 61, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1542
+      ID: 1543
       Name: Probe[main.testStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17322,11 +17458,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 8
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1543
+      ID: 1544
       Name: Probe[main.testStruct]
       ByteSize: 113
       PresenceBitsetSize: 1
@@ -17338,7 +17474,7 @@ Types:
             Type: 322 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
         - Name: x
@@ -17348,11 +17484,11 @@ Types:
             Type: 322 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1525
+      ID: 1526
       Name: Probe[main.testSubslices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -17364,7 +17500,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: as}
+                  Variable: {subprogram: 142, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
         - Name: as
@@ -17374,7 +17510,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: as}
+                  Variable: {subprogram: 142, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
         - Name: bs
@@ -17384,7 +17520,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 1, name: bs}
+                  Variable: {subprogram: 142, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
         - Name: bs
@@ -17394,7 +17530,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 1, name: bs}
+                  Variable: {subprogram: 142, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
         - Name: cs
@@ -17404,7 +17540,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 2, name: cs}
+                  Variable: {subprogram: 142, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
         - Name: cs
@@ -17414,11 +17550,11 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 2, name: cs}
+                  Variable: {subprogram: 142, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1539
+      ID: 1540
       Name: Probe[main.testSubstrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17430,7 +17566,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: a}
+                  Variable: {subprogram: 152, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -17440,7 +17576,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: a}
+                  Variable: {subprogram: 152, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -17450,7 +17586,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 1, name: b}
+                  Variable: {subprogram: 152, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -17460,7 +17596,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 1, name: b}
+                  Variable: {subprogram: 152, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: c
@@ -17470,7 +17606,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 2, name: c}
+                  Variable: {subprogram: 152, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
         - Name: c
@@ -17480,11 +17616,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 2, name: c}
+                  Variable: {subprogram: 152, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1532
+      ID: 1533
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17496,7 +17632,7 @@ Types:
             Type: 275 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -17506,11 +17642,11 @@ Types:
             Type: 275 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1533
+      ID: 1534
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17522,7 +17658,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -17535,7 +17671,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -17548,14 +17684,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
                   Bias: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1530
+      ID: 1531
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17567,7 +17703,7 @@ Types:
             Type: 274 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
         - Name: a
@@ -17577,11 +17713,11 @@ Types:
             Type: 274 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1531
+      ID: 1532
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17593,7 +17729,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: t.b
@@ -17603,7 +17739,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 16
                   ByteSize: 16
         - Name: t.c
@@ -17613,11 +17749,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1529
+      ID: 1530
       Name: Probe[main.testThreeStrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17629,7 +17765,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: x}
+                  Variable: {subprogram: 145, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -17639,7 +17775,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: x}
+                  Variable: {subprogram: 145, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -17649,7 +17785,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 1, name: y}
+                  Variable: {subprogram: 145, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -17659,7 +17795,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 1, name: y}
+                  Variable: {subprogram: 145, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -17669,7 +17805,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 2, name: z}
+                  Variable: {subprogram: 145, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -17679,7 +17815,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 2, name: z}
+                  Variable: {subprogram: 145, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -17839,7 +17975,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1431
+      ID: 1432
       Name: Probe[main.testUintPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17851,7 +17987,7 @@ Types:
             Type: 112 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: x}
+                  Variable: {subprogram: 93, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -17861,11 +17997,11 @@ Types:
             Type: 112 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: x}
+                  Variable: {subprogram: 93, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1513
+      ID: 1514
       Name: Probe[main.testUintSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17877,7 +18013,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: u}
+                  Variable: {subprogram: 131, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -17887,11 +18023,11 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: u}
+                  Variable: {subprogram: 131, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1537
+      ID: 1538
       Name: Probe[main.testUnitializedString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17903,7 +18039,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: x}
+                  Variable: {subprogram: 150, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -17913,11 +18049,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: x}
+                  Variable: {subprogram: 150, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1430
+      ID: 1431
       Name: Probe[main.testUnsafePointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17929,7 +18065,7 @@ Types:
             Type: 16 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: x}
+                  Variable: {subprogram: 92, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -17939,7 +18075,7 @@ Types:
             Type: 16 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: x}
+                  Variable: {subprogram: 92, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -17969,32 +18105,6 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1522
-      Name: Probe[main.testVeryLargeSlice]
-      ByteSize: 49
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: xs
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 263 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: xs
-          Offset: 25
-          Kind: template_segment
-          Expression:
-            Type: 263 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
       ID: 1523
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
@@ -18007,7 +18117,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: xs}
+                  Variable: {subprogram: 140, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -18017,11 +18127,37 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: xs}
+                  Variable: {subprogram: 140, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1511
+      ID: 1524
+      Name: Probe[main.testVeryLargeSlice]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 263 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 140, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: xs
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 263 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 140, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1512
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -18033,7 +18169,7 @@ Types:
             Type: 259 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: a}
+                  Variable: {subprogram: 130, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
         - Name: a
@@ -18043,7 +18179,7 @@ Types:
             Type: 259 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: a}
+                  Variable: {subprogram: 130, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
         - Name: b
@@ -18053,7 +18189,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 1, name: b}
+                  Variable: {subprogram: 130, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -18063,11 +18199,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 1, name: b}
+                  Variable: {subprogram: 130, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1512
+      ID: 1513
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -18079,7 +18215,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 2, name: ~r0}
+                  Variable: {subprogram: 130, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -18089,7 +18225,7 @@ Types:
             Type: 259 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 3, name: ~r1}
+                  Variable: {subprogram: 130, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 0
     - __kind: ArrayType
@@ -26751,7 +26887,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 1.003232e+06
       GoKind: 5
-MaxTypeID: 1565
+MaxTypeID: 1566
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x1321d00", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
@@ -4,14 +4,14 @@ Package: main
 		Arg: x: []int (declared at line 12, available: [12-12])
 	Function: executeArrayFuncs (main.executeArrayFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [102:129] injectible: [102-117], [119-122], [124-124], [128-129]
 	Function: executeBasicFuncs (main.executeBasicFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [76:95] injectible: [76-80], [82-87], [89-95]
-	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [227:293] injectible: [227-227], [230-233], [238-239], [241-244], [247-247], [258-258], [261-262], [264-265], [267-268], [270-270], [275-275], [277-278], [280-281], [283-284], [286-290], [292-293]
-		Var: o: main.outer (declared at line 228, available: )
-		Var: s: []*string (declared at line 239, available: )
-		Var: str: string (declared at line 238, available: [227-293])
-		Var: circ: main.circularReferenceType (declared at line 260, available: [227-293])
-		Var: s1: main.stringType1 (declared at line 286, available: [281-293])
-		Var: s2: main.stringType2 (declared at line 287, available: [281-293])
-		Var: s2p: *main.stringType2 (declared at line 288, available: [281-293])
+	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [246:314] injectible: [246-246], [249-252], [257-258], [260-263], [266-266], [277-277], [280-281], [283-284], [286-287], [289-289], [294-294], [296-296], [298-299], [301-302], [304-305], [307-311], [313-314]
+		Var: o: main.outer (declared at line 247, available: )
+		Var: s: []*string (declared at line 258, available: )
+		Var: str: string (declared at line 257, available: [246-314])
+		Var: circ: main.circularReferenceType (declared at line 279, available: [246-314])
+		Var: s1: main.stringType1 (declared at line 307, available: [302-314])
+		Var: s2: main.stringType2 (declared at line 308, available: [302-314])
+		Var: s2p: *main.stringType2 (declared at line 309, available: [302-314])
 	Function: executeEsoteric (main.executeEsoteric) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [51:69] injectible: [51-52], [55-58], [60-62], [68-69]
 		Var: &capture: *int (declared at line 52, available: [51-69])
 		Var: esotericHeap: *main.esotericHeap (declared at line 61, available: [61-62], [68-69])
@@ -178,9 +178,9 @@ Package: main
 		Var: result: map[string][]main.structWithMap (declared at line 110, available: [109-119])
 		Scope: 109-119
 			Var: i: int (declared at line 111, available: [109-119])
-	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [114:114] injectible: [114-114]
-	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [140:140] injectible: [140-140]
-	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [178:178] injectible: [178-178]
+	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [133:133] injectible: [133-133]
+	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [159:159] injectible: [159-159]
+	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [197:197] injectible: [197-197]
 	Function: iterExample.rangeOverIterator-range1 (main.iterExample.rangeOverIterator-range1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/ranges.go [16:18] injectible: [16-18]
 		Arg: value: int (declared at line 16, available: [16-17])
 	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:52] injectible: [19-20], [23-24], [26-38], [40-40], [42-43], [46-52]
@@ -297,18 +297,18 @@ Package: main
 		Arg: z: *main.reallyComplexType (declared at line 75, available: [75-75])
 	Function: testCycle (main.testCycle) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [109:109] injectible: [109-109]
 		Arg: t: *main.t (declared at line 109, available: [109-109])
-	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [181:181] injectible: [181-181]
-		Arg: a: main.deepMap1 (declared at line 181, available: [181-181])
-	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [184:184] injectible: [184-184]
-		Arg: a: *main.deepMap7 (declared at line 184, available: [184-184])
-	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [117:117] injectible: [117-117]
-		Arg: a: main.deepPtr1 (declared at line 117, available: [117-117])
-	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [120:120] injectible: [120-120]
-		Arg: a: *main.deepPtr7 (declared at line 120, available: [120-120])
-	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [143:143] injectible: [143-143]
-		Arg: a: main.deepSlice1 (declared at line 143, available: [143-143])
-	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [146:146] injectible: [146-146]
-		Arg: a: *main.deepSlice7 (declared at line 146, available: [146-146])
+	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [200:200] injectible: [200-200]
+		Arg: a: main.deepMap1 (declared at line 200, available: [200-200])
+	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [203:203] injectible: [203-203]
+		Arg: a: *main.deepMap7 (declared at line 203, available: [203-203])
+	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [136:136] injectible: [136-136]
+		Arg: a: main.deepPtr1 (declared at line 136, available: [136-136])
+	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [139:139] injectible: [139-139]
+		Arg: a: *main.deepPtr7 (declared at line 139, available: [139-139])
+	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [162:162] injectible: [162-162]
+		Arg: a: main.deepSlice1 (declared at line 162, available: [162-162])
+	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [165:165] injectible: [165-165]
+		Arg: a: *main.deepSlice7 (declared at line 165, available: [165-165])
 	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [120:120] injectible: [120-120]
 		Arg: t: main.deepStruct1 (declared at line 120, available: [120-120])
 	Function: testEmptySlice (main.testEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [33:33] injectible: [33-33]
@@ -324,6 +324,11 @@ Package: main
 		Arg: e: *main.emptyStruct (declared at line 128, available: [128-128])
 	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [60:60] injectible: [60-60]
 		Arg: e: error (declared at line 60, available: [60-60])
+	Function: testErrorAtLine (main.testErrorAtLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [101:112] injectible: [101-101], [103-104], [108-110], [112-112]
+		Arg: shouldErr: bool (declared at line 101, available: [101-103])
+		Arg: ~r0: int (declared at line 101, available: )
+		Var: x: int (declared at line 106, available: )
+		Var: err: error (declared at line 102, available: [101-112])
 	Function: testEsotericHeap (main.testEsotericHeap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [47:49] injectible: [47-49]
 		Arg: e: *main.esotericHeap (declared at line 47, available: [47-48])
 	Function: testEsotericStack (main.testEsotericStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [42:44] injectible: [42-44]
@@ -384,10 +389,10 @@ Package: main
 		Arg: ~r0: main.largeStruct (declared at line 264, available: )
 	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42] injectible: [42-42]
 		Arg: a: main.node (declared at line 42, available: [42-42])
-	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [204:224] injectible: [204-204], [211-211], [214-215], [217-220], [222-224]
-		Var: s: int (declared at line 205, available: [218-218], [223-223])
-		Var: aPerArch: int (declared at line 209, available: [204-224])
-		Var: b: int (declared at line 210, available: [204-224])
+	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [223:243] injectible: [223-223], [230-230], [233-234], [236-239], [241-243]
+		Var: s: int (declared at line 224, available: [237-237], [242-242])
+		Var: aPerArch: int (declared at line 228, available: [223-243])
+		Var: b: int (declared at line 229, available: [223-243])
 	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132] injectible: [132-132]
 		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
 	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [311:313] injectible: [311-313]
@@ -731,10 +736,10 @@ Package: main
 		Arg: a: *[]string (declared at line 95, available: [95-95])
 	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [116:116] injectible: [116-116]
 		Arg: t: main.threestrings (declared at line 116, available: [116-116])
-	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [195:195] injectible: [195-195]
-		Arg: a: *main.stringType1 (declared at line 195, available: [195-195])
-	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [201:201] injectible: [201-201]
-		Arg: a: **main.stringType2 (declared at line 201, available: [201-201])
+	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [214:214] injectible: [214-214]
+		Arg: a: *main.stringType1 (declared at line 214, available: [214-214])
+	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [220:220] injectible: [220-220]
+		Arg: a: **main.stringType2 (declared at line 220, available: [220-220])
 	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84] injectible: [84-84]
 		Arg: x: main.aStruct (declared at line 84, available: [84-84])
 	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [104:104] injectible: [104-104]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
@@ -4,13 +4,13 @@ Package: main
 		Arg: x: []int (declared at line 12, available: [12-12])
 	Function: executeArrayFuncs (main.executeArrayFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [102:129] injectible: [102-117], [119-122], [124-124], [128-129]
 	Function: executeBasicFuncs (main.executeBasicFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [76:95] injectible: [76-80], [82-87], [89-95]
-	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [227:293] injectible: [227-227], [230-233], [238-239], [241-244], [247-247], [258-258], [261-262], [264-265], [267-268], [270-270], [275-275], [277-278], [280-281], [283-284], [286-290], [292-293]
-		Var: s: []*string (declared at line 239, available: )
-		Var: str: string (declared at line 238, available: [227-293])
-		Var: circ: main.circularReferenceType (declared at line 260, available: [227-293])
-		Var: s1: main.stringType1 (declared at line 286, available: [281-293])
-		Var: s2: main.stringType2 (declared at line 287, available: [281-293])
-		Var: s2p: *main.stringType2 (declared at line 288, available: [281-293])
+	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [246:314] injectible: [246-246], [249-252], [257-258], [260-263], [266-266], [277-277], [280-281], [283-284], [286-287], [289-289], [294-294], [296-296], [298-299], [301-302], [304-305], [307-311], [313-314]
+		Var: s: []*string (declared at line 258, available: )
+		Var: str: string (declared at line 257, available: [246-314])
+		Var: circ: main.circularReferenceType (declared at line 279, available: [246-314])
+		Var: s1: main.stringType1 (declared at line 307, available: [302-314])
+		Var: s2: main.stringType2 (declared at line 308, available: [302-314])
+		Var: s2p: *main.stringType2 (declared at line 309, available: [302-314])
 	Function: executeEsoteric (main.executeEsoteric) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [51:69] injectible: [51-52], [55-58], [60-62], [68-69]
 		Var: &capture: *int (declared at line 52, available: [51-69])
 		Var: esotericHeap: *main.esotericHeap (declared at line 61, available: [61-62], [68-69])
@@ -166,9 +166,9 @@ Package: main
 		Var: result: map[string][]main.structWithMap (declared at line 110, available: [109-119])
 		Scope: 109-119
 			Var: i: int (declared at line 111, available: [109-119])
-	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [114:114] injectible: [114-114]
-	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [140:140] injectible: [140-140]
-	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [178:178] injectible: [178-178]
+	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [133:133] injectible: [133-133]
+	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [159:159] injectible: [159-159]
+	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [197:197] injectible: [197-197]
 	Function: iterExample.rangeOverIterator-range1 (main.iterExample.rangeOverIterator-range1) in  [16:0] injectible: 
 		Arg: #r: bool (declared at line 0, available: )
 		Var: #tmpState: int (declared at line 0, available: )
@@ -286,18 +286,18 @@ Package: main
 		Arg: z: *main.reallyComplexType (declared at line 75, available: [75-75])
 	Function: testCycle (main.testCycle) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [109:109] injectible: [109-109]
 		Arg: t: *main.t (declared at line 109, available: [109-109])
-	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [181:181] injectible: [181-181]
-		Arg: a: main.deepMap1 (declared at line 181, available: [181-181])
-	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [184:184] injectible: [184-184]
-		Arg: a: *main.deepMap7 (declared at line 184, available: [184-184])
-	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [117:117] injectible: [117-117]
-		Arg: a: main.deepPtr1 (declared at line 117, available: [117-117])
-	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [120:120] injectible: [120-120]
-		Arg: a: *main.deepPtr7 (declared at line 120, available: [120-120])
-	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [143:143] injectible: [143-143]
-		Arg: a: main.deepSlice1 (declared at line 143, available: [143-143])
-	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [146:146] injectible: [146-146]
-		Arg: a: *main.deepSlice7 (declared at line 146, available: [146-146])
+	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [200:200] injectible: [200-200]
+		Arg: a: main.deepMap1 (declared at line 200, available: [200-200])
+	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [203:203] injectible: [203-203]
+		Arg: a: *main.deepMap7 (declared at line 203, available: [203-203])
+	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [136:136] injectible: [136-136]
+		Arg: a: main.deepPtr1 (declared at line 136, available: [136-136])
+	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [139:139] injectible: [139-139]
+		Arg: a: *main.deepPtr7 (declared at line 139, available: [139-139])
+	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [162:162] injectible: [162-162]
+		Arg: a: main.deepSlice1 (declared at line 162, available: [162-162])
+	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [165:165] injectible: [165-165]
+		Arg: a: *main.deepSlice7 (declared at line 165, available: [165-165])
 	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [120:120] injectible: [120-120]
 		Arg: t: main.deepStruct1 (declared at line 120, available: [120-120])
 	Function: testEmptySlice (main.testEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [33:33] injectible: [33-33]
@@ -313,6 +313,11 @@ Package: main
 		Arg: e: *main.emptyStruct (declared at line 128, available: [128-128])
 	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [60:60] injectible: [60-60]
 		Arg: e: error (declared at line 60, available: [60-60])
+	Function: testErrorAtLine (main.testErrorAtLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [101:112] injectible: [101-101], [103-104], [108-110], [112-112]
+		Arg: shouldErr: bool (declared at line 101, available: [101-103])
+		Arg: ~r0: int (declared at line 101, available: )
+		Var: x: int (declared at line 106, available: )
+		Var: err: error (declared at line 102, available: [101-112])
 	Function: testEsotericHeap (main.testEsotericHeap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [47:49] injectible: [47-49]
 		Arg: e: *main.esotericHeap (declared at line 47, available: [47-48])
 	Function: testEsotericStack (main.testEsotericStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [42:44] injectible: [42-44]
@@ -373,10 +378,10 @@ Package: main
 		Arg: ~r0: main.largeStruct (declared at line 264, available: )
 	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42] injectible: [42-42]
 		Arg: a: main.node (declared at line 42, available: [42-42])
-	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [204:224] injectible: [204-204], [211-211], [214-215], [217-220], [222-224]
-		Var: s: int (declared at line 205, available: [218-218], [223-223])
-		Var: aPerArch: int (declared at line 209, available: [204-224])
-		Var: b: int (declared at line 210, available: [204-224])
+	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [223:243] injectible: [223-223], [230-230], [233-234], [236-239], [241-243]
+		Var: s: int (declared at line 224, available: [237-237], [242-242])
+		Var: aPerArch: int (declared at line 228, available: [223-243])
+		Var: b: int (declared at line 229, available: [223-243])
 	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132] injectible: [132-132]
 		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
 	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [311:313] injectible: [311-313]
@@ -720,10 +725,10 @@ Package: main
 		Arg: a: *[]string (declared at line 95, available: [95-95])
 	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [116:116] injectible: [116-116]
 		Arg: t: main.threestrings (declared at line 116, available: [116-116])
-	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [195:195] injectible: [195-195]
-		Arg: a: *main.stringType1 (declared at line 195, available: [195-195])
-	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [201:201] injectible: [201-201]
-		Arg: a: **main.stringType2 (declared at line 201, available: [201-201])
+	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [214:214] injectible: [214-214]
+		Arg: a: *main.stringType1 (declared at line 214, available: [214-214])
+	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [220:220] injectible: [220-220]
+		Arg: a: **main.stringType2 (declared at line 220, available: [220-220])
 	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84] injectible: [84-84]
 		Arg: x: main.aStruct (declared at line 84, available: [84-84])
 	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [104:104] injectible: [104-104]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
@@ -4,13 +4,13 @@ Package: main
 		Arg: x: []int (declared at line 12, available: [12-12])
 	Function: executeArrayFuncs (main.executeArrayFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [102:129] injectible: [102-117], [119-122], [124-124], [128-129]
 	Function: executeBasicFuncs (main.executeBasicFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [76:95] injectible: [76-80], [82-87], [89-95]
-	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [227:293] injectible: [227-227], [230-233], [238-239], [241-244], [247-247], [258-258], [261-262], [264-265], [267-268], [270-270], [275-275], [277-278], [280-281], [283-284], [286-290], [292-293]
-		Var: s: []*string (declared at line 239, available: )
-		Var: str: string (declared at line 238, available: [227-293])
-		Var: circ: main.circularReferenceType (declared at line 260, available: [227-293])
-		Var: s1: main.stringType1 (declared at line 286, available: [281-293])
-		Var: s2: main.stringType2 (declared at line 287, available: [281-293])
-		Var: s2p: *main.stringType2 (declared at line 288, available: [281-293])
+	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [246:314] injectible: [246-246], [249-252], [257-258], [260-263], [266-266], [277-277], [280-281], [283-284], [286-287], [289-289], [294-294], [296-296], [298-299], [301-302], [304-305], [307-311], [313-314]
+		Var: s: []*string (declared at line 258, available: )
+		Var: str: string (declared at line 257, available: [246-314])
+		Var: circ: main.circularReferenceType (declared at line 279, available: [246-314])
+		Var: s1: main.stringType1 (declared at line 307, available: [302-314])
+		Var: s2: main.stringType2 (declared at line 308, available: [302-314])
+		Var: s2p: *main.stringType2 (declared at line 309, available: [302-314])
 	Function: executeEsoteric (main.executeEsoteric) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [51:69] injectible: [51-52], [55-58], [60-62], [68-69]
 		Var: &capture: *int (declared at line 52, available: [51-69])
 		Var: esotericHeap: *main.esotericHeap (declared at line 61, available: [61-62], [68-69])
@@ -165,9 +165,9 @@ Package: main
 		Var: result: map[string][]main.structWithMap (declared at line 110, available: [109-119])
 		Scope: 109-119
 			Var: i: int (declared at line 111, available: [109-119])
-	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [114:114] injectible: [114-114]
-	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [140:140] injectible: [140-140]
-	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [178:178] injectible: [178-178]
+	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [133:133] injectible: [133-133]
+	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [159:159] injectible: [159-159]
+	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [197:197] injectible: [197-197]
 	Function: iterExample.rangeOverIterator-range1 (main.iterExample.rangeOverIterator-range1) in  [16:0] injectible: 
 		Arg: #r: bool (declared at line 0, available: )
 		Var: #tmpState: int (declared at line 0, available: )
@@ -285,18 +285,18 @@ Package: main
 		Arg: z: *main.reallyComplexType (declared at line 75, available: [75-75])
 	Function: testCycle (main.testCycle) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [109:109] injectible: [109-109]
 		Arg: t: *main.t (declared at line 109, available: [109-109])
-	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [181:181] injectible: [181-181]
-		Arg: a: main.deepMap1 (declared at line 181, available: [181-181])
-	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [184:184] injectible: [184-184]
-		Arg: a: *main.deepMap7 (declared at line 184, available: [184-184])
-	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [117:117] injectible: [117-117]
-		Arg: a: main.deepPtr1 (declared at line 117, available: [117-117])
-	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [120:120] injectible: [120-120]
-		Arg: a: *main.deepPtr7 (declared at line 120, available: [120-120])
-	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [143:143] injectible: [143-143]
-		Arg: a: main.deepSlice1 (declared at line 143, available: [143-143])
-	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [146:146] injectible: [146-146]
-		Arg: a: *main.deepSlice7 (declared at line 146, available: [146-146])
+	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [200:200] injectible: [200-200]
+		Arg: a: main.deepMap1 (declared at line 200, available: [200-200])
+	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [203:203] injectible: [203-203]
+		Arg: a: *main.deepMap7 (declared at line 203, available: [203-203])
+	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [136:136] injectible: [136-136]
+		Arg: a: main.deepPtr1 (declared at line 136, available: [136-136])
+	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [139:139] injectible: [139-139]
+		Arg: a: *main.deepPtr7 (declared at line 139, available: [139-139])
+	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [162:162] injectible: [162-162]
+		Arg: a: main.deepSlice1 (declared at line 162, available: [162-162])
+	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [165:165] injectible: [165-165]
+		Arg: a: *main.deepSlice7 (declared at line 165, available: [165-165])
 	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [120:120] injectible: [120-120]
 		Arg: t: main.deepStruct1 (declared at line 120, available: [120-120])
 	Function: testEmptySlice (main.testEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [33:33] injectible: [33-33]
@@ -312,6 +312,11 @@ Package: main
 		Arg: e: *main.emptyStruct (declared at line 128, available: [128-128])
 	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [60:60] injectible: [60-60]
 		Arg: e: error (declared at line 60, available: [60-60])
+	Function: testErrorAtLine (main.testErrorAtLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [101:112] injectible: [101-101], [103-104], [108-110], [112-112]
+		Arg: shouldErr: bool (declared at line 101, available: [101-103])
+		Arg: ~r0: int (declared at line 101, available: )
+		Var: x: int (declared at line 106, available: )
+		Var: err: error (declared at line 102, available: )
 	Function: testEsotericHeap (main.testEsotericHeap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [47:49] injectible: [47-49]
 		Arg: e: *main.esotericHeap (declared at line 47, available: [47-48])
 	Function: testEsotericStack (main.testEsotericStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [42:44] injectible: [42-44]
@@ -372,10 +377,10 @@ Package: main
 		Arg: ~r0: main.largeStruct (declared at line 264, available: )
 	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42] injectible: [42-42]
 		Arg: a: main.node (declared at line 42, available: [42-42])
-	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [204:224] injectible: [204-204], [211-211], [214-215], [217-220], [222-224]
-		Var: s: int (declared at line 205, available: [218-218], [223-223])
-		Var: aPerArch: int (declared at line 209, available: [204-224])
-		Var: b: int (declared at line 210, available: [204-224])
+	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [223:243] injectible: [223-223], [230-230], [233-234], [236-239], [241-243]
+		Var: s: int (declared at line 224, available: [237-237], [242-242])
+		Var: aPerArch: int (declared at line 228, available: [223-243])
+		Var: b: int (declared at line 229, available: [223-243])
 	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132] injectible: [132-132]
 		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
 	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [311:313] injectible: [311-313]
@@ -719,10 +724,10 @@ Package: main
 		Arg: a: *[]string (declared at line 95, available: [95-95])
 	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [116:116] injectible: [116-116]
 		Arg: t: main.threestrings (declared at line 116, available: [116-116])
-	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [195:195] injectible: [195-195]
-		Arg: a: *main.stringType1 (declared at line 195, available: [195-195])
-	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [201:201] injectible: [201-201]
-		Arg: a: **main.stringType2 (declared at line 201, available: [201-201])
+	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [214:214] injectible: [214-214]
+		Arg: a: *main.stringType1 (declared at line 214, available: [214-214])
+	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [220:220] injectible: [220-220]
+		Arg: a: **main.stringType2 (declared at line 220, available: [220-220])
 	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84] injectible: [84-84]
 		Arg: x: main.aStruct (declared at line 84, available: [84-84])
 	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [104:104] injectible: [104-104]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.26rc1.out
@@ -4,13 +4,13 @@ Package: main
 		Arg: x: []int (declared at line 12, available: [12-12])
 	Function: executeArrayFuncs (main.executeArrayFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [102:129] injectible: [102-117], [119-122], [124-124], [128-129]
 	Function: executeBasicFuncs (main.executeBasicFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [76:95] injectible: [76-80], [82-87], [89-95]
-	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [227:293] injectible: [227-227], [230-233], [238-239], [241-244], [247-247], [258-258], [261-262], [264-264], [268-268], [270-270], [275-275], [277-278], [280-281], [283-284], [286-290], [292-293]
-		Var: s: []*string (declared at line 239, available: )
-		Var: str: string (declared at line 238, available: [227-293])
-		Var: circ: main.circularReferenceType (declared at line 260, available: [227-293])
-		Var: s1: main.stringType1 (declared at line 286, available: [281-293])
-		Var: s2: main.stringType2 (declared at line 287, available: [281-293])
-		Var: s2p: *main.stringType2 (declared at line 288, available: [281-293])
+	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [246:314] injectible: [246-246], [249-252], [257-258], [260-263], [266-266], [277-277], [280-281], [283-283], [287-287], [289-289], [294-294], [296-296], [298-299], [301-302], [304-305], [307-311], [313-314]
+		Var: s: []*string (declared at line 258, available: )
+		Var: str: string (declared at line 257, available: [246-314])
+		Var: circ: main.circularReferenceType (declared at line 279, available: [246-314])
+		Var: s1: main.stringType1 (declared at line 307, available: [302-314])
+		Var: s2: main.stringType2 (declared at line 308, available: [302-314])
+		Var: s2p: *main.stringType2 (declared at line 309, available: [302-314])
 	Function: executeEsoteric (main.executeEsoteric) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [51:69] injectible: [51-52], [55-58], [60-62], [68-69]
 		Var: &capture: *int (declared at line 52, available: [51-69])
 		Var: esotericHeap: *main.esotericHeap (declared at line 61, available: [61-62], [68-69])
@@ -165,9 +165,9 @@ Package: main
 		Var: result: map[string][]main.structWithMap (declared at line 110, available: [109-119])
 		Scope: 110-119
 			Var: i: int (declared at line 111, available: [109-119])
-	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [114:114] injectible: [114-114]
-	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [140:140] injectible: [140-140]
-	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [178:178] injectible: [178-178]
+	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [133:133] injectible: [133-133]
+	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [159:159] injectible: [159-159]
+	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [197:197] injectible: [197-197]
 	Function: iterExample.rangeOverIterator-range1 (main.iterExample.rangeOverIterator-range1) in  [16:0] injectible: 
 		Arg: #r: bool (declared at line 0, available: )
 		Var: #tmpState: int (declared at line 0, available: )
@@ -285,18 +285,18 @@ Package: main
 		Arg: z: *main.reallyComplexType (declared at line 75, available: [75-75])
 	Function: testCycle (main.testCycle) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [109:109] injectible: [109-109]
 		Arg: t: *main.t (declared at line 109, available: [109-109])
-	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [181:181] injectible: [181-181]
-		Arg: a: main.deepMap1 (declared at line 181, available: [181-181])
-	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [184:184] injectible: [184-184]
-		Arg: a: *main.deepMap7 (declared at line 184, available: [184-184])
-	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [117:117] injectible: [117-117]
-		Arg: a: main.deepPtr1 (declared at line 117, available: [117-117])
-	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [120:120] injectible: [120-120]
-		Arg: a: *main.deepPtr7 (declared at line 120, available: [120-120])
-	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [143:143] injectible: [143-143]
-		Arg: a: main.deepSlice1 (declared at line 143, available: [143-143])
-	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [146:146] injectible: [146-146]
-		Arg: a: *main.deepSlice7 (declared at line 146, available: [146-146])
+	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [200:200] injectible: [200-200]
+		Arg: a: main.deepMap1 (declared at line 200, available: [200-200])
+	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [203:203] injectible: [203-203]
+		Arg: a: *main.deepMap7 (declared at line 203, available: [203-203])
+	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [136:136] injectible: [136-136]
+		Arg: a: main.deepPtr1 (declared at line 136, available: [136-136])
+	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [139:139] injectible: [139-139]
+		Arg: a: *main.deepPtr7 (declared at line 139, available: [139-139])
+	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [162:162] injectible: [162-162]
+		Arg: a: main.deepSlice1 (declared at line 162, available: [162-162])
+	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [165:165] injectible: [165-165]
+		Arg: a: *main.deepSlice7 (declared at line 165, available: [165-165])
 	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [120:120] injectible: [120-120]
 		Arg: t: main.deepStruct1 (declared at line 120, available: [120-120])
 	Function: testEmptySlice (main.testEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [33:33] injectible: [33-33]
@@ -312,6 +312,11 @@ Package: main
 		Arg: e: *main.emptyStruct (declared at line 128, available: [128-128])
 	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [60:60] injectible: [60-60]
 		Arg: e: error (declared at line 60, available: [60-60])
+	Function: testErrorAtLine (main.testErrorAtLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [101:112] injectible: [101-101], [103-104], [106-106], [108-110], [112-112]
+		Arg: shouldErr: bool (declared at line 101, available: [101-103])
+		Arg: ~r0: int (declared at line 101, available: )
+		Var: x: int (declared at line 106, available: )
+		Var: err: error (declared at line 102, available: [108-108])
 	Function: testEsotericHeap (main.testEsotericHeap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [47:49] injectible: [47-49]
 		Arg: e: *main.esotericHeap (declared at line 47, available: [47-48])
 	Function: testEsotericStack (main.testEsotericStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [42:44] injectible: [42-44]
@@ -372,10 +377,10 @@ Package: main
 		Arg: ~r0: main.largeStruct (declared at line 264, available: )
 	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42] injectible: [42-42]
 		Arg: a: main.node (declared at line 42, available: [42-42])
-	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [204:224] injectible: [204-204], [211-211], [214-215], [217-220], [222-224]
-		Var: s: int (declared at line 205, available: [218-218], [223-223])
-		Var: aPerArch: int (declared at line 209, available: [204-224])
-		Var: b: int (declared at line 210, available: [204-224])
+	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [223:243] injectible: [223-223], [230-230], [233-234], [236-239], [241-243]
+		Var: s: int (declared at line 224, available: [237-237], [242-242])
+		Var: aPerArch: int (declared at line 228, available: [223-243])
+		Var: b: int (declared at line 229, available: [223-243])
 	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132] injectible: [132-132]
 		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
 	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [311:313] injectible: [311-313]
@@ -719,10 +724,10 @@ Package: main
 		Arg: a: *[]string (declared at line 95, available: [95-95])
 	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [116:116] injectible: [116-116]
 		Arg: t: main.threestrings (declared at line 116, available: [116-116])
-	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [195:195] injectible: [195-195]
-		Arg: a: *main.stringType1 (declared at line 195, available: [195-195])
-	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [201:201] injectible: [201-201]
-		Arg: a: **main.stringType2 (declared at line 201, available: [201-201])
+	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [214:214] injectible: [214-214]
+		Arg: a: *main.stringType1 (declared at line 214, available: [214-214])
+	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [220:220] injectible: [220-220]
+		Arg: a: **main.stringType2 (declared at line 220, available: [220-220])
 	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84] injectible: [84-84]
 		Arg: x: main.aStruct (declared at line 84, available: [84-84])
 	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [104:104] injectible: [104-104]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
@@ -4,14 +4,14 @@ Package: main
 		Arg: x: []int (declared at line 12, available: [12-12])
 	Function: executeArrayFuncs (main.executeArrayFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [102:129] injectible: [102-117], [119-122], [124-124], [128-129]
 	Function: executeBasicFuncs (main.executeBasicFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [76:95] injectible: [76-80], [82-87], [89-95]
-	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [227:293] injectible: [227-227], [230-233], [238-239], [241-244], [247-247], [258-258], [261-262], [264-265], [267-268], [270-270], [275-275], [277-278], [280-281], [283-284], [286-290], [292-293]
-		Var: o: main.outer (declared at line 228, available: )
-		Var: s: []*string (declared at line 239, available: )
-		Var: str: string (declared at line 238, available: [227-293])
-		Var: circ: main.circularReferenceType (declared at line 260, available: [227-293])
-		Var: s1: main.stringType1 (declared at line 286, available: [281-293])
-		Var: s2: main.stringType2 (declared at line 287, available: [281-293])
-		Var: s2p: *main.stringType2 (declared at line 288, available: [281-293])
+	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [246:314] injectible: [246-246], [249-252], [257-258], [260-263], [266-266], [277-277], [280-281], [283-284], [286-287], [289-289], [294-294], [296-296], [298-299], [301-302], [304-305], [307-311], [313-314]
+		Var: o: main.outer (declared at line 247, available: )
+		Var: s: []*string (declared at line 258, available: )
+		Var: str: string (declared at line 257, available: [246-314])
+		Var: circ: main.circularReferenceType (declared at line 279, available: [246-314])
+		Var: s1: main.stringType1 (declared at line 307, available: [302-314])
+		Var: s2: main.stringType2 (declared at line 308, available: [302-314])
+		Var: s2p: *main.stringType2 (declared at line 309, available: [302-314])
 	Function: executeEsoteric (main.executeEsoteric) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [51:69] injectible: [51-52], [55-58], [60-62], [68-69]
 		Var: &capture: *int (declared at line 52, available: [51-69])
 		Var: esotericHeap: *main.esotericHeap (declared at line 61, available: [61-62], [68-69])
@@ -178,9 +178,9 @@ Package: main
 		Var: result: map[string][]main.structWithMap (declared at line 110, available: [109-119])
 		Scope: 109-119
 			Var: i: int (declared at line 111, available: [109-119])
-	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [114:114] injectible: [114-114]
-	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [140:140] injectible: [140-140]
-	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [178:178] injectible: [178-178]
+	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [133:133] injectible: [133-133]
+	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [159:159] injectible: [159-159]
+	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [197:197] injectible: [197-197]
 	Function: iterExample.rangeOverIterator-range1 (main.iterExample.rangeOverIterator-range1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/ranges.go [16:18] injectible: [16-18]
 		Arg: value: int (declared at line 16, available: [16-17])
 	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:52] injectible: [19-20], [23-24], [26-38], [40-40], [42-43], [46-52]
@@ -297,18 +297,18 @@ Package: main
 		Arg: z: *main.reallyComplexType (declared at line 75, available: [75-75])
 	Function: testCycle (main.testCycle) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [109:109] injectible: [109-109]
 		Arg: t: *main.t (declared at line 109, available: [109-109])
-	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [181:181] injectible: [181-181]
-		Arg: a: main.deepMap1 (declared at line 181, available: [181-181])
-	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [184:184] injectible: [184-184]
-		Arg: a: *main.deepMap7 (declared at line 184, available: [184-184])
-	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [117:117] injectible: [117-117]
-		Arg: a: main.deepPtr1 (declared at line 117, available: [117-117])
-	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [120:120] injectible: [120-120]
-		Arg: a: *main.deepPtr7 (declared at line 120, available: [120-120])
-	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [143:143] injectible: [143-143]
-		Arg: a: main.deepSlice1 (declared at line 143, available: [143-143])
-	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [146:146] injectible: [146-146]
-		Arg: a: *main.deepSlice7 (declared at line 146, available: [146-146])
+	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [200:200] injectible: [200-200]
+		Arg: a: main.deepMap1 (declared at line 200, available: [200-200])
+	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [203:203] injectible: [203-203]
+		Arg: a: *main.deepMap7 (declared at line 203, available: [203-203])
+	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [136:136] injectible: [136-136]
+		Arg: a: main.deepPtr1 (declared at line 136, available: [136-136])
+	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [139:139] injectible: [139-139]
+		Arg: a: *main.deepPtr7 (declared at line 139, available: [139-139])
+	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [162:162] injectible: [162-162]
+		Arg: a: main.deepSlice1 (declared at line 162, available: [162-162])
+	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [165:165] injectible: [165-165]
+		Arg: a: *main.deepSlice7 (declared at line 165, available: [165-165])
 	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [120:120] injectible: [120-120]
 		Arg: t: main.deepStruct1 (declared at line 120, available: [120-120])
 	Function: testEmptySlice (main.testEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [33:33] injectible: [33-33]
@@ -324,6 +324,11 @@ Package: main
 		Arg: e: *main.emptyStruct (declared at line 128, available: [128-128])
 	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [60:60] injectible: [60-60]
 		Arg: e: error (declared at line 60, available: [60-60])
+	Function: testErrorAtLine (main.testErrorAtLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [101:112] injectible: [101-101], [103-104], [108-110], [112-112]
+		Arg: shouldErr: bool (declared at line 101, available: [101-103])
+		Arg: ~r0: int (declared at line 101, available: )
+		Var: x: int (declared at line 106, available: )
+		Var: err: error (declared at line 102, available: [101-112])
 	Function: testEsotericHeap (main.testEsotericHeap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [47:49] injectible: [47-49]
 		Arg: e: *main.esotericHeap (declared at line 47, available: [47-48])
 	Function: testEsotericStack (main.testEsotericStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [42:44] injectible: [42-44]
@@ -385,10 +390,10 @@ Package: main
 		Arg: ~r0: main.largeStruct (declared at line 264, available: )
 	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42] injectible: [42-42]
 		Arg: a: main.node (declared at line 42, available: [42-42])
-	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [204:224] injectible: [204-204], [211-211], [214-215], [217-220], [222-224]
-		Var: s: int (declared at line 205, available: [218-218], [223-223])
-		Var: aPerArch: int (declared at line 209, available: [204-224])
-		Var: b: int (declared at line 210, available: [204-224])
+	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [223:243] injectible: [223-223], [230-230], [233-234], [236-239], [241-243]
+		Var: s: int (declared at line 224, available: [237-237], [242-242])
+		Var: aPerArch: int (declared at line 228, available: [223-243])
+		Var: b: int (declared at line 229, available: [223-243])
 	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132] injectible: [132-132]
 		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
 	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [311:313] injectible: [311-313]
@@ -736,10 +741,10 @@ Package: main
 		Arg: a: *[]string (declared at line 95, available: [95-95])
 	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [116:116] injectible: [116-116]
 		Arg: t: main.threestrings (declared at line 116, available: [116-116])
-	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [195:195] injectible: [195-195]
-		Arg: a: *main.stringType1 (declared at line 195, available: [195-195])
-	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [201:201] injectible: [201-201]
-		Arg: a: **main.stringType2 (declared at line 201, available: [201-201])
+	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [214:214] injectible: [214-214]
+		Arg: a: *main.stringType1 (declared at line 214, available: [214-214])
+	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [220:220] injectible: [220-220]
+		Arg: a: **main.stringType2 (declared at line 220, available: [220-220])
 	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84] injectible: [84-84]
 		Arg: x: main.aStruct (declared at line 84, available: [84-84])
 	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [104:104] injectible: [104-104]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
@@ -4,13 +4,13 @@ Package: main
 		Arg: x: []int (declared at line 12, available: [12-12])
 	Function: executeArrayFuncs (main.executeArrayFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [102:129] injectible: [102-117], [119-122], [124-124], [128-129]
 	Function: executeBasicFuncs (main.executeBasicFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [76:95] injectible: [76-80], [82-87], [89-95]
-	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [227:293] injectible: [227-227], [230-233], [238-239], [241-244], [247-247], [258-258], [261-262], [264-265], [267-268], [270-270], [275-275], [277-278], [280-281], [283-284], [286-290], [292-293]
-		Var: s: []*string (declared at line 239, available: )
-		Var: str: string (declared at line 238, available: [227-293])
-		Var: circ: main.circularReferenceType (declared at line 260, available: [227-293])
-		Var: s1: main.stringType1 (declared at line 286, available: [281-293])
-		Var: s2: main.stringType2 (declared at line 287, available: [281-293])
-		Var: s2p: *main.stringType2 (declared at line 288, available: [281-293])
+	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [246:314] injectible: [246-246], [249-252], [257-258], [260-263], [266-266], [277-277], [280-281], [283-284], [286-287], [289-289], [294-294], [296-296], [298-299], [301-302], [304-305], [307-311], [313-314]
+		Var: s: []*string (declared at line 258, available: )
+		Var: str: string (declared at line 257, available: [246-314])
+		Var: circ: main.circularReferenceType (declared at line 279, available: [246-314])
+		Var: s1: main.stringType1 (declared at line 307, available: [302-314])
+		Var: s2: main.stringType2 (declared at line 308, available: [302-314])
+		Var: s2p: *main.stringType2 (declared at line 309, available: [302-314])
 	Function: executeEsoteric (main.executeEsoteric) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [51:69] injectible: [51-52], [55-58], [60-62], [68-69]
 		Var: &capture: *int (declared at line 52, available: [51-69])
 		Var: esotericHeap: *main.esotericHeap (declared at line 61, available: [61-62], [68-69])
@@ -166,9 +166,9 @@ Package: main
 		Var: result: map[string][]main.structWithMap (declared at line 110, available: [109-119])
 		Scope: 109-119
 			Var: i: int (declared at line 111, available: [109-119])
-	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [114:114] injectible: [114-114]
-	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [140:140] injectible: [140-140]
-	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [178:178] injectible: [178-178]
+	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [133:133] injectible: [133-133]
+	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [159:159] injectible: [159-159]
+	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [197:197] injectible: [197-197]
 	Function: iterExample.rangeOverIterator-range1 (main.iterExample.rangeOverIterator-range1) in  [16:0] injectible: 
 		Arg: #r: bool (declared at line 0, available: )
 		Var: #tmpState: int (declared at line 0, available: )
@@ -286,18 +286,18 @@ Package: main
 		Arg: z: *main.reallyComplexType (declared at line 75, available: [75-75])
 	Function: testCycle (main.testCycle) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [109:109] injectible: [109-109]
 		Arg: t: *main.t (declared at line 109, available: [109-109])
-	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [181:181] injectible: [181-181]
-		Arg: a: main.deepMap1 (declared at line 181, available: [181-181])
-	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [184:184] injectible: [184-184]
-		Arg: a: *main.deepMap7 (declared at line 184, available: [184-184])
-	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [117:117] injectible: [117-117]
-		Arg: a: main.deepPtr1 (declared at line 117, available: [117-117])
-	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [120:120] injectible: [120-120]
-		Arg: a: *main.deepPtr7 (declared at line 120, available: [120-120])
-	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [143:143] injectible: [143-143]
-		Arg: a: main.deepSlice1 (declared at line 143, available: [143-143])
-	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [146:146] injectible: [146-146]
-		Arg: a: *main.deepSlice7 (declared at line 146, available: [146-146])
+	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [200:200] injectible: [200-200]
+		Arg: a: main.deepMap1 (declared at line 200, available: [200-200])
+	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [203:203] injectible: [203-203]
+		Arg: a: *main.deepMap7 (declared at line 203, available: [203-203])
+	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [136:136] injectible: [136-136]
+		Arg: a: main.deepPtr1 (declared at line 136, available: [136-136])
+	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [139:139] injectible: [139-139]
+		Arg: a: *main.deepPtr7 (declared at line 139, available: [139-139])
+	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [162:162] injectible: [162-162]
+		Arg: a: main.deepSlice1 (declared at line 162, available: [162-162])
+	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [165:165] injectible: [165-165]
+		Arg: a: *main.deepSlice7 (declared at line 165, available: [165-165])
 	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [120:120] injectible: [120-120]
 		Arg: t: main.deepStruct1 (declared at line 120, available: [120-120])
 	Function: testEmptySlice (main.testEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [33:33] injectible: [33-33]
@@ -313,6 +313,11 @@ Package: main
 		Arg: e: *main.emptyStruct (declared at line 128, available: [128-128])
 	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [60:60] injectible: [60-60]
 		Arg: e: error (declared at line 60, available: [60-60])
+	Function: testErrorAtLine (main.testErrorAtLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [101:112] injectible: [101-101], [103-104], [108-110], [112-112]
+		Arg: shouldErr: bool (declared at line 101, available: [101-103])
+		Arg: ~r0: int (declared at line 101, available: )
+		Var: x: int (declared at line 106, available: )
+		Var: err: error (declared at line 102, available: [101-112])
 	Function: testEsotericHeap (main.testEsotericHeap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [47:49] injectible: [47-49]
 		Arg: e: *main.esotericHeap (declared at line 47, available: [47-48])
 	Function: testEsotericStack (main.testEsotericStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [42:44] injectible: [42-44]
@@ -374,10 +379,10 @@ Package: main
 		Arg: ~r0: main.largeStruct (declared at line 264, available: )
 	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42] injectible: [42-42]
 		Arg: a: main.node (declared at line 42, available: [42-42])
-	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [204:224] injectible: [204-204], [211-211], [214-215], [217-220], [222-224]
-		Var: s: int (declared at line 205, available: [218-218], [223-223])
-		Var: aPerArch: int (declared at line 209, available: [204-224])
-		Var: b: int (declared at line 210, available: [204-224])
+	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [223:243] injectible: [223-223], [230-230], [233-234], [236-239], [241-243]
+		Var: s: int (declared at line 224, available: [237-237], [242-242])
+		Var: aPerArch: int (declared at line 228, available: [223-243])
+		Var: b: int (declared at line 229, available: [223-243])
 	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132] injectible: [132-132]
 		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
 	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [311:313] injectible: [311-313]
@@ -725,10 +730,10 @@ Package: main
 		Arg: a: *[]string (declared at line 95, available: [95-95])
 	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [116:116] injectible: [116-116]
 		Arg: t: main.threestrings (declared at line 116, available: [116-116])
-	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [195:195] injectible: [195-195]
-		Arg: a: *main.stringType1 (declared at line 195, available: [195-195])
-	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [201:201] injectible: [201-201]
-		Arg: a: **main.stringType2 (declared at line 201, available: [201-201])
+	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [214:214] injectible: [214-214]
+		Arg: a: *main.stringType1 (declared at line 214, available: [214-214])
+	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [220:220] injectible: [220-220]
+		Arg: a: **main.stringType2 (declared at line 220, available: [220-220])
 	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84] injectible: [84-84]
 		Arg: x: main.aStruct (declared at line 84, available: [84-84])
 	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [104:104] injectible: [104-104]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
@@ -4,13 +4,13 @@ Package: main
 		Arg: x: []int (declared at line 12, available: [12-12])
 	Function: executeArrayFuncs (main.executeArrayFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [102:129] injectible: [102-117], [119-122], [124-124], [128-129]
 	Function: executeBasicFuncs (main.executeBasicFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [76:95] injectible: [76-80], [82-87], [89-95]
-	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [227:293] injectible: [227-227], [230-233], [238-239], [241-242], [244-244], [247-247], [258-258], [261-262], [264-265], [267-268], [275-275], [277-278], [280-281], [283-284], [286-290], [292-293]
-		Var: s: []*string (declared at line 239, available: )
-		Var: str: string (declared at line 238, available: [227-293])
-		Var: circ: main.circularReferenceType (declared at line 260, available: [227-293])
-		Var: s1: main.stringType1 (declared at line 286, available: [281-293])
-		Var: s2: main.stringType2 (declared at line 287, available: [281-293])
-		Var: s2p: *main.stringType2 (declared at line 288, available: [281-293])
+	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [246:314] injectible: [246-246], [249-252], [257-258], [260-261], [263-263], [266-266], [277-277], [280-281], [283-284], [286-287], [294-294], [296-296], [298-299], [301-302], [304-305], [307-311], [313-314]
+		Var: s: []*string (declared at line 258, available: )
+		Var: str: string (declared at line 257, available: [246-314])
+		Var: circ: main.circularReferenceType (declared at line 279, available: [246-314])
+		Var: s1: main.stringType1 (declared at line 307, available: [302-314])
+		Var: s2: main.stringType2 (declared at line 308, available: [302-314])
+		Var: s2p: *main.stringType2 (declared at line 309, available: [302-314])
 	Function: executeEsoteric (main.executeEsoteric) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [51:69] injectible: [51-52], [55-58], [60-62], [68-69]
 		Var: &capture: *int (declared at line 52, available: [51-69])
 		Var: esotericHeap: *main.esotericHeap (declared at line 61, available: [61-62], [68-69])
@@ -165,9 +165,9 @@ Package: main
 		Var: result: map[string][]main.structWithMap (declared at line 110, available: [109-119])
 		Scope: 109-119
 			Var: i: int (declared at line 111, available: [109-119])
-	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [114:114] injectible: [114-114]
-	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [140:140] injectible: [140-140]
-	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [178:178] injectible: [178-178]
+	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [133:133] injectible: [133-133]
+	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [159:159] injectible: [159-159]
+	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [197:197] injectible: [197-197]
 	Function: iterExample.rangeOverIterator-range1 (main.iterExample.rangeOverIterator-range1) in  [16:0] injectible: 
 		Arg: #r: bool (declared at line 0, available: )
 		Var: #tmpState: int (declared at line 0, available: )
@@ -285,18 +285,18 @@ Package: main
 		Arg: z: *main.reallyComplexType (declared at line 75, available: [75-75])
 	Function: testCycle (main.testCycle) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [109:109] injectible: [109-109]
 		Arg: t: *main.t (declared at line 109, available: [109-109])
-	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [181:181] injectible: [181-181]
-		Arg: a: main.deepMap1 (declared at line 181, available: [181-181])
-	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [184:184] injectible: [184-184]
-		Arg: a: *main.deepMap7 (declared at line 184, available: [184-184])
-	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [117:117] injectible: [117-117]
-		Arg: a: main.deepPtr1 (declared at line 117, available: [117-117])
-	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [120:120] injectible: [120-120]
-		Arg: a: *main.deepPtr7 (declared at line 120, available: [120-120])
-	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [143:143] injectible: [143-143]
-		Arg: a: main.deepSlice1 (declared at line 143, available: [143-143])
-	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [146:146] injectible: [146-146]
-		Arg: a: *main.deepSlice7 (declared at line 146, available: [146-146])
+	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [200:200] injectible: [200-200]
+		Arg: a: main.deepMap1 (declared at line 200, available: [200-200])
+	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [203:203] injectible: [203-203]
+		Arg: a: *main.deepMap7 (declared at line 203, available: [203-203])
+	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [136:136] injectible: [136-136]
+		Arg: a: main.deepPtr1 (declared at line 136, available: [136-136])
+	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [139:139] injectible: [139-139]
+		Arg: a: *main.deepPtr7 (declared at line 139, available: [139-139])
+	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [162:162] injectible: [162-162]
+		Arg: a: main.deepSlice1 (declared at line 162, available: [162-162])
+	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [165:165] injectible: [165-165]
+		Arg: a: *main.deepSlice7 (declared at line 165, available: [165-165])
 	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [120:120] injectible: [120-120]
 		Arg: t: main.deepStruct1 (declared at line 120, available: [120-120])
 	Function: testEmptySlice (main.testEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [33:33] injectible: [33-33]
@@ -312,6 +312,11 @@ Package: main
 		Arg: e: *main.emptyStruct (declared at line 128, available: [128-128])
 	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [60:60] injectible: [60-60]
 		Arg: e: error (declared at line 60, available: [60-60])
+	Function: testErrorAtLine (main.testErrorAtLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [101:112] injectible: [101-101], [103-104], [108-110], [112-112]
+		Arg: shouldErr: bool (declared at line 101, available: [101-108])
+		Arg: ~r0: int (declared at line 101, available: )
+		Var: x: int (declared at line 106, available: )
+		Var: err: error (declared at line 102, available: )
 	Function: testEsotericHeap (main.testEsotericHeap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [47:49] injectible: [47-49]
 		Arg: e: *main.esotericHeap (declared at line 47, available: [47-48])
 	Function: testEsotericStack (main.testEsotericStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [42:44] injectible: [42-44]
@@ -373,10 +378,10 @@ Package: main
 		Arg: ~r0: main.largeStruct (declared at line 264, available: )
 	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42] injectible: [42-42]
 		Arg: a: main.node (declared at line 42, available: [42-42])
-	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [204:224] injectible: [204-204], [211-211], [214-215], [217-220], [222-224]
-		Var: s: int (declared at line 205, available: [218-218], [223-223])
-		Var: aPerArch: int (declared at line 209, available: [204-224])
-		Var: b: int (declared at line 210, available: [204-224])
+	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [223:243] injectible: [223-223], [230-230], [233-234], [236-239], [241-243]
+		Var: s: int (declared at line 224, available: [237-237], [242-242])
+		Var: aPerArch: int (declared at line 228, available: [223-243])
+		Var: b: int (declared at line 229, available: [223-243])
 	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132] injectible: [132-132]
 		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
 	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [311:313] injectible: [311-313]
@@ -724,10 +729,10 @@ Package: main
 		Arg: a: *[]string (declared at line 95, available: [95-95])
 	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [116:116] injectible: [116-116]
 		Arg: t: main.threestrings (declared at line 116, available: [116-116])
-	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [195:195] injectible: [195-195]
-		Arg: a: *main.stringType1 (declared at line 195, available: [195-195])
-	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [201:201] injectible: [201-201]
-		Arg: a: **main.stringType2 (declared at line 201, available: [201-201])
+	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [214:214] injectible: [214-214]
+		Arg: a: *main.stringType1 (declared at line 214, available: [214-214])
+	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [220:220] injectible: [220-220]
+		Arg: a: **main.stringType2 (declared at line 220, available: [220-220])
 	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84] injectible: [84-84]
 		Arg: x: main.aStruct (declared at line 84, available: [84-84])
 	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [104:104] injectible: [104-104]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.26rc1.out
@@ -4,13 +4,13 @@ Package: main
 		Arg: x: []int (declared at line 12, available: [12-12])
 	Function: executeArrayFuncs (main.executeArrayFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [102:129] injectible: [102-117], [119-122], [124-124], [128-129]
 	Function: executeBasicFuncs (main.executeBasicFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [76:95] injectible: [76-80], [82-87], [89-95]
-	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [227:293] injectible: [227-227], [230-233], [238-239], [241-244], [247-247], [258-258], [261-262], [264-264], [268-268], [270-270], [275-275], [277-278], [280-281], [283-284], [286-290], [292-293]
-		Var: s: []*string (declared at line 239, available: )
-		Var: str: string (declared at line 238, available: [227-293])
-		Var: circ: main.circularReferenceType (declared at line 260, available: [227-293])
-		Var: s1: main.stringType1 (declared at line 286, available: [281-293])
-		Var: s2: main.stringType2 (declared at line 287, available: [281-293])
-		Var: s2p: *main.stringType2 (declared at line 288, available: [281-293])
+	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [246:314] injectible: [246-246], [249-252], [257-258], [260-263], [266-266], [277-277], [280-281], [283-283], [287-287], [289-289], [294-294], [296-296], [298-299], [301-302], [304-305], [307-311], [313-314]
+		Var: s: []*string (declared at line 258, available: )
+		Var: str: string (declared at line 257, available: [246-314])
+		Var: circ: main.circularReferenceType (declared at line 279, available: [246-314])
+		Var: s1: main.stringType1 (declared at line 307, available: [302-314])
+		Var: s2: main.stringType2 (declared at line 308, available: [302-314])
+		Var: s2p: *main.stringType2 (declared at line 309, available: [302-314])
 	Function: executeEsoteric (main.executeEsoteric) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [51:69] injectible: [51-52], [55-58], [60-62], [68-69]
 		Var: &capture: *int (declared at line 52, available: [51-69])
 		Var: esotericHeap: *main.esotericHeap (declared at line 61, available: [61-62], [68-69])
@@ -165,9 +165,9 @@ Package: main
 		Var: result: map[string][]main.structWithMap (declared at line 110, available: [109-119])
 		Scope: 110-119
 			Var: i: int (declared at line 111, available: [109-119])
-	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [114:114] injectible: [114-114]
-	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [140:140] injectible: [140-140]
-	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [178:178] injectible: [178-178]
+	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [133:133] injectible: [133-133]
+	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [159:159] injectible: [159-159]
+	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [197:197] injectible: [197-197]
 	Function: iterExample.rangeOverIterator-range1 (main.iterExample.rangeOverIterator-range1) in  [16:0] injectible: 
 		Arg: #r: bool (declared at line 0, available: )
 		Var: #tmpState: int (declared at line 0, available: )
@@ -285,18 +285,18 @@ Package: main
 		Arg: z: *main.reallyComplexType (declared at line 75, available: [75-75])
 	Function: testCycle (main.testCycle) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [109:109] injectible: [109-109]
 		Arg: t: *main.t (declared at line 109, available: [109-109])
-	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [181:181] injectible: [181-181]
-		Arg: a: main.deepMap1 (declared at line 181, available: [181-181])
-	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [184:184] injectible: [184-184]
-		Arg: a: *main.deepMap7 (declared at line 184, available: [184-184])
-	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [117:117] injectible: [117-117]
-		Arg: a: main.deepPtr1 (declared at line 117, available: [117-117])
-	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [120:120] injectible: [120-120]
-		Arg: a: *main.deepPtr7 (declared at line 120, available: [120-120])
-	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [143:143] injectible: [143-143]
-		Arg: a: main.deepSlice1 (declared at line 143, available: [143-143])
-	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [146:146] injectible: [146-146]
-		Arg: a: *main.deepSlice7 (declared at line 146, available: [146-146])
+	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [200:200] injectible: [200-200]
+		Arg: a: main.deepMap1 (declared at line 200, available: [200-200])
+	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [203:203] injectible: [203-203]
+		Arg: a: *main.deepMap7 (declared at line 203, available: [203-203])
+	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [136:136] injectible: [136-136]
+		Arg: a: main.deepPtr1 (declared at line 136, available: [136-136])
+	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [139:139] injectible: [139-139]
+		Arg: a: *main.deepPtr7 (declared at line 139, available: [139-139])
+	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [162:162] injectible: [162-162]
+		Arg: a: main.deepSlice1 (declared at line 162, available: [162-162])
+	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [165:165] injectible: [165-165]
+		Arg: a: *main.deepSlice7 (declared at line 165, available: [165-165])
 	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [120:120] injectible: [120-120]
 		Arg: t: main.deepStruct1 (declared at line 120, available: [120-120])
 	Function: testEmptySlice (main.testEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [33:33] injectible: [33-33]
@@ -312,6 +312,11 @@ Package: main
 		Arg: e: *main.emptyStruct (declared at line 128, available: [128-128])
 	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [60:60] injectible: [60-60]
 		Arg: e: error (declared at line 60, available: [60-60])
+	Function: testErrorAtLine (main.testErrorAtLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [101:112] injectible: [101-101], [103-104], [106-106], [108-110], [112-112]
+		Arg: shouldErr: bool (declared at line 101, available: [101-106])
+		Arg: ~r0: int (declared at line 101, available: )
+		Var: x: int (declared at line 106, available: )
+		Var: err: error (declared at line 102, available: [101-112])
 	Function: testEsotericHeap (main.testEsotericHeap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [47:49] injectible: [47-49]
 		Arg: e: *main.esotericHeap (declared at line 47, available: [47-48])
 	Function: testEsotericStack (main.testEsotericStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [42:44] injectible: [42-44]
@@ -373,10 +378,10 @@ Package: main
 		Arg: ~r0: main.largeStruct (declared at line 264, available: )
 	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42] injectible: [42-42]
 		Arg: a: main.node (declared at line 42, available: [42-42])
-	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [204:224] injectible: [204-204], [211-211], [214-215], [217-220], [222-224]
-		Var: s: int (declared at line 205, available: [218-218], [223-223])
-		Var: aPerArch: int (declared at line 209, available: [204-224])
-		Var: b: int (declared at line 210, available: [204-224])
+	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [223:243] injectible: [223-223], [230-230], [233-234], [236-239], [241-243]
+		Var: s: int (declared at line 224, available: [237-237], [242-242])
+		Var: aPerArch: int (declared at line 228, available: [223-243])
+		Var: b: int (declared at line 229, available: [223-243])
 	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132] injectible: [132-132]
 		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
 	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [311:313] injectible: [311-313]
@@ -724,10 +729,10 @@ Package: main
 		Arg: a: *[]string (declared at line 95, available: [95-95])
 	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [116:116] injectible: [116-116]
 		Arg: t: main.threestrings (declared at line 116, available: [116-116])
-	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [195:195] injectible: [195-195]
-		Arg: a: *main.stringType1 (declared at line 195, available: [195-195])
-	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [201:201] injectible: [201-201]
-		Arg: a: **main.stringType2 (declared at line 201, available: [201-201])
+	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [214:214] injectible: [214-214]
+		Arg: a: *main.stringType1 (declared at line 214, available: [214-214])
+	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [220:220] injectible: [220-220]
+		Arg: a: **main.stringType2 (declared at line 220, available: [220-220])
 	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84] injectible: [84-84]
 		Arg: x: main.aStruct (declared at line 84, available: [84-84])
 	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [104:104] injectible: [104-104]

--- a/pkg/dyninst/testdata/decoded/sample/testBigStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testBigStruct.json
@@ -23,7 +23,7 @@
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 241
+            "lineNumber": 260
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testBigStruct_geq_go1.26rc1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testBigStruct_geq_go1.26rc1.json
@@ -23,7 +23,7 @@
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 241
+            "lineNumber": 260
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testDeepMap1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepMap1.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testDeepMap1",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 181
+            "lineNumber": 200
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 283
+            "lineNumber": 304
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testDeepMap7.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepMap7.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testDeepMap7",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 184
+            "lineNumber": 203
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 284
+            "lineNumber": 305
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testDeepPtr1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepPtr1.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testDeepPtr1",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 117
+            "lineNumber": 136
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 277
+            "lineNumber": 298
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testDeepPtr7.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepPtr7.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testDeepPtr7",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 120
+            "lineNumber": 139
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 278
+            "lineNumber": 299
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testDeepSlice1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepSlice1.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testDeepSlice1",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 143
+            "lineNumber": 162
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 280
+            "lineNumber": 301
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testDeepSlice7.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepSlice7.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testDeepSlice7",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 146
+            "lineNumber": 165
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 281
+            "lineNumber": 302
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testErrorAtLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testErrorAtLine.json
@@ -4,7 +4,7 @@
     "ddsource": "dd_debugger",
     "logger": {
       "name": "",
-      "method": "main.testLongFunctionWithChangingState",
+      "method": "main.testErrorAtLine",
       "version": 0,
       "thread_id": "[goid]",
       "thread_name": ""
@@ -16,14 +16,14 @@
         "language": "go",
         "stack": [
           {
-            "function": "main.testLongFunctionWithChangingState",
+            "function": "main.testErrorAtLine",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 237
+            "lineNumber": 108
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 313
+            "lineNumber": 296
           },
           {
             "function": "main.main",
@@ -42,28 +42,28 @@
           }
         ],
         "probe": {
-          "id": "testLongFunctionWithChangingStateLineB",
+          "id": "testErrorAtLine",
           "location": {
-            "method": "main.testLongFunctionWithChangingState",
+            "method": "main.testErrorAtLine",
             "file": "complex.go",
-            "line": 237
+            "line": 108
           }
         },
         "captures": {
           "lines": {
-            "237": {
+            "108": {
               "locals": {
-                "s": {
+                "~r0": {
                   "type": "int",
-                  "value": "58"
+                  "notCapturedReason": "unavailable"
                 },
-                "aPerArch": {
+                "x": {
                   "type": "int",
-                  "value": "[per-arch-value]"
+                  "notCapturedReason": "unavailable"
                 },
-                "b": {
-                  "type": "int",
-                  "value": "89"
+                "err": {
+                  "type": "error",
+                  "notCapturedReason": "unavailable"
                 }
               }
             }
@@ -73,6 +73,6 @@
       "type": "snapshot"
     },
     "timestamp": "[ts]",
-    "message": "testLongFunctionWithChangingState"
+    "message": "x={unavailable}, err={unavailable}"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testErrorAtLine_config_arch=amd64,toolchain=go1.26rc1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testErrorAtLine_config_arch=amd64,toolchain=go1.26rc1.json
@@ -4,7 +4,7 @@
     "ddsource": "dd_debugger",
     "logger": {
       "name": "",
-      "method": "main.testLongFunctionWithChangingState",
+      "method": "main.testErrorAtLine",
       "version": 0,
       "thread_id": "[goid]",
       "thread_name": ""
@@ -16,14 +16,14 @@
         "language": "go",
         "stack": [
           {
-            "function": "main.testLongFunctionWithChangingState",
+            "function": "main.testErrorAtLine",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 237
+            "lineNumber": 108
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 313
+            "lineNumber": 296
           },
           {
             "function": "main.main",
@@ -42,28 +42,39 @@
           }
         ],
         "probe": {
-          "id": "testLongFunctionWithChangingStateLineB",
+          "id": "testErrorAtLine",
           "location": {
-            "method": "main.testLongFunctionWithChangingState",
+            "method": "main.testErrorAtLine",
             "file": "complex.go",
-            "line": 237
+            "line": 108
           }
         },
         "captures": {
           "lines": {
-            "237": {
+            "108": {
               "locals": {
-                "s": {
+                "~r0": {
                   "type": "int",
-                  "value": "58"
+                  "notCapturedReason": "unavailable"
                 },
-                "aPerArch": {
+                "x": {
                   "type": "int",
-                  "value": "[per-arch-value]"
+                  "notCapturedReason": "unavailable"
                 },
-                "b": {
-                  "type": "int",
-                  "value": "89"
+                "err": {
+                  "type": "error",
+                  "fields": {
+                    "data": {
+                      "type": "*errors.errorString",
+                      "address": "[addr]",
+                      "fields": {
+                        "s": {
+                          "type": "string",
+                          "value": "test error"
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -73,6 +84,6 @@
       "type": "snapshot"
     },
     "timestamp": "[ts]",
-    "message": "testLongFunctionWithChangingState"
+    "message": "x={unavailable}, err={s: test error}"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineA.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineA.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testLongFunctionWithChangingState",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 211
+            "lineNumber": 230
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 292
+            "lineNumber": 313
           },
           {
             "function": "main.main",
@@ -46,12 +46,12 @@
           "location": {
             "method": "main.testLongFunctionWithChangingState",
             "file": "complex.go",
-            "line": 211
+            "line": 230
           }
         },
         "captures": {
           "lines": {
-            "211": {}
+            "230": {}
           }
         }
       },

--- a/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineB.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineB.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testLongFunctionWithChangingState",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 218
+            "lineNumber": 237
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 292
+            "lineNumber": 313
           },
           {
             "function": "main.main",
@@ -46,12 +46,12 @@
           "location": {
             "method": "main.testLongFunctionWithChangingState",
             "file": "complex.go",
-            "line": 218
+            "line": 237
           }
         },
         "captures": {
           "lines": {
-            "218": {
+            "237": {
               "locals": {
                 "aPerArch": {
                   "type": "int",
@@ -90,12 +90,12 @@
           {
             "function": "main.testLongFunctionWithChangingState",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 218
+            "lineNumber": 237
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 292
+            "lineNumber": 313
           },
           {
             "function": "main.main",
@@ -118,12 +118,12 @@
           "location": {
             "method": "main.testLongFunctionWithChangingState",
             "file": "complex.go",
-            "line": 218
+            "line": 237
           }
         },
         "captures": {
           "lines": {
-            "218": {
+            "237": {
               "locals": {
                 "aPerArch": {
                   "type": "int",
@@ -162,12 +162,12 @@
           {
             "function": "main.testLongFunctionWithChangingState",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 218
+            "lineNumber": 237
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 292
+            "lineNumber": 313
           },
           {
             "function": "main.main",
@@ -190,12 +190,12 @@
           "location": {
             "method": "main.testLongFunctionWithChangingState",
             "file": "complex.go",
-            "line": 218
+            "line": 237
           }
         },
         "captures": {
           "lines": {
-            "218": {
+            "237": {
               "locals": {
                 "aPerArch": {
                   "type": "int",
@@ -234,12 +234,12 @@
           {
             "function": "main.testLongFunctionWithChangingState",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 218
+            "lineNumber": 237
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 292
+            "lineNumber": 313
           },
           {
             "function": "main.main",
@@ -262,12 +262,12 @@
           "location": {
             "method": "main.testLongFunctionWithChangingState",
             "file": "complex.go",
-            "line": 218
+            "line": 237
           }
         },
         "captures": {
           "lines": {
-            "218": {
+            "237": {
               "locals": {
                 "aPerArch": {
                   "type": "int",
@@ -306,12 +306,12 @@
           {
             "function": "main.testLongFunctionWithChangingState",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 218
+            "lineNumber": 237
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 292
+            "lineNumber": 313
           },
           {
             "function": "main.main",
@@ -334,12 +334,12 @@
           "location": {
             "method": "main.testLongFunctionWithChangingState",
             "file": "complex.go",
-            "line": 218
+            "line": 237
           }
         },
         "captures": {
           "lines": {
-            "218": {
+            "237": {
               "locals": {
                 "aPerArch": {
                   "type": "int",
@@ -378,12 +378,12 @@
           {
             "function": "main.testLongFunctionWithChangingState",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 218
+            "lineNumber": 237
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 292
+            "lineNumber": 313
           },
           {
             "function": "main.main",
@@ -406,12 +406,12 @@
           "location": {
             "method": "main.testLongFunctionWithChangingState",
             "file": "complex.go",
-            "line": 218
+            "line": 237
           }
         },
         "captures": {
           "lines": {
-            "218": {
+            "237": {
               "locals": {
                 "aPerArch": {
                   "type": "int",
@@ -450,12 +450,12 @@
           {
             "function": "main.testLongFunctionWithChangingState",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 218
+            "lineNumber": 237
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 292
+            "lineNumber": 313
           },
           {
             "function": "main.main",
@@ -478,12 +478,12 @@
           "location": {
             "method": "main.testLongFunctionWithChangingState",
             "file": "complex.go",
-            "line": 218
+            "line": 237
           }
         },
         "captures": {
           "lines": {
-            "218": {
+            "237": {
               "locals": {
                 "aPerArch": {
                   "type": "int",
@@ -522,12 +522,12 @@
           {
             "function": "main.testLongFunctionWithChangingState",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 218
+            "lineNumber": 237
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 292
+            "lineNumber": 313
           },
           {
             "function": "main.main",
@@ -550,12 +550,12 @@
           "location": {
             "method": "main.testLongFunctionWithChangingState",
             "file": "complex.go",
-            "line": 218
+            "line": 237
           }
         },
         "captures": {
           "lines": {
-            "218": {
+            "237": {
               "locals": {
                 "aPerArch": {
                   "type": "int",
@@ -594,12 +594,12 @@
           {
             "function": "main.testLongFunctionWithChangingState",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 218
+            "lineNumber": 237
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 292
+            "lineNumber": 313
           },
           {
             "function": "main.main",
@@ -622,12 +622,12 @@
           "location": {
             "method": "main.testLongFunctionWithChangingState",
             "file": "complex.go",
-            "line": 218
+            "line": 237
           }
         },
         "captures": {
           "lines": {
-            "218": {
+            "237": {
               "locals": {
                 "aPerArch": {
                   "type": "int",
@@ -666,12 +666,12 @@
           {
             "function": "main.testLongFunctionWithChangingState",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 218
+            "lineNumber": 237
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 292
+            "lineNumber": 313
           },
           {
             "function": "main.main",
@@ -694,12 +694,12 @@
           "location": {
             "method": "main.testLongFunctionWithChangingState",
             "file": "complex.go",
-            "line": 218
+            "line": 237
           }
         },
         "captures": {
           "lines": {
-            "218": {
+            "237": {
               "locals": {
                 "aPerArch": {
                   "type": "int",

--- a/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineC.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineC.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testLongFunctionWithChangingState",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 223
+            "lineNumber": 242
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 292
+            "lineNumber": 313
           },
           {
             "function": "main.main",
@@ -46,12 +46,12 @@
           "location": {
             "method": "main.testLongFunctionWithChangingState",
             "file": "complex.go",
-            "line": 223
+            "line": 242
           }
         },
         "captures": {
           "lines": {
-            "223": {
+            "242": {
               "locals": {
                 "aPerArch": {
                   "type": "int",
@@ -90,12 +90,12 @@
           {
             "function": "main.testLongFunctionWithChangingState",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 223
+            "lineNumber": 242
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 292
+            "lineNumber": 313
           },
           {
             "function": "main.main",
@@ -118,12 +118,12 @@
           "location": {
             "method": "main.testLongFunctionWithChangingState",
             "file": "complex.go",
-            "line": 223
+            "line": 242
           }
         },
         "captures": {
           "lines": {
-            "223": {
+            "242": {
               "locals": {
                 "aPerArch": {
                   "type": "int",
@@ -162,12 +162,12 @@
           {
             "function": "main.testLongFunctionWithChangingState",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 223
+            "lineNumber": 242
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 292
+            "lineNumber": 313
           },
           {
             "function": "main.main",
@@ -190,12 +190,12 @@
           "location": {
             "method": "main.testLongFunctionWithChangingState",
             "file": "complex.go",
-            "line": 223
+            "line": 242
           }
         },
         "captures": {
           "lines": {
-            "223": {
+            "242": {
               "locals": {
                 "aPerArch": {
                   "type": "int",
@@ -234,12 +234,12 @@
           {
             "function": "main.testLongFunctionWithChangingState",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 223
+            "lineNumber": 242
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 292
+            "lineNumber": 313
           },
           {
             "function": "main.main",
@@ -262,12 +262,12 @@
           "location": {
             "method": "main.testLongFunctionWithChangingState",
             "file": "complex.go",
-            "line": 223
+            "line": 242
           }
         },
         "captures": {
           "lines": {
-            "223": {
+            "242": {
               "locals": {
                 "aPerArch": {
                   "type": "int",
@@ -306,12 +306,12 @@
           {
             "function": "main.testLongFunctionWithChangingState",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 223
+            "lineNumber": 242
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 292
+            "lineNumber": 313
           },
           {
             "function": "main.main",
@@ -334,12 +334,12 @@
           "location": {
             "method": "main.testLongFunctionWithChangingState",
             "file": "complex.go",
-            "line": 223
+            "line": 242
           }
         },
         "captures": {
           "lines": {
-            "223": {
+            "242": {
               "locals": {
                 "aPerArch": {
                   "type": "int",
@@ -378,12 +378,12 @@
           {
             "function": "main.testLongFunctionWithChangingState",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 223
+            "lineNumber": 242
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 292
+            "lineNumber": 313
           },
           {
             "function": "main.main",
@@ -406,12 +406,12 @@
           "location": {
             "method": "main.testLongFunctionWithChangingState",
             "file": "complex.go",
-            "line": 223
+            "line": 242
           }
         },
         "captures": {
           "lines": {
-            "223": {
+            "242": {
               "locals": {
                 "aPerArch": {
                   "type": "int",
@@ -450,12 +450,12 @@
           {
             "function": "main.testLongFunctionWithChangingState",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 223
+            "lineNumber": 242
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 292
+            "lineNumber": 313
           },
           {
             "function": "main.main",
@@ -478,12 +478,12 @@
           "location": {
             "method": "main.testLongFunctionWithChangingState",
             "file": "complex.go",
-            "line": 223
+            "line": 242
           }
         },
         "captures": {
           "lines": {
-            "223": {
+            "242": {
               "locals": {
                 "aPerArch": {
                   "type": "int",
@@ -522,12 +522,12 @@
           {
             "function": "main.testLongFunctionWithChangingState",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 223
+            "lineNumber": 242
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 292
+            "lineNumber": 313
           },
           {
             "function": "main.main",
@@ -550,12 +550,12 @@
           "location": {
             "method": "main.testLongFunctionWithChangingState",
             "file": "complex.go",
-            "line": 223
+            "line": 242
           }
         },
         "captures": {
           "lines": {
-            "223": {
+            "242": {
               "locals": {
                 "aPerArch": {
                   "type": "int",
@@ -594,12 +594,12 @@
           {
             "function": "main.testLongFunctionWithChangingState",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 223
+            "lineNumber": 242
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 292
+            "lineNumber": 313
           },
           {
             "function": "main.main",
@@ -622,12 +622,12 @@
           "location": {
             "method": "main.testLongFunctionWithChangingState",
             "file": "complex.go",
-            "line": 223
+            "line": 242
           }
         },
         "captures": {
           "lines": {
-            "223": {
+            "242": {
               "locals": {
                 "aPerArch": {
                   "type": "int",
@@ -666,12 +666,12 @@
           {
             "function": "main.testLongFunctionWithChangingState",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 223
+            "lineNumber": 242
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 292
+            "lineNumber": 313
           },
           {
             "function": "main.main",
@@ -694,12 +694,12 @@
           "location": {
             "method": "main.testLongFunctionWithChangingState",
             "file": "complex.go",
-            "line": 223
+            "line": 242
           }
         },
         "captures": {
           "lines": {
-            "223": {
+            "242": {
               "locals": {
                 "aPerArch": {
                   "type": "int",

--- a/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineC_geq_go1.26rc1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineC_geq_go1.26rc1.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testLongFunctionWithChangingState",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 223
+            "lineNumber": 242
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 292
+            "lineNumber": 313
           },
           {
             "function": "main.main",
@@ -46,12 +46,12 @@
           "location": {
             "method": "main.testLongFunctionWithChangingState",
             "file": "complex.go",
-            "line": 223
+            "line": 242
           }
         },
         "captures": {
           "lines": {
-            "223": {
+            "242": {
               "locals": {
                 "s": {
                   "type": "int",

--- a/pkg/dyninst/testdata/decoded/sample/testStringType1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStringType1.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testStringType1",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 195
+            "lineNumber": 214
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 289
+            "lineNumber": 310
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStringType2.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStringType2.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testStringType2",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 201
+            "lineNumber": 220
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 290
+            "lineNumber": 311
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testprogs/progs/sample/complex.go
+++ b/pkg/dyninst/testprogs/progs/sample/complex.go
@@ -93,6 +93,25 @@ func testCircularType(x circularReferenceType) {}
 //go:noinline
 func testInterfaceAndInt(a int, b error, c uint) {}
 
+// testErrorAtLine tests line probes with error interface variables in scope.
+// The error variable is created at the start and should be available at the
+// line probe location (the fmt.Println call).
+//
+//go:noinline
+func testErrorAtLine(shouldErr bool) int {
+	var err error
+	if shouldErr {
+		err = errors.New("test error")
+	}
+	x := 42
+	// Line probe should be placed here - error variable is in scope
+	fmt.Println("testErrorAtLine", x, err)
+	if err != nil {
+		return -1
+	}
+	return x
+}
+
 //nolint:all
 type (
 	deepPtr1 struct{ a *deepPtr2 }
@@ -273,6 +292,8 @@ func executeComplexFuncs() {
 	})
 
 	testInterfaceAndInt(1, errors.New("two"), 3)
+
+	testErrorAtLine(true)
 
 	testDeepPtr1(aDeepPtr1)
 	testDeepPtr7(aDeepPtr1.a.a.a.a.a.a)

--- a/pkg/dyninst/testprogs/testdata/probes/sample.yaml
+++ b/pkg/dyninst/testprogs/testdata/probes/sample.yaml
@@ -1939,7 +1939,7 @@ probes:
       methodName: main.testLongFunctionWithChangingState
       sourceFile: complex.go
       lines:
-        - "211"
+        - "230"
     template: "testLongFunctionWithChangingState"
     segments:
       - str: "testLongFunctionWithChangingState"
@@ -1954,7 +1954,7 @@ probes:
       methodName: main.testLongFunctionWithChangingState
       sourceFile: complex.go
       lines:
-        - "218"
+        - "237"
     template: "testLongFunctionWithChangingState"
     segments:
       - str: "testLongFunctionWithChangingState"
@@ -1969,7 +1969,7 @@ probes:
       methodName: main.testLongFunctionWithChangingState
       sourceFile: complex.go
       lines:
-        - "223"
+        - "242"
     captureSnapshot: true
     sampling:
       snapshotsPerSecond: 100
@@ -2432,5 +2432,29 @@ probes:
           dsl: "x"
           json:
             ref: "x"
+    sampling:
+      snapshotsPerSecond: 100
+  # Test for error interface at line probe - captures error variable in scope
+  - id: testErrorAtLine
+    type: LOG_PROBE
+    tags:
+      - "config_diff:arch=amd64,toolchain=go1.26rc1"
+      - "skip_integration:arch=arm64,toolchain=go1.25.0" # https://github.com/golang/go/issues/74576
+    where:
+      methodName: main.testErrorAtLine
+      sourceFile: complex.go
+      lines:
+        - "108"
+    template: "x={x}, err={err}"
+    segments:
+      - str: "x="
+      - json:
+          ref: "x"
+        dsl: "x"
+      - str: ", err="
+      - json:
+          ref: "err"
+        dsl: "err"
+    captureSnapshot: true
     sampling:
       snapshotsPerSecond: 100


### PR DESCRIPTION
### What does this PR do?

This PR handles partially available variables as not being available at all. It also adds a relevant test.

### Motivation

Prior to this change, we'd see odd behavior when interfaces were partially available (as they commonly are).

### Describe how you validated your changes

Added testing

### Additional Notes

[DEBUG-5259]: https://datadoghq.atlassian.net/browse/DEBUG-5259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ