### PR TITLE
fix(discovery): update NON_DISCOVERY_ENV_VARS to match Go

### DIFF
--- a/pkg/discovery/module/rust/src/config.rs
+++ b/pkg/discovery/module/rust/src/config.rs
@@ -133,28 +133,27 @@ fn find_non_discovery_yaml_key(yaml_doc: &Option<Yaml>) -> Option<&str> {
 }
 
 static NON_DISCOVERY_ENV_VARS: phf::Set<&'static str> = phf_set! {
-  "DD_NETWORK_CONFIG_ENABLED", // Network Performance Monitoring
-  "DD_SERVICE_MONITORING_CONFIG_ENABLED", // Universal Service Monitoring
-  "DD_CCM_NETWORK_CONFIG_ENABLED", // Cloud Cost Management
-  "DD_RUNTIME_SECURITY_CONFIG_ENABLED", // CSM with network monitoring
-  "DD_RUNTIME_SECURITY_CONFIG_NETWORK_MONITORING_ENABLED", // CSM with network monitoring
-  "DD_SYSTEM_PROBE_CONFIG_ENABLE_TCP_QUEUE_LENGTH", // TCP Queue Length Tracer Module
-  "DD_SYSTEM_PROBE_CONFIG_ENABLE_OOM_KILL", // OOM Kill Probe Module
-  "DD_EVENT_MONITORING_CONFIG_PROCESS_ENABLED", // Process event monitoring
-  "DD_SERVICE_MONITORING_CONFIG_ENABLE_EVENT_STREAM", // USM with event stream
-  "DD_EVENT_MONITORING_CONFIG_NETWORK_PROCESS_ENABLED", // Network Tracer Module enabled AND DD_EVENT_MONITORING_CONFIG_NETWORK_PROCESS_ENABLED=true
-  "DD_GPU_MONITORING_ENABLED", // GPU monitoring
-  "DD_DYNAMIC_INSTRUMENTATION_ENABLED", // Dynamic instrumentation
-  "DD_COMPLIANCE_CONFIG_ENABLED", // Compliance Module
-  "DD_RUNTIME_SECURITY_CONFIG_COMPLIANCE_MODULE_ENABLED", // CSM with compliance module
-  "DD_SYSTEM_PROBE_CONFIG_PROCESS_CONFIG_ENABLED", // Process Module
-  "DD_EBPF_CHECK_ENABLED", // eBPF Module
-  "DD_LANGUAGE_DETECTION_ENABLED", // Language Detection Module
-  "DD_PING_ENABLED", // Ping Module
-  "DD_TRACEROUTE_ENABLED", // Traceroute Module
-  "DD_SOFTWARE_INVENTORY_ENABLED", // Software Inventory Module
-  "DD_PRIVILEGED_LOGS_ENABLED", // Privileged Logs Module
-  "DD_WINDOWS_CRASH_DETECTION_ENABLED", // Windows Crash Detection Module
+  "DD_CCM_NETWORK_CONFIG_ENABLED",
+  "DD_COMPLIANCE_CONFIG_DATABASE_BENCHMARKS_ENABLED",
+  "DD_COMPLIANCE_CONFIG_ENABLED",
+  "DD_COMPLIANCE_CONFIG_RUN_IN_SYSTEM_PROBE",
+  "DD_DYNAMIC_INSTRUMENTATION_ENABLED",
+  "DD_EBPF_CHECK_ENABLED",
+  "DD_GPU_MONITORING_ENABLED",
+  "DD_NOISY_NEIGHBOR_ENABLED",
+  "DD_PING_ENABLED",
+  "DD_PRIVILEGED_LOGS_ENABLED",
+  "DD_RUNTIME_SECURITY_CONFIG_ENABLED",
+  "DD_RUNTIME_SECURITY_CONFIG_FIM_ENABLED",
+  "DD_SOFTWARE_INVENTORY_ENABLED",
+  "DD_SYSTEM_PROBE_CONFIG_ENABLE_OOM_KILL",
+  "DD_SYSTEM_PROBE_CONFIG_ENABLE_TCP_QUEUE_LENGTH",
+  "DD_SYSTEM_PROBE_CONFIG_LANGUAGE_DETECTION_ENABLED",
+  "DD_SYSTEM_PROBE_NETWORK_ENABLED",
+  "DD_SYSTEM_PROBE_PROCESS_ENABLED",
+  "DD_SYSTEM_PROBE_SERVICE_MONITORING_ENABLED",
+  "DD_TRACEROUTE_ENABLED",
+  "DD_WINDOWS_CRASH_DETECTION_ENABLED",
 };
 
 /// Returns the non-discovery environment variable that is set and not
@@ -162,7 +161,7 @@ static NON_DISCOVERY_ENV_VARS: phf::Set<&'static str> = phf_set! {
 ///
 /// We check the value of each env var rather than just its presence to avoid
 /// unnecessary fallback. This is needed because the Helm chart sets feature
-/// env vars even for disabled features (e.g. `DD_NETWORK_CONFIG_ENABLED=false`).
+/// env vars even for disabled features (e.g. `DD_SYSTEM_PROBE_NETWORK_ENABLED=false`).
 ///
 /// The logic uses `!= Some(false)` so that non-boolean values still trigger
 /// fallback as a safety net — matching the YAML side where a section without
@@ -339,7 +338,7 @@ mod tests {
 
     #[test]
     fn test_network_tracer_needs_fallback() {
-        temp_env::with_var("DD_NETWORK_CONFIG_ENABLED", Some("true"), || {
+        temp_env::with_var("DD_SYSTEM_PROBE_NETWORK_ENABLED", Some("true"), || {
             let decision = determine_action_no_config();
             assert_eq!(decision, FallbackDecision::FallbackToSystemProbe);
         });
@@ -356,7 +355,7 @@ discovery:
         let config_file = create_test_config(yaml);
 
         // Env var says true, YAML says false
-        temp_env::with_var("DD_NETWORK_CONFIG_ENABLED", Some("true"), || {
+        temp_env::with_var("DD_SYSTEM_PROBE_NETWORK_ENABLED", Some("true"), || {
             let config = load_config(Some(config_file.path().to_path_buf()));
             let decision = determine_action(&config);
             assert_eq!(
@@ -404,7 +403,7 @@ discovery:
         temp_env::with_vars(
             [
                 ("DD_DISCOVERY_ENABLED", Some("true")),
-                ("DD_NETWORK_CONFIG_ENABLED", Some("true")),
+                ("DD_SYSTEM_PROBE_NETWORK_ENABLED", Some("true")),
             ],
             || {
                 let decision = determine_action_no_config();
@@ -499,7 +498,7 @@ discovery:
 
     #[test]
     fn test_find_non_discovery_env_var_false_no_fallback() {
-        temp_env::with_var("DD_NETWORK_CONFIG_ENABLED", Some("false"), || {
+        temp_env::with_var("DD_SYSTEM_PROBE_NETWORK_ENABLED", Some("false"), || {
             assert!(
                 find_non_discovery_env_var().is_none(),
                 "Env var set to 'false' should not trigger fallback"
@@ -509,7 +508,7 @@ discovery:
 
     #[test]
     fn test_find_non_discovery_env_var_zero_no_fallback() {
-        temp_env::with_var("DD_NETWORK_CONFIG_ENABLED", Some("0"), || {
+        temp_env::with_var("DD_SYSTEM_PROBE_NETWORK_ENABLED", Some("0"), || {
             assert!(
                 find_non_discovery_env_var().is_none(),
                 "Env var set to '0' should not trigger fallback"
@@ -519,10 +518,10 @@ discovery:
 
     #[test]
     fn test_find_non_discovery_env_var_non_boolean_triggers_fallback() {
-        temp_env::with_var("DD_NETWORK_CONFIG_ENABLED", Some("maybe"), || {
+        temp_env::with_var("DD_SYSTEM_PROBE_NETWORK_ENABLED", Some("maybe"), || {
             assert_eq!(
                 find_non_discovery_env_var().as_deref(),
-                Some("DD_NETWORK_CONFIG_ENABLED"),
+                Some("DD_SYSTEM_PROBE_NETWORK_ENABLED"),
             );
         });
     }
@@ -690,7 +689,7 @@ network_config:
         temp_env::with_vars(
             [
                 ("DD_DISCOVERY_ENABLED", Some("true")),
-                ("DD_SERVICE_MONITORING_CONFIG_ENABLED", Some("true")),
+                ("DD_SYSTEM_PROBE_SERVICE_MONITORING_ENABLED", Some("true")),
             ],
             || {
                 let decision = determine_action_no_config();
@@ -1086,7 +1085,7 @@ log_level: 12345
             [
                 ("DD_DISCOVERY_USE_SD_AGENT", Some("true")),
                 ("DD_DISCOVERY_ENABLED", Some("true")),
-                ("DD_NETWORK_CONFIG_ENABLED", Some("true")), // Non-discovery module
+                ("DD_SYSTEM_PROBE_NETWORK_ENABLED", Some("true")), // Non-discovery module
             ],
             || {
                 let decision = determine_action(&Ok(None));

--- a/pkg/discovery/module/rust/tests/fallback_integration_test.rs
+++ b/pkg/discovery/module/rust/tests/fallback_integration_test.rs
@@ -43,7 +43,7 @@ fn test_fallback_on_npm_enabled() {
         .arg("run")
         .arg("--pid=/var/run/test.pid")
         .arg("--debug")
-        .env("DD_NETWORK_CONFIG_ENABLED", "true")
+        .env("DD_SYSTEM_PROBE_NETWORK_ENABLED", "true")
         .output()
         .expect("Failed to execute sd-agent");
 
@@ -132,7 +132,7 @@ fn test_missing_fallback_binary() {
         .arg("--")
         .arg("/nonexistent/system-probe")
         .arg("run")
-        .env("DD_NETWORK_CONFIG_ENABLED", "true")
+        .env("DD_SYSTEM_PROBE_NETWORK_ENABLED", "true")
         .output()
         .expect("Failed to execute sd-agent");
 
@@ -444,7 +444,7 @@ fn test_env_var_false_no_fallback() {
         .arg(format!("--config={}", config_file.path().display()))
         .env("DD_DISCOVERY_USE_SD_AGENT", "true")
         .env("DD_DISCOVERY_ENABLED", "true")
-        .env("DD_NETWORK_CONFIG_ENABLED", "false")
+        .env("DD_SYSTEM_PROBE_NETWORK_ENABLED", "false")
         .spawn()
         .expect("Failed to spawn sd-agent");
 
@@ -480,7 +480,7 @@ fn test_env_var_zero_no_fallback() {
         .arg(format!("--config={}", config_file.path().display()))
         .env("DD_DISCOVERY_USE_SD_AGENT", "true")
         .env("DD_DISCOVERY_ENABLED", "true")
-        .env("DD_NETWORK_CONFIG_ENABLED", "0")
+        .env("DD_SYSTEM_PROBE_NETWORK_ENABLED", "0")
         .spawn()
         .expect("Failed to spawn sd-agent");
 
@@ -508,7 +508,7 @@ fn test_env_var_non_boolean_triggers_fallback() {
         .arg(&mock_sp_source)
         .arg(&marker_file)
         .arg("run")
-        .env("DD_NETWORK_CONFIG_ENABLED", "maybe")
+        .env("DD_SYSTEM_PROBE_NETWORK_ENABLED", "maybe")
         .output()
         .expect("Failed to execute sd-agent");
 


### PR DESCRIPTION
### What does this PR do?

Updates the `NON_DISCOVERY_ENV_VARS` set in the Rust sd-agent fallback config to match Go's implementation.

- Renames stale env vars (e.g. `DD_NETWORK_CONFIG_ENABLED` → `DD_SYSTEM_PROBE_NETWORK_ENABLED`)
- Removes 5 env vars that don't exist in Go's implementation
- Adds 4 missing env vars from Go

### Motivation

The Rust env var list had drifted from Go's actual implementation, meaning some env vars that should trigger fallback to system-probe were being missed, and others that do not exist in Go were being wrongly checked.

### Describe how you validated your changes

- `cargo test` — 559 tests pass
- `bazel test //pkg/discovery/module/rust:dd_discovery_test`
- `bazel test //pkg/discovery/module/rust:fallback_integration_test`

A follow-up PR (#47297) adds a canonical JSON file and automated tests on both the Go and Rust sides to ensure these env vars cannot drift out of sync in the future.