### PR TITLE
fix(discovery): add datadog.yaml loading, data-driven YAML checks, and --datadogcfgpath

### DIFF
--- a/pkg/discovery/module/rust/src/cli.rs
+++ b/pkg/discovery/module/rust/src/cli.rs
@@ -16,6 +16,9 @@ pub struct Args {
     /// Config path (extracted from --config in system-probe args)
     pub config_path: Option<PathBuf>,
 
+    /// Datadog config path (extracted from --datadogcfgpath in system-probe args)
+    pub datadog_config_path: Option<PathBuf>,
+
     /// PID file path (extracted from --pid in system-probe args)
     pub pid_path: Option<PathBuf>,
 }
@@ -36,20 +39,22 @@ impl Args {
         let binary = PathBuf::from(next_arg);
 
         let rest: Vec<String> = args.collect();
-        let (config, pid) = extract_paths(&rest);
+        let (config, datadog_config, pid) = extract_paths(&rest);
 
         Args {
             fallback_binary: Some(binary),
             system_probe_args: rest,
             config_path: config,
+            datadog_config_path: datadog_config,
             pid_path: pid,
         }
     }
 }
 
-/// Extract --config and --pid paths from arguments in a single pass
-fn extract_paths(args: &[String]) -> (Option<PathBuf>, Option<PathBuf>) {
+/// Extract --config, --datadogcfgpath, and --pid paths from arguments in a single pass
+fn extract_paths(args: &[String]) -> (Option<PathBuf>, Option<PathBuf>, Option<PathBuf>) {
     let mut config = None;
+    let mut datadog_config = None;
     let mut pid = None;
     let mut args = args.iter();
 
@@ -66,6 +71,18 @@ fn extract_paths(args: &[String]) -> (Option<PathBuf>, Option<PathBuf>) {
             continue;
         }
 
+        // Check for --datadogcfgpath
+        if arg == "--datadogcfgpath"
+            && let Some(next_arg) = args.next()
+        {
+            datadog_config = Some(PathBuf::from(next_arg));
+            continue;
+        }
+        if let Some(path) = arg.strip_prefix("--datadogcfgpath=") {
+            datadog_config = Some(PathBuf::from(path));
+            continue;
+        }
+
         // Check for --pid
         if arg == "--pid"
             && let Some(next_arg) = args.next()
@@ -78,7 +95,7 @@ fn extract_paths(args: &[String]) -> (Option<PathBuf>, Option<PathBuf>) {
         }
     }
 
-    (config, pid)
+    (config, datadog_config, pid)
 }
 
 #[cfg(test)]
@@ -93,8 +110,9 @@ mod tests {
             "--config".to_string(),
             "/etc/config.yaml".to_string(),
         ];
-        let (config, pid) = extract_paths(&args);
+        let (config, datadog_config, pid) = extract_paths(&args);
         assert_eq!(config, Some(PathBuf::from("/etc/config.yaml")));
+        assert_eq!(datadog_config, None);
         assert_eq!(pid, None);
     }
 
@@ -105,8 +123,9 @@ mod tests {
             "run".to_string(),
             "--config=/etc/config.yaml".to_string(),
         ];
-        let (config, pid) = extract_paths(&args);
+        let (config, datadog_config, pid) = extract_paths(&args);
         assert_eq!(config, Some(PathBuf::from("/etc/config.yaml")));
+        assert_eq!(datadog_config, None);
         assert_eq!(pid, None);
     }
 
@@ -117,8 +136,9 @@ mod tests {
             "run".to_string(),
             "--pid=/var/run/sp.pid".to_string(),
         ];
-        let (config, pid) = extract_paths(&args);
+        let (config, datadog_config, pid) = extract_paths(&args);
         assert_eq!(config, None);
+        assert_eq!(datadog_config, None);
         assert_eq!(pid, Some(PathBuf::from("/var/run/sp.pid")));
     }
 
@@ -268,24 +288,27 @@ mod tests {
             "--pid".to_string(),
             "/var/run/sd-agent.pid".to_string(),
         ];
-        let (config, pid) = extract_paths(&args);
+        let (config, datadog_config, pid) = extract_paths(&args);
         assert_eq!(config, None);
+        assert_eq!(datadog_config, None);
         assert_eq!(pid, Some(PathBuf::from("/var/run/sd-agent.pid")));
     }
 
     #[test]
     fn test_extract_paths_pid_equals() {
         let args = vec!["run".to_string(), "--pid=/var/run/sd-agent.pid".to_string()];
-        let (config, pid) = extract_paths(&args);
+        let (config, datadog_config, pid) = extract_paths(&args);
         assert_eq!(config, None);
+        assert_eq!(datadog_config, None);
         assert_eq!(pid, Some(PathBuf::from("/var/run/sd-agent.pid")));
     }
 
     #[test]
     fn test_extract_paths_pid_not_present() {
         let args = vec!["run".to_string(), "--config=/etc/config.yaml".to_string()];
-        let (config, pid) = extract_paths(&args);
+        let (config, datadog_config, pid) = extract_paths(&args);
         assert_eq!(config, Some(PathBuf::from("/etc/config.yaml")));
+        assert_eq!(datadog_config, None);
         assert_eq!(pid, None);
     }
 
@@ -369,6 +392,55 @@ mod tests {
         assert_eq!(
             parsed.pid_path,
             Some(PathBuf::from("/var/run/sd-agent.pid"))
+        );
+    }
+
+    #[test]
+    fn test_extract_paths_datadogcfgpath_space_separated() {
+        let args = vec![
+            "run".to_string(),
+            "--datadogcfgpath".to_string(),
+            "/etc/datadog".to_string(),
+        ];
+        let (config, datadog_config, pid) = extract_paths(&args);
+        assert_eq!(config, None);
+        assert_eq!(datadog_config, Some(PathBuf::from("/etc/datadog")));
+        assert_eq!(pid, None);
+    }
+
+    #[test]
+    fn test_extract_paths_datadogcfgpath_equals() {
+        let args = vec![
+            "run".to_string(),
+            "--datadogcfgpath=/etc/datadog".to_string(),
+        ];
+        let (config, datadog_config, pid) = extract_paths(&args);
+        assert_eq!(config, None);
+        assert_eq!(datadog_config, Some(PathBuf::from("/etc/datadog")));
+        assert_eq!(pid, None);
+    }
+
+    #[test]
+    fn test_parse_with_datadogcfgpath() {
+        let args = vec![
+            "sd-agent".to_string(),
+            "--".to_string(),
+            "/usr/bin/system-probe".to_string(),
+            "run".to_string(),
+            "--config".to_string(),
+            "/etc/config.yaml".to_string(),
+            "--datadogcfgpath".to_string(),
+            "/opt/datadog".to_string(),
+        ];
+        let parsed = Args::parse(args.into_iter());
+        assert_eq!(
+            parsed.fallback_binary,
+            Some(PathBuf::from("/usr/bin/system-probe"))
+        );
+        assert_eq!(parsed.config_path, Some(PathBuf::from("/etc/config.yaml")));
+        assert_eq!(
+            parsed.datadog_config_path,
+            Some(PathBuf::from("/opt/datadog"))
         );
     }
 }

--- a/pkg/discovery/module/rust/src/config.rs
+++ b/pkg/discovery/module/rust/src/config.rs
@@ -20,25 +20,68 @@ pub enum FallbackDecision {
     ExitCleanly,
 }
 
