### PR TITLE
feat(healthplatform): populate Service field in HealthReport with agent flavor

### DIFF
--- a/comp/healthplatform/impl/forwarder.go
+++ b/comp/healthplatform/impl/forwarder.go
@@ -19,6 +19,7 @@ import (
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 	configutils "github.com/DataDog/datadog-agent/pkg/config/utils"
+	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 	"github.com/DataDog/datadog-agent/pkg/version"
@@ -154,6 +155,7 @@ func (f *forwarder) buildReport(issues map[string]*healthplatform.Issue) *health
 	return &healthplatform.HealthReport{
 		EventType: eventType,
 		EmittedAt: time.Now().UTC().Format(time.RFC3339),
+		Service:   flavor.GetFlavor(),
 		Host: &healthplatform.HostInfo{
 			Hostname:     f.hostname,
 			AgentVersion: pointer.Ptr(version.AgentVersion),

--- a/comp/healthplatform/impl/forwarder.go
+++ b/comp/healthplatform/impl/forwarder.go
@@ -150,12 +150,23 @@ func (f *forwarder) sendHealthReport() {
 	f.log.Info(fmt.Sprintf("Successfully sent health report with %d issues", count))
 }
 
+// safeGetFlavor returns the current agent flavor, falling back to the default
+// if flavor.GetFlavor() panics (e.g. called before main init).
+func safeGetFlavor() (f string) {
+	defer func() {
+		if r := recover(); r != nil {
+			f = flavor.DefaultAgent
+		}
+	}()
+	return flavor.GetFlavor()
+}
+
 // buildReport creates a HealthReport from the current issues
 func (f *forwarder) buildReport(issues map[string]*healthplatform.Issue) *healthplatform.HealthReport {
 	return &healthplatform.HealthReport{
 		EventType: eventType,
 		EmittedAt: time.Now().UTC().Format(time.RFC3339),
-		Service:   flavor.GetFlavor(),
+		Service:   safeGetFlavor(),
 		Host: &healthplatform.HostInfo{
 			Hostname:     f.hostname,
 			AgentVersion: pointer.Ptr(version.AgentVersion),

--- a/comp/healthplatform/impl/forwarder_test.go
+++ b/comp/healthplatform/impl/forwarder_test.go
@@ -74,7 +74,7 @@ func TestForwarderBuildReport(t *testing.T) {
 	report := fwd.buildReport(provider.issues)
 
 	assert.Equal(t, "agent-health-issues", report.EventType)
-	assert.Equal(t, flavor.GetFlavor(), report.Service)
+	assert.Equal(t, flavor.DefaultAgent, report.Service)
 	assert.Equal(t, "test-host", report.Host.Hostname)
 	assert.Equal(t, version.AgentVersion, report.Host.GetAgentVersion())
 	assert.Len(t, report.Issues, 2)

--- a/comp/healthplatform/impl/forwarder_test.go
+++ b/comp/healthplatform/impl/forwarder_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
+	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
@@ -73,6 +74,7 @@ func TestForwarderBuildReport(t *testing.T) {
 	report := fwd.buildReport(provider.issues)
 
 	assert.Equal(t, "agent-health-issues", report.EventType)
+	assert.Equal(t, flavor.GetFlavor(), report.Service)
 	assert.Equal(t, "test-host", report.Host.Hostname)
 	assert.Equal(t, version.AgentVersion, report.Host.GetAgentVersion())
 	assert.Len(t, report.Issues, 2)

--- a/comp/healthplatform/impl/health-platform.go
+++ b/comp/healthplatform/impl/health-platform.go
@@ -29,7 +29,6 @@ import (
 	compdef "github.com/DataDog/datadog-agent/comp/def"
 	healthplatformdef "github.com/DataDog/datadog-agent/comp/healthplatform/def"
 	issuesmod "github.com/DataDog/datadog-agent/comp/healthplatform/impl/issues"
-	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	"github.com/DataDog/datadog-agent/pkg/version"
 
 	// Import issue modules to trigger their init() registration
@@ -732,7 +731,7 @@ func (h *healthPlatformImpl) fillFlare(fb flaretypes.FlareBuilder) error {
 	report := &healthplatform.HealthReport{
 		EventType: "agent.health",
 		EmittedAt: time.Now().UTC().Format(time.RFC3339),
-		Service:   flavor.GetFlavor(),
+		Service:   safeGetFlavor(),
 		Host: &healthplatform.HostInfo{
 			Hostname:     hostname,
 			AgentVersion: &agentVersion,

--- a/comp/healthplatform/impl/health-platform.go
+++ b/comp/healthplatform/impl/health-platform.go
@@ -29,6 +29,7 @@ import (
 	compdef "github.com/DataDog/datadog-agent/comp/def"
 	healthplatformdef "github.com/DataDog/datadog-agent/comp/healthplatform/def"
 	issuesmod "github.com/DataDog/datadog-agent/comp/healthplatform/impl/issues"
+	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	"github.com/DataDog/datadog-agent/pkg/version"
 
 	// Import issue modules to trigger their init() registration
@@ -731,6 +732,7 @@ func (h *healthPlatformImpl) fillFlare(fb flaretypes.FlareBuilder) error {
 	report := &healthplatform.HealthReport{
 		EventType: "agent.health",
 		EmittedAt: time.Now().UTC().Format(time.RFC3339),
+		Service:   flavor.GetFlavor(),
 		Host: &healthplatform.HostInfo{
 			Hostname:     hostname,
 			AgentVersion: &agentVersion,


### PR DESCRIPTION
### What does this PR do?

Populates the `Service` field in `HealthReport` with the current agent flavor (e.g. `agent`, `cluster_agent`, `dogstatsd`) using `flavor.GetFlavor()`.

This field identifies which agent binary emitted the health report, allowing the backend to distinguish reports coming from the core agent vs. the cluster-agent vs. dogstatsd, etc.

### Motivation

The `Service` field was added to the `HealthReport` proto (field 6) to track _"the service that detected the issue (datadog-agent, cluster-agent, backend service)"_ but was not being populated. This PR fills it in.

Note: `Service` is a report-level field (one value per report = the binary that emitted it). Per-issue origin is tracked separately via `Issue.Source` and `Issue.Location`.

### Describe how you validated your changes

- Existing unit tests updated to assert the `Service` field matches the current agent flavor.
- `forwarder_test.go`: added assertion on `report.Service`.

### Additional Notes

`flavor.GetFlavor()` returns the flavor set at agent startup (e.g. `"agent"`, `"cluster_agent"`, `"dogstatsd"`). It is safe to call at runtime (per its godoc: must not be called before the main package is initialized).