### PR TITLE
[workloadmeta/kubemetadata] Use streamed namespace metadata

### DIFF
--- a/cmd/cluster-agent/api/grpc.go
+++ b/cmd/cluster-agent/api/grpc.go
@@ -8,15 +8,19 @@ package api
 import (
 	"context"
 
-	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
-
 	taggerserver "github.com/DataDog/datadog-agent/comp/core/tagger/server"
+	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 )
+
+type kubeMetadataStreamer interface {
+	StreamKubeMetadata(*pbgo.KubeMetadataStreamRequest, pbgo.AgentSecure_StreamKubeMetadataServer) error
+}
 
 type serverSecure struct {
 	pbgo.UnimplementedAgentSecureServer
 
-	taggerServer *taggerserver.Server
+	taggerServer       *taggerserver.Server
+	kubeMetadataServer kubeMetadataStreamer
 }
 
 func (s *serverSecure) TaggerStreamEntities(req *pbgo.StreamTagsRequest, srv pbgo.AgentSecure_TaggerStreamEntitiesServer) error {
@@ -25,4 +29,11 @@ func (s *serverSecure) TaggerStreamEntities(req *pbgo.StreamTagsRequest, srv pbg
 
 func (s *serverSecure) TaggerFetchEntity(ctx context.Context, req *pbgo.FetchEntityRequest) (*pbgo.FetchEntityResponse, error) {
 	return s.taggerServer.TaggerFetchEntity(ctx, req)
+}
+
+func (s *serverSecure) StreamKubeMetadata(req *pbgo.KubeMetadataStreamRequest, srv pbgo.AgentSecure_StreamKubeMetadataServer) error {
+	if s.kubeMetadataServer == nil {
+		return s.UnimplementedAgentSecureServer.StreamKubeMetadata(req, srv)
+	}
+	return s.kubeMetadataServer.StreamKubeMetadata(req, srv)
 }

--- a/cmd/cluster-agent/api/grpc_kubemetadata.go
+++ b/cmd/cluster-agent/api/grpc_kubemetadata.go
@@ -8,13 +8,15 @@
 package api
 
 import (
+	"context"
+
 	v1 "github.com/DataDog/datadog-agent/cmd/cluster-agent/api/v1"
-	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/controllers"
 )
 
-var kubeMetadataServer = v1.NewKubeMetadataStreamServer(controllers.GetGlobalMetaBundleStore())
-
-func (s *serverSecure) StreamKubeMetadata(req *pbgo.KubeMetadataStreamRequest, srv pbgo.AgentSecure_StreamKubeMetadataServer) error {
-	return kubeMetadataServer.StreamKubeMetadata(req, srv)
+func startKubeMetadataStreamer(ctx context.Context, wmeta workloadmeta.Component) kubeMetadataStreamer {
+	srv := v1.NewKubeMetadataStreamServer(controllers.GetGlobalMetaBundleStore(), wmeta)
+	srv.Start(ctx)
+	return srv
 }

--- a/cmd/cluster-agent/api/grpc_kubemetadata_nocompile.go
+++ b/cmd/cluster-agent/api/grpc_kubemetadata_nocompile.go
@@ -1,0 +1,18 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !kubeapiserver
+
+package api
+
+import (
+	"context"
+
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+)
+
+func startKubeMetadataStreamer(_ context.Context, _ workloadmeta.Component) kubeMetadataStreamer {
+	return nil
+}

--- a/cmd/cluster-agent/api/server.go
+++ b/cmd/cluster-agent/api/server.go
@@ -125,8 +125,10 @@ func StartServer(ctx context.Context, w workloadmeta.Component, taggerComp tagge
 	grpcSrv := grpc.NewServer(opts...)
 	// event size should be small enough to fit within the grpc max message size
 	maxEventSize := maxMessageSize / 2
+
 	pb.RegisterAgentSecureServer(grpcSrv, &serverSecure{
-		taggerServer: taggerserver.NewServer(taggerComp, telemetry, maxEventSize, cfg.GetInt("remote_tagger.max_concurrent_sync")),
+		taggerServer:       taggerserver.NewServer(taggerComp, telemetry, maxEventSize, cfg.GetInt("remote_tagger.max_concurrent_sync")),
+		kubeMetadataServer: startKubeMetadataStreamer(ctx, w),
 	})
 
 	timeout := pkgconfigsetup.Datadog().GetDuration("cluster_agent.server.idle_timeout_seconds") * time.Second

--- a/cmd/cluster-agent/api/v1/kubernetes_metadata_stream.go
+++ b/cmd/cluster-agent/api/v1/kubernetes_metadata_stream.go
@@ -8,10 +8,14 @@
 package v1
 
 import (
+	"context"
+	"maps"
+	"sync"
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 	"github.com/DataDog/datadog-agent/pkg/util/grpc"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
@@ -23,7 +27,8 @@ const (
 	streamSendTimeout = 10 * time.Second
 	// keepAliveInterval must be shorter than the client's timeout (10 min) to
 	// prevent the client from treating an idle stream as dead.
-	keepAliveInterval = 9 * time.Minute
+	keepAliveInterval   = 9 * time.Minute
+	wmetaSubscriberName = "kube-metadata-stream"
 )
 
 type podServiceEntry struct {
@@ -32,30 +37,75 @@ type podServiceEntry struct {
 	services  sets.Set[string]
 }
 
-// KubeMetadataStreamServer streams pod-to-service metadata from the DCA to node agents.
+type namespaceEntry struct {
+	labels      map[string]string
+	annotations map[string]string
+}
+
+// KubeMetadataStreamServer streams pod-to-service mappings and namespace
+// labels/annotations from the DCA to node agents.
 type KubeMetadataStreamServer struct {
 	store *controllers.MetaBundleStore
+	wmeta workloadmeta.Component
+
+	namespacesMutex      sync.RWMutex
+	namespaces           map[string]namespaceEntry // keys are namespace names
+	namespaceSubscribers map[string]chan struct{}  // keys are node names
 }
 
-// NewKubeMetadataStreamServer creates a new stream server with the given meta
-// bundle store.
-func NewKubeMetadataStreamServer(store *controllers.MetaBundleStore) *KubeMetadataStreamServer {
-	return &KubeMetadataStreamServer{store: store}
+// NewKubeMetadataStreamServer creates a new KubeMetadataStreamServer
+func NewKubeMetadataStreamServer(store *controllers.MetaBundleStore, wmeta workloadmeta.Component) *KubeMetadataStreamServer {
+	return &KubeMetadataStreamServer{
+		store:                store,
+		wmeta:                wmeta,
+		namespaces:           make(map[string]namespaceEntry),
+		namespaceSubscribers: make(map[string]chan struct{}),
+	}
 }
 
-// StreamKubeMetadata streams pod-to-service mappings to the requesting node
-// agent.
-func (s *KubeMetadataStreamServer) StreamKubeMetadata(req *pb.KubeMetadataStreamRequest, srv pb.AgentSecure_StreamKubeMetadataServer) error {
+// Start subscribes to workloadmeta for namespace metadata changes and
+// maintains the namespace state. It must be called before serving streams.
+func (srv *KubeMetadataStreamServer) Start(ctx context.Context) {
+	ch := srv.wmeta.Subscribe(
+		wmetaSubscriberName,
+		workloadmeta.NormalPriority,
+		namespaceMetadataFilter(),
+	)
+
+	go func() {
+		defer srv.wmeta.Unsubscribe(ch)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case bundle, ok := <-ch:
+				if !ok {
+					return
+				}
+				bundle.Acknowledge()
+				srv.processNamespaceEvents(bundle.Events)
+			}
+		}
+	}()
+}
+
+// StreamKubeMetadata streams pod-to-service mappings and namespace metadata to
+// the requesting node agent.
+func (srv *KubeMetadataStreamServer) StreamKubeMetadata(req *pb.KubeMetadataStreamRequest, stream pb.AgentSecure_StreamKubeMetadataServer) error {
 	nodeName := req.GetNodeName()
 
-	notifyCh := s.store.Subscribe(nodeName)
-	defer s.store.Unsubscribe(nodeName)
+	podServicesNotifyCh := srv.store.Subscribe(nodeName)
+	defer srv.store.Unsubscribe(nodeName)
+
+	namespacesNotifyCh := srv.subscribeToNamespaceEvents(nodeName)
+	defer srv.unsubscribeFromNamespaceEvents(nodeName)
 
 	// Send initial full state
-	lastSentState := s.buildSnapshot(nodeName)
-	initialResp := fullStateResponse(lastSentState)
+	lastSentPodServicesState := srv.buildPodServiceMappingsSnapshot(nodeName)
+	lastSentNamespacesState := srv.buildNamespacesSnapshot()
+	initialResp := fullStateResponse(lastSentPodServicesState, lastSentNamespacesState)
 	if err := grpc.DoWithTimeout(func() error {
-		return srv.Send(initialResp)
+		return stream.Send(initialResp)
 	}, streamSendTimeout); err != nil {
 		log.Warnf("Error sending initial kube metadata state for node %s: %s", nodeName, err)
 		return err
@@ -64,35 +114,54 @@ func (s *KubeMetadataStreamServer) StreamKubeMetadata(req *pb.KubeMetadataStream
 	ticker := time.NewTicker(keepAliveInterval)
 	defer ticker.Stop()
 
-	ctx := srv.Context()
+	ctx := stream.Context()
 	for {
 		select {
 		case <-ctx.Done():
 			return nil
 
-		case <-notifyCh:
-			currentState := s.buildSnapshot(nodeName)
-			diff := computeDiff(lastSentState, currentState)
-			if len(diff) == 0 {
+		case <-podServicesNotifyCh:
+			currentPodServiceMappingsState := srv.buildPodServiceMappingsSnapshot(nodeName)
+			podServiceMappingsDiff := computePodServiceMappingsDiff(lastSentPodServicesState, currentPodServiceMappingsState)
+			if len(podServiceMappingsDiff) == 0 {
 				continue
 			}
 			resp := &pb.KubeMetadataStreamResponse{
 				IsFullState: false,
-				Mappings:    diff,
+				Mappings:    podServiceMappingsDiff,
 			}
 			if err := grpc.DoWithTimeout(func() error {
-				return srv.Send(resp)
+				return stream.Send(resp)
 			}, streamSendTimeout); err != nil {
-				log.Warnf("Error sending kube metadata diff for node %s: %s", nodeName, err)
+				log.Warnf("Error sending pod-service metadata diff for node %s: %s", nodeName, err)
 				return err
 			}
-			lastSentState = currentState
+			lastSentPodServicesState = currentPodServiceMappingsState
+			ticker.Reset(keepAliveInterval)
+
+		case <-namespacesNotifyCh:
+			currentNamespacesState := srv.buildNamespacesSnapshot()
+			namespacesDiff := computeNamespacesDiff(lastSentNamespacesState, currentNamespacesState)
+			if len(namespacesDiff) == 0 {
+				continue
+			}
+			resp := &pb.KubeMetadataStreamResponse{
+				IsFullState:       false,
+				NamespaceMetadata: namespacesDiff,
+			}
+			if err := grpc.DoWithTimeout(func() error {
+				return stream.Send(resp)
+			}, streamSendTimeout); err != nil {
+				log.Warnf("Error sending namespace metadata diff for node %s: %s", nodeName, err)
+				return err
+			}
+			lastSentNamespacesState = currentNamespacesState
 			ticker.Reset(keepAliveInterval)
 
 		case <-ticker.C:
 			// Send empty keepalive
 			if err := grpc.DoWithTimeout(func() error {
-				return srv.Send(&pb.KubeMetadataStreamResponse{})
+				return stream.Send(&pb.KubeMetadataStreamResponse{})
 			}, streamSendTimeout); err != nil {
 				log.Warnf("Error sending kube metadata keepalive for node %s: %s", nodeName, err)
 				return err
@@ -101,17 +170,97 @@ func (s *KubeMetadataStreamServer) StreamKubeMetadata(req *pb.KubeMetadataStream
 	}
 }
 
-// buildSnapshot reads the current bundle for a node and converts it to a
+func (srv *KubeMetadataStreamServer) processNamespaceEvents(events []workloadmeta.Event) {
+	srv.namespacesMutex.Lock()
+	defer srv.namespacesMutex.Unlock()
+
+	changed := false
+	for _, event := range events {
+		metadata := event.Entity.(*workloadmeta.KubernetesMetadata)
+		namespaceName := metadata.Name
+
+		switch event.Type {
+		case workloadmeta.EventTypeSet:
+			srv.namespaces[namespaceName] = namespaceEntry{
+				labels:      metadata.Labels,
+				annotations: metadata.Annotations,
+			}
+			changed = true
+		case workloadmeta.EventTypeUnset:
+			if _, exists := srv.namespaces[namespaceName]; exists {
+				delete(srv.namespaces, namespaceName)
+				changed = true
+			}
+		default:
+			log.Errorf("Unknown event type %d for namespace %s", event.Type, namespaceName)
+		}
+	}
+
+	if changed {
+		srv.notifyNamespaceSubscribers()
+	}
+}
+
+func (srv *KubeMetadataStreamServer) notifyNamespaceSubscribers() {
+	for _, ch := range srv.namespaceSubscribers {
+		select {
+		case ch <- struct{}{}:
+		default:
+		}
+	}
+}
+
+func (srv *KubeMetadataStreamServer) subscribeToNamespaceEvents(nodeName string) <-chan struct{} {
+	srv.namespacesMutex.Lock()
+	defer srv.namespacesMutex.Unlock()
+
+	ch := make(chan struct{}, 1)
+	srv.namespaceSubscribers[nodeName] = ch
+	return ch
+}
+
+func (srv *KubeMetadataStreamServer) unsubscribeFromNamespaceEvents(nodeName string) {
+	srv.namespacesMutex.Lock()
+	defer srv.namespacesMutex.Unlock()
+
+	delete(srv.namespaceSubscribers, nodeName)
+}
+
+func (srv *KubeMetadataStreamServer) buildNamespacesSnapshot() map[string]namespaceEntry {
+	srv.namespacesMutex.RLock()
+	defer srv.namespacesMutex.RUnlock()
+
+	snapshot := make(map[string]namespaceEntry, len(srv.namespaces))
+	for ns, entry := range srv.namespaces {
+		snapshot[ns] = namespaceEntry{
+			labels:      maps.Clone(entry.labels),
+			annotations: maps.Clone(entry.annotations),
+		}
+	}
+	return snapshot
+}
+
+// buildPodServiceMappingsSnapshot reads the current bundle for a node and converts it to a
 // snapshot map keyed by "namespace/podName".
-func (s *KubeMetadataStreamServer) buildSnapshot(nodeName string) map[string]podServiceEntry {
-	bundle, ok := s.store.Get(nodeName)
+func (srv *KubeMetadataStreamServer) buildPodServiceMappingsSnapshot(nodeName string) map[string]podServiceEntry {
+	bundle, ok := srv.store.Get(nodeName)
 	if !ok {
 		return nil
 	}
-	return bundleToSnapshot(bundle)
+	return bundleToPodServiceMappingsSnapshot(bundle)
 }
 
-func bundleToSnapshot(bundle *apiserver.MetadataMapperBundle) map[string]podServiceEntry {
+func namespaceMetadataFilter() *workloadmeta.Filter {
+	return workloadmeta.NewFilterBuilder().AddKindWithEntityFilter(
+		workloadmeta.KindKubernetesMetadata,
+		func(entity workloadmeta.Entity) bool {
+			metadata := entity.(*workloadmeta.KubernetesMetadata)
+			return workloadmeta.IsNamespaceMetadata(metadata)
+		},
+	).Build()
+}
+
+func bundleToPodServiceMappingsSnapshot(bundle *apiserver.MetadataMapperBundle) map[string]podServiceEntry {
 	snapshot := make(map[string]podServiceEntry)
 	for ns, pods := range bundle.Services {
 		for podName, svcs := range pods {
@@ -127,10 +276,11 @@ func bundleToSnapshot(bundle *apiserver.MetadataMapperBundle) map[string]podServ
 }
 
 // fullStateResponse creates a KubeMetadataStreamResponse with
-// is_full_state=true containing all current mappings.
-func fullStateResponse(snapshot map[string]podServiceEntry) *pb.KubeMetadataStreamResponse {
-	mappings := make([]*pb.PodServiceMapping, 0, len(snapshot))
-	for _, entry := range snapshot {
+// is_full_state=true containing all current mappings and namespace labels and
+// annotations.
+func fullStateResponse(podServices map[string]podServiceEntry, namespaces map[string]namespaceEntry) *pb.KubeMetadataStreamResponse {
+	mappings := make([]*pb.PodServiceMapping, 0, len(podServices))
+	for _, entry := range podServices {
 		mappings = append(mappings, &pb.PodServiceMapping{
 			Namespace:    entry.namespace,
 			PodName:      entry.podName,
@@ -139,14 +289,25 @@ func fullStateResponse(snapshot map[string]podServiceEntry) *pb.KubeMetadataStre
 		})
 	}
 
+	namespacesMetadata := make([]*pb.NamespaceMetadata, 0, len(namespaces))
+	for namespace, entry := range namespaces {
+		namespacesMetadata = append(namespacesMetadata, &pb.NamespaceMetadata{
+			Namespace:   namespace,
+			Labels:      entry.labels,
+			Annotations: entry.annotations,
+			Type:        pb.KubeMetadataEventType_SET,
+		})
+	}
+
 	return &pb.KubeMetadataStreamResponse{
-		IsFullState: true,
-		Mappings:    mappings,
+		IsFullState:       true,
+		Mappings:          mappings,
+		NamespaceMetadata: namespacesMetadata,
 	}
 }
 
-// computeDiff compares old and new snapshots and returns set/unset events.
-func computeDiff(old, current map[string]podServiceEntry) []*pb.PodServiceMapping {
+// computePodServiceMappingsDiff compares old and new snapshots and returns set/unset events.
+func computePodServiceMappingsDiff(old, current map[string]podServiceEntry) []*pb.PodServiceMapping {
 	var diff []*pb.PodServiceMapping
 
 	// Add events for new or changed entries
@@ -168,6 +329,34 @@ func computeDiff(old, current map[string]podServiceEntry) []*pb.PodServiceMappin
 			diff = append(diff, &pb.PodServiceMapping{
 				Namespace: prev.namespace,
 				PodName:   prev.podName,
+				Type:      pb.KubeMetadataEventType_UNSET,
+			})
+		}
+	}
+
+	return diff
+}
+
+// computeNamespacesDiff compares old and new namespace snapshots and returns set/unset events.
+func computeNamespacesDiff(old, current map[string]namespaceEntry) []*pb.NamespaceMetadata {
+	var diff []*pb.NamespaceMetadata
+
+	for ns, cur := range current {
+		prev, existed := old[ns]
+		if !existed || !maps.Equal(prev.labels, cur.labels) || !maps.Equal(prev.annotations, cur.annotations) {
+			diff = append(diff, &pb.NamespaceMetadata{
+				Namespace:   ns,
+				Labels:      cur.labels,
+				Annotations: cur.annotations,
+				Type:        pb.KubeMetadataEventType_SET,
+			})
+		}
+	}
+
+	for ns := range old {
+		if _, exists := current[ns]; !exists {
+			diff = append(diff, &pb.NamespaceMetadata{
+				Namespace: ns,
 				Type:      pb.KubeMetadataEventType_UNSET,
 			})
 		}

--- a/cmd/cluster-agent/api/v1/kubernetes_metadata_stream_test.go
+++ b/cmd/cluster-agent/api/v1/kubernetes_metadata_stream_test.go
@@ -8,21 +8,96 @@
 package v1
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/fx"
+	"google.golang.org/protobuf/proto"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/util"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
+	workloadmetamock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/mock"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 )
 
-func TestBundleToSnapshot(t *testing.T) {
+func TestStart(t *testing.T) {
+	wmetaMock := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
+		core.MockBundle(),
+		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+	))
+
+	srv := NewKubeMetadataStreamServer(nil, wmetaMock)
+
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
+	ch := srv.subscribeToNamespaceEvents("node1")
+	srv.Start(ctx)
+
+	namespace := "ns1"
+	namespaceKubeMetadataID := string(util.GenerateKubeMetadataEntityID("", "namespaces", "", namespace))
+
+	wmetaMock.Set(&workloadmeta.KubernetesMetadata{
+		EntityID: workloadmeta.EntityID{
+			Kind: workloadmeta.KindKubernetesMetadata,
+			ID:   namespaceKubeMetadataID,
+		},
+		EntityMeta: workloadmeta.EntityMeta{
+			Name:        namespace,
+			Labels:      map[string]string{"l1": "v1"},
+			Annotations: map[string]string{"a1": "v2"},
+		},
+		GVR: &schema.GroupVersionResource{Resource: "namespaces"},
+	})
+
+	select {
+	case <-ch:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for set notification")
+	}
+
+	snapshot := srv.buildNamespacesSnapshot()
+	assert.Equal(t, map[string]namespaceEntry{
+		namespace: {
+			labels:      map[string]string{"l1": "v1"},
+			annotations: map[string]string{"a1": "v2"},
+		},
+	}, snapshot)
+
+	wmetaMock.Unset(&workloadmeta.KubernetesMetadata{
+		EntityID: workloadmeta.EntityID{
+			Kind: workloadmeta.KindKubernetesMetadata,
+			ID:   namespaceKubeMetadataID,
+		},
+		EntityMeta: workloadmeta.EntityMeta{
+			Name: namespace,
+		},
+		GVR: &schema.GroupVersionResource{Resource: "namespaces"},
+	})
+
+	select {
+	case <-ch:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for unset notification")
+	}
+
+	assert.Empty(t, srv.buildNamespacesSnapshot())
+}
+
+func TestBundleToPodServiceMappingsSnapshot(t *testing.T) {
 	bundle := apiserver.NewMetadataMapperBundle()
 	bundle.Services.Set("ns1", "pod1", "svc1", "svc2")
 	bundle.Services.Set("ns2", "pod2", "svc3", "svc4")
 
-	snapshot := bundleToSnapshot(bundle)
+	snapshot := bundleToPodServiceMappingsSnapshot(bundle)
 
 	assert.Len(t, snapshot, 2)
 
@@ -43,7 +118,7 @@ func TestBundleToSnapshot(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
-func TestComputeDiff(t *testing.T) {
+func TestComputePodServiceMappingsDiff(t *testing.T) {
 	tests := []struct {
 		name     string
 		old      map[string]podServiceEntry
@@ -202,8 +277,163 @@ func TestComputeDiff(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			diff := computeDiff(test.old, test.current)
+			diff := computePodServiceMappingsDiff(test.old, test.current)
 			assert.ElementsMatch(t, test.expected, diff)
 		})
 	}
+}
+
+func TestComputeNamespacesDiff(t *testing.T) {
+	tests := []struct {
+		name     string
+		old      map[string]namespaceEntry
+		current  map[string]namespaceEntry
+		expected []*pb.NamespaceMetadata
+	}{
+		{
+			name: "no changes",
+			old: map[string]namespaceEntry{
+				"ns1": {labels: map[string]string{"l1": "v1"}},
+			},
+			current: map[string]namespaceEntry{
+				"ns1": {labels: map[string]string{"l1": "v1"}},
+			},
+			expected: nil,
+		},
+		{
+			name: "new namespace",
+			old:  map[string]namespaceEntry{},
+			current: map[string]namespaceEntry{
+				"ns1": {
+					labels:      map[string]string{"l1": "v1"},
+					annotations: map[string]string{"a1": "v2"},
+				},
+			},
+			expected: []*pb.NamespaceMetadata{
+				{
+					Namespace:   "ns1",
+					Labels:      map[string]string{"l1": "v1"},
+					Annotations: map[string]string{"a1": "v2"},
+					Type:        pb.KubeMetadataEventType_SET,
+				},
+			},
+		},
+		{
+			name: "removed namespace",
+			old: map[string]namespaceEntry{
+				"ns1": {labels: map[string]string{"l1": "v1"}},
+			},
+			current: map[string]namespaceEntry{},
+			expected: []*pb.NamespaceMetadata{
+				{
+					Namespace: "ns1",
+					Type:      pb.KubeMetadataEventType_UNSET,
+				},
+			},
+		},
+		{
+			name: "labels changed",
+			old: map[string]namespaceEntry{
+				"ns1": {labels: map[string]string{"l1": "v1"}},
+			},
+			current: map[string]namespaceEntry{
+				"ns1": {labels: map[string]string{"l1": "v2"}},
+			},
+			expected: []*pb.NamespaceMetadata{
+				{
+					Namespace: "ns1",
+					Labels:    map[string]string{"l1": "v2"},
+					Type:      pb.KubeMetadataEventType_SET,
+				},
+			},
+		},
+		{
+			name: "current is nil unsets all",
+			old: map[string]namespaceEntry{
+				"ns1": {labels: map[string]string{"l1": "v1"}},
+				"ns2": {labels: map[string]string{"l1": "v2"}},
+			},
+			current: nil,
+			expected: []*pb.NamespaceMetadata{
+				{
+					Namespace: "ns1",
+					Type:      pb.KubeMetadataEventType_UNSET,
+				},
+				{
+					Namespace: "ns2",
+					Type:      pb.KubeMetadataEventType_UNSET,
+				},
+			},
+		},
+		{
+			name: "annotations changed",
+			old: map[string]namespaceEntry{
+				"ns1": {
+					labels:      map[string]string{"l1": "v1"},
+					annotations: map[string]string{"a1": "v2"},
+				},
+			},
+			current: map[string]namespaceEntry{
+				"ns1": {
+					labels:      map[string]string{"l1": "v1"},
+					annotations: map[string]string{"a1": "v3"},
+				},
+			},
+			expected: []*pb.NamespaceMetadata{
+				{
+					Namespace:   "ns1",
+					Labels:      map[string]string{"l1": "v1"},
+					Annotations: map[string]string{"a1": "v3"},
+					Type:        pb.KubeMetadataEventType_SET,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			diff := computeNamespacesDiff(test.old, test.current)
+			assert.ElementsMatch(t, test.expected, diff)
+		})
+	}
+}
+
+func TestFullStateResponse(t *testing.T) {
+	pods := map[string]podServiceEntry{
+		"ns1/pod1": {
+			namespace: "ns1",
+			podName:   "pod1",
+			services:  sets.New("svc1"),
+		},
+	}
+	namespaces := map[string]namespaceEntry{
+		"ns1": {
+			labels:      map[string]string{"l1": "v1"},
+			annotations: map[string]string{"a1": "v2"},
+		},
+	}
+
+	resp := fullStateResponse(pods, namespaces)
+
+	expected := &pb.KubeMetadataStreamResponse{
+		IsFullState: true,
+		Mappings: []*pb.PodServiceMapping{
+			{
+				Namespace:    "ns1",
+				PodName:      "pod1",
+				ServiceNames: []string{"svc1"},
+				Type:         pb.KubeMetadataEventType_SET,
+			},
+		},
+		NamespaceMetadata: []*pb.NamespaceMetadata{
+			{
+				Namespace:   "ns1",
+				Labels:      map[string]string{"l1": "v1"},
+				Annotations: map[string]string{"a1": "v2"},
+				Type:        pb.KubeMetadataEventType_SET,
+			},
+		},
+	}
+
+	assert.True(t, proto.Equal(expected, resp))
 }

--- a/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata.go
+++ b/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata.go
@@ -54,8 +54,8 @@ type collector struct {
 	collectNamespaceLabels      bool
 	collectNamespaceAnnotations bool
 
-	// stream is the gRPC streaming client for pod-to-service metadata. nil if
-	// streaming is disabled or the DCA is not enabled.
+	// stream is the gRPC streaming client for pod-to-service and namespace
+	// metadata. nil if streaming is disabled or the DCA is not enabled.
 	stream *streamClient
 }
 
@@ -145,10 +145,13 @@ func (c *collector) Start(ctx context.Context, store workloadmeta.Component) err
 
 // Pull triggers an event collection from kubelet and the Datadog Cluster Agent.
 //
-// Pod-to-service mappings can be streamed via grpc, but the collector remains
-// pull-based because namespace metadata is not yet streamed, and streaming is
-// not always available (older DCA versions, fallback to the local API server
-// metadata mapper).
+// Pod-to-service mappings and namespace metadata can be streamed via gRPC, but
+// the collector remains pull-based because streaming is not always available
+// (older DCA versions, fallback to the local API server metadata mapper).
+//
+// TODO: When streaming is active, decouple from the pull interval to take
+// advantage of real-time updates (extract streaming to a separate collector,
+// reduce the pull frequency, or something similar).
 func (c *collector) Pull(ctx context.Context) error {
 	// Time constraints, get the delta in seconds to display it in the logs:
 	timeDelta := c.lastUpdate.Add(c.updateFreq).Unix() - time.Now().Unix()
@@ -330,7 +333,22 @@ func (c *collector) parsePods(
 
 		var nsLabels, nsAnnotations map[string]string
 
-		if c.isDCAEnabled() && c.dcaClient.SupportsNamespaceMetadataCollection() {
+		if streamActive {
+			if labels, annotations, ok := c.stream.getNamespaceMetadata(pod.Metadata.Namespace); ok {
+				if c.collectNamespaceLabels {
+					nsLabels = labels
+				}
+				if c.collectNamespaceAnnotations {
+					nsAnnotations = annotations
+				}
+				if c.collectNamespaceLabels || c.collectNamespaceAnnotations {
+					metadataByNS[pod.Metadata.Namespace] = &clusteragent.Metadata{
+						Labels:      labels,
+						Annotations: annotations,
+					}
+				}
+			}
+		} else if c.isDCAEnabled() && c.dcaClient.SupportsNamespaceMetadataCollection() {
 			// Cluster agent with version 7.55+
 			nsMetadata, ok := metadataByNS[pod.Metadata.Namespace]
 			if !ok {

--- a/comp/core/workloadmeta/collectors/internal/kubemetadata/stream.go
+++ b/comp/core/workloadmeta/collectors/internal/kubemetadata/stream.go
@@ -36,14 +36,20 @@ const (
 	streamRecvTimeout     = 10 * time.Minute
 )
 
+type namespaceMetadata struct {
+	labels      map[string]string
+	annotations map[string]string
+}
+
 // streamClient manages a gRPC streaming connection to the DCA for
-// pod-to-service metadata and keeps a local cache with the mappings.
+// pod-to-service and namespace metadata. It keeps a local cache.
 type streamClient struct {
 	nodeName string
 	cfg      configmodel.Reader
 
 	mu          sync.RWMutex
-	podServices map[string][]string // "namespace/podName" -> services
+	podServices map[string][]string          // "namespace/podName" -> services
+	namespaces  map[string]namespaceMetadata // namespace name -> labels/annotations
 	active      bool
 }
 
@@ -52,6 +58,7 @@ func newStreamClient(nodeName string, cfg configmodel.Reader) *streamClient {
 		nodeName:    nodeName,
 		cfg:         cfg,
 		podServices: make(map[string][]string),
+		namespaces:  make(map[string]namespaceMetadata),
 	}
 }
 
@@ -107,6 +114,21 @@ func (sc *streamClient) getServices(namespace, podName string) ([]string, bool) 
 	return svcs, ok
 }
 
+func (sc *streamClient) getNamespaceMetadata(namespace string) (labels, annotations map[string]string, found bool) {
+	sc.mu.RLock()
+	defer sc.mu.RUnlock()
+
+	if !sc.active {
+		return nil, nil, false
+	}
+
+	ns, ok := sc.namespaces[namespace]
+	if !ok {
+		return nil, nil, false
+	}
+	return ns.labels, ns.annotations, true
+}
+
 func (sc *streamClient) isActive() bool {
 	sc.mu.RLock()
 	defer sc.mu.RUnlock()
@@ -153,7 +175,7 @@ func (sc *streamClient) streamOnce(ctx context.Context) error {
 			return fmt.Errorf("stream recv error: %w", err)
 		}
 
-		sc.updateMappings(resp)
+		sc.applyResponse(resp)
 	}
 }
 
@@ -177,24 +199,34 @@ func dialDCA(ctx context.Context) (*grpc.ClientConn, error) {
 	)
 }
 
-// updateMappings updates pod => service mappings according to a streaming
-// response.
-func (sc *streamClient) updateMappings(resp *pb.KubeMetadataStreamResponse) {
+// applyResponse updates pod-service mappings and namespace metadata according
+// to a streaming response.
+func (sc *streamClient) applyResponse(resp *pb.KubeMetadataStreamResponse) {
 	sc.mu.Lock()
 	defer sc.mu.Unlock()
 
 	if resp.IsFullState {
-		newCache := make(map[string][]string, len(resp.Mappings))
+		newPodServices := make(map[string][]string, len(resp.Mappings))
 		for _, mapping := range resp.Mappings {
 			key := mapping.Namespace + "/" + mapping.PodName
-			newCache[key] = mapping.ServiceNames
+			newPodServices[key] = mapping.ServiceNames
 		}
-		sc.podServices = newCache
+		sc.podServices = newPodServices
+
+		newNamespaces := make(map[string]namespaceMetadata, len(resp.NamespaceMetadata))
+		for _, ns := range resp.NamespaceMetadata {
+			newNamespaces[ns.Namespace] = namespaceMetadata{
+				labels:      ns.Labels,
+				annotations: ns.Annotations,
+			}
+		}
+		sc.namespaces = newNamespaces
+
 		sc.active = true
 		return
 	}
 
-	if !sc.active && len(resp.Mappings) > 0 {
+	if !sc.active && (len(resp.Mappings) > 0 || len(resp.NamespaceMetadata) > 0) {
 		log.Errorf("Received incremental kube metadata update before full state, ignoring")
 		return
 	}
@@ -206,6 +238,22 @@ func (sc *streamClient) updateMappings(resp *pb.KubeMetadataStreamResponse) {
 			sc.podServices[key] = mapping.ServiceNames
 		case pb.KubeMetadataEventType_UNSET:
 			delete(sc.podServices, key)
+		default:
+			log.Errorf("Unknown event type %d for pod-service mapping %s", mapping.Type, key)
+		}
+	}
+
+	for _, ns := range resp.NamespaceMetadata {
+		switch ns.Type {
+		case pb.KubeMetadataEventType_SET:
+			sc.namespaces[ns.Namespace] = namespaceMetadata{
+				labels:      ns.Labels,
+				annotations: ns.Annotations,
+			}
+		case pb.KubeMetadataEventType_UNSET:
+			delete(sc.namespaces, ns.Namespace)
+		default:
+			log.Errorf("Unknown event type %d for namespace metadata %s", ns.Type, ns.Namespace)
 		}
 	}
 }

--- a/comp/core/workloadmeta/collectors/internal/kubemetadata/stream_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubemetadata/stream_test.go
@@ -15,18 +15,21 @@ import (
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 )
 
-func TestUpdateMappings(t *testing.T) {
+func TestApplyResponse(t *testing.T) {
 	tests := []struct {
-		name          string
-		initialState  map[string][]string
-		initialActive bool
-		response      *pb.KubeMetadataStreamResponse
-		expectedState map[string][]string
+		name                string
+		initialPodServices  map[string][]string
+		initialNamespaces   map[string]namespaceMetadata
+		initialActive       bool
+		response            *pb.KubeMetadataStreamResponse
+		expectedPodServices map[string][]string
+		expectedNamespaces  map[string]namespaceMetadata
 	}{
 		{
-			name:          "full state with empty initial state",
-			initialState:  nil,
-			initialActive: false,
+			name:               "full state with empty initial state",
+			initialPodServices: nil,
+			initialNamespaces:  nil,
+			initialActive:      false,
 			response: &pb.KubeMetadataStreamResponse{
 				IsFullState: true,
 				Mappings: []*pb.PodServiceMapping{
@@ -43,16 +46,33 @@ func TestUpdateMappings(t *testing.T) {
 						Type:         pb.KubeMetadataEventType_SET,
 					},
 				},
+				NamespaceMetadata: []*pb.NamespaceMetadata{
+					{
+						Namespace:   "test-namespace-1",
+						Labels:      map[string]string{"l1": "v1"},
+						Annotations: map[string]string{"a1": "v2"},
+						Type:        pb.KubeMetadataEventType_SET,
+					},
+				},
 			},
-			expectedState: map[string][]string{
+			expectedPodServices: map[string][]string{
 				"test-namespace-1/pod1": {"svc1", "svc2"},
 				"test-namespace-2/pod2": {"svc3"},
+			},
+			expectedNamespaces: map[string]namespaceMetadata{
+				"test-namespace-1": {
+					labels:      map[string]string{"l1": "v1"},
+					annotations: map[string]string{"a1": "v2"},
+				},
 			},
 		},
 		{
 			name: "full state response replaces existing data",
-			initialState: map[string][]string{
+			initialPodServices: map[string][]string{
 				"test-namespace/old-pod": {"old-svc"},
+			},
+			initialNamespaces: map[string]namespaceMetadata{
+				"old-ns": {labels: map[string]string{"l1": "v1"}},
 			},
 			initialActive: true,
 			response: &pb.KubeMetadataStreamResponse{
@@ -65,15 +85,30 @@ func TestUpdateMappings(t *testing.T) {
 						Type:         pb.KubeMetadataEventType_SET,
 					},
 				},
+				NamespaceMetadata: []*pb.NamespaceMetadata{
+					{
+						Namespace: "new-ns",
+						Labels:    map[string]string{"l1": "v1"},
+						Type:      pb.KubeMetadataEventType_SET,
+					},
+				},
 			},
-			expectedState: map[string][]string{
+			expectedPodServices: map[string][]string{
 				"test-namespace/new-pod": {"new-svc"},
+			},
+			expectedNamespaces: map[string]namespaceMetadata{
+				"new-ns": {
+					labels: map[string]string{"l1": "v1"},
+				},
 			},
 		},
 		{
 			name: "incremental set",
-			initialState: map[string][]string{
+			initialPodServices: map[string][]string{
 				"test-namespace/pod1": {"svc1"},
+			},
+			initialNamespaces: map[string]namespaceMetadata{
+				"ns1": {labels: map[string]string{"l1": "v1"}},
 			},
 			initialActive: true,
 			response: &pb.KubeMetadataStreamResponse{
@@ -92,17 +127,35 @@ func TestUpdateMappings(t *testing.T) {
 						Type:         pb.KubeMetadataEventType_SET,
 					},
 				},
+				NamespaceMetadata: []*pb.NamespaceMetadata{
+					{
+						Namespace: "ns2",
+						Labels:    map[string]string{"l1": "v2"},
+						Type:      pb.KubeMetadataEventType_SET,
+					},
+				},
 			},
-			expectedState: map[string][]string{
+			expectedPodServices: map[string][]string{
 				"test-namespace/pod1": {"svc1", "svc2"},
 				"test-namespace/pod2": {"svc3"},
+			},
+			expectedNamespaces: map[string]namespaceMetadata{
+				"ns1": {labels: map[string]string{"l1": "v1"}},
+				"ns2": {
+					labels:      map[string]string{"l1": "v2"},
+					annotations: nil,
+				},
 			},
 		},
 		{
 			name: "unset",
-			initialState: map[string][]string{
+			initialPodServices: map[string][]string{
 				"test-namespace/pod1": {"svc1"},
 				"test-namespace/pod2": {"svc2"},
+			},
+			initialNamespaces: map[string]namespaceMetadata{
+				"ns1": {labels: map[string]string{"l1": "v1"}},
+				"ns2": {labels: map[string]string{"l1": "v2"}},
 			},
 			initialActive: true,
 			response: &pb.KubeMetadataStreamResponse{
@@ -114,20 +167,35 @@ func TestUpdateMappings(t *testing.T) {
 						Type:      pb.KubeMetadataEventType_UNSET,
 					},
 				},
+				NamespaceMetadata: []*pb.NamespaceMetadata{
+					{
+						Namespace: "ns1",
+						Type:      pb.KubeMetadataEventType_UNSET,
+					},
+				},
 			},
-			expectedState: map[string][]string{
+			expectedPodServices: map[string][]string{
 				"test-namespace/pod2": {"svc2"},
+			},
+			expectedNamespaces: map[string]namespaceMetadata{
+				"ns2": {labels: map[string]string{"l1": "v2"}},
 			},
 		},
 		{
 			name: "empty keepalive",
-			initialState: map[string][]string{
+			initialPodServices: map[string][]string{
 				"test-namespace/pod1": {"svc1"},
+			},
+			initialNamespaces: map[string]namespaceMetadata{
+				"ns1": {labels: map[string]string{"l1": "v1"}},
 			},
 			initialActive: true,
 			response:      &pb.KubeMetadataStreamResponse{},
-			expectedState: map[string][]string{ // Shouldn't change anything
+			expectedPodServices: map[string][]string{
 				"test-namespace/pod1": {"svc1"},
+			},
+			expectedNamespaces: map[string]namespaceMetadata{
+				"ns1": {labels: map[string]string{"l1": "v1"}},
 			},
 		},
 	}
@@ -135,14 +203,16 @@ func TestUpdateMappings(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			sc := &streamClient{
-				podServices: test.initialState,
+				podServices: test.initialPodServices,
+				namespaces:  test.initialNamespaces,
 				active:      test.initialActive,
 			}
 
-			sc.updateMappings(test.response)
+			sc.applyResponse(test.response)
 
 			assert.True(t, sc.active)
-			assert.Equal(t, test.expectedState, sc.podServices)
+			assert.Equal(t, test.expectedPodServices, sc.podServices)
+			assert.Equal(t, test.expectedNamespaces, sc.namespaces)
 		})
 	}
 }

--- a/comp/core/workloadmeta/def/filter.go
+++ b/comp/core/workloadmeta/def/filter.go
@@ -22,7 +22,13 @@ func EntityFilterFuncAcceptAll(_ Entity) bool { return true }
 // IsNodeMetadata is a filter function that returns true if the metadata
 // belongs to a node.
 var IsNodeMetadata = func(metadata *KubernetesMetadata) bool {
-	return metadata.GVR.Group == "" && metadata.GVR.Resource == "nodes"
+	return metadata.GVR != nil && metadata.GVR.Group == "" && metadata.GVR.Resource == "nodes"
+}
+
+// IsNamespaceMetadata is a filter function that returns true if the metadata
+// belongs to a namespace.
+var IsNamespaceMetadata = func(metadata *KubernetesMetadata) bool {
+	return metadata.GVR != nil && metadata.GVR.Group == "" && metadata.GVR.Resource == "namespaces"
 }
 
 // Filter allows a subscriber to filter events by entity kind, event source, and

--- a/comp/core/workloadmeta/def/filter_test.go
+++ b/comp/core/workloadmeta/def/filter_test.go
@@ -55,6 +55,53 @@ func TestIsNodeMetadata(t *testing.T) {
 	}
 
 }
+
+func TestIsNamespaceMetadata(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata KubernetesMetadata
+		expected bool
+	}{
+		{
+			name: "namespace metadata",
+			metadata: KubernetesMetadata{
+				GVR: &schema.GroupVersionResource{
+					Version:  "v1",
+					Resource: "namespaces",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "namespace metadata with custom group",
+			metadata: KubernetesMetadata{
+				GVR: &schema.GroupVersionResource{
+					Group:    "customgroup",
+					Version:  "v1",
+					Resource: "namespaces",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "node metadata is not namespace metadata",
+			metadata: KubernetesMetadata{
+				GVR: &schema.GroupVersionResource{
+					Version:  "v1",
+					Resource: "nodes",
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			assert.Equal(tt, test.expected, IsNamespaceMetadata(&test.metadata))
+		})
+	}
+}
+
 func TestFilterBuilder_Build(t *testing.T) {
 	dummyEntityFilterFunc := func(entity Entity) bool {
 		return len(entity.GetID().ID) == 5

--- a/pkg/proto/datadog/kubemetadata/kubemetadata.proto
+++ b/pkg/proto/datadog/kubemetadata/kubemetadata.proto
@@ -20,7 +20,15 @@ message PodServiceMapping {
   KubeMetadataEventType type = 4;
 }
 
+message NamespaceMetadata {
+  string namespace = 1;
+  map<string, string> labels = 2;
+  map<string, string> annotations = 3;
+  KubeMetadataEventType type = 4;
+}
+
 message KubeMetadataStreamResponse {
   bool is_full_state = 1;
   repeated PodServiceMapping mappings = 2;
+  repeated NamespaceMetadata namespace_metadata = 3;
 }

--- a/pkg/proto/pbgo/core/kubemetadata.pb.go
+++ b/pkg/proto/pbgo/core/kubemetadata.pb.go
@@ -179,17 +179,86 @@ func (x *PodServiceMapping) GetType() KubeMetadataEventType {
 	return KubeMetadataEventType_SET
 }
 
-type KubeMetadataStreamResponse struct {
+type NamespaceMetadata struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	IsFullState   bool                   `protobuf:"varint,1,opt,name=is_full_state,json=isFullState,proto3" json:"is_full_state,omitempty"`
-	Mappings      []*PodServiceMapping   `protobuf:"bytes,2,rep,name=mappings,proto3" json:"mappings,omitempty"`
+	Namespace     string                 `protobuf:"bytes,1,opt,name=namespace,proto3" json:"namespace,omitempty"`
+	Labels        map[string]string      `protobuf:"bytes,2,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Annotations   map[string]string      `protobuf:"bytes,3,rep,name=annotations,proto3" json:"annotations,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Type          KubeMetadataEventType  `protobuf:"varint,4,opt,name=type,proto3,enum=datadog.kubemetadata.KubeMetadataEventType" json:"type,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
+func (x *NamespaceMetadata) Reset() {
+	*x = NamespaceMetadata{}
+	mi := &file_datadog_kubemetadata_kubemetadata_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *NamespaceMetadata) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*NamespaceMetadata) ProtoMessage() {}
+
+func (x *NamespaceMetadata) ProtoReflect() protoreflect.Message {
+	mi := &file_datadog_kubemetadata_kubemetadata_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use NamespaceMetadata.ProtoReflect.Descriptor instead.
+func (*NamespaceMetadata) Descriptor() ([]byte, []int) {
+	return file_datadog_kubemetadata_kubemetadata_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *NamespaceMetadata) GetNamespace() string {
+	if x != nil {
+		return x.Namespace
+	}
+	return ""
+}
+
+func (x *NamespaceMetadata) GetLabels() map[string]string {
+	if x != nil {
+		return x.Labels
+	}
+	return nil
+}
+
+func (x *NamespaceMetadata) GetAnnotations() map[string]string {
+	if x != nil {
+		return x.Annotations
+	}
+	return nil
+}
+
+func (x *NamespaceMetadata) GetType() KubeMetadataEventType {
+	if x != nil {
+		return x.Type
+	}
+	return KubeMetadataEventType_SET
+}
+
+type KubeMetadataStreamResponse struct {
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	IsFullState       bool                   `protobuf:"varint,1,opt,name=is_full_state,json=isFullState,proto3" json:"is_full_state,omitempty"`
+	Mappings          []*PodServiceMapping   `protobuf:"bytes,2,rep,name=mappings,proto3" json:"mappings,omitempty"`
+	NamespaceMetadata []*NamespaceMetadata   `protobuf:"bytes,3,rep,name=namespace_metadata,json=namespaceMetadata,proto3" json:"namespace_metadata,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
 func (x *KubeMetadataStreamResponse) Reset() {
 	*x = KubeMetadataStreamResponse{}
-	mi := &file_datadog_kubemetadata_kubemetadata_proto_msgTypes[2]
+	mi := &file_datadog_kubemetadata_kubemetadata_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -201,7 +270,7 @@ func (x *KubeMetadataStreamResponse) String() string {
 func (*KubeMetadataStreamResponse) ProtoMessage() {}
 
 func (x *KubeMetadataStreamResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_kubemetadata_kubemetadata_proto_msgTypes[2]
+	mi := &file_datadog_kubemetadata_kubemetadata_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -214,7 +283,7 @@ func (x *KubeMetadataStreamResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KubeMetadataStreamResponse.ProtoReflect.Descriptor instead.
 func (*KubeMetadataStreamResponse) Descriptor() ([]byte, []int) {
-	return file_datadog_kubemetadata_kubemetadata_proto_rawDescGZIP(), []int{2}
+	return file_datadog_kubemetadata_kubemetadata_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *KubeMetadataStreamResponse) GetIsFullState() bool {
@@ -231,6 +300,13 @@ func (x *KubeMetadataStreamResponse) GetMappings() []*PodServiceMapping {
 	return nil
 }
 
+func (x *KubeMetadataStreamResponse) GetNamespaceMetadata() []*NamespaceMetadata {
+	if x != nil {
+		return x.NamespaceMetadata
+	}
+	return nil
+}
+
 var File_datadog_kubemetadata_kubemetadata_proto protoreflect.FileDescriptor
 
 const file_datadog_kubemetadata_kubemetadata_proto_rawDesc = "" +
@@ -242,10 +318,22 @@ const file_datadog_kubemetadata_kubemetadata_proto_rawDesc = "" +
 	"\tnamespace\x18\x01 \x01(\tR\tnamespace\x12\x19\n" +
 	"\bpod_name\x18\x02 \x01(\tR\apodName\x12#\n" +
 	"\rservice_names\x18\x03 \x03(\tR\fserviceNames\x12?\n" +
-	"\x04type\x18\x04 \x01(\x0e2+.datadog.kubemetadata.KubeMetadataEventTypeR\x04type\"\x85\x01\n" +
+	"\x04type\x18\x04 \x01(\x0e2+.datadog.kubemetadata.KubeMetadataEventTypeR\x04type\"\x96\x03\n" +
+	"\x11NamespaceMetadata\x12\x1c\n" +
+	"\tnamespace\x18\x01 \x01(\tR\tnamespace\x12K\n" +
+	"\x06labels\x18\x02 \x03(\v23.datadog.kubemetadata.NamespaceMetadata.LabelsEntryR\x06labels\x12Z\n" +
+	"\vannotations\x18\x03 \x03(\v28.datadog.kubemetadata.NamespaceMetadata.AnnotationsEntryR\vannotations\x12?\n" +
+	"\x04type\x18\x04 \x01(\x0e2+.datadog.kubemetadata.KubeMetadataEventTypeR\x04type\x1a9\n" +
+	"\vLabelsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a>\n" +
+	"\x10AnnotationsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xdd\x01\n" +
 	"\x1aKubeMetadataStreamResponse\x12\"\n" +
 	"\ris_full_state\x18\x01 \x01(\bR\visFullState\x12C\n" +
-	"\bmappings\x18\x02 \x03(\v2'.datadog.kubemetadata.PodServiceMappingR\bmappings*+\n" +
+	"\bmappings\x18\x02 \x03(\v2'.datadog.kubemetadata.PodServiceMappingR\bmappings\x12V\n" +
+	"\x12namespace_metadata\x18\x03 \x03(\v2'.datadog.kubemetadata.NamespaceMetadataR\x11namespaceMetadata*+\n" +
 	"\x15KubeMetadataEventType\x12\a\n" +
 	"\x03SET\x10\x00\x12\t\n" +
 	"\x05UNSET\x10\x01B\x15Z\x13pkg/proto/pbgo/coreb\x06proto3"
@@ -263,21 +351,28 @@ func file_datadog_kubemetadata_kubemetadata_proto_rawDescGZIP() []byte {
 }
 
 var file_datadog_kubemetadata_kubemetadata_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_datadog_kubemetadata_kubemetadata_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
+var file_datadog_kubemetadata_kubemetadata_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
 var file_datadog_kubemetadata_kubemetadata_proto_goTypes = []any{
 	(KubeMetadataEventType)(0),         // 0: datadog.kubemetadata.KubeMetadataEventType
 	(*KubeMetadataStreamRequest)(nil),  // 1: datadog.kubemetadata.KubeMetadataStreamRequest
 	(*PodServiceMapping)(nil),          // 2: datadog.kubemetadata.PodServiceMapping
-	(*KubeMetadataStreamResponse)(nil), // 3: datadog.kubemetadata.KubeMetadataStreamResponse
+	(*NamespaceMetadata)(nil),          // 3: datadog.kubemetadata.NamespaceMetadata
+	(*KubeMetadataStreamResponse)(nil), // 4: datadog.kubemetadata.KubeMetadataStreamResponse
+	nil,                                // 5: datadog.kubemetadata.NamespaceMetadata.LabelsEntry
+	nil,                                // 6: datadog.kubemetadata.NamespaceMetadata.AnnotationsEntry
 }
 var file_datadog_kubemetadata_kubemetadata_proto_depIdxs = []int32{
 	0, // 0: datadog.kubemetadata.PodServiceMapping.type:type_name -> datadog.kubemetadata.KubeMetadataEventType
-	2, // 1: datadog.kubemetadata.KubeMetadataStreamResponse.mappings:type_name -> datadog.kubemetadata.PodServiceMapping
-	2, // [2:2] is the sub-list for method output_type
-	2, // [2:2] is the sub-list for method input_type
-	2, // [2:2] is the sub-list for extension type_name
-	2, // [2:2] is the sub-list for extension extendee
-	0, // [0:2] is the sub-list for field type_name
+	5, // 1: datadog.kubemetadata.NamespaceMetadata.labels:type_name -> datadog.kubemetadata.NamespaceMetadata.LabelsEntry
+	6, // 2: datadog.kubemetadata.NamespaceMetadata.annotations:type_name -> datadog.kubemetadata.NamespaceMetadata.AnnotationsEntry
+	0, // 3: datadog.kubemetadata.NamespaceMetadata.type:type_name -> datadog.kubemetadata.KubeMetadataEventType
+	2, // 4: datadog.kubemetadata.KubeMetadataStreamResponse.mappings:type_name -> datadog.kubemetadata.PodServiceMapping
+	3, // 5: datadog.kubemetadata.KubeMetadataStreamResponse.namespace_metadata:type_name -> datadog.kubemetadata.NamespaceMetadata
+	6, // [6:6] is the sub-list for method output_type
+	6, // [6:6] is the sub-list for method input_type
+	6, // [6:6] is the sub-list for extension type_name
+	6, // [6:6] is the sub-list for extension extendee
+	0, // [0:6] is the sub-list for field type_name
 }
 
 func init() { file_datadog_kubemetadata_kubemetadata_proto_init() }
@@ -291,7 +386,7 @@ func file_datadog_kubemetadata_kubemetadata_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_datadog_kubemetadata_kubemetadata_proto_rawDesc), len(file_datadog_kubemetadata_kubemetadata_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   3,
+			NumMessages:   6,
 			NumExtensions: 0,
 			NumServices:   0,
 		},


### PR DESCRIPTION
### What does this PR do?

This PR is a continuation of https://github.com/DataDog/datadog-agent/pull/47025

That PR added grpc streaming for pod-to-service metadata from the DCA to node agents and used that streaming connection in the kubemetadata workloadmeta collector.

This PR expands that streaming endpoint to also include namespace labels and annotations, which is the other piece of information needed by the kubemetadata workloadmeta collector.

Some things to note:
- To keep things simple, the streaming connection reports all namespaces. It's not possible to subscribe to specific ones. We can optimize that later if needed.
- There's a single endpoint for both kubernetes services and namespace labels/annotations. I think that makes sense since everything is part of the "kubernetes metadata" that the collector needs. It also means we don't need two separate grpc connections, which could matter in large clusters where every node agent opens these connections to the DCA.
- In a future PR, we should decouple from the pull interval when streaming is active so we can take advantage of real-time updates. For example, by extracting streaming to a separate collector or reducing the pull frequency.


### Describe how you validated your changes

Unit tests + local tests on a local kind cluster verifying that the namespace labels/annotations as tags still appear as expected.