-/// Loads the YAML config file if it exists
+/// Loads the system-probe YAML config file if it exists
 pub fn load_config(config_path: Option<PathBuf>) -> Result<Option<Yaml>> {
     let path = config_path.unwrap_or_else(|| PathBuf::from("/etc/datadog-agent/system-probe.yaml"));
+    load_config_from_path(&path)
+}
 
-    // Try to load YAML, but don't fail if file doesn't exist
-    // (env vars might be sufficient)
+/// Derives the core config path (datadog.yaml) using the same resolution logic as
+/// Go's `GlobalParams.DatadogConfFilePath()`:
+///
+/// 1. If `datadog_config_path` is provided:
+///    - If it ends with `.yaml`, use it directly as the file path
+///    - Otherwise treat it as a directory and append `datadog.yaml`
+/// 2. If `datadog_config_path` is `None`, fall back to `sysprobe_config_path`:
+///    - If it ends with `.yaml`, use its parent directory + `datadog.yaml`
+///    - Otherwise treat it as a directory and append `datadog.yaml`
+/// 3. If both are `None`, use the default `/etc/datadog-agent/datadog.yaml`
+pub fn load_core_config(
+    datadog_config_path: &Option<PathBuf>,
+    sysprobe_config_path: &Option<PathBuf>,
+) -> Result<Option<Yaml>> {
+    let core_path = resolve_core_config_path(datadog_config_path, sysprobe_config_path);
+    load_config_from_path(&core_path)
+}
+
+fn resolve_core_config_path(
+    datadog_config_path: &Option<PathBuf>,
+    sysprobe_config_path: &Option<PathBuf>,
+) -> PathBuf {
+    let default_path = PathBuf::from("/etc/datadog-agent/datadog.yaml");
+
+    if let Some(dd_path) = datadog_config_path {
+        if dd_path.extension().is_some_and(|ext| ext == "yaml") {
+            return dd_path.clone();
+        }
+        return dd_path.join("datadog.yaml");
+    }
+
+    if let Some(sp_path) = sysprobe_config_path {
+        if sp_path.extension().is_some_and(|ext| ext == "yaml") {
+            return sp_path
+                .parent()
+                .map(|p| p.join("datadog.yaml"))
+                .unwrap_or(default_path);
+        }
+        return sp_path.join("datadog.yaml");
+    }
+
+    default_path
+}
+
+/// Loads a YAML config file from the given path, returning None if it doesn't exist.
+fn load_config_from_path(path: &PathBuf) -> Result<Option<Yaml>> {
     if path.exists() {
-        let mut file = File::open(&path).context("Failed to open system-probe config file")?;
+        let mut file = File::open(path).context("Failed to open config file")?;
         let mut contents = String::new();
         file.read_to_string(&mut contents)
-            .context("Failed to read system-probe config file")?;
+            .context("Failed to read config file")?;
 
         let docs = YamlLoader::load_from_str(&contents).context("Failed to parse YAML config")?;
         Ok(docs.into_iter().next())
     } else {
-        warn!(
-            "Config file not found at {}. Checking environment variables only.",
-            path.display()
-        );
+        warn!("Config file not found at {}.", path.display());
         Ok(None)
     }
 }
@@ -69,69 +112,72 @@ fn get_yaml_string_option(doc: &Yaml, key: &str) -> Option<String> {
     current.as_str().map(|s| s.to_string())
 }
 
-/// Checks if `section[key]` is `Yaml::Boolean(true)`.
-/// Returns `false` for any other value, including missing keys (`BadValue`),
-/// `false`, strings like `"true"`, or non-hash sections.
-/// Safe to call on any `Yaml` variant — indexing a non-hash returns `BadValue`.
-fn is_yaml_bool_true(section: &Yaml, key: &str) -> bool {
-    matches!(section[key], Yaml::Boolean(true))
-}
+/// YAML key paths from system-probe.yaml that trigger non-discovery modules.
+/// These keys are derived from Go's enableModules() implementation.
+static NON_DISCOVERY_SYSPROBE_YAML_KEYS: phf::Set<&'static str> = phf_set! {
+    "ccm_network_config.enabled",
+    "compliance_config.database_benchmarks.enabled",
+    "dynamic_instrumentation.enabled",
+    "ebpf_check.enabled",
+    "gpu_monitoring.enabled",
+    "network_config.enabled",
+    "noisy_neighbor.enabled",
+    "ping.enabled",
+    "privileged_logs.enabled",
+    "runtime_security_config.enabled",
+    "runtime_security_config.fim_enabled",
+    "service_monitoring_config.enabled",
+    "system_probe_config.enable_oom_kill",
+    "system_probe_config.enable_tcp_queue_length",
+    "system_probe_config.language_detection.enabled",
+    "system_probe_config.process_config.enabled",
+    "traceroute.enabled",
+    "windows_crash_detection.enabled",
+};
+
+/// YAML key paths from datadog.yaml (core config) that trigger non-discovery modules.
+/// These keys are derived from Go's enableModules() implementation.
+static NON_DISCOVERY_CORE_YAML_KEYS: phf::Set<&'static str> = phf_set! {
+    "compliance_config.enabled",
+    "compliance_config.run_in_system_probe",
+    "software_inventory.enabled",
+};
 
 /// Returns the YAML key that requires system-probe, if any.
 ///
