### PR TITLE
Add workflow to populate Bazel cache from `main`

### DIFF
--- a/.github/actions/bazel-cache/action.yml
+++ b/.github/actions/bazel-cache/action.yml
@@ -1,3 +1,4 @@
+---
 name: Bazel Cache
 description: Pull or push Bazel-related cache(s)
 runs:

--- a/.github/actions/bazel-cache/action.yml
+++ b/.github/actions/bazel-cache/action.yml
@@ -1,0 +1,23 @@
+name: Bazel Cache
+description: Pull or push Bazel-related cache(s)
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: echo "XDG_CACHE_HOME=$GITHUB_WORKSPACE/.cache" >>"$GITHUB_ENV"
+    - name: Pull or push Bazel installation cache(s)
+      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      with:
+        key: bazelversion-${{ hashFiles('.bazelversion') }}
+        path: |
+          .cache/bazelisk
+          .cache/bazel/*/install
+    - name: Pull or push Bazel-managed repository cache(s)
+      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      with:
+        key: bazel-${{ hashFiles('.go-version', '.python-version') }}
+        path: |
+          .cache/bazel/*/cache
+          .cache/go*
+          .cache/ms-go*
+          .cache/pip

--- a/.github/workflows/go_mod_tidy.yml
+++ b/.github/workflows/go_mod_tidy.yml
@@ -12,28 +12,12 @@ jobs:
     permissions:
       contents: write
     runs-on: ubuntu-latest
-    env:
-      XDG_CACHE_HOME: ${{ github.workspace }}/.cache
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
-      - name: Restore Bazel installation
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-        with:
-          key: bazelisk-${{ hashFiles('.bazelversion') }}
-          path: |
-            .cache/bazelisk
-            .cache/bazel/*/install
-      - name: Restore Bazel repositories
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-        with:
-          key: bazel-${{ hashFiles('.go-version', '.python-version') }}
-          path: |
-            .cache/bazel/*/cache
-            .cache/go*
-            .cache/pip
+      - uses: ./.github/actions/bazel-cache
       - name: Install go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:

--- a/.github/workflows/go_mod_tidy.yml
+++ b/.github/workflows/go_mod_tidy.yml
@@ -1,3 +1,4 @@
+---
 name: "Run Go Mod Tidy And Generate Licenses"
 on:
   pull_request:
@@ -13,7 +14,7 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0

--- a/.github/workflows/push-bazel-cache.yml
+++ b/.github/workflows/push-bazel-cache.yml
@@ -1,0 +1,15 @@
+name: "Push Bazel Cache"
+on:
+  push:
+    branches: [main]
+    paths: ["**/*MODULE.bazel*"]
+  workflow_dispatch:
+permissions: {}
+jobs:
+  push_bazel_cache:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: ./.github/actions/bazel-cache
+      - name: Fetch Bazel module dependencies
+        run: bazel mod deps

--- a/.github/workflows/push-bazel-cache.yml
+++ b/.github/workflows/push-bazel-cache.yml
@@ -1,3 +1,4 @@
+---
 name: "Push Bazel Cache"
 on:
   push:
@@ -9,7 +10,7 @@ jobs:
   push_bazel_cache:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/bazel-cache
       - name: Fetch Bazel module dependencies
         run: bazel mod deps


### PR DESCRIPTION
### What does this PR do?
- add `push-bazel-cache.yml` workflow running `bazel mod deps` on push to `main` to populate Bazel caches for downstream consumers, starting with dependabot PRs,
- extract Bazel cache steps into a `.github/actions/bazel-cache` composite action, including `XDG_CACHE_HOME` setup,
- update `go_mod_tidy.yml` to use that composite action.

### Motivation
I realized GitHub Actions caches are _scoped to the very branch_ that created them and PRs _can only restore from their base branch_:
Since `go_mod_tidy.yml` only runs on Dependabot PRs and never on `main`, no base-branch cache ever exists and every run starts cold, defeating the intended purpose...