### PR TITLE
fix(ci): Handle reviewers with no display name in add_reviewers

### DIFF
--- a/tasks/issue.py
+++ b/tasks/issue.py
@@ -108,7 +108,7 @@ def add_reviewers(ctx, pr_id, dry_run=False, owner_file=".github/CODEOWNERS"):
 
     if len(requested_reviewers) > 0:
         print(
-            f"This PR already has already requested review to {', '.join([rr.name for rr in requested_reviewers])}, this action should not be run on it."
+            f"This PR already has already requested review to {requested_reviewers}, this action should not be run on it."
         )
         return
 


### PR DESCRIPTION
### What does this PR do?

Fixes the `add_reviewers` task in `tasks/issue.py` to handle GitHub users whose `.name` is `None`. Instead of joining `rr.name` (which can be `None`), the log message now prints the list of reviewer objects directly.

### Motivation

The `add_reviewers` GitHub Actions workflow crashes when a PR already has requested reviewers and one of them has no display name set on their GitHub profile:

```
TypeError: sequence item 0: expected str instance, NoneType found
```

See: https://github.com/DataDog/datadog-agent/actions/runs/22648234934/job/65641324658?pr=47111

### Describe how you validated your changes

Code inspection — the fix removes the `.name` attribute access that can return `None` and uses the default string representation of the reviewer objects instead.

### Additional Notes

None.