### PR TITLE
Fix path resolution for standalone.xml

### DIFF
--- a/pkg/discovery/module/rust/src/service_name/jee/jboss.rs
+++ b/pkg/discovery/module/rust/src/service_name/jee/jboss.rs
@@ -971,7 +971,9 @@ mod tests {
                 if let Some(setup) = test.setup_temp_fs {
                     setup(fs.as_ref());
                 }
-                (HashMap::new(), fs)
+                let mut envs = HashMap::new();
+                envs.insert("PWD".to_string(), "/".to_string());
+                (envs, fs)
             };
             let ctx = DetectionContext::new(1, envs, fs.as_ref());
 


### PR DESCRIPTION
### What does this PR do?
`test_find_deployed_apps` was failing in the container. The test is using `/proc/1/cwd` to resolve path to `jboss` and `jboss/standalone/configuration/standalone.xml` but if `cwd` isn't set to `/` the test fails to find the xml file. This can happen if one sets `--workdir` to `docker run` command that points to another location. This change sets `PWD` to `/` making the test "cwd agnostic".

```
failures:

---- service_name::jee::jboss::tests::test_find_deployed_apps stdout ----

thread 'service_name::jee::jboss::tests::test_find_deployed_apps' (4227) panicked at pkg/discovery/module/rust/src/service_name/jee/jboss.rs:704:21:
Expected JeeError::XmlParse but got Io(Os { code: 2, kind: NotFound, message: "No such file or directory" })
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    service_name::jee::jboss::tests::test_find_deployed_apps

test result: FAILED. 444 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s
```

### Describe how you validated your changes
I ran the tests multiple times in container with and without `--workdir` set to ensure it works.