### PR TITLE
otlp/metrics: reduce allocations in Dimensions.String() and tag handling hot paths

### DIFF
--- a/pkg/opentelemetry-mapping-go/otlp/metrics/dimensions.go
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/dimensions.go
@@ -76,17 +76,6 @@ func (d *Dimensions) OriginProductDetail() OriginProductDetail {
 	return d.originProductDetail
 }
 
-// getTags maps an attributeMap into a slice of Datadog tags
-func getTags(labels pcommon.Map) []string {
-	tags := make([]string, 0, labels.Len())
-	labels.Range(func(key string, value pcommon.Value) bool {
-		v := value.AsString()
-		tags = append(tags, utils.FormatKeyValueTag(key, v))
-		return true
-	})
-	return tags
-}
-
 // AddTags to metrics dimensions.
 func (d *Dimensions) AddTags(tags ...string) *Dimensions {
 	// defensively copy the tags
@@ -105,8 +94,29 @@ func (d *Dimensions) AddTags(tags ...string) *Dimensions {
 }
 
 // WithAttributeMap creates a new metricDimensions struct with additional tags from attributes.
+// It builds the new tags slice in a single allocation, avoiding the intermediate slice from getTags.
 func (d *Dimensions) WithAttributeMap(labels pcommon.Map) *Dimensions {
-	return d.AddTags(getTags(labels)...)
+	labelsLen := labels.Len()
+	if labelsLen == 0 {
+		return d
+	}
+	// Match AddTags ordering: attribute tags come first, then existing d.tags.
+	newTags := make([]string, 0, labelsLen+len(d.tags))
+	labels.Range(func(key string, value pcommon.Value) bool {
+		v := value.AsString()
+		newTags = append(newTags, utils.FormatKeyValueTag(key, v))
+		return true
+	})
+	newTags = append(newTags, d.tags...)
+	return &Dimensions{
+		name:                d.name,
+		tags:                newTags,
+		host:                d.host,
+		originID:            d.originID,
+		originProduct:       d.originProduct,
+		originSubProduct:    d.originSubProduct,
+		originProductDetail: d.originProductDetail,
+	}
 }
 
 // WithSuffix creates a new dimensions struct with an extra name suffix.
@@ -122,35 +132,72 @@ func (d *Dimensions) WithSuffix(suffix string) *Dimensions {
 	}
 }
 
-// Uses a logic similar to what is done in the span processor to build metric keys:
-// https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/b2327211df976e0a57ef0425493448988772a16b/processor/spanmetricsprocessor/processor.go#L353-L387
-// TODO: make this a public util function?
-func concatDimensionValue(metricKeyBuilder *strings.Builder, value string) {
-	metricKeyBuilder.WriteString(value)
-	metricKeyBuilder.WriteString(dimensionSeparator)
-}
-
 // String maps dimensions to a string to use as an identifier.
 // The tags order does not matter.
 func (d *Dimensions) String() string {
-	// Allocate the slice with exact capacity upfront to avoid any re-growth.
-	dimensions := make([]string, len(d.tags), len(d.tags)+3)
-	copy(dimensions, d.tags)
-	dimensions = append(dimensions, "name:"+d.name)
-	dimensions = append(dimensions, "host:"+d.host)
-	dimensions = append(dimensions, "originID:"+d.originID)
-	sort.Strings(dimensions)
+	// Sort only the tags slice (copy to avoid mutating d.tags).
+	sortedTags := make([]string, len(d.tags))
+	copy(sortedTags, d.tags)
+	sort.Strings(sortedTags)
 
-	// Pre-compute total length so the Builder does a single allocation.
-	totalLen := 0
-	for _, dim := range dimensions {
-		totalLen += len(dim) + 1 // +1 for dimensionSeparator
+	// The three fixed fields, in sorted order by their full "prefix:value" representation.
+	// "host:" < "name:" < "originID:" (lexicographic), so insertion order is fixed.
+	const (
+		prefixHost     = "host:"
+		prefixName     = "name:"
+		prefixOriginID = "originID:"
+	)
+	fixed := [3]struct{ prefix, value string }{
+		{prefixHost, d.host},
+		{prefixName, d.name},
+		{prefixOriginID, d.originID},
 	}
 
-	var metricKeyBuilder strings.Builder
-	metricKeyBuilder.Grow(totalLen)
-	for _, dim := range dimensions {
-		concatDimensionValue(&metricKeyBuilder, dim)
+	// Pre-compute total length for a single Builder allocation.
+	totalLen := len(dimensionSeparator) * (len(sortedTags) + 3)
+	for _, t := range sortedTags {
+		totalLen += len(t)
 	}
-	return metricKeyBuilder.String()
+	for _, f := range fixed {
+		totalLen += len(f.prefix) + len(f.value)
+	}
+
+	// Merge sortedTags and fixed entries in sorted order, writing directly to the builder.
+	// This avoids allocating the "prefix:value" concatenated strings.
+	var b strings.Builder
+	b.Grow(totalLen)
+	ti := 0 // index into sortedTags
+	for _, f := range fixed {
+		// Flush all tags that sort before this fixed entry.
+		for ti < len(sortedTags) {
+			// Compare tag to "prefix" + value. We avoid building a full string:
+			// a tag t sorts before fixed entry f if t < f.prefix+f.value.
+			t := sortedTags[ti]
+			if len(t) < len(f.prefix) {
+				if t < f.prefix[:len(t)] || (t == f.prefix[:len(t)]) {
+					b.WriteString(t)
+					b.WriteString(dimensionSeparator)
+					ti++
+					continue
+				}
+			} else {
+				if t[:len(f.prefix)] < f.prefix || (t[:len(f.prefix)] == f.prefix && t[len(f.prefix):] < f.value) {
+					b.WriteString(t)
+					b.WriteString(dimensionSeparator)
+					ti++
+					continue
+				}
+			}
+			break
+		}
+		b.WriteString(f.prefix)
+		b.WriteString(f.value)
+		b.WriteString(dimensionSeparator)
+	}
+	// Flush any remaining tags.
+	for ; ti < len(sortedTags); ti++ {
+		b.WriteString(sortedTags[ti])
+		b.WriteString(dimensionSeparator)
+	}
+	return b.String()
 }

--- a/pkg/opentelemetry-mapping-go/otlp/metrics/dimensions_test.go
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/dimensions_test.go
@@ -79,6 +79,58 @@ func TestMetricDimensionsStringNoTagsChange(t *testing.T) {
 
 }
 
+func TestWithAttributeMapEmptyLabels(t *testing.T) {
+	// WithAttributeMap with an empty map should return the same pointer (early-return path).
+	dims := &Dimensions{name: "metric", tags: []string{"k:v"}, host: "h"}
+	result := dims.WithAttributeMap(pcommon.NewMap())
+	assert.Same(t, dims, result)
+}
+
+func TestMetricDimensionsStringTagShorterThanPrefix(t *testing.T) {
+	// Tags that are lexicographically shorter than a fixed prefix ("host:", "name:", "originID:")
+	// exercise the len(t) < len(f.prefix) branch in the merge loop.
+	//
+	// "h" < "host:" and "n" < "name:", so both sort before their respective fixed fields.
+	dims := Dimensions{name: "m", tags: []string{"h", "n"}, host: "myhost"}
+	key := dims.String()
+	// Must be stable across repeated calls.
+	assert.Equal(t, dims.String(), key)
+	// Must differ from a key with no tags.
+	assert.NotEqual(t, (&Dimensions{name: "m", host: "myhost"}).String(), key)
+}
+
+func TestMetricDimensionsStringTagEqualToFixedPrefix(t *testing.T) {
+	// A tag exactly equal to a fixed prefix string (e.g. "host:") exercises the
+	// `t == f.prefix[:len(t)]` equality branch; the tag should sort before the fixed field.
+	dims := Dimensions{name: "m", tags: []string{"host:"}, host: "myhost"}
+	key := dims.String()
+	assert.Equal(t, dims.String(), key)
+	// Verify the tag is actually included and not swallowed.
+	dimsNoTag := &Dimensions{name: "m", host: "myhost"}
+	assert.NotEqual(t, dimsNoTag.String(), key)
+}
+
+func TestMetricDimensionsStringTagsAfterAllFixed(t *testing.T) {
+	// Tags that sort after all three fixed fields (e.g. starting with 'z') exercise
+	// the trailing-flush loop after the fixed-field merge loop.
+	dims := Dimensions{name: "m", tags: []string{"z:last"}, host: "h"}
+	key := dims.String()
+	assert.Equal(t, dims.String(), key)
+	dimsNoTag := &Dimensions{name: "m", host: "h"}
+	assert.NotEqual(t, dimsNoTag.String(), key)
+}
+
+func TestMetricDimensionsStringDoesNotMutateOriginalTags(t *testing.T) {
+	// Regression: String() must not reorder or append to the original tags slice
+	// even when the slice has spare capacity.
+	tags := make([]string, 2, 5)
+	tags[0] = "z:last"
+	tags[1] = "a:first"
+	dims := Dimensions{name: "metric", tags: tags, host: "host"}
+	_ = dims.String()
+	assert.Equal(t, []string{"z:last", "a:first"}, tags, "String() must not mutate the original tags slice")
+}
+
 var testDims = Dimensions{
 	name: "test.metric",
 	tags: []string{"key:val"},

--- a/pkg/opentelemetry-mapping-go/otlp/metrics/key_hash_cache.go
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/key_hash_cache.go
@@ -55,7 +55,8 @@ func (m *keyHashCache) computeKey(s string) keyHashCacheKey {
 	binary.LittleEndian.PutUint64(bytes[0:], h1)
 	binary.LittleEndian.PutUint64(bytes[8:], h2)
 
-	buf := make([]byte, ascii85.MaxEncodedLen(len(bytes)))
-	n := ascii85.Encode(buf, bytes[:])
+	// ascii85.MaxEncodedLen(16) == 20, use a stack-allocated array to avoid heap alloc
+	var buf [20]byte
+	n := ascii85.Encode(buf[:], bytes[:])
 	return keyHashCacheKey(buf[:n])
 }


### PR DESCRIPTION
### What does this PR do?

Optimizes the `Dimensions` type in the OTel metrics mapping package by reducing allocations in hot paths:

- **`WithAttributeMap`**: Builds the tags slice in a single allocation and adds an early return (same pointer) when the input label map is empty.
- **`String()`**: Replaces the intermediate slice allocation with a two-pointer merge directly into a `strings.Builder`, pre-computing the total length for a single `Grow` call. Removes the `concatDimensionValue` and `getTags` helpers.
- **`key_hash_cache.go`**: Replaces a heap-allocated `[]byte` with a stack-allocated `[20]byte` array for the ascii85 encoding buffer, since the maximum encoded length of a 16-byte hash is a compile-time constant (20).

### Motivation

Reduce memory allocations and GC pressure in the OTel metrics pipeline, which processes high-throughput metric streams where `Dimensions.String()` and tag handling are called frequently.

### Describe how you validated your changes

Run unit test

### Additional Notes

New tests cover previously untested edge cases in the merge loop: tags shorter than a fixed prefix, tags equal to a fixed prefix string, tags that sort after all fixed fields, and a regression test confirming `String()` does not mutate the original tags slice.