### PR TITLE
feat(discovery): add canonical JSON sync mechanism for env vars and YAML keys

### DIFF
--- a/pkg/discovery/module/rust/BUILD.bazel
+++ b/pkg/discovery/module/rust/BUILD.bazel
@@ -183,7 +183,10 @@ rust_test(
     name = "dd_discovery_test",
     crate = ":dd_discovery",
     # Make test data available to tests
-    data = [":testdata"],
+    data = [
+        ":testdata",
+        "//pkg/system-probe/config:testdata/non_discovery_module_config.json",
+    ],
     edition = "2024",
     deps = [
         # Dev dependencies from Cargo.toml

--- a/pkg/discovery/module/rust/src/config.rs
+++ b/pkg/discovery/module/rust/src/config.rs
@@ -113,7 +113,9 @@ fn get_yaml_string_option(doc: &Yaml, key: &str) -> Option<String> {
 }
 
 /// YAML key paths from system-probe.yaml that trigger non-discovery modules.
-/// These keys are derived from Go's enableModules() implementation.
+/// Validated against the canonical JSON at
+/// pkg/system-probe/config/testdata/non_discovery_module_config.json
+/// by test_non_discovery_config_matches_canonical.
 static NON_DISCOVERY_SYSPROBE_YAML_KEYS: phf::Set<&'static str> = phf_set! {
     "ccm_network_config.enabled",
     "compliance_config.database_benchmarks.enabled",
@@ -136,7 +138,9 @@ static NON_DISCOVERY_SYSPROBE_YAML_KEYS: phf::Set<&'static str> = phf_set! {
 };
 
 /// YAML key paths from datadog.yaml (core config) that trigger non-discovery modules.
-/// These keys are derived from Go's enableModules() implementation.
+/// Validated against the canonical JSON at
+/// pkg/system-probe/config/testdata/non_discovery_module_config.json
+/// by test_non_discovery_config_matches_canonical.
 static NON_DISCOVERY_CORE_YAML_KEYS: phf::Set<&'static str> = phf_set! {
     "compliance_config.enabled",
     "compliance_config.run_in_system_probe",
@@ -147,7 +151,7 @@ static NON_DISCOVERY_CORE_YAML_KEYS: phf::Set<&'static str> = phf_set! {
 ///
 /// Checks sysprobe keys against the system-probe.yaml doc and core keys
 /// against the datadog.yaml doc. The sets of keys are derived from Go's
-/// enableModules() implementation.
+/// enableModules() and kept in sync via the canonical JSON file.
 fn find_non_discovery_yaml_key(
     sysprobe_doc: &Option<Yaml>,
     core_doc: &Option<Yaml>,
@@ -177,7 +181,10 @@ fn find_non_discovery_yaml_key(
     None
 }
 
-/// These keys are derived from Go's enableModules() implementation.
+/// Validated against the canonical JSON at
+/// pkg/system-probe/config/testdata/non_discovery_module_config.json
+/// by test_non_discovery_config_matches_canonical. See also
+/// TestEnableModulesConfig in pkg/system-probe/config/module_config_sync_test.go.
 static NON_DISCOVERY_ENV_VARS: phf::Set<&'static str> = phf_set! {
   "DD_CCM_NETWORK_CONFIG_ENABLED",
   "DD_COMPLIANCE_CONFIG_DATABASE_BENCHMARKS_ENABLED",
@@ -1547,5 +1554,107 @@ system_probe_config:
     fn test_resolve_core_config_path_fallback_sysprobe_dir() {
         let resolved = resolve_core_config_path(&None, &Some(PathBuf::from("/custom/dir")));
         assert_eq!(resolved, PathBuf::from("/custom/dir/datadog.yaml"));
+    }
+
+    // Sync test: validates NON_DISCOVERY_ENV_VARS, NON_DISCOVERY_SYSPROBE_YAML_KEYS,
+    // and NON_DISCOVERY_CORE_YAML_KEYS match the canonical JSON file.
+
+    #[derive(serde::Deserialize)]
+    struct CanonicalConfig {
+        env_vars: Vec<String>,
+        sysprobe_yaml_keys: Vec<String>,
+        core_yaml_keys: Vec<String>,
+    }
+
+    #[test]
+    fn test_non_discovery_config_matches_canonical() {
+        let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string());
+        let json_path = std::path::PathBuf::from(manifest_dir)
+            .join("..")
+            .join("..")
+            .join("..")
+            .join("system-probe")
+            .join("config")
+            .join("testdata")
+            .join("non_discovery_module_config.json");
+
+        let json_content = std::fs::read_to_string(&json_path).unwrap_or_else(|e| {
+            panic!("Cannot read canonical JSON at {}: {e}", json_path.display())
+        });
+
+        let canonical: CanonicalConfig = serde_json::from_str(&json_content).unwrap_or_else(|e| {
+            panic!(
+                "Cannot parse canonical JSON at {}: {e}",
+                json_path.display()
+            )
+        });
+
+        // Validate env vars
+        let file_env_vars: std::collections::BTreeSet<&str> =
+            canonical.env_vars.iter().map(|s| s.as_str()).collect();
+        let rust_env_vars: std::collections::BTreeSet<&str> =
+            NON_DISCOVERY_ENV_VARS.iter().copied().collect();
+
+        let env_in_file_not_rust: Vec<&&str> = file_env_vars.difference(&rust_env_vars).collect();
+        let env_in_rust_not_file: Vec<&&str> = rust_env_vars.difference(&file_env_vars).collect();
+
+        assert!(
+            env_in_file_not_rust.is_empty() && env_in_rust_not_file.is_empty(),
+            "NON_DISCOVERY_ENV_VARS does not match canonical JSON at {}.\n\
+             In JSON but not in Rust: {:?}\n\
+             In Rust but not in JSON: {:?}\n\
+             Update NON_DISCOVERY_ENV_VARS to match the file.",
+            json_path.display(),
+            env_in_file_not_rust,
+            env_in_rust_not_file
+        );
+
+        // Validate sysprobe YAML keys
+        let file_sp_keys: std::collections::BTreeSet<&str> = canonical
+            .sysprobe_yaml_keys
+            .iter()
+            .map(|s| s.as_str())
+            .collect();
+        let rust_sp_keys: std::collections::BTreeSet<&str> =
+            NON_DISCOVERY_SYSPROBE_YAML_KEYS.iter().copied().collect();
+
+        let sp_in_file_not_rust: Vec<&&str> = file_sp_keys.difference(&rust_sp_keys).collect();
+        let sp_in_rust_not_file: Vec<&&str> = rust_sp_keys.difference(&file_sp_keys).collect();
+
+        assert!(
+            sp_in_file_not_rust.is_empty() && sp_in_rust_not_file.is_empty(),
+            "NON_DISCOVERY_SYSPROBE_YAML_KEYS does not match canonical JSON at {}.\n\
+             In JSON but not in Rust: {:?}\n\
+             In Rust but not in JSON: {:?}\n\
+             Update NON_DISCOVERY_SYSPROBE_YAML_KEYS to match the file.",
+            json_path.display(),
+            sp_in_file_not_rust,
+            sp_in_rust_not_file
+        );
+
+        // Validate core YAML keys
+        let file_core_keys: std::collections::BTreeSet<&str> = canonical
+            .core_yaml_keys
+            .iter()
+            .map(|s| s.as_str())
+            .collect();
+        let rust_core_keys: std::collections::BTreeSet<&str> =
+            NON_DISCOVERY_CORE_YAML_KEYS.iter().copied().collect();
+
+        let core_in_file_not_rust: Vec<&&str> =
+            file_core_keys.difference(&rust_core_keys).collect();
+        let core_in_rust_not_file: Vec<&&str> =
+            rust_core_keys.difference(&file_core_keys).collect();
+
+        assert!(
+            core_in_file_not_rust.is_empty() && core_in_rust_not_file.is_empty(),
+            "NON_DISCOVERY_CORE_YAML_KEYS does not match canonical JSON at {}.\n\
+             In JSON but not in Rust: {:?}\n\
+             In Rust but not in JSON: {:?}\n\
+             Update NON_DISCOVERY_CORE_YAML_KEYS to match the file.",
+            json_path.display(),
+            core_in_file_not_rust,
+            core_in_rust_not_file
+        );
     }
 }

--- a/pkg/system-probe/config/BUILD.bazel
+++ b/pkg/system-probe/config/BUILD.bazel
@@ -1,0 +1,4 @@
+exports_files(
+    ["testdata/non_discovery_module_config.json"],
+    visibility = ["//pkg/discovery/module/rust:__pkg__"],
+)

--- a/pkg/system-probe/config/config.go
+++ b/pkg/system-probe/config/config.go
@@ -119,6 +119,16 @@ func load() (*types.Config, error) {
 		TelemetryEnabled: cfg.GetBool(spNS("telemetry_enabled")),
 	}
 
+	return enableModules(c, coreCfg, cfg)
+}
+
+// NOTE: When adding a new module check below, the env var and YAML key that
+// enable it will be automatically discovered by TestEnableModulesConfig which
+// will check if they are present in the canonical JSON file.
+//
+// If more complex handling than checking for true is needed, the test may need
+// to be updated to handle the new case.
+func enableModules(c *types.Config, coreCfg pkgconfigmodel.Config, cfg pkgconfigmodel.Config) (*types.Config, error) {
 	npmEnabled := cfg.GetBool(netNS("enabled"))
 	usmEnabled := cfg.GetBool(smNS("enabled"))
 	ccmEnabled := cfg.GetBool(ccmNS("enabled"))

--- a/pkg/system-probe/config/module_config_sync_test.go
+++ b/pkg/system-probe/config/module_config_sync_test.go
@@ -1,0 +1,186 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build linux
+
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/config/mock"
+	"github.com/DataDog/datadog-agent/pkg/config/model"
+	"github.com/DataDog/datadog-agent/pkg/system-probe/config/types"
+)
+
+type canonicalConfig struct {
+	EnvVars          []string `json:"env_vars"`
+	SysprobeYAMLKeys []string `json:"sysprobe_yaml_keys"`
+	CoreYAMLKeys     []string `json:"core_yaml_keys"`
+}
+
+type testConfig struct {
+	model.Config
+	t    *testing.T
+	keys map[string]struct{}
+}
+
+func newTestConfig(t *testing.T, cfg model.Config) *testConfig {
+	return &testConfig{
+		Config: cfg,
+		t:      t,
+		keys:   make(map[string]struct{}),
+	}
+}
+
+func (c *testConfig) GetBool(key string) bool {
+	// If any of the keys are default true, we may need special handling to ensure
+	// that the correct code paths are exercised.  Ignore this case for for now but
+	// make sure we don't silently miss it if it happens later.
+	assert.False(c.t, c.Config.GetBool(key), "default true conditions not handled: %s", key)
+
+	if key != "discovery.enabled" {
+		c.keys[key] = struct{}{}
+	}
+
+	return false
+}
+
+func (c *testConfig) Set(_ string, _ interface{}, _ model.Source) {
+}
+
+func (c *testConfig) sortedKeys() []string {
+	keys := make([]string, 0, len(c.keys))
+	for k := range c.keys {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func (c *testConfig) resolveEnvVars() []string {
+	var envVars []string
+	for key := range c.keys {
+		envVar := resolveEnvVar(key, c.Config)
+		assert.NotEmpty(c.t, envVar, "env var not found for key: %s", key)
+		envVars = append(envVars, envVar)
+	}
+	return envVars
+}
+
+func resolveEnvVar(key string, cfg model.Reader) string {
+	// Try the auto-generated name: DD_ + UPPER(key with . replaced by _)
+	auto := "DD_" + strings.ToUpper(strings.NewReplacer(".", "_").Replace(key))
+	os.Setenv(auto, "resolution_sentinel")
+	defer os.Unsetenv(auto)
+	if cfg.GetString(key) == "resolution_sentinel" {
+		return auto
+	}
+	os.Unsetenv(auto)
+
+	// Fallback: search all registered env vars for one that maps to this key.  The config
+	// model doesn't support finding env vars by key, so we have to search all
+	// registered env vars.
+	for _, ev := range cfg.GetEnvVars() {
+		os.Setenv(ev, "resolution_sentinel")
+		if cfg.GetString(key) == "resolution_sentinel" {
+			os.Unsetenv(ev)
+			return ev
+		}
+		os.Unsetenv(ev)
+	}
+	return ""
+}
+
+// TestEnableModulesConfig collects all the env vars and YAML keys that trigger
+// non-discovery modules and verifies that they match the canonical JSON file.
+func TestEnableModulesConfig(t *testing.T) {
+	var c types.Config
+
+	realCoreCfg := mock.New(t)
+	realSpCfg := mock.NewSystemProbe(t)
+
+	coreCfgCollector := newTestConfig(t, realCoreCfg)
+	spCfgCollector := newTestConfig(t, realSpCfg)
+
+	enableModules(&c, coreCfgCollector, spCfgCollector)
+
+	// Collect YAML keys from each config collector separately.
+	sysprobeYAMLKeys := spCfgCollector.sortedKeys()
+	coreYAMLKeys := coreCfgCollector.sortedKeys()
+
+	// Collect env vars from both config collectors.
+	var envVars []string
+	envVars = append(envVars, coreCfgCollector.resolveEnvVars()...)
+	envVars = append(envVars, spCfgCollector.resolveEnvVars()...)
+	sort.Strings(envVars)
+
+	t.Logf("Discovered %d env vars:", len(envVars))
+	for _, v := range envVars {
+		t.Logf("  %s", v)
+	}
+	t.Logf("Discovered %d sysprobe YAML keys:", len(sysprobeYAMLKeys))
+	for _, v := range sysprobeYAMLKeys {
+		t.Logf("  %s", v)
+	}
+	t.Logf("Discovered %d core YAML keys:", len(coreYAMLKeys))
+	for _, v := range coreYAMLKeys {
+		t.Logf("  %s", v)
+	}
+
+	jsonPath := filepath.Join("testdata", "non_discovery_module_config.json")
+	jsonBytes, err := os.ReadFile(jsonPath)
+	require.NoErrorf(t, err,
+		"Cannot read canonical JSON at %s.\n"+
+			"Create it with the discovered env vars and YAML keys listed above.", jsonPath)
+
+	var canonical canonicalConfig
+	require.NoError(t, json.Unmarshal(jsonBytes, &canonical),
+		"Failed to parse canonical JSON at %s", jsonPath)
+
+	assert.Equal(t, canonical.EnvVars, envVars,
+		"Mismatch between discovered env vars and canonical list at %s.\n"+
+			"Update the env_vars array with the discovered list shown above.\n"+
+			"Then update NON_DISCOVERY_ENV_VARS in pkg/discovery/module/rust/src/config.rs.",
+		jsonPath)
+
+	assert.Equal(t, canonical.SysprobeYAMLKeys, sysprobeYAMLKeys,
+		"Mismatch between discovered sysprobe YAML keys and canonical list at %s.\n"+
+			"Update the sysprobe_yaml_keys array with the discovered list shown above.\n"+
+			"Then update NON_DISCOVERY_SYSPROBE_YAML_KEYS in pkg/discovery/module/rust/src/config.rs.",
+		jsonPath)
+
+	assert.Equal(t, canonical.CoreYAMLKeys, coreYAMLKeys,
+		"Mismatch between discovered core YAML keys and canonical list at %s.\n"+
+			"Update the core_yaml_keys array with the discovered list shown above.\n"+
+			"Then update NON_DISCOVERY_CORE_YAML_KEYS in pkg/discovery/module/rust/src/config.rs.",
+		jsonPath)
+}
+
+// TestNonDiscoveryEnvVarsDiscoveryOnly verifies that setting only the
+// discovery env var does not trigger any non-discovery modules.
+func TestNonDiscoveryEnvVarsDiscoveryOnly(t *testing.T) {
+	mock.New(t)
+	mock.NewSystemProbe(t)
+
+	t.Setenv("DD_DISCOVERY_ENABLED", "true")
+
+	cfg, err := load()
+	require.NoError(t, err)
+
+	for mod := range cfg.EnabledModules {
+		if mod != DiscoveryModule {
+			t.Fatalf("expected only DiscoveryModule, but %s is also enabled", mod)
+		}
+	}
+}

--- a/pkg/system-probe/config/testdata/non_discovery_module_config.json
+++ b/pkg/system-probe/config/testdata/non_discovery_module_config.json
@@ -1,0 +1,50 @@
+{
+  "env_vars": [
+    "DD_CCM_NETWORK_CONFIG_ENABLED",
+    "DD_COMPLIANCE_CONFIG_DATABASE_BENCHMARKS_ENABLED",
+    "DD_COMPLIANCE_CONFIG_ENABLED",
+    "DD_COMPLIANCE_CONFIG_RUN_IN_SYSTEM_PROBE",
+    "DD_DYNAMIC_INSTRUMENTATION_ENABLED",
+    "DD_EBPF_CHECK_ENABLED",
+    "DD_GPU_MONITORING_ENABLED",
+    "DD_NOISY_NEIGHBOR_ENABLED",
+    "DD_PING_ENABLED",
+    "DD_PRIVILEGED_LOGS_ENABLED",
+    "DD_RUNTIME_SECURITY_CONFIG_ENABLED",
+    "DD_RUNTIME_SECURITY_CONFIG_FIM_ENABLED",
+    "DD_SOFTWARE_INVENTORY_ENABLED",
+    "DD_SYSTEM_PROBE_CONFIG_ENABLE_OOM_KILL",
+    "DD_SYSTEM_PROBE_CONFIG_ENABLE_TCP_QUEUE_LENGTH",
+    "DD_SYSTEM_PROBE_CONFIG_LANGUAGE_DETECTION_ENABLED",
+    "DD_SYSTEM_PROBE_NETWORK_ENABLED",
+    "DD_SYSTEM_PROBE_PROCESS_ENABLED",
+    "DD_SYSTEM_PROBE_SERVICE_MONITORING_ENABLED",
+    "DD_TRACEROUTE_ENABLED",
+    "DD_WINDOWS_CRASH_DETECTION_ENABLED"
+  ],
+  "sysprobe_yaml_keys": [
+    "ccm_network_config.enabled",
+    "compliance_config.database_benchmarks.enabled",
+    "dynamic_instrumentation.enabled",
+    "ebpf_check.enabled",
+    "gpu_monitoring.enabled",
+    "network_config.enabled",
+    "noisy_neighbor.enabled",
+    "ping.enabled",
+    "privileged_logs.enabled",
+    "runtime_security_config.enabled",
+    "runtime_security_config.fim_enabled",
+    "service_monitoring_config.enabled",
+    "system_probe_config.enable_oom_kill",
+    "system_probe_config.enable_tcp_queue_length",
+    "system_probe_config.language_detection.enabled",
+    "system_probe_config.process_config.enabled",
+    "traceroute.enabled",
+    "windows_crash_detection.enabled"
+  ],
+  "core_yaml_keys": [
+    "compliance_config.enabled",
+    "compliance_config.run_in_system_probe",
+    "software_inventory.enabled"
+  ]
+}


### PR DESCRIPTION
### What does this PR do?

Adds a canonical JSON file as the single source of truth for which env vars and YAML keys trigger fallback from sd-agent to system-probe, with automated tests on both the Go and Rust sides.

- `pkg/system-probe/config/testdata/non_discovery_module_config.json` — canonical lists of `env_vars`, `sysprobe_yaml_keys`, and `core_yaml_keys`
- Go test (`TestEnableModulesConfig`) — instruments `enableModules()` at runtime to discover all env vars and YAML keys, then asserts they match the canonical JSON
- Rust test (`test_non_discovery_config_matches_canonical`) — reads the same JSON and validates the Rust `phf` sets match

### Motivation

The Rust env var and YAML key lists can drift from Go's actual `enableModules()` implementation. By deriving both sets from the same `enableModules()` function and validating them against a shared canonical JSON file, both sides stay in sync automatically. When a new system-probe module is added, `TestEnableModulesConfig` will fail in CI, prompting updates to the JSON and Rust sets.

### Describe how you validated your changes

- `cargo test` — 588 tests pass (including `test_non_discovery_config_matches_canonical`)
- `go test -run TestEnableModulesConfig ./pkg/system-probe/config/`
- `bazel test //pkg/discovery/module/rust:dd_discovery_test`

### Additional Notes

**Depends on #47296.** Part 3 of 3 stacked PRs. Merge order: #47295 → #47296 → this PR.