### PR TITLE
fix(ci): Handle None PR body in report_merged_pr workflow

### DIFF
--- a/tasks/github_tasks.py
+++ b/tasks/github_tasks.py
@@ -469,10 +469,12 @@ tags: {tags}''')
     print(f"Event sent to Datadog for PR #{pr.number}")
 
 
-def extract_test_qa_description(pr_body: str) -> str:
+def extract_test_qa_description(pr_body: str | None) -> str:
     """
     Extract the test/QA description section from the PR body
     """
+    if not pr_body:
+        return ''
     # Extract the test/QA description section from the PR body
     # Based on PULL_REQUEST_TEMPLATE.md
     pr_body_lines = pr_body.splitlines()


### PR DESCRIPTION
### What does this PR do?

Adds a `None` guard in `extract_test_qa_description` (`tasks/github_tasks.py`) so that the `report_merged_pr` GitHub Actions workflow no longer crashes when a PR has no body.

The type hint is also updated from `str` to `str | None` to reflect the actual GitHub API contract (`pr.body` can be `None`).

### Motivation

The `Report Merged PR` workflow fails when a PR with an empty body is merged to `main`. This happened for example with PR #46792 ("[release] Update last stable to 7.76.0"), an automated release PR with no description:

```
AttributeError: 'NoneType' object has no attribute 'splitlines'
```

See: https://github.com/DataDog/datadog-agent/actions/runs/22305762570/job/64524468021

### Describe how you validated your changes

Code inspection — the fix is a straightforward `None` check before calling `.splitlines()`.

### Additional Notes

None.