### PR TITLE
Automatically gather & patch openscap dependencies from bazel

### DIFF
--- a/bazel/rules/packaged_artifacts.bzl
+++ b/bazel/rules/packaged_artifacts.bzl
@@ -1,0 +1,218 @@
+"""Rules for declaring and collecting installation files for dependencies.
+
+When a target is a transitive dynamic dependency, its files (shared objects,
+versioned symlinks, data files, …) must be installed alongside the primary
+artifact.  This module provides:
+
+  packaged_artifacts  — wraps any dependency target and carries a reference
+                        to the pkg_filegroup that should be installed with it
+                        (typically the output of so_symlink, already
+                        rpath-patched).
+
+  collect_packaged_artifacts — traverses the dependency graph (via srcs, deps,
+                        and dynamic_deps attributes) and merges the
+                        PackageFilegroupInfo from every packaged_artifacts
+                        target it encounters into a single target usable in
+                        pkg_filegroup.srcs.
+
+Typical usage in a dependency's BUILD file:
+
+    rewrite_rpath(
+        name = "foo_rpath_patched",
+        inputs = [":foo_lib"],
+    )
+
+    so_symlink(
+        name = "lib_files",
+        src = ":foo_rpath_patched",
+        libname = "libfoo",
+        version = VERSION,
+        prefix = "embedded",
+    )
+
+    packaged_artifacts(
+        name = "foo",               # same label used in dynamic_deps elsewhere
+        src = ":foo_lib",           # the underlying dependency target
+        install_filegroups = [
+            ":lib_files",           # shared object + versioned symlinks
+            ":bin_files",           # executables shipped with the dependency (if any)
+        ],
+    )
+
+Typical usage in the consumer's BUILD file:
+
+    collect_packaged_artifacts(
+        name = "all_deps_shipping",
+        srcs = [":my_cc_shared_library"],
+    )
+
+    pkg_filegroup(
+        name = "all_files",
+        srcs = [
+            ":all_deps_shipping",
+            ":bin_files",
+            ":lib_files",
+            ...
+        ],
+        prefix = "embedded",
+    )
+"""
+
+load("@rules_cc//cc/common:cc_shared_library_info.bzl", "CcSharedLibraryInfo")
+load("@rules_pkg//pkg:providers.bzl", "PackageFilegroupInfo", "PackageFilesInfo")
+
+# ── Public provider ───────────────────────────────────────────────────────────
+
+PackagedArtifactsInfo = provider(
+    doc = """Associates a dependency target with its installation pkg_filegroups.
+
+    Add this (via packaged_artifacts) to any target that is used as a
+    dependency so that collect_packaged_artifacts can automatically gather all
+    the files that must be installed alongside the primary binary.""",
+    fields = {
+        "install_filegroups": "list of Targets each providing PackageFilegroupInfo (e.g. so_symlink output, bin_files, …)",
+    },
+)
+
+# ── packaged_artifacts rule ───────────────────────────────────────────────────
+
+def _packaged_artifacts_impl(ctx):
+    src = ctx.attr.src
+    providers = [
+        src[DefaultInfo],
+        PackagedArtifactsInfo(
+            install_filegroups = ctx.attr.install_filegroups,
+        ),
+    ]
+    # Re-export CcSharedLibraryInfo when present so the target remains usable
+    # in other cc_shared_library dynamic_deps attributes.
+    if CcSharedLibraryInfo in src:
+        providers.append(src[CcSharedLibraryInfo])
+    if CcInfo in src:
+        providers.append(src[CcInfo])
+    return providers
+
+packaged_artifacts = rule(
+    implementation = _packaged_artifacts_impl,
+    doc = """Wraps a dependency target and declares its installation files.
+
+    The resulting target is a drop-in replacement for the wrapped target in
+    other rules' dynamic_deps (or deps / srcs) attributes: it re-exports
+    CcSharedLibraryInfo and CcInfo when present, and always provides
+    PackagedArtifactsInfo so that collect_packaged_artifacts can find the
+    associated packaging target.""",
+    attrs = {
+        "src": attr.label(
+            doc = "The underlying dependency target to wrap.",
+            mandatory = True,
+        ),
+        "install_filegroups": attr.label_list(
+            doc = """pkg_filegroup (or similar) targets whose PackageFilegroupInfo
+            should be included whenever this target appears as a transitive
+            dependency.  Typically includes the output of so_symlink (built from
+            the rpath-patched shared object) and, where applicable, a bin_files
+            target for any executables shipped with the dependency.""",
+            mandatory = True,
+        ),
+    },
+)
+
+# ── Aspect + collector rule ───────────────────────────────────────────────────
+
+_TransitivePackagedArtifactsInfo = provider(
+    doc = "Internal: accumulates install_filegroup targets reached via the dependency graph.",
+    fields = {
+        "shipping_targets": "depset of Targets (each providing PackageFilegroupInfo)",
+    },
+)
+
+def _packaged_artifacts_aspect_impl(target, ctx):
+    transitive = []
+    direct = []
+
+    for attr_name in ["srcs", "deps", "dynamic_deps"]:
+        if hasattr(ctx.rule.attr, attr_name):
+            attr_value = getattr(ctx.rule.attr, attr_name)
+            if type(attr_value) != "list":
+                continue
+            for dep in attr_value:
+                if _TransitivePackagedArtifactsInfo in dep:
+                    transitive.append(dep[_TransitivePackagedArtifactsInfo].shipping_targets)
+
+    if PackagedArtifactsInfo in target:
+        direct.extend(target[PackagedArtifactsInfo].install_filegroups)
+
+    return [_TransitivePackagedArtifactsInfo(
+        shipping_targets = depset(direct, transitive = transitive),
+    )]
+
+_packaged_artifacts_aspect = aspect(
+    implementation = _packaged_artifacts_aspect_impl,
+    attr_aspects = ["srcs", "deps", "dynamic_deps"],
+    provides = [_TransitivePackagedArtifactsInfo],
+    doc = """Traverses dynamic_deps (and srcs/deps for pkg_filegroup hierarchies)
+    and collects PackagedArtifactsInfo.install_filegroups from every
+    packaged_artifacts target encountered.""",
+)
+
+def _collect_packaged_artifacts_impl(ctx):
+    all_pkg_files = []
+    all_pkg_dirs = []
+    all_pkg_symlinks = []
+    all_actual_files = []
+    seen = {}
+
+    for dep in ctx.attr.srcs:
+        if _TransitivePackagedArtifactsInfo not in dep:
+            continue
+        for target in dep[_TransitivePackagedArtifactsInfo].shipping_targets.to_list():
+            # Deduplicate: the same dep can appear via multiple paths.
+            label = str(target.label)
+            if label in seen:
+                continue
+            seen[label] = True
+
+            if PackageFilegroupInfo in target:
+                info = target[PackageFilegroupInfo]
+                all_pkg_files.extend(info.pkg_files)
+                all_pkg_dirs.extend(info.pkg_dirs)
+                all_pkg_symlinks.extend(info.pkg_symlinks)
+                for pkg_files_info, _ in info.pkg_files:
+                    all_actual_files.extend(pkg_files_info.dest_src_map.values())
+            elif PackageFilesInfo in target:
+                # install_filegroups may point directly to pkg_files targets
+                # (which provide PackageFilesInfo rather than PackageFilegroupInfo).
+                info = target[PackageFilesInfo]
+                all_pkg_files.append((info, target.label))
+                all_actual_files.extend(info.dest_src_map.values())
+            else:
+                continue
+
+    return [
+        DefaultInfo(files = depset(all_actual_files)),
+        PackageFilegroupInfo(
+            pkg_files = all_pkg_files,
+            pkg_dirs = all_pkg_dirs,
+            pkg_symlinks = all_pkg_symlinks,
+        ),
+    ]
+
+collect_packaged_artifacts = rule(
+    implementation = _collect_packaged_artifacts_impl,
+    doc = """Collects installation files from all transitive packaged_artifacts dependencies.
+
+    Apply this to the top-level cc_shared_library (or binary, or any target
+    with dependencies) of a component. The rule walks the dependency graph via
+    srcs, deps, and dynamic_deps attributes, finds every packaged_artifacts
+    target, and merges their associated PackageFilegroupInfo (shared objects,
+    versioned symlinks, data files …) into a single target.
+
+    The result provides PackageFilegroupInfo and can therefore appear directly
+    in pkg_filegroup.srcs, pkg_tar.srcs, pkg_deb.data, etc.""",
+    attrs = {
+        "srcs": attr.label_list(
+            doc = "Top-level targets whose dependency subgraph to search.",
+            aspects = [_packaged_artifacts_aspect],
+        ),
+    },
+)

--- a/deps/curl/overlay/overlay.BUILD.bazel
+++ b/deps/curl/overlay/overlay.BUILD.bazel
@@ -1,7 +1,9 @@
 """ Agent specific curl build."""
 
 load("@@//bazel/rules:dd_agent_expand_template.bzl", "dd_agent_expand_template")
+load("@@//bazel/rules:packaged_artifacts.bzl", "packaged_artifacts")
 load("@@//bazel/rules:so_symlink.bzl", "so_symlink")
+load("@@//bazel/rules/rewrite_rpath:rewrite_rpath.bzl", "rewrite_rpath")
 load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_shared_library.bzl", "cc_shared_library")
@@ -234,6 +236,22 @@ cc_shared_library(
     visibility = ["//visibility:public"],
 )
 
+rewrite_rpath(
+    name = "curl_rpath_patched",
+    inputs = [":curl"],
+    visibility = ["//visibility:private"],
+)
+
+packaged_artifacts(
+    name = "curl_artifacts",
+    src = ":curl",
+    install_filegroups = [
+        ":lib_files",
+        ":bin_files",
+    ],
+    visibility = ["//visibility:public"],
+)
+
 dd_agent_expand_template(
     name = "gen_pkgconfig",
     out = "libcurl.pc",
@@ -265,28 +283,27 @@ pkg_files(
     renames = {
         "curl_bin": "curl",
     },
-    prefix = "embedded/bin",
+    prefix = "bin",
 )
 
 so_symlink(
     name = "lib_files",
-    src = ":curl",
+    src = ":curl_rpath_patched",
     libname = "libcurl",
     version = SO_VERSION,
-    prefix = "embedded",
     attributes = pkg_attributes(mode = "0755"),
 )
 
 pkg_files(
     name = "hdr_files",
     srcs = PUBLIC_HEADERS,
-    prefix = "embedded/include/curl",
+    prefix = "include/curl",
 )
 
 pkg_files(
     name = "pc_files",
     srcs = [":gen_pkgconfig"],
-    prefix = "embedded/lib/pkgconfig",
+    prefix = "lib/pkgconfig",
 )
 
 pkg_filegroup(
@@ -297,6 +314,7 @@ pkg_filegroup(
         ":lib_files",
         ":pc_files",
     ],
+    prefix = "embedded",
 )
 
 pkg_install(

--- a/deps/openscap/BUILD.bazel
+++ b/deps/openscap/BUILD.bazel
@@ -26,33 +26,7 @@ alias(
 pkg_filegroup(
     name = "all_files",
     srcs = [
-        ":all_embedded",
-        "@acl//:all_files",
-        "@attr//:all_files",
-        "@bzip2//:all_files",
-    ],
-    # Do not pick up with ... expansion.
-    tags = ["manual"],
-    visibility = ["//packages:__subpackages__"],
-)
-
-# TODO: Fix all of these packages so that embedded is part of the prefix they
-# know about. Right now, we rely on the pkg_install dest_dir to put it into
-# embedded.
-pkg_filegroup(
-    name = "all_embedded",
-    srcs = [
-        "@dbus//:all_files",
-        "@gcrypt//:all_files",
-        "@libselinux//:all_files",
-        "@libsepol//:all_files",
-        "@libxslt//:all_files",
-        "@libyaml//:all_files",
-        "@pcre2//:all_files",
-        "@popt//:all_files",
-        "@rpm//:all_files",
-        "@util-linux//:all_files",
-        "@xmlsec//:all_files",
+        "@openscap//:all_deps_patched",
     ],
     prefix = "embedded",
     # Do not pick up with ... expansion.

--- a/deps/openscap/openscap.BUILD.bazel
+++ b/deps/openscap/openscap.BUILD.bazel
@@ -1,9 +1,8 @@
 """BUILD for openscap."""
 
-load("@@//bazel/rules:collect_cc_dynamic_deps.bzl", "cc_dynamic_deps_filegroup")
 load("@@//bazel/rules:dd_agent_expand_template.bzl", "dd_agent_expand_template")
+load("@@//bazel/rules:packaged_artifacts.bzl", "collect_packaged_artifacts")
 load("@@//bazel/rules:so_symlink.bzl", "so_symlink")
-load("@@//bazel/rules/rewrite_rpath:rewrite_rpath.bzl", "rewrite_rpath")
 load("@@//compliance/rules:purl.bzl", "purl_for_generic")
 load("@package_metadata//rules:package_metadata.bzl", "package_metadata")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
@@ -64,22 +63,21 @@ filegroup(
     ],
 )
 
-cc_dynamic_deps_filegroup(
-    name = "all_deps_dynamic_libs",
-    srcs = [":openscap", ":openscap_sce"],
+# The openscap artifacts (libraries + binaries) without their dependencies.
+# Used as the root for collect_packaged_artifacts so the aspect can traverse
+# into both the cc_shared_library dynamic_deps AND the cc_binary dynamic_deps.
+pkg_filegroup(
+    name = "openscap_artifacts",
+    srcs = [
+        ":bin_files",
+        ":lib_files",
+    ],
     visibility = ["//visibility:private"],
 )
 
-rewrite_rpath(
-    name = "all_deps_rpath_patched",
-    inputs = [":all_deps_dynamic_libs"],
-    visibility = ["//visibility:private"],
-)
-
-pkg_files(
+collect_packaged_artifacts(
     name = "all_deps_patched",
-    srcs = [":all_deps_rpath_patched"],
-    prefix = "lib",
+    srcs = [":openscap_artifacts"],
     tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
 )

--- a/deps/openscap/openscap.BUILD.bazel
+++ b/deps/openscap/openscap.BUILD.bazel
@@ -510,7 +510,7 @@ cc_shared_library(
     dynamic_deps = [
         "@attr//:attr",
         "@bzip2//:bz2",
-        "@curl//:curl",
+        "@curl//:curl_artifacts",
         # dbus is only needed by openscap and is linked statically
         "@gcrypt//:gcrypt",
         "@libselinux//:selinux",
@@ -555,7 +555,7 @@ cc_binary(
         ":openscap",
         "@attr//:attr",
         "@bzip2//:bz2",
-        "@curl//:curl",
+        "@curl//:curl_artifacts",
         # dbus is only needed by openscap and is linked statically
         "@gcrypt//:gcrypt",
         "@libselinux//:selinux",
@@ -600,7 +600,7 @@ cc_binary(
         ":openscap",
         "@attr//:attr",
         "@bzip2//:bz2",
-        "@curl//:curl",
+        "@curl//:curl_artifacts",
         "@gcrypt//:gcrypt",
         "@libselinux//:selinux",
         "@libsepol//:sepol",

--- a/deps/openscap/openscap.BUILD.bazel
+++ b/deps/openscap/openscap.BUILD.bazel
@@ -1,7 +1,9 @@
 """BUILD for openscap."""
 
+load("@@//bazel/rules:collect_cc_dynamic_deps.bzl", "cc_dynamic_deps_filegroup")
 load("@@//bazel/rules:dd_agent_expand_template.bzl", "dd_agent_expand_template")
 load("@@//bazel/rules:so_symlink.bzl", "so_symlink")
+load("@@//bazel/rules/rewrite_rpath:rewrite_rpath.bzl", "rewrite_rpath")
 load("@@//compliance/rules:purl.bzl", "purl_for_generic")
 load("@package_metadata//rules:package_metadata.bzl", "package_metadata")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
@@ -60,6 +62,26 @@ filegroup(
         "@popt",
         "@zstd",
     ],
+)
+
+cc_dynamic_deps_filegroup(
+    name = "all_deps_dynamic_libs",
+    srcs = [":openscap", ":openscap_sce"],
+    visibility = ["//visibility:private"],
+)
+
+rewrite_rpath(
+    name = "all_deps_rpath_patched",
+    inputs = [":all_deps_dynamic_libs"],
+    visibility = ["//visibility:private"],
+)
+
+pkg_files(
+    name = "all_deps_patched",
+    srcs = [":all_deps_rpath_patched"],
+    prefix = "lib",
+    tags = ["manual"],
+    target_compatible_with = ["@platforms//os:linux"],
 )
 
 ENABLED_FEATURES = [
@@ -655,6 +677,7 @@ pkg_files(
 pkg_filegroup(
     name = "all_files",
     srcs = [
+        ":all_deps_patched",
         ":bin_files",
         ":lib_files",
         ":xccdf-resources",

--- a/omnibus/config/software/openscap.rb
+++ b/omnibus/config/software/openscap.rb
@@ -7,71 +7,8 @@ name 'openscap'
 default_version '1.4.3'
 
 build do
-  command_on_repo_root "bazelisk run -- @acl//:install --destdir='#{install_dir}'"
-  command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
-    " #{install_dir}/embedded/lib/libacl.so"
-
-  command_on_repo_root "bazelisk run -- @attr//:install --destdir='#{install_dir}'"
-  command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
-    " #{install_dir}/embedded/lib/libattr.so"
-
-  command_on_repo_root "bazelisk run -- @dbus//:install --destdir='#{install_dir}'"
-
-  command_on_repo_root "bazelisk run -- @libselinux//:install --destdir='#{install_dir}'"
-  command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
-    " #{install_dir}/embedded/lib/libselinux.so"
-
-  command_on_repo_root "bazelisk run -- @libsepol//:install --destdir='#{install_dir}'"
-  command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
-    " #{install_dir}/embedded/lib/libsepol.so"
-
-  command_on_repo_root "bazelisk run -- @libyaml//:install --destdir='#{install_dir}'"
-  sh_lib = if linux_target? then "libyaml.so" else "libyaml.dylib" end
-  command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded' " \
-    "#{install_dir}/embedded/lib/#{sh_lib}"
-
-  command_on_repo_root "bazelisk run -- @pcre2//:install --destdir=#{install_dir}"
-  command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix " \
-    "--prefix #{install_dir}/embedded " \
-    "#{install_dir}/embedded/lib/libpcre2*.so"
-
-  command_on_repo_root "bazelisk run -- @popt//:install --destdir='#{install_dir}'"
-  command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
-    " #{install_dir}/embedded/lib/libpopt.so"
-
-  command_on_repo_root "bazelisk run -- @rpm//:install --destdir='#{install_dir}'"
-  command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
-    " #{install_dir}/embedded/lib/librpm.so" \
-    " #{install_dir}/embedded/lib/librpmio.so"
-
-  command_on_repo_root "bazelisk run -- @util-linux//:blkid_install --destdir='#{install_dir}'"
-  command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
-    " #{install_dir}/embedded/lib/libblkid.so"
-
-  command_on_repo_root "bazelisk run -- @gpg-error//:install --destdir='#{install_dir}'"
-  command_on_repo_root "bazelisk run -- @gcrypt//:install --destdir='#{install_dir}'"
-  command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
-    " #{install_dir}/embedded/lib/libgcrypt.so" \
-    " #{install_dir}/embedded/lib/libgpg-error.so" \
-
-  command_on_repo_root "bazelisk run -- @libxml2//:install --destdir='#{install_dir}'"
-  command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
-    " #{install_dir}/embedded/lib/libxml2.so"
-
-  command_on_repo_root "bazelisk run -- @libxslt//:install --destdir='#{install_dir}'"
-  command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
-    " #{install_dir}/embedded/lib/libxslt.so" \
-    " #{install_dir}/embedded/lib/libexslt.so"
-
-  command_on_repo_root "bazelisk run -- @xmlsec//:install --destdir='#{install_dir}'"
-  command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
-    " #{install_dir}/embedded/lib/libxmlsec1*.so" \
-
   command_on_repo_root "bazelisk run -- @openscap//:install --destdir='#{install_dir}'"
   command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
-    " #{install_dir}/embedded/lib/libopenscap.so" \
-    " #{install_dir}/embedded/lib/libopenscap_sce.so" \
     " #{install_dir}/embedded/bin/oscap" \
     " #{install_dir}/embedded/bin/oscap-io"
-
 end


### PR DESCRIPTION
### What does this PR do?

Move away from manually calling `:install` targets from all OpenSCAP dependencies and let bazel do it for us.

### Motivation

We want to remove the omnibus recipes for the code we already migrated, but we currently still need some code to invoke the rpath patching rule.
This PR leverages the recently added `cc_dynamic_deps_filegroup` rule to automatically gather all dependencies shared libraries and patch their rpath before injecting them in the list of installed files.

### Describe how you validated your changes

A local `bazel run -- @openscap//:install ...` still installs openscap & all its shared libraries into `/o/d/e`

### Additional Notes

This currently only handles curl when it comes to binaries, headers, or any other file that need to be installed.
All other openscap dependencies are currently dropped

Ultimately I suppose we should remove all `:install` targets and let the final package handle it, but this is simpler to iterate on