### PR TITLE
otlp/metrics: reduce allocations in TTL cache key generation and dimension handling

### DIFF
--- a/pkg/opentelemetry-mapping-go/otlp/metrics/dimensions.go
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/dimensions.go
@@ -76,17 +76,6 @@ func (d *Dimensions) OriginProductDetail() OriginProductDetail {
 	return d.originProductDetail
 }
 
-// getTags maps an attributeMap into a slice of Datadog tags
-func getTags(labels pcommon.Map) []string {
-	tags := make([]string, 0, labels.Len())
-	labels.Range(func(key string, value pcommon.Value) bool {
-		v := value.AsString()
-		tags = append(tags, utils.FormatKeyValueTag(key, v))
-		return true
-	})
-	return tags
-}
-
 // AddTags to metrics dimensions.
 func (d *Dimensions) AddTags(tags ...string) *Dimensions {
 	// defensively copy the tags
@@ -105,8 +94,23 @@ func (d *Dimensions) AddTags(tags ...string) *Dimensions {
 }
 
 // WithAttributeMap creates a new metricDimensions struct with additional tags from attributes.
+// It combines the tag-building and dimension-copying into a single allocation.
 func (d *Dimensions) WithAttributeMap(labels pcommon.Map) *Dimensions {
-	return d.AddTags(getTags(labels)...)
+	newTags := make([]string, 0, labels.Len()+len(d.tags))
+	labels.Range(func(key string, value pcommon.Value) bool {
+		newTags = append(newTags, utils.FormatKeyValueTag(key, value.AsString()))
+		return true
+	})
+	newTags = append(newTags, d.tags...)
+	return &Dimensions{
+		name:                d.name,
+		tags:                newTags,
+		host:                d.host,
+		originID:            d.originID,
+		originProduct:       d.originProduct,
+		originSubProduct:    d.originSubProduct,
+		originProductDetail: d.originProductDetail,
+	}
 }
 
 // WithSuffix creates a new dimensions struct with an extra name suffix.
@@ -153,4 +157,54 @@ func (d *Dimensions) String() string {
 		concatDimensionValue(&metricKeyBuilder, dim)
 	}
 	return metricKeyBuilder.String()
+}
+
+// stringKey builds the dimensions key string used by the cache hot path.
+// It sorts the tags in-place (the local copy) to avoid an extra allocation,
+// and writes the fixed fields (name/host/originID) inline to the builder
+// instead of pre-concatenating them.
+// The tags order does not matter.
+func (d *Dimensions) stringKey() string {
+	// Copy tags into a local slice so we can sort without mutating the original.
+	tags := make([]string, len(d.tags))
+	copy(tags, d.tags)
+	sort.Strings(tags)
+
+	// Pre-compute total length:
+	//   tags + separators
+	//   + "name:" + d.name + sep
+	//   + "host:" + d.host + sep
+	//   + "originID:" + d.originID + sep
+	const (
+		namePrefix     = "name:"
+		hostPrefix     = "host:"
+		originIDPrefix = "originID:"
+		sepLen         = 1 // len(dimensionSeparator)
+	)
+	totalLen := len(namePrefix) + len(d.name) + sepLen +
+		len(hostPrefix) + len(d.host) + sepLen +
+		len(originIDPrefix) + len(d.originID) + sepLen
+	for _, tag := range tags {
+		totalLen += len(tag) + sepLen
+	}
+
+	var b strings.Builder
+	b.Grow(totalLen)
+
+	// Write sorted tags first, then the three fixed fields.
+	// (The exact order doesn't matter for cache key correctness as long as it's consistent.)
+	for _, tag := range tags {
+		b.WriteString(tag)
+		b.WriteString(dimensionSeparator)
+	}
+	b.WriteString(namePrefix)
+	b.WriteString(d.name)
+	b.WriteString(dimensionSeparator)
+	b.WriteString(hostPrefix)
+	b.WriteString(d.host)
+	b.WriteString(dimensionSeparator)
+	b.WriteString(originIDPrefix)
+	b.WriteString(d.originID)
+	b.WriteString(dimensionSeparator)
+	return b.String()
 }

--- a/pkg/opentelemetry-mapping-go/otlp/metrics/dimensions_test.go
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/dimensions_test.go
@@ -100,6 +100,86 @@ func TestAddTags(t *testing.T) {
 	assert.ElementsMatch(t, []string{"key:val"}, testDims.tags)
 }
 
+func TestStringKeyConsistency(t *testing.T) {
+	// stringKey must produce the same key for dimensions with the same content
+	// regardless of tag order, and must not mutate the original tags.
+	originalTags := make([]string, 2, 3)
+	originalTags[0] = "key1:val1"
+	originalTags[1] = "key2:val2"
+
+	dims := Dimensions{
+		name:     "a.metric.name",
+		tags:     originalTags,
+		host:     "my-host",
+		originID: "origin-42",
+	}
+
+	key1 := dims.stringKey()
+	key2 := dims.stringKey()
+	assert.Equal(t, key1, key2, "stringKey must be deterministic")
+
+	// Tags in reverse order must produce the same key.
+	dims2 := Dimensions{
+		name:     "a.metric.name",
+		tags:     []string{"key2:val2", "key1:val1"},
+		host:     "my-host",
+		originID: "origin-42",
+	}
+	assert.Equal(t, key1, dims2.stringKey(), "stringKey must be order-independent")
+
+	// Original tags must not be mutated.
+	assert.Equal(t, []string{"key1:val1", "key2:val2"}, originalTags)
+}
+
+func TestStringKeyUniqueness(t *testing.T) {
+	// Different dimensions must produce different cache keys.
+	keys := map[string]string{}
+	cases := []struct {
+		label string
+		dims  Dimensions
+	}{
+		{"different name", Dimensions{name: "metric.a", host: "h", tags: []string{"k:v"}}},
+		{"different host", Dimensions{name: "metric.b", host: "h", tags: []string{"k:v"}}},
+		{"different tags", Dimensions{name: "metric.a", host: "h", tags: []string{"k:w"}}},
+		{"no tags", Dimensions{name: "metric.a", host: "h"}},
+		{"different originID", Dimensions{name: "metric.a", host: "h", originID: "o1"}},
+	}
+	for _, tc := range cases {
+		k := tc.dims.stringKey()
+		for prevLabel, prevKey := range keys {
+			assert.NotEqual(t, prevKey, k,
+				"key collision between %q and %q", prevLabel, tc.label)
+		}
+		keys[tc.label] = k
+	}
+}
+
+func TestStringKeyNoTags(t *testing.T) {
+	// stringKey must work correctly when there are no tags.
+	dims := Dimensions{name: "metric", host: "host", originID: "oid"}
+	k1 := dims.stringKey()
+	k2 := dims.stringKey()
+	assert.Equal(t, k1, k2, "stringKey must be stable with no tags")
+	assert.NotEmpty(t, k1)
+}
+
+func TestWithAttributeMapPreservesBaseTags(t *testing.T) {
+	// Attribute tags should come before base tags in the resulting slice.
+	baseDims := &Dimensions{
+		name: "m",
+		tags: []string{"base:tag"},
+	}
+	attrs := pcommon.NewMap()
+	attrs.FromRaw(map[string]interface{}{"attr": "val"})
+
+	newDims := baseDims.WithAttributeMap(attrs)
+
+	// Both base and attribute tags must be present.
+	assert.ElementsMatch(t, []string{"attr:val", "base:tag"}, newDims.tags)
+	// Original dims must be unchanged.
+	assert.Equal(t, []string{"base:tag"}, baseDims.tags)
+}
+
 func TestAllFieldsAreCopied(t *testing.T) {
 	dims := &Dimensions{
 		name:     "example.name",

--- a/pkg/opentelemetry-mapping-go/otlp/metrics/key_hash_cache.go
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/key_hash_cache.go
@@ -55,7 +55,8 @@ func (m *keyHashCache) computeKey(s string) keyHashCacheKey {
 	binary.LittleEndian.PutUint64(bytes[0:], h1)
 	binary.LittleEndian.PutUint64(bytes[8:], h2)
 
-	buf := make([]byte, ascii85.MaxEncodedLen(len(bytes)))
-	n := ascii85.Encode(buf, bytes[:])
+	// ascii85.MaxEncodedLen(16) == 20; use a stack-allocated array to avoid a heap allocation.
+	var buf [20]byte
+	n := ascii85.Encode(buf[:], bytes[:])
 	return keyHashCacheKey(buf[:n])
 }

--- a/pkg/opentelemetry-mapping-go/otlp/metrics/ttlcache.go
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/ttlcache.go
@@ -86,7 +86,7 @@ func (t *ttlCache) putAndGetMonotonic(
 	// assume it's first point before cache check.
 	firstPoint = true
 
-	key := t.cache.computeKey(dimensions.String())
+	key := t.cache.computeKey(dimensions.stringKey())
 	if c, found := t.cache.get(key); found {
 		cnt := c.(numberCounter)
 		if cnt.ts >= ts {
@@ -121,7 +121,7 @@ func (t *ttlCache) putAndGetDiff(
 	startTs, ts uint64,
 	val float64,
 ) (dx float64, ok bool) {
-	key := t.cache.computeKey(dimensions.String())
+	key := t.cache.computeKey(dimensions.stringKey())
 	if c, found := t.cache.get(key); found {
 		cnt := c.(numberCounter)
 		if cnt.ts > ts {
@@ -159,7 +159,7 @@ func (t *ttlCache) putAndCheckExtrema(
 	curExtrema float64,
 	min bool,
 ) (assumeFromLastWindow bool) {
-	key := t.cache.computeKey(dimensions.String())
+	key := t.cache.computeKey(dimensions.stringKey())
 	if c, found := t.cache.get(key); found {
 		cnt := c.(extrema)
 		if cnt.ts > ts {


### PR DESCRIPTION
### What does this PR do?

Reduces heap allocations on the OTLP metrics hot path by optimizing cache key generation and dimension tag merging:

- Adds a new `stringKey()` method on `Dimensions` that builds cache lookup keys with fewer intermediate allocations than `String()`, by avoiding `"key:value"` string construction for fixed fields and using a pre-sized `strings.Builder`.
- Updates `ttlcache.go` to use `stringKey()` instead of `String()` at all three cache call sites (`putAndGetMonotonic`, `putAndGetDiff`, `putAndCheckExtrema`).
- Refactors `WithAttributeMap` to pre-allocate a single combined tag slice instead of performing two separate allocations.
- Replaces a heap-allocated `make([]byte, 20)` buffer in `key_hash_cache.go`'s `computeKey()` with a fixed-size stack-allocated `[20]byte` array, since the input size is always 16 bytes.
- Adds a regression test fixture for the `ddot_metrics_sum_cumulative` scenario.

### Motivation

Under high-throughput OTLP metrics ingestion, the TTL cache used to track cumulative metric state (sums, diffs, extrema) is exercised on every metric data point. Reducing per-point heap allocations lowers GC pressure and improves sustained throughput.

### Describe how you validated your changes

Run unit test

### Additional Notes

`String()` is kept as a public method for logging and display purposes. `stringKey()` is an unexported, allocation-optimized variant intended solely for internal cache key computation.