### PR TITLE
Fetch Maven from Maven Central in Windows FIPS Docker build

### DIFF
--- a/Dockerfiles/agent/install-fips.ps1
+++ b/Dockerfiles/agent/install-fips.ps1
@@ -16,7 +16,7 @@ $maven_version = '3.9.11'
 
 if ("$env:WITH_JMX" -ne "false") {
     cd \fips-build
-    Invoke-WebRequest -Outfile maven.zip https://archive.apache.org/dist/maven/maven-3/${maven_version}/binaries/apache-maven-${maven_version}-bin.zip
+    Invoke-WebRequest -Outfile maven.zip https://repo1.maven.org/maven2/org/apache/maven/apache-maven/${maven_version}/apache-maven-${maven_version}-bin.zip
     if ((Get-FileHash -Algorithm SHA512 maven.zip).Hash -eq $maven_sha512) {
         Write-Host "Maven checksum match"
     } else {


### PR DESCRIPTION
### What does this PR do?
Replace the `archive.apache.org` URL in `install-fips.ps1` with the Maven Central equivalent.

### Motivation
[Issue](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1472197295#L352):
```
Invoke-WebRequest: C:\install-fips.ps1:19
Line |
  19 |      Invoke-WebRequest -Outfile maven.zip https://archive.apache.org/d …
     |      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | A connection attempt failed because the connected party did not properly
     | respond after a period of time, or established connection failed because
     | connected host has failed to respond.
```

`archive.apache.org` is unreachable at times from the Windows Docker build environment. 
Beyond that, it is a historical archive with no SLA, noted as "[MAY BE UNSUPPORTED AND UNSAFE TO USE](https://archive.apache.org/dist/)" by the Apache Foundation itself.
Maven Central (`repo1.maven.org`) hosts all versions permanently, is CDN-backed with 99.97%+ uptime, and is designed for production build traffic.

### Describe how you validated your changes
Confirmed the mirror URL resolves (HTTP 200).