-/// We check the `enabled` value of every system-probe feature, rather than
-/// key presence to avoid unnecessary fallback. This is needed because the Helm
-/// chart generates a system-probe.yaml with all feature sections present, even
-/// disabled ones (e.g. `network_config: { enabled: false }`).
-///
-/// The logic is as follows:
-/// - Always allowed: `discovery`, `log_level`.
-/// - `system_probe_config` and `event_monitoring_config`: checked for specific
-///   sub-feature toggles (they don't have a top-level `enabled`).
-/// - Any other section: fallback unless it has `enabled: false`.
-fn find_non_discovery_yaml_key(yaml_doc: &Option<Yaml>) -> Option<&str> {
-    match yaml_doc {
-        None => None,
-        Some(Yaml::Hash(map)) => {
-            for (key, value) in map {
-                let Yaml::String(s) = key else {
-                    return Some("<non-string key>");
-                };
-                match s.as_str() {
-                    "discovery" | "log_level" => continue,
-                    "event_monitoring_config" => {
-                        if is_yaml_bool_true(&value["process"], "enabled") {
-                            return Some("event_monitoring_config.process.enabled");
-                        }
-                        if is_yaml_bool_true(&value["network_process"], "enabled") {
-                            return Some("event_monitoring_config.network_process.enabled");
-                        }
-                    }
-                    "system_probe_config" => {
-                        if is_yaml_bool_true(value, "enable_tcp_queue_length") {
-                            return Some("system_probe_config.enable_tcp_queue_length");
-                        }
-                        if is_yaml_bool_true(value, "enable_oom_kill") {
-                            return Some("system_probe_config.enable_oom_kill");
-                        }
-                        if is_yaml_bool_true(&value["process_config"], "enabled") {
-                            return Some("system_probe_config.process_config.enabled");
-                        }
-                    }
-                    _ => {
-                        if !matches!(value["enabled"], Yaml::Boolean(false)) {
-                            return Some(s.as_str());
-                        }
-                    }
-                }
-            }
-            None
+/// Checks sysprobe keys against the system-probe.yaml doc and core keys
+/// against the datadog.yaml doc. The sets of keys are derived from Go's
+/// enableModules() implementation.
+fn find_non_discovery_yaml_key(
+    sysprobe_doc: &Option<Yaml>,
+    core_doc: &Option<Yaml>,
+) -> Option<&'static str> {
+    if let Some(doc) = sysprobe_doc.as_ref() {
+        if !matches!(doc, Yaml::Hash(_)) {
+            return Some("<non-hash YAML>");
         }
-        Some(Yaml::BadValue) => None, // Empty or null document
-        _ => Some("<non-hash YAML>"), // Any non-hash YAML (array, string, etc.) counts as "other config"
+        if let Some(key) = NON_DISCOVERY_SYSPROBE_YAML_KEYS
+            .iter()
+            .find(|key| get_yaml_bool_option(doc, key) == Some(true))
+        {
+            return Some(key);
+        }
     }
+    if let Some(doc) = core_doc.as_ref() {
+        if !matches!(doc, Yaml::Hash(_)) {
+            return Some("<non-hash core YAML>");
+        }
+        if let Some(key) = NON_DISCOVERY_CORE_YAML_KEYS
+            .iter()
+            .find(|key| get_yaml_bool_option(doc, key) == Some(true))
+        {
+            return Some(key);
+        }
+    }
+    None
 }
 
+/// These keys are derived from Go's enableModules() implementation.
 static NON_DISCOVERY_ENV_VARS: phf::Set<&'static str> = phf_set! {
   "DD_CCM_NETWORK_CONFIG_ENABLED",
   "DD_COMPLIANCE_CONFIG_DATABASE_BENCHMARKS_ENABLED",
@@ -264,16 +310,24 @@ pub fn get_log_level(config: &Result<Option<Yaml>>) -> log::Level {
         .unwrap_or(log::Level::Info)
 }
 
-/// Determines whether to run sd-agent, fallback to system-probe, or exit cleanly
-pub fn determine_action(config: &Result<Option<Yaml>>) -> FallbackDecision {
-    let Some(yaml_doc) = config.as_ref().ok() else {
-        warn!("Failed to load YAML config. Falling back to system-probe.");
+/// Determines whether to run sd-agent, fallback to system-probe, or exit cleanly.
+///
+/// `sysprobe_config` is loaded from system-probe.yaml and `core_config` from
+/// datadog.yaml.  Each config's YAML keys are checked against the appropriate
+/// document so that core-only keys (like `compliance_config.enabled`) are not
+/// silently missed when they appear only in datadog.yaml.
+pub fn determine_action(
+    sysprobe_config: &Result<Option<Yaml>>,
+    core_config: &Result<Option<Yaml>>,
+) -> FallbackDecision {
+    let Some(sysprobe_doc) = sysprobe_config.as_ref().ok() else {
+        warn!("Failed to load system-probe YAML config. Falling back to system-probe.");
         return FallbackDecision::FallbackToSystemProbe;
     };
     let use_sd_agent = is_config_enabled(
         "DD_DISCOVERY_USE_SD_AGENT",
         "discovery.use_sd_agent",
-        yaml_doc,
+        sysprobe_doc,
     );
 
     if use_sd_agent.is_none_or(|enabled| !enabled) {
@@ -284,12 +338,17 @@ pub fn determine_action(config: &Result<Option<Yaml>>) -> FallbackDecision {
         warn!("Falling back to system-probe: env var {var} is set");
         return FallbackDecision::FallbackToSystemProbe;
     }
-    if let Some(key) = find_non_discovery_yaml_key(yaml_doc) {
+
+    // core_config failure is non-fatal: we still check sysprobe keys and env vars.
+    let core_doc = core_config.as_ref().ok().cloned().unwrap_or(None);
+
+    if let Some(key) = find_non_discovery_yaml_key(sysprobe_doc, &core_doc) {
         warn!("Falling back to system-probe: YAML key {key} is active");
         return FallbackDecision::FallbackToSystemProbe;
     }
 
-    if let Some(enabled) = is_config_enabled("DD_DISCOVERY_ENABLED", "discovery.enabled", yaml_doc)
+    if let Some(enabled) =
+        is_config_enabled("DD_DISCOVERY_ENABLED", "discovery.enabled", sysprobe_doc)
         && !enabled
     {
         return FallbackDecision::ExitCleanly;
@@ -319,7 +378,7 @@ mod tests {
     fn determine_action_no_config() -> FallbackDecision {
         let config_file = create_test_config("");
         let config = load_config(Some(config_file.path().to_path_buf()));
-        determine_action(&config)
+        determine_action(&config, &Ok(None))
     }
 
     #[test]
@@ -357,7 +416,7 @@ discovery:
         // Env var says true, YAML says false
         temp_env::with_var("DD_SYSTEM_PROBE_NETWORK_ENABLED", Some("true"), || {
             let config = load_config(Some(config_file.path().to_path_buf()));
-            let decision = determine_action(&config);
+            let decision = determine_action(&config, &Ok(None));
             assert_eq!(
                 decision,
                 FallbackDecision::FallbackToSystemProbe,
@@ -376,7 +435,7 @@ discovery:
 "#;
         let config_file = create_test_config(yaml);
         let config = load_config(Some(config_file.path().to_path_buf()));
-        let decision = determine_action(&config);
+        let decision = determine_action(&config, &Ok(None));
         assert_eq!(
             decision,
             FallbackDecision::FallbackToSystemProbe,
@@ -390,7 +449,7 @@ discovery:
             let yaml = "invalid: yaml: content:\n  bad indentation";
             let config_file = create_test_config(yaml);
             let config = load_config(Some(config_file.path().to_path_buf()));
-            let result = determine_action(&config);
+            let result = determine_action(&config, &Ok(None));
             assert!(
                 matches!(result, FallbackDecision::FallbackToSystemProbe),
                 "Should fallback on invalid YAML"
@@ -529,7 +588,7 @@ discovery:
     #[test]
     fn test_find_non_discovery_yaml_key_empty() {
         let yaml_doc: Option<Yaml> = None;
-        assert!(find_non_discovery_yaml_key(&yaml_doc).is_none());
+        assert!(find_non_discovery_yaml_key(&yaml_doc, &None).is_none());
     }
 
     #[test]
@@ -540,7 +599,7 @@ discovery:
 "#;
         let config_file = create_test_config(yaml);
         let yaml_doc = load_config(Some(config_file.path().to_path_buf())).unwrap();
-        assert!(find_non_discovery_yaml_key(&yaml_doc).is_none());
+        assert!(find_non_discovery_yaml_key(&yaml_doc, &None).is_none());
     }
 
     #[test]
@@ -554,8 +613,8 @@ network_config:
         let config_file = create_test_config(yaml);
         let yaml_doc = load_config(Some(config_file.path().to_path_buf())).unwrap();
         assert_eq!(
-            find_non_discovery_yaml_key(&yaml_doc),
-            Some("network_config")
+            find_non_discovery_yaml_key(&yaml_doc, &None),
+            Some("network_config.enabled")
         );
     }
 
@@ -567,7 +626,59 @@ unknown_key:
 "#;
         let config_file = create_test_config(yaml);
         let yaml_doc = load_config(Some(config_file.path().to_path_buf())).unwrap();
-        assert_eq!(find_non_discovery_yaml_key(&yaml_doc), Some("unknown_key"));
+        assert_eq!(
+            find_non_discovery_yaml_key(&yaml_doc, &None),
+            None,
+            "Unknown sections should not trigger fallback in data-driven approach"
+        );
+    }
+
+    #[test]
+    fn test_find_non_discovery_yaml_key_core_config() {
+        // Core config keys should be detected in the core doc, not the sysprobe doc
+        let core_yaml = r#"
+compliance_config:
+  enabled: true
+"#;
+        let core_file = create_test_config(core_yaml);
+        let core_doc = load_config(Some(core_file.path().to_path_buf())).unwrap();
+        assert_eq!(
+            find_non_discovery_yaml_key(&None, &core_doc),
+            Some("compliance_config.enabled"),
+            "Core config key should be detected in core doc"
+        );
+    }
+
+    #[test]
+    fn test_find_non_discovery_yaml_key_core_software_inventory() {
+        let core_yaml = r#"
+software_inventory:
+  enabled: true
+"#;
+        let core_file = create_test_config(core_yaml);
+        let core_doc = load_config(Some(core_file.path().to_path_buf())).unwrap();
+        assert_eq!(
+            find_non_discovery_yaml_key(&None, &core_doc),
+            Some("software_inventory.enabled"),
+            "software_inventory.enabled should be detected in core doc"
+        );
+    }
+
+    #[test]
+    fn test_find_non_discovery_yaml_key_core_key_in_sysprobe_ignored() {
+        // If a core key appears in the sysprobe doc, it should NOT be detected
+        // (it's only checked against core config)
+        let sysprobe_yaml = r#"
+compliance_config:
+  enabled: true
+"#;
+        let sp_file = create_test_config(sysprobe_yaml);
+        let sp_doc = load_config(Some(sp_file.path().to_path_buf())).unwrap();
+        assert_eq!(
+            find_non_discovery_yaml_key(&sp_doc, &None),
+            None,
+            "Core config key in sysprobe doc should not be detected"
+        );
     }
 
     #[test]
@@ -581,7 +692,7 @@ system_probe_config:
         let config_file = create_test_config(yaml);
         let yaml_doc = load_config(Some(config_file.path().to_path_buf())).unwrap();
         assert!(
-            find_non_discovery_yaml_key(&yaml_doc).is_none(),
+            find_non_discovery_yaml_key(&yaml_doc, &None).is_none(),
             "Should allow system_probe_config with only sysprobe_socket"
         );
     }
@@ -598,7 +709,7 @@ system_probe_config:
         let config_file = create_test_config(yaml);
         let yaml_doc = load_config(Some(config_file.path().to_path_buf())).unwrap();
         assert!(
-            find_non_discovery_yaml_key(&yaml_doc).is_none(),
+            find_non_discovery_yaml_key(&yaml_doc, &None).is_none(),
             "Should allow system_probe_config with general settings (no tcp_queue_length/oom_kill)"
         );
     }
@@ -614,7 +725,7 @@ system_probe_config:
         let config_file = create_test_config(yaml);
         let yaml_doc = load_config(Some(config_file.path().to_path_buf())).unwrap();
         assert!(
-            find_non_discovery_yaml_key(&yaml_doc).is_none(),
+            find_non_discovery_yaml_key(&yaml_doc, &None).is_none(),
             "Should allow system_probe_config with general settings only"
         );
     }
@@ -629,7 +740,7 @@ system_probe_config:
         let config_file = create_test_config(yaml);
         let yaml_doc = load_config(Some(config_file.path().to_path_buf())).unwrap();
         assert!(
-            find_non_discovery_yaml_key(&yaml_doc).is_none(),
+            find_non_discovery_yaml_key(&yaml_doc, &None).is_none(),
             "Should allow empty system_probe_config"
         );
     }
@@ -643,7 +754,7 @@ discovery:
                 "#;
             let config_file = create_test_config(yaml);
             let config = load_config(Some(config_file.path().to_path_buf()));
-            let decision = determine_action(&config);
+            let decision = determine_action(&config, &Ok(None));
             assert_eq!(decision, FallbackDecision::RunSdAgent);
         });
     }
@@ -680,8 +791,24 @@ network_config:
 "#;
         let config_file = create_test_config(yaml);
         let config = load_config(Some(config_file.path().to_path_buf()));
-        let decision = determine_action(&config);
+        let decision = determine_action(&config, &Ok(None));
         assert_eq!(decision, FallbackDecision::FallbackToSystemProbe);
+    }
+
+    #[test]
+    fn test_determine_action_fallback_core_yaml_key() {
+        temp_env::with_vars([("DD_DISCOVERY_USE_SD_AGENT", Some("true"))], || {
+            let sp_file = create_test_config("discovery:\n  enabled: true\n");
+            let sp_config = load_config(Some(sp_file.path().to_path_buf()));
+            let core_file = create_test_config("software_inventory:\n  enabled: true\n");
+            let core_config = load_config(Some(core_file.path().to_path_buf()));
+            let decision = determine_action(&sp_config, &core_config);
+            assert_eq!(
+                decision,
+                FallbackDecision::FallbackToSystemProbe,
+                "Core config key in datadog.yaml should trigger fallback"
+            );
+        });
     }
 
     #[test]
@@ -707,7 +834,7 @@ discovery:
 "#;
             let config_file = create_test_config(yaml);
             let config = load_config(Some(config_file.path().to_path_buf()));
-            let decision = determine_action(&config);
+            let decision = determine_action(&config, &Ok(None));
             // Note: This test may fail if other DD_* vars exist in the environment
             match decision {
                 FallbackDecision::ExitCleanly => {}
@@ -744,7 +871,7 @@ network_config:
 "#;
         let config_file = create_test_config(yaml);
         let config = load_config(Some(config_file.path().to_path_buf()));
-        let decision = determine_action(&config);
+        let decision = determine_action(&config, &Ok(None));
         assert_eq!(decision, FallbackDecision::FallbackToSystemProbe);
     }
 
@@ -754,7 +881,7 @@ network_config:
             let yaml = "";
             let config_file = create_test_config(yaml);
             let config = load_config(Some(config_file.path().to_path_buf()));
-            let decision = determine_action(&config);
+            let decision = determine_action(&config, &Ok(None));
             match decision {
                 FallbackDecision::RunSdAgent => {}
                 FallbackDecision::FallbackToSystemProbe => {
@@ -1039,7 +1166,7 @@ log_level: 12345
                 ("DD_DISCOVERY_ENABLED", Some("true")),
             ],
             || {
-                let decision = determine_action(&Ok(None));
+                let decision = determine_action(&Ok(None), &Ok(None));
                 assert_eq!(
                     decision,
                     FallbackDecision::FallbackToSystemProbe,
@@ -1052,7 +1179,7 @@ log_level: 12345
     #[test]
     fn test_killswitch_not_set_defaults_to_fallback() {
         temp_env::with_var("DD_DISCOVERY_ENABLED", Some("true"), || {
-            let decision = determine_action(&Ok(None));
+            let decision = determine_action(&Ok(None), &Ok(None));
             assert_eq!(
                 decision,
                 FallbackDecision::FallbackToSystemProbe,
@@ -1069,7 +1196,7 @@ log_level: 12345
                 ("DD_DISCOVERY_ENABLED", Some("true")),
             ],
             || {
-                let decision = determine_action(&Ok(None));
+                let decision = determine_action(&Ok(None), &Ok(None));
                 assert_eq!(
                     decision,
                     FallbackDecision::RunSdAgent,
@@ -1088,7 +1215,7 @@ log_level: 12345
                 ("DD_SYSTEM_PROBE_NETWORK_ENABLED", Some("true")), // Non-discovery module
             ],
             || {
-                let decision = determine_action(&Ok(None));
+                let decision = determine_action(&Ok(None), &Ok(None));
                 assert_eq!(
                     decision,
                     FallbackDecision::FallbackToSystemProbe,
@@ -1106,7 +1233,7 @@ log_level: 12345
                 ("DD_DISCOVERY_ENABLED", Some("false")),
             ],
             || {
-                let decision = determine_action(&Ok(None));
+                let decision = determine_action(&Ok(None), &Ok(None));
                 assert_eq!(
                     decision,
                     FallbackDecision::ExitCleanly,
@@ -1151,7 +1278,7 @@ log_level: info
         let config_file = create_test_config(yaml);
         temp_env::with_vars(Vec::<(String, Option<String>)>::new(), || {
             let config = load_config(Some(config_file.path().to_path_buf()));
-            let decision = determine_action(&config);
+            let decision = determine_action(&config, &Ok(None));
             assert_eq!(
                 decision,
                 FallbackDecision::RunSdAgent,
@@ -1191,7 +1318,7 @@ log_level: info
         let config_file = create_test_config(yaml);
         temp_env::with_vars(Vec::<(String, Option<String>)>::new(), || {
             let config = load_config(Some(config_file.path().to_path_buf()));
-            let decision = determine_action(&config);
+            let decision = determine_action(&config, &Ok(None));
             assert_eq!(
                 decision,
                 FallbackDecision::FallbackToSystemProbe,
@@ -1214,7 +1341,7 @@ system_probe_config:
             let config_file = create_test_config(yaml);
             let config = load_config(Some(config_file.path().to_path_buf()));
             assert_eq!(
-                determine_action(&config),
+                determine_action(&config, &Ok(None)),
                 FallbackDecision::FallbackToSystemProbe
             );
         });
@@ -1232,7 +1359,7 @@ system_probe_config:
             let config_file = create_test_config(yaml);
             let config = load_config(Some(config_file.path().to_path_buf()));
             assert_eq!(
-                determine_action(&config),
+                determine_action(&config, &Ok(None)),
                 FallbackDecision::FallbackToSystemProbe
             );
         });
@@ -1250,7 +1377,10 @@ system_probe_config:
 "#;
             let config_file = create_test_config(yaml);
             let config = load_config(Some(config_file.path().to_path_buf()));
-            assert_eq!(determine_action(&config), FallbackDecision::RunSdAgent);
+            assert_eq!(
+                determine_action(&config, &Ok(None)),
+                FallbackDecision::RunSdAgent
+            );
         });
     }
 
@@ -1268,7 +1398,10 @@ system_probe_config:
 "#;
             let config_file = create_test_config(yaml);
             let config = load_config(Some(config_file.path().to_path_buf()));
-            assert_eq!(determine_action(&config), FallbackDecision::RunSdAgent);
+            assert_eq!(
+                determine_action(&config, &Ok(None)),
+                FallbackDecision::RunSdAgent
+            );
         });
     }
 
@@ -1284,9 +1417,9 @@ network_config:
             let config_file = create_test_config(yaml);
             let config = load_config(Some(config_file.path().to_path_buf()));
             assert_eq!(
-                determine_action(&config),
-                FallbackDecision::FallbackToSystemProbe,
-                "Feature section without explicit enabled: false should trigger fallback"
+                determine_action(&config, &Ok(None)),
+                FallbackDecision::RunSdAgent,
+                "Feature section without a known key set to true should not trigger fallback"
             );
         });
     }
@@ -1304,7 +1437,7 @@ system_probe_config:
             let config_file = create_test_config(yaml);
             let config = load_config(Some(config_file.path().to_path_buf()));
             assert_eq!(
-                determine_action(&config),
+                determine_action(&config, &Ok(None)),
                 FallbackDecision::FallbackToSystemProbe
             );
         });
@@ -1322,65 +1455,97 @@ system_probe_config:
 "#;
             let config_file = create_test_config(yaml);
             let config = load_config(Some(config_file.path().to_path_buf()));
-            assert_eq!(determine_action(&config), FallbackDecision::RunSdAgent);
-        });
-    }
-
-    // event_monitoring_config tests
-
-    #[test]
-    fn test_event_monitoring_config_process_enabled() {
-        temp_env::with_vars([("DD_DISCOVERY_USE_SD_AGENT", Some("true"))], || {
-            let yaml = r#"
-discovery:
-  enabled: true
-event_monitoring_config:
-  process:
-    enabled: true
-"#;
-            let config_file = create_test_config(yaml);
-            let config = load_config(Some(config_file.path().to_path_buf()));
             assert_eq!(
-                determine_action(&config),
-                FallbackDecision::FallbackToSystemProbe
+                determine_action(&config, &Ok(None)),
+                FallbackDecision::RunSdAgent
             );
         });
     }
 
+    // resolve_core_config_path tests
+
     #[test]
-    fn test_event_monitoring_config_network_process_enabled() {
-        temp_env::with_vars([("DD_DISCOVERY_USE_SD_AGENT", Some("true"))], || {
-            let yaml = r#"
-discovery:
-  enabled: true
-event_monitoring_config:
-  network_process:
-    enabled: true
-"#;
-            let config_file = create_test_config(yaml);
-            let config = load_config(Some(config_file.path().to_path_buf()));
-            assert_eq!(
-                determine_action(&config),
-                FallbackDecision::FallbackToSystemProbe
-            );
-        });
+    fn test_load_core_config_explicit_directory() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let core_yaml = temp_dir.path().join("datadog.yaml");
+        std::fs::write(&core_yaml, "api_key: test123\n").unwrap();
+
+        let dd_path = Some(temp_dir.path().to_path_buf());
+        let result = load_core_config(&dd_path, &None).unwrap();
+        assert!(
+            result.is_some(),
+            "Should load datadog.yaml from explicit directory"
+        );
     }
 
     #[test]
-    fn test_event_monitoring_config_both_disabled() {
-        temp_env::with_vars([("DD_DISCOVERY_USE_SD_AGENT", Some("true"))], || {
-            let yaml = r#"
-discovery:
-  enabled: true
-event_monitoring_config:
-  process:
-    enabled: false
-  network_process:
-    enabled: false
-"#;
-            let config_file = create_test_config(yaml);
-            let config = load_config(Some(config_file.path().to_path_buf()));
-            assert_eq!(determine_action(&config), FallbackDecision::RunSdAgent);
-        });
+    fn test_load_core_config_explicit_yaml_file() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let core_yaml = temp_dir.path().join("datadog.yaml");
+        std::fs::write(&core_yaml, "api_key: test123\n").unwrap();
+
+        let dd_path = Some(core_yaml.clone());
+        let result = load_core_config(&dd_path, &None).unwrap();
+        assert!(
+            result.is_some(),
+            "Should load datadog.yaml when path ends with .yaml"
+        );
+    }
+
+    #[test]
+    fn test_load_core_config_fallback_to_sysprobe_dir() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let sp_yaml = temp_dir.path().join("system-probe.yaml");
+        std::fs::write(&sp_yaml, "discovery:\n  enabled: true\n").unwrap();
+        let core_yaml = temp_dir.path().join("datadog.yaml");
+        std::fs::write(&core_yaml, "api_key: from_sp_dir\n").unwrap();
+
+        let sp_path = Some(sp_yaml);
+        let result = load_core_config(&None, &sp_path).unwrap();
+        assert!(
+            result.is_some(),
+            "Should fallback to sysprobe dir for datadog.yaml"
+        );
+    }
+
+    #[test]
+    fn test_load_core_config_both_none_uses_default() {
+        let resolved = resolve_core_config_path(&None, &None);
+        assert_eq!(
+            resolved,
+            PathBuf::from("/etc/datadog-agent/datadog.yaml"),
+            "Should use default path when both are None"
+        );
+    }
+
+    #[test]
+    fn test_resolve_core_config_path_explicit_dir() {
+        let resolved = resolve_core_config_path(
+            &Some(PathBuf::from("/opt/datadog")),
+            &Some(PathBuf::from("/etc/system-probe.yaml")),
+        );
+        assert_eq!(resolved, PathBuf::from("/opt/datadog/datadog.yaml"));
+    }
+
+    #[test]
+    fn test_resolve_core_config_path_explicit_yaml() {
+        let resolved = resolve_core_config_path(
+            &Some(PathBuf::from("/opt/datadog/custom.yaml")),
+            &Some(PathBuf::from("/etc/system-probe.yaml")),
+        );
+        assert_eq!(resolved, PathBuf::from("/opt/datadog/custom.yaml"));
+    }
+
+    #[test]
+    fn test_resolve_core_config_path_fallback_sysprobe_yaml() {
+        let resolved =
+            resolve_core_config_path(&None, &Some(PathBuf::from("/custom/dir/system-probe.yaml")));
+        assert_eq!(resolved, PathBuf::from("/custom/dir/datadog.yaml"));
+    }
+
+    #[test]
+    fn test_resolve_core_config_path_fallback_sysprobe_dir() {
+        let resolved = resolve_core_config_path(&None, &Some(PathBuf::from("/custom/dir")));
+        assert_eq!(resolved, PathBuf::from("/custom/dir/datadog.yaml"));
     }
 }

--- a/pkg/discovery/module/rust/src/config.rs
+++ b/pkg/discovery/module/rust/src/config.rs
@@ -133,28 +133,27 @@ fn find_non_discovery_yaml_key(yaml_doc: &Option<Yaml>) -> Option<&str> {
 }
 
 static NON_DISCOVERY_ENV_VARS: phf::Set<&'static str> = phf_set! {
-  "DD_NETWORK_CONFIG_ENABLED", // Network Performance Monitoring
-  "DD_SERVICE_MONITORING_CONFIG_ENABLED", // Universal Service Monitoring
-  "DD_CCM_NETWORK_CONFIG_ENABLED", // Cloud Cost Management
-  "DD_RUNTIME_SECURITY_CONFIG_ENABLED", // CSM with network monitoring
-  "DD_RUNTIME_SECURITY_CONFIG_NETWORK_MONITORING_ENABLED", // CSM with network monitoring
-  "DD_SYSTEM_PROBE_CONFIG_ENABLE_TCP_QUEUE_LENGTH", // TCP Queue Length Tracer Module
-  "DD_SYSTEM_PROBE_CONFIG_ENABLE_OOM_KILL", // OOM Kill Probe Module
-  "DD_EVENT_MONITORING_CONFIG_PROCESS_ENABLED", // Process event monitoring
-  "DD_SERVICE_MONITORING_CONFIG_ENABLE_EVENT_STREAM", // USM with event stream
-  "DD_EVENT_MONITORING_CONFIG_NETWORK_PROCESS_ENABLED", // Network Tracer Module enabled AND DD_EVENT_MONITORING_CONFIG_NETWORK_PROCESS_ENABLED=true
-  "DD_GPU_MONITORING_ENABLED", // GPU monitoring
-  "DD_DYNAMIC_INSTRUMENTATION_ENABLED", // Dynamic instrumentation
-  "DD_COMPLIANCE_CONFIG_ENABLED", // Compliance Module
-  "DD_RUNTIME_SECURITY_CONFIG_COMPLIANCE_MODULE_ENABLED", // CSM with compliance module
-  "DD_SYSTEM_PROBE_CONFIG_PROCESS_CONFIG_ENABLED", // Process Module
-  "DD_EBPF_CHECK_ENABLED", // eBPF Module
-  "DD_LANGUAGE_DETECTION_ENABLED", // Language Detection Module
-  "DD_PING_ENABLED", // Ping Module
-  "DD_TRACEROUTE_ENABLED", // Traceroute Module
-  "DD_SOFTWARE_INVENTORY_ENABLED", // Software Inventory Module
-  "DD_PRIVILEGED_LOGS_ENABLED", // Privileged Logs Module
-  "DD_WINDOWS_CRASH_DETECTION_ENABLED", // Windows Crash Detection Module
+  "DD_CCM_NETWORK_CONFIG_ENABLED",
+  "DD_COMPLIANCE_CONFIG_DATABASE_BENCHMARKS_ENABLED",
+  "DD_COMPLIANCE_CONFIG_ENABLED",
+  "DD_COMPLIANCE_CONFIG_RUN_IN_SYSTEM_PROBE",
+  "DD_DYNAMIC_INSTRUMENTATION_ENABLED",
+  "DD_EBPF_CHECK_ENABLED",
+  "DD_GPU_MONITORING_ENABLED",
+  "DD_NOISY_NEIGHBOR_ENABLED",
+  "DD_PING_ENABLED",
+  "DD_PRIVILEGED_LOGS_ENABLED",
+  "DD_RUNTIME_SECURITY_CONFIG_ENABLED",
+  "DD_RUNTIME_SECURITY_CONFIG_FIM_ENABLED",
+  "DD_SOFTWARE_INVENTORY_ENABLED",
+  "DD_SYSTEM_PROBE_CONFIG_ENABLE_OOM_KILL",
+  "DD_SYSTEM_PROBE_CONFIG_ENABLE_TCP_QUEUE_LENGTH",
+  "DD_SYSTEM_PROBE_CONFIG_LANGUAGE_DETECTION_ENABLED",
+  "DD_SYSTEM_PROBE_NETWORK_ENABLED",
+  "DD_SYSTEM_PROBE_PROCESS_ENABLED",
+  "DD_SYSTEM_PROBE_SERVICE_MONITORING_ENABLED",
+  "DD_TRACEROUTE_ENABLED",
+  "DD_WINDOWS_CRASH_DETECTION_ENABLED",
 };
 
 /// Returns the non-discovery environment variable that is set and not
@@ -162,7 +161,7 @@ static NON_DISCOVERY_ENV_VARS: phf::Set<&'static str> = phf_set! {
 ///
 /// We check the value of each env var rather than just its presence to avoid
 /// unnecessary fallback. This is needed because the Helm chart sets feature
-/// env vars even for disabled features (e.g. `DD_NETWORK_CONFIG_ENABLED=false`).
+/// env vars even for disabled features (e.g. `DD_SYSTEM_PROBE_NETWORK_ENABLED=false`).
 ///
 /// The logic uses `!= Some(false)` so that non-boolean values still trigger
 /// fallback as a safety net — matching the YAML side where a section without
@@ -339,7 +338,7 @@ mod tests {
 
     #[test]
     fn test_network_tracer_needs_fallback() {
-        temp_env::with_var("DD_NETWORK_CONFIG_ENABLED", Some("true"), || {
+        temp_env::with_var("DD_SYSTEM_PROBE_NETWORK_ENABLED", Some("true"), || {
             let decision = determine_action_no_config();
             assert_eq!(decision, FallbackDecision::FallbackToSystemProbe);
         });
@@ -356,7 +355,7 @@ discovery:
         let config_file = create_test_config(yaml);
 
         // Env var says true, YAML says false
-        temp_env::with_var("DD_NETWORK_CONFIG_ENABLED", Some("true"), || {
+        temp_env::with_var("DD_SYSTEM_PROBE_NETWORK_ENABLED", Some("true"), || {
             let config = load_config(Some(config_file.path().to_path_buf()));
             let decision = determine_action(&config);
             assert_eq!(
@@ -404,7 +403,7 @@ discovery:
         temp_env::with_vars(
             [
                 ("DD_DISCOVERY_ENABLED", Some("true")),
-                ("DD_NETWORK_CONFIG_ENABLED", Some("true")),
+                ("DD_SYSTEM_PROBE_NETWORK_ENABLED", Some("true")),
             ],
             || {
                 let decision = determine_action_no_config();
@@ -499,7 +498,7 @@ discovery:
 
     #[test]
     fn test_find_non_discovery_env_var_false_no_fallback() {
-        temp_env::with_var("DD_NETWORK_CONFIG_ENABLED", Some("false"), || {
+        temp_env::with_var("DD_SYSTEM_PROBE_NETWORK_ENABLED", Some("false"), || {
             assert!(
                 find_non_discovery_env_var().is_none(),
                 "Env var set to 'false' should not trigger fallback"
@@ -509,7 +508,7 @@ discovery:
 
     #[test]
     fn test_find_non_discovery_env_var_zero_no_fallback() {
-        temp_env::with_var("DD_NETWORK_CONFIG_ENABLED", Some("0"), || {
+        temp_env::with_var("DD_SYSTEM_PROBE_NETWORK_ENABLED", Some("0"), || {
             assert!(
                 find_non_discovery_env_var().is_none(),
                 "Env var set to '0' should not trigger fallback"
@@ -519,10 +518,10 @@ discovery:
 
     #[test]
     fn test_find_non_discovery_env_var_non_boolean_triggers_fallback() {
-        temp_env::with_var("DD_NETWORK_CONFIG_ENABLED", Some("maybe"), || {
+        temp_env::with_var("DD_SYSTEM_PROBE_NETWORK_ENABLED", Some("maybe"), || {
             assert_eq!(
                 find_non_discovery_env_var().as_deref(),
-                Some("DD_NETWORK_CONFIG_ENABLED"),
+                Some("DD_SYSTEM_PROBE_NETWORK_ENABLED"),
             );
         });
     }
@@ -690,7 +689,7 @@ network_config:
         temp_env::with_vars(
             [
                 ("DD_DISCOVERY_ENABLED", Some("true")),
-                ("DD_SERVICE_MONITORING_CONFIG_ENABLED", Some("true")),
+                ("DD_SYSTEM_PROBE_SERVICE_MONITORING_ENABLED", Some("true")),
             ],
             || {
                 let decision = determine_action_no_config();
@@ -1086,7 +1085,7 @@ log_level: 12345
             [
                 ("DD_DISCOVERY_USE_SD_AGENT", Some("true")),
                 ("DD_DISCOVERY_ENABLED", Some("true")),
-                ("DD_NETWORK_CONFIG_ENABLED", Some("true")), // Non-discovery module
+                ("DD_SYSTEM_PROBE_NETWORK_ENABLED", Some("true")), // Non-discovery module
             ],
             || {
                 let decision = determine_action(&Ok(None));

--- a/pkg/discovery/module/rust/src/main.rs
+++ b/pkg/discovery/module/rust/src/main.rs
@@ -299,7 +299,8 @@ async fn run_sd_agent(config: Option<yaml_rust2::Yaml>, pid_path: Option<PathBuf
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = Args::parse(env::args());
-    let config = config::load_config(args.config_path);
+    let config = config::load_config(args.config_path.clone());
+    let core_config = config::load_core_config(&args.datadog_config_path, &args.config_path);
     let log_level = config::get_log_level(&config);
     simple_logger::init_with_level(log_level)?;
     info!("Log level set to: {:?}", log_level);
@@ -316,7 +317,7 @@ async fn main() -> Result<()> {
             );
         }
 
-        match config::determine_action(&config) {
+        match config::determine_action(&config, &core_config) {
             config::FallbackDecision::FallbackToSystemProbe => {
                 info!("Unsupported configuration detected. Falling back to system-probe.");
                 fallback_to_system_probe(fallback_binary, &args.system_probe_args)?;

--- a/pkg/discovery/module/rust/tests/fallback_integration_test.rs
+++ b/pkg/discovery/module/rust/tests/fallback_integration_test.rs
@@ -43,7 +43,7 @@ fn test_fallback_on_npm_enabled() {
         .arg("run")
         .arg("--pid=/var/run/test.pid")
         .arg("--debug")
-        .env("DD_NETWORK_CONFIG_ENABLED", "true")
+        .env("DD_SYSTEM_PROBE_NETWORK_ENABLED", "true")
         .output()
         .expect("Failed to execute sd-agent");
 
@@ -132,7 +132,7 @@ fn test_missing_fallback_binary() {
         .arg("--")
         .arg("/nonexistent/system-probe")
         .arg("run")
-        .env("DD_NETWORK_CONFIG_ENABLED", "true")
+        .env("DD_SYSTEM_PROBE_NETWORK_ENABLED", "true")
         .output()
         .expect("Failed to execute sd-agent");
 
@@ -444,7 +444,7 @@ fn test_env_var_false_no_fallback() {
         .arg(format!("--config={}", config_file.path().display()))
         .env("DD_DISCOVERY_USE_SD_AGENT", "true")
         .env("DD_DISCOVERY_ENABLED", "true")
-        .env("DD_NETWORK_CONFIG_ENABLED", "false")
+        .env("DD_SYSTEM_PROBE_NETWORK_ENABLED", "false")
         .spawn()
         .expect("Failed to spawn sd-agent");
 
@@ -480,7 +480,7 @@ fn test_env_var_zero_no_fallback() {
         .arg(format!("--config={}", config_file.path().display()))
         .env("DD_DISCOVERY_USE_SD_AGENT", "true")
         .env("DD_DISCOVERY_ENABLED", "true")
-        .env("DD_NETWORK_CONFIG_ENABLED", "0")
+        .env("DD_SYSTEM_PROBE_NETWORK_ENABLED", "0")
         .spawn()
         .expect("Failed to spawn sd-agent");
 
@@ -508,7 +508,7 @@ fn test_env_var_non_boolean_triggers_fallback() {
         .arg(&mock_sp_source)
         .arg(&marker_file)
         .arg("run")
-        .env("DD_NETWORK_CONFIG_ENABLED", "maybe")
+        .env("DD_SYSTEM_PROBE_NETWORK_ENABLED", "maybe")
         .output()
         .expect("Failed to execute sd-agent");
 

--- a/pkg/discovery/module/rust/tests/fallback_integration_test.rs
+++ b/pkg/discovery/module/rust/tests/fallback_integration_test.rs
@@ -43,6 +43,7 @@ fn test_fallback_on_npm_enabled() {
         .arg("run")
         .arg("--pid=/var/run/test.pid")
         .arg("--debug")
+        .env("DD_DISCOVERY_USE_SD_AGENT", "true")
         .env("DD_SYSTEM_PROBE_NETWORK_ENABLED", "true")
         .output()
         .expect("Failed to execute sd-agent");
@@ -132,6 +133,7 @@ fn test_missing_fallback_binary() {
         .arg("--")
         .arg("/nonexistent/system-probe")
         .arg("run")
+        .env("DD_DISCOVERY_USE_SD_AGENT", "true")
         .env("DD_SYSTEM_PROBE_NETWORK_ENABLED", "true")
         .output()
         .expect("Failed to execute sd-agent");
@@ -259,6 +261,124 @@ fn test_discovery_enabled_with_fallback() {
         marker_file.exists(),
         "Discovery + Runtime Security Config Enabled should trigger fallback"
     );
+}
+
+// --datadogcfgpath integration tests
+#[test]
+fn test_datadogcfgpath_overrides_sysprobe_dir() {
+    let temp_dir = TempDir::new().unwrap();
+    let marker_file = temp_dir.path().join("sp-called");
+
+    let mock_sp_source = mock_system_probe_path();
+
+    // Create two separate directories: one for system-probe.yaml, one for datadog.yaml
+    let sp_dir = TempDir::new().unwrap();
+    let dd_dir = TempDir::new().unwrap();
+
+    // system-probe.yaml with only discovery enabled
+    let sp_config_path = sp_dir.path().join("system-probe.yaml");
+    fs::write(
+        &sp_config_path,
+        "discovery:\n  enabled: true\n  use_sd_agent: true\n",
+    )
+    .unwrap();
+
+    // datadog.yaml in a DIFFERENT directory with a core config key that triggers fallback
+    let core_config_path = dd_dir.path().join("datadog.yaml");
+    fs::write(&core_config_path, "software_inventory:\n  enabled: true\n").unwrap();
+
+    // Use --datadogcfgpath to point to the separate directory
+    let _output = Command::new(SD_AGENT_BIN)
+        .arg("--")
+        .arg(&mock_sp_source)
+        .arg(&marker_file)
+        .arg("run")
+        .arg(format!("--config={}", sp_config_path.display()))
+        .arg(format!("--datadogcfgpath={}", dd_dir.path().display()))
+        .output()
+        .expect("Failed to execute sd-agent");
+
+    assert!(
+        marker_file.exists(),
+        "--datadogcfgpath should cause core config to be loaded from the specified directory, \
+         triggering fallback due to software_inventory.enabled"
+    );
+}
+
+// Core config (datadog.yaml) integration tests
+#[test]
+fn test_core_config_key_triggers_fallback() {
+    let temp_dir = TempDir::new().unwrap();
+    let marker_file = temp_dir.path().join("sp-called");
+
+    let mock_sp_source = mock_system_probe_path();
+
+    // Create a config directory with both system-probe.yaml and datadog.yaml
+    let config_dir = TempDir::new().unwrap();
+
+    // system-probe.yaml with only discovery enabled
+    let sp_config_path = config_dir.path().join("system-probe.yaml");
+    fs::write(
+        &sp_config_path,
+        "discovery:\n  enabled: true\n  use_sd_agent: true\n",
+    )
+    .unwrap();
+
+    // datadog.yaml with a core config key that should trigger fallback
+    let core_config_path = config_dir.path().join("datadog.yaml");
+    fs::write(&core_config_path, "software_inventory:\n  enabled: true\n").unwrap();
+
+    let _output = Command::new(SD_AGENT_BIN)
+        .arg("--")
+        .arg(&mock_sp_source)
+        .arg(&marker_file)
+        .arg("run")
+        .arg(format!("--config={}", sp_config_path.display()))
+        .output()
+        .expect("Failed to execute sd-agent");
+
+    assert!(
+        marker_file.exists(),
+        "Core config key (software_inventory.enabled) in datadog.yaml should trigger fallback"
+    );
+}
+
+#[test]
+fn test_core_config_absent_no_fallback() {
+    let temp_dir = TempDir::new().unwrap();
+    let marker_file = temp_dir.path().join("sp-called");
+
+    let mock_sp_source = mock_system_probe_path();
+
+    // Create a config directory with only system-probe.yaml (no datadog.yaml)
+    let config_dir = TempDir::new().unwrap();
+
+    let sp_config_path = config_dir.path().join("system-probe.yaml");
+    fs::write(
+        &sp_config_path,
+        "discovery:\n  enabled: true\n  use_sd_agent: true\n",
+    )
+    .unwrap();
+
+    // No datadog.yaml - should be fine, sd-agent should run
+    let mut child = Command::new(SD_AGENT_BIN)
+        .arg("--")
+        .arg(&mock_sp_source)
+        .arg(&marker_file)
+        .arg("run")
+        .arg(format!("--config={}", sp_config_path.display()))
+        .spawn()
+        .expect("Failed to spawn sd-agent");
+
+    std::thread::sleep(std::time::Duration::from_millis(500));
+
+    assert!(
+        !marker_file.exists(),
+        "Missing datadog.yaml should NOT trigger fallback"
+    );
+
+    child.kill().ok();
+    child.wait().expect("Failed to wait on sd-agent");
 }
 
 // Killswitch integration tests
@@ -508,6 +628,7 @@ fn test_env_var_non_boolean_triggers_fallback() {
         .arg(&mock_sp_source)
         .arg(&marker_file)
         .arg("run")
+        .env("DD_DISCOVERY_USE_SD_AGENT", "true")
         .env("DD_SYSTEM_PROBE_NETWORK_ENABLED", "maybe")
         .output()
         .expect("Failed to execute sd-agent");


### PR DESCRIPTION
### What does this PR do?

Replaces the hardcoded `find_non_discovery_yaml_key()` in the Rust sd-agent with a data-driven approach, adds `datadog.yaml` loading, and adds `--datadogcfgpath` CLI support.

- Introduces `NON_DISCOVERY_SYSPROBE_YAML_KEYS` and `NON_DISCOVERY_CORE_YAML_KEYS` phf sets derived from Go's `enableModules()`
- Loads `datadog.yaml` to check core config keys (e.g. `compliance_config.enabled`, `software_inventory.enabled`) that should trigger fallback — previously these were silently missed
- Adds `--datadogcfgpath` flag matching Go's `DatadogConfFilePath()` so `datadog.yaml` can live in a different directory than `system-probe.yaml`
- Updates `determine_action()` to accept both sysprobe and core config

### Motivation

1. **Core config keys were ignored**: Some non-discovery features (e.g. `compliance_config`, `software_inventory`) are configured in `datadog.yaml`, not `system-probe.yaml`. Without loading `datadog.yaml`, the fallback logic missed these entirely, incorrectly running sd-agent when it should fall back to system-probe.

2. **`--datadogcfgpath` was unsupported**: Go's system-probe accepts `--datadogcfgpath` to specify where `datadog.yaml` lives independently of `system-probe.yaml`. The sd-agent previously derived the path solely from `--config`'s parent directory, which broke when the two config files lived in different directories.

3. **Hardcoded YAML checks were fragile**: The old `find_non_discovery_yaml_key()` had special-cased sections (`system_probe_config`, `event_monitoring_config`) and a catch-all for unknown sections that could drift from Go's actual module enablement logic. The data-driven approach checks only the specific keys that Go uses.

### Describe how you validated your changes

- `cargo test` — 586 tests pass
- `bazel test //pkg/discovery/module/rust:dd_discovery_test`
- `bazel test //pkg/discovery/module/rust:fallback_integration_test`

A follow-up PR (#47297) adds a canonical JSON file and automated tests on both the Go and Rust sides to ensure these YAML keys cannot drift out of sync in the future.

### Additional Notes

**Depends on #47295.** Part 2 of 3 stacked PRs. Merge order: #47295 → this PR → #47297.

Behavioral changes from the data-driven approach:

| Scenario | Old behavior | New behavior |
|----------|-------------|-------------|
| Core config key in `datadog.yaml` | RunSdAgent (missed) | FallbackToSystemProbe |
| `--datadogcfgpath` pointing to separate dir | Ignored (wrong dir) | Correctly resolved |
| Unknown YAML section with `enabled: true` | FallbackToSystemProbe | RunSdAgent |
| `network_config` without `enabled` key | FallbackToSystemProbe | RunSdAgent |