### PR TITLE
[INCIDENT-50468] fix(.github): Reinstate `.github/chainguard/self.gitlab.deps-fetch.sts.yaml`

### DIFF
--- a/.github/chainguard/self.gitlab.deps-fetch.sts.yaml
+++ b/.github/chainguard/self.gitlab.deps-fetch.sts.yaml
@@ -1,0 +1,11 @@
+issuer: https://gitlab.ddbuild.io
+
+subject_pattern: "project_path:DataDog/.*"
+
+claim_pattern:
+  project_id: "4670"
+
+# This token is used by go_e2e_deps to make authenticated requests to download plugins
+# It doesn't even read from the datadog-agent repo but this is our only way to get a token
+permissions:
+  contents: read


### PR DESCRIPTION
### What does this PR do?
Reinstates the `.github/chainguard/self.gitlab.deps-fetch.sts.yaml` policy deleted in #46312

### Motivation
Quick fix for incident-50468 without needing to backport a PR as this is impacting the final build of 7.76.2

### Describe how you validated your changes

### Additional Notes
Will revert once no longer necessary