### PR TITLE
feat(ssi): implement SSI status reporting on Windows

### DIFF
--- a/comp/updater/ssistatus/impl/ssistatus.go
+++ b/comp/updater/ssistatus/impl/ssistatus.go
@@ -131,6 +131,8 @@ func (c *ssiStatusComponent) populateStatus(stats map[string]interface{}) {
 	modes := make(map[string]bool)
 	switch os := runtime.GOOS; os {
 	case "windows":
+		modes["iis"] = slices.Contains(instrumentationModes, "iis")
+		modes["host"] = slices.Contains(instrumentationModes, "host")
 	case "linux":
 		modes["host"] = slices.Contains(instrumentationModes, "host")
 		modes["docker"] = slices.Contains(instrumentationModes, "docker")

--- a/comp/updater/ssistatus/impl/ssistatus_windows.go
+++ b/comp/updater/ssistatus/impl/ssistatus_windows.go
@@ -7,7 +7,37 @@
 
 package ssistatusimpl
 
-// autoInstrumentationStatus checks if the APM auto-instrumentation is enabled on the host. This will return false on Kubernetes
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/ssi"
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/paths"
+)
+
+// autoInstrumentationStatus checks if the APM auto-instrumentation is enabled on the host.
 func (c *ssiStatusComponent) autoInstrumentationStatus() (bool, []string, error) {
-	return false, nil, nil // TBD on Windows
+	injectorInstalled := false
+	_, err := os.Stat(filepath.Join(paths.PackagesPath, "datadog-apm-inject"))
+	if err == nil {
+		injectorInstalled = true
+	} else if !os.IsNotExist(err) {
+		return false, nil, fmt.Errorf("could not check if injector package is installed: %w", err)
+	}
+
+	instrumentationStatus, err := ssi.GetInstrumentationStatus()
+	if err != nil {
+		return false, nil, fmt.Errorf("could not get APM injection status: %w", err)
+	}
+
+	var modes []string
+	if instrumentationStatus.IISInstrumented {
+		modes = append(modes, "iis")
+	}
+	if instrumentationStatus.HostInstrumented {
+		modes = append(modes, "host")
+	}
+
+	return injectorInstalled && len(modes) > 0, modes, nil
 }

--- a/comp/updater/ssistatus/impl/ssistatus_windows.go
+++ b/comp/updater/ssistatus/impl/ssistatus_windows.go
@@ -9,23 +9,12 @@ package ssistatusimpl
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/ssi"
-	"github.com/DataDog/datadog-agent/pkg/fleet/installer/paths"
 )
 
 // autoInstrumentationStatus checks if the APM auto-instrumentation is enabled on the host.
 func (c *ssiStatusComponent) autoInstrumentationStatus() (bool, []string, error) {
-	injectorInstalled := false
-	_, err := os.Stat(filepath.Join(paths.PackagesPath, "datadog-apm-inject"))
-	if err == nil {
-		injectorInstalled = true
-	} else if !os.IsNotExist(err) {
-		return false, nil, fmt.Errorf("could not check if injector package is installed: %w", err)
-	}
-
 	instrumentationStatus, err := ssi.GetInstrumentationStatus()
 	if err != nil {
 		return false, nil, fmt.Errorf("could not get APM injection status: %w", err)
@@ -39,5 +28,5 @@ func (c *ssiStatusComponent) autoInstrumentationStatus() (bool, []string, error)
 		modes = append(modes, "host")
 	}
 
-	return injectorInstalled && len(modes) > 0, modes, nil
+	return len(modes) > 0, modes, nil
 }

--- a/pkg/fleet/installer/packages/apm_library_dotnet_windows.go
+++ b/pkg/fleet/installer/packages/apm_library_dotnet_windows.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/env"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/exec"
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/ssi"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/paths"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -142,7 +143,13 @@ func instrumentDotnetLibrary(ctx context.Context, target string) (err error) {
 	}
 	dotnetExec := exec.NewDotnetLibraryExec(getExecutablePath(installDir))
 	_, err = dotnetExec.EnableIISInstrumentation(ctx, getLibraryPath(installDir))
-	return err
+	if err != nil {
+		return err
+	}
+	if markerErr := ssi.SetIISInstrumentedMarker(true); markerErr != nil {
+		log.Warnf("Failed to set IIS instrumentation registry marker: %v", markerErr)
+	}
+	return nil
 }
 
 func uninstrumentDotnetLibrary(ctx context.Context, target string) (err error) {
@@ -155,7 +162,13 @@ func uninstrumentDotnetLibrary(ctx context.Context, target string) (err error) {
 	}
 	dotnetExec := exec.NewDotnetLibraryExec(getExecutablePath(installDir))
 	_, err = dotnetExec.RemoveIISInstrumentation(ctx)
-	return err
+	if err != nil {
+		return err
+	}
+	if markerErr := ssi.SetIISInstrumentedMarker(false); markerErr != nil {
+		log.Warnf("Failed to clear IIS instrumentation registry marker: %v", markerErr)
+	}
+	return nil
 }
 
 func instrumentDotnetLibraryIfNeeded(ctx context.Context, target string) (err error) {

--- a/pkg/fleet/installer/packages/ssi/status.go
+++ b/pkg/fleet/installer/packages/ssi/status.go
@@ -11,4 +11,5 @@ type APMInstrumentationStatus struct {
 	HostInstrumented   bool `json:"host_instrumented"`
 	DockerInstalled    bool `json:"docker_installed"`
 	DockerInstrumented bool `json:"docker_instrumented"`
+	IISInstrumented    bool `json:"iis_instrumented"`
 }

--- a/pkg/fleet/installer/packages/ssi/status_windows.go
+++ b/pkg/fleet/installer/packages/ssi/status_windows.go
@@ -8,27 +8,60 @@
 package ssi
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 
 	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/registry"
 
 	"github.com/DataDog/datadog-agent/pkg/util/winutil"
 )
 
+const (
+	// iisInstrumentedRegistryKey is the registry key used to store the IIS instrumentation status.
+	// It is set by the fleet installer when IIS instrumentation is enabled or disabled.
+	// The agent reads this key to report the IIS instrumentation status without requiring admin permissions.
+	iisInstrumentedRegistryKey   = `SOFTWARE\Datadog\APM SSI`
+	iisInstrumentedRegistryValue = "IISInstrumented"
+)
+
+// SetIISInstrumentedMarker sets or clears the registry marker for IIS instrumentation.
+// This should be called by the fleet installer after enabling or disabling IIS instrumentation.
+func SetIISInstrumentedMarker(enabled bool) error {
+	if enabled {
+		k, _, err := registry.CreateKey(registry.LOCAL_MACHINE, iisInstrumentedRegistryKey, registry.SET_VALUE)
+		if err != nil {
+			return fmt.Errorf("could not create IIS instrumentation registry key: %w", err)
+		}
+		defer k.Close()
+		return k.SetDWordValue(iisInstrumentedRegistryValue, 1)
+	}
+	k, err := registry.OpenKey(registry.LOCAL_MACHINE, iisInstrumentedRegistryKey, registry.SET_VALUE)
+	if err != nil {
+		// key doesn't exist, nothing to clear
+		return nil
+	}
+	defer k.Close()
+	err = k.DeleteValue(iisInstrumentedRegistryValue)
+	if err != nil && !errors.Is(err, registry.ErrNotExist) {
+		return fmt.Errorf("could not delete IIS instrumentation registry value: %w", err)
+	}
+	return nil
+}
+
 // GetInstrumentationStatus returns the status of the APM auto-instrumentation on Windows.
 func GetInstrumentationStatus() (status APMInstrumentationStatus, err error) {
-	// IIS instrumentation: check applicationHost.config for Datadog .NET library
-	iisCfgPath := filepath.Join(os.Getenv("windir"), "System32", "inetsrv", "config", "applicationHost.config")
-	iisContent, iisErr := os.ReadFile(iisCfgPath)
-	if iisErr != nil && !errors.Is(iisErr, os.ErrNotExist) {
-		return status, fmt.Errorf("could not read applicationHost.config: %w", iisErr)
-	}
-	if bytes.Contains(iisContent, []byte("datadog-apm-library-dotnet")) {
-		status.IISInstrumented = true
+	// IIS instrumentation: check registry marker set by the fleet installer.
+	// Reading applicationHost.config requires admin permissions, so we use a registry
+	// key set by the fleet installer (which runs with sufficient privileges) instead.
+	k, err := registry.OpenKey(registry.LOCAL_MACHINE, iisInstrumentedRegistryKey, registry.QUERY_VALUE)
+	if err == nil {
+		defer k.Close()
+		val, _, err := k.GetIntegerValue(iisInstrumentedRegistryValue)
+		if err != nil && !errors.Is(err, registry.ErrNotExist) {
+			return status, fmt.Errorf("could not read IIS instrumentation registry value: %w", err)
+		}
+		status.IISInstrumented = val == 1
 	}
 
 	// Host instrumentation: check if the DDInjector kernel driver service is running

--- a/pkg/fleet/installer/packages/ssi/status_windows.go
+++ b/pkg/fleet/installer/packages/ssi/status_windows.go
@@ -7,7 +7,36 @@
 
 package ssi
 
-// GetInstrumentationStatus contains the status of the APM auto-instrumentation.
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/windows"
+
+	"github.com/DataDog/datadog-agent/pkg/util/winutil"
+)
+
+// GetInstrumentationStatus returns the status of the APM auto-instrumentation on Windows.
 func GetInstrumentationStatus() (status APMInstrumentationStatus, err error) {
-	return status, nil // TBD on Windows
+	// IIS instrumentation: check applicationHost.config for Datadog .NET library
+	iisCfgPath := filepath.Join(os.Getenv("windir"), "System32", "inetsrv", "config", "applicationHost.config")
+	iisContent, iisErr := os.ReadFile(iisCfgPath)
+	if iisErr != nil && !errors.Is(iisErr, os.ErrNotExist) {
+		return status, fmt.Errorf("could not read applicationHost.config: %w", iisErr)
+	}
+	if bytes.Contains(iisContent, []byte("datadog-apm-library-dotnet")) {
+		status.IISInstrumented = true
+	}
+
+	// Host instrumentation: check if the DDInjector kernel driver service is running
+	running, svcErr := winutil.IsServiceRunning("DDInjector")
+	if svcErr != nil && !errors.Is(svcErr, windows.ERROR_SERVICE_DOES_NOT_EXIST) {
+		return status, fmt.Errorf("could not check DDInjector service: %w", svcErr)
+	}
+	status.HostInstrumented = running
+
+	return status, nil
 }

--- a/pkg/fleet/installer/packages/ssi/status_windows.go
+++ b/pkg/fleet/installer/packages/ssi/status_windows.go
@@ -38,13 +38,14 @@ func SetIISInstrumentedMarker(enabled bool) error {
 	}
 	k, err := registry.OpenKey(registry.LOCAL_MACHINE, iisInstrumentedRegistryKey, registry.SET_VALUE)
 	if err != nil {
-		// key doesn't exist, nothing to clear
-		return nil
+		if errors.Is(err, registry.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("could not open IIS instrumentation registry key: %w", err)
 	}
-	defer k.Close()
-	err = k.DeleteValue(iisInstrumentedRegistryValue)
-	if err != nil && !errors.Is(err, registry.ErrNotExist) {
-		return fmt.Errorf("could not delete IIS instrumentation registry value: %w", err)
+	k.Close()
+	if err := registry.DeleteKey(registry.LOCAL_MACHINE, iisInstrumentedRegistryKey); err != nil && !errors.Is(err, registry.ErrNotExist) {
+		return fmt.Errorf("could not delete IIS instrumentation registry key: %w", err)
 	}
 	return nil
 }
@@ -62,6 +63,8 @@ func GetInstrumentationStatus() (status APMInstrumentationStatus, err error) {
 			return status, fmt.Errorf("could not read IIS instrumentation registry value: %w", err)
 		}
 		status.IISInstrumented = val == 1
+	} else if !errors.Is(err, registry.ErrNotExist) {
+		return status, fmt.Errorf("could not open IIS instrumentation registry key: %w", err)
 	}
 
 	// Host instrumentation: check if the DDInjector kernel driver service is running


### PR DESCRIPTION
### What does this PR do?

Replaces the Windows stub implementations for SSI status reporting with real logic:

- **Host instrumentation**: queries whether the `DDInjector` kernel driver service is running via `winutil.IsServiceRunning`.
- **IIS instrumentation**: reads a registry key (`HKLM\SOFTWARE\Datadog\APM SSI\IISInstrumented`) set by the fleet installer when enabling/disabling IIS instrumentation. This avoids reading `applicationHost.config` directly, which requires admin permissions the agent doesn't have.
- **`comp/updater/ssistatus/impl/ssistatus_windows.go`**: builds the instrumentation modes (`iis`, `host`) from the status above.
- **`comp/updater/ssistatus/impl/ssistatus.go`**: populates the `iis` and `host` modes in the Windows case of `populateStatus()`.
- **`pkg/fleet/installer/packages/ssi/status.go`**: adds `IISInstrumented bool` field to `APMInstrumentationStatus`.

### Motivation

On Windows, `feature_auto_instrumentation_enabled` in the agent inventory metadata was always `false` even when SSI was actively working, because both Windows stubs returned zero values. This caused Fleet Automation to incorrectly show "SSI disabled" for Windows hosts where SSI was running (SPFA-92).

Windows supports two instrumentation methods:
- **IIS**: the `datadog-apm-library-dotnet` fleet installer sets a registry marker when enabling/disabling IIS instrumentation
- **Host**: the `DDInjector` kernel driver service is running

### IIS detection approach

Reading `applicationHost.config` directly requires admin permissions that the agent doesn't have (see error in PR comments). Instead, the fleet installer (which runs with sufficient privileges) now writes a registry key when IIS instrumentation is enabled or disabled, and the agent reads that key.

**Known limitation for existing installations**: hosts that already had IIS instrumentation enabled before this change will report `IISInstrumented: false` until the next `datadog-apm-library-dotnet` package update triggers re-instrumentation and sets the registry key. This is accepted given that IIS mode is planned to be deprecated once host instrumentation matures.

### Describe how you validated your changes

Cross-compiled for `GOOS=windows GOARCH=amd64` — both `./pkg/fleet/installer/packages/ssi/...` and `./comp/updater/ssistatus/...` build cleanly. Linux build also verified.

On a real Windows host with SSI enabled, `agent status` should show SSI as enabled and `feature_auto_instrumentation_enabled: true` should appear in the inventory payload.

### Additional Notes

- `ERROR_SERVICE_DOES_NOT_EXIST` from `IsServiceRunning` is treated as "not running" (not an error), so hosts without the DDInjector service silently report `HostInstrumented: false`.

**Jira:** [FA-1132](https://datadoghq.atlassian.net/browse/FA-1132)

[FA-1132]: https://datadoghq.atlassian.net/browse/FA-1132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