### PR TITLE
[WP] Serialize IsExec and IsParentMissing

### DIFF
--- a/docs/cloud-workload-security/backend.schema.json
+++ b/docs/cloud-workload-security/backend.schema.json
@@ -1039,9 +1039,17 @@
           "type": "boolean",
           "description": "Indicates whether the process is a kworker"
         },
+        "is_exec": {
+          "type": "boolean",
+          "description": "Indicates whether the process entry is from a new binary execution"
+        },
         "is_exec_child": {
           "type": "boolean",
           "description": "Indicates whether the process is an exec following another exec"
+        },
+        "is_parent_missing": {
+          "type": "boolean",
+          "description": "Indicates whether the direct parent is missing"
         },
         "source": {
           "type": "string",
@@ -1178,9 +1186,17 @@
           "type": "boolean",
           "description": "Indicates whether the process is a kworker"
         },
+        "is_exec": {
+          "type": "boolean",
+          "description": "Indicates whether the process entry is from a new binary execution"
+        },
         "is_exec_child": {
           "type": "boolean",
           "description": "Indicates whether the process is an exec following another exec"
+        },
+        "is_parent_missing": {
+          "type": "boolean",
+          "description": "Indicates whether the direct parent is missing"
         },
         "source": {
           "type": "string",

--- a/docs/cloud-workload-security/backend_linux.md
+++ b/docs/cloud-workload-security/backend_linux.md
@@ -1449,9 +1449,17 @@ Workload Protection events for Linux systems have the following JSON schema:
                     "type": "boolean",
                     "description": "Indicates whether the process is a kworker"
                 },
+                "is_exec": {
+                    "type": "boolean",
+                    "description": "Indicates whether the process entry is from a new binary execution"
+                },
                 "is_exec_child": {
                     "type": "boolean",
                     "description": "Indicates whether the process is an exec following another exec"
+                },
+                "is_parent_missing": {
+                    "type": "boolean",
+                    "description": "Indicates whether the direct parent is missing"
                 },
                 "source": {
                     "type": "string",
@@ -1613,9 +1621,17 @@ Workload Protection events for Linux systems have the following JSON schema:
                     "type": "boolean",
                     "description": "Indicates whether the process is a kworker"
                 },
+                "is_exec": {
+                    "type": "boolean",
+                    "description": "Indicates whether the process entry is from a new binary execution"
+                },
                 "is_exec_child": {
                     "type": "boolean",
                     "description": "Indicates whether the process is an exec following another exec"
+                },
+                "is_parent_missing": {
+                    "type": "boolean",
+                    "description": "Indicates whether the direct parent is missing"
                 },
                 "source": {
                     "type": "string",
@@ -4575,9 +4591,17 @@ Workload Protection events for Linux systems have the following JSON schema:
             "type": "boolean",
             "description": "Indicates whether the process is a kworker"
         },
+        "is_exec": {
+            "type": "boolean",
+            "description": "Indicates whether the process entry is from a new binary execution"
+        },
         "is_exec_child": {
             "type": "boolean",
             "description": "Indicates whether the process is an exec following another exec"
+        },
+        "is_parent_missing": {
+            "type": "boolean",
+            "description": "Indicates whether the direct parent is missing"
         },
         "source": {
             "type": "string",
@@ -4643,7 +4667,9 @@ Workload Protection events for Linux systems have the following JSON schema:
 | `envs_truncated` | Indicator of environments variable truncation |
 | `is_thread` | Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program) |
 | `is_kworker` | Indicates whether the process is a kworker |
+| `is_exec` | Indicates whether the process entry is from a new binary execution |
 | `is_exec_child` | Indicates whether the process is an exec following another exec |
+| `is_parent_missing` | Indicates whether the direct parent is missing |
 | `source` | Process source |
 | `syscalls` | List of syscalls captured to generate the event |
 | `aws_security_credentials` | List of AWS Security Credentials that the process had access to |
@@ -4791,9 +4817,17 @@ Workload Protection events for Linux systems have the following JSON schema:
             "type": "boolean",
             "description": "Indicates whether the process is a kworker"
         },
+        "is_exec": {
+            "type": "boolean",
+            "description": "Indicates whether the process entry is from a new binary execution"
+        },
         "is_exec_child": {
             "type": "boolean",
             "description": "Indicates whether the process is an exec following another exec"
+        },
+        "is_parent_missing": {
+            "type": "boolean",
+            "description": "Indicates whether the direct parent is missing"
         },
         "source": {
             "type": "string",
@@ -4878,7 +4912,9 @@ Workload Protection events for Linux systems have the following JSON schema:
 | `envs_truncated` | Indicator of environments variable truncation |
 | `is_thread` | Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program) |
 | `is_kworker` | Indicates whether the process is a kworker |
+| `is_exec` | Indicates whether the process entry is from a new binary execution |
 | `is_exec_child` | Indicates whether the process is an exec following another exec |
+| `is_parent_missing` | Indicates whether the direct parent is missing |
 | `source` | Process source |
 | `syscalls` | List of syscalls captured to generate the event |
 | `aws_security_credentials` | List of AWS Security Credentials that the process had access to |

--- a/docs/cloud-workload-security/backend_linux.schema.json
+++ b/docs/cloud-workload-security/backend_linux.schema.json
@@ -1438,9 +1438,17 @@
           "type": "boolean",
           "description": "Indicates whether the process is a kworker"
         },
+        "is_exec": {
+          "type": "boolean",
+          "description": "Indicates whether the process entry is from a new binary execution"
+        },
         "is_exec_child": {
           "type": "boolean",
           "description": "Indicates whether the process is an exec following another exec"
+        },
+        "is_parent_missing": {
+          "type": "boolean",
+          "description": "Indicates whether the direct parent is missing"
         },
         "source": {
           "type": "string",
@@ -1602,9 +1610,17 @@
           "type": "boolean",
           "description": "Indicates whether the process is a kworker"
         },
+        "is_exec": {
+          "type": "boolean",
+          "description": "Indicates whether the process entry is from a new binary execution"
+        },
         "is_exec_child": {
           "type": "boolean",
           "description": "Indicates whether the process is an exec following another exec"
+        },
+        "is_parent_missing": {
+          "type": "boolean",
+          "description": "Indicates whether the direct parent is missing"
         },
         "source": {
           "type": "string",

--- a/pkg/security/secl/schemas/process.schema.json
+++ b/pkg/security/secl/schemas/process.schema.json
@@ -48,6 +48,18 @@
         "is_kworker": {
             "type": "boolean"
         },
+        "is_thread": {
+            "type": "boolean"
+        },
+        "is_exec": {
+            "type": "boolean"
+        },
+        "is_exec_child": {
+            "type": "boolean"
+        },
+        "is_parent_missing": {
+            "type": "boolean"
+        },
         "args": {
             "type": "array",
             "items": {

--- a/pkg/security/serializers/serializers_base_linux_easyjson.go
+++ b/pkg/security/serializers/serializers_base_linux_easyjson.go
@@ -1153,11 +1153,23 @@ func easyjsonA1e47abeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers6(i
 			} else {
 				out.IsKworker = bool(in.Bool())
 			}
+		case "is_exec":
+			if in.IsNull() {
+				in.Skip()
+			} else {
+				out.IsExec = bool(in.Bool())
+			}
 		case "is_exec_child":
 			if in.IsNull() {
 				in.Skip()
 			} else {
 				out.IsExecExec = bool(in.Bool())
+			}
+		case "is_parent_missing":
+			if in.IsNull() {
+				in.Skip()
+			} else {
+				out.IsParentMissing = bool(in.Bool())
 			}
 		case "source":
 			if in.IsNull() {
@@ -1514,10 +1526,20 @@ func easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers6(o
 		out.RawString(prefix)
 		out.Bool(bool(in.IsKworker))
 	}
+	if in.IsExec {
+		const prefix string = ",\"is_exec\":"
+		out.RawString(prefix)
+		out.Bool(bool(in.IsExec))
+	}
 	if in.IsExecExec {
 		const prefix string = ",\"is_exec_child\":"
 		out.RawString(prefix)
 		out.Bool(bool(in.IsExecExec))
+	}
+	if in.IsParentMissing {
+		const prefix string = ",\"is_parent_missing\":"
+		out.RawString(prefix)
+		out.Bool(bool(in.IsParentMissing))
 	}
 	if in.Source != "" {
 		const prefix string = ",\"source\":"

--- a/pkg/security/serializers/serializers_linux.go
+++ b/pkg/security/serializers/serializers_linux.go
@@ -318,8 +318,12 @@ type ProcessSerializer struct {
 	IsThread bool `json:"is_thread,omitempty"`
 	// Indicates whether the process is a kworker
 	IsKworker bool `json:"is_kworker,omitempty"`
+	// Indicates whether the process entry is from a new binary execution
+	IsExec bool `json:"is_exec,omitempty"`
 	// Indicates whether the process is an exec following another exec
 	IsExecExec bool `json:"is_exec_child,omitempty"`
+	// Indicates whether the direct parent is missing
+	IsParentMissing bool `json:"is_parent_missing,omitempty"`
 	// Process source
 	Source string `json:"source,omitempty"`
 	// List of syscalls captured to generate the event
@@ -951,23 +955,25 @@ func newProcessSerializer(ps *model.Process, e *model.Event) *ProcessSerializer 
 			ExecTime: utils.NewEasyjsonTimeIfNotZero(ps.ExecTime),
 			ExitTime: utils.NewEasyjsonTimeIfNotZero(ps.ExitTime),
 
-			Pid:           ps.Pid,
-			Tid:           ps.Tid,
-			PPid:          createNumPointer(ps.PPid),
-			Comm:          ps.Comm,
-			TTY:           ps.TTYName,
-			Executable:    newFileSerializer(&ps.FileEvent, e, 0, nil),
-			Argv0:         argv0,
-			Args:          argv,
-			ArgsTruncated: argvTruncated,
-			Envs:          envs,
-			EnvsTruncated: envsTruncated,
-			IsThread:      ps.IsThread,
-			IsKworker:     ps.IsKworker,
-			IsExecExec:    ps.IsExecExec,
-			Source:        model.ProcessSourceToString(ps.Source),
-			CapsAttempted: model.KernelCapability(ps.CapsAttempted).StringArray(),
-			CapsUsed:      model.KernelCapability(ps.CapsUsed).StringArray(),
+			Pid:             ps.Pid,
+			Tid:             ps.Tid,
+			PPid:            createNumPointer(ps.PPid),
+			Comm:            ps.Comm,
+			TTY:             ps.TTYName,
+			Executable:      newFileSerializer(&ps.FileEvent, e, 0, nil),
+			Argv0:           argv0,
+			Args:            argv,
+			ArgsTruncated:   argvTruncated,
+			Envs:            envs,
+			EnvsTruncated:   envsTruncated,
+			IsThread:        ps.IsThread,
+			IsKworker:       ps.IsKworker,
+			IsExec:          ps.IsExec,
+			IsExecExec:      ps.IsExecExec,
+			IsParentMissing: ps.IsParentMissing,
+			Source:          model.ProcessSourceToString(ps.Source),
+			CapsAttempted:   model.KernelCapability(ps.CapsAttempted).StringArray(),
+			CapsUsed:        model.KernelCapability(ps.CapsUsed).StringArray(),
 		}
 
 		if ps.HasInterpreter() {
@@ -1022,11 +1028,13 @@ func newProcessSerializer(ps *model.Process, e *model.Event) *ProcessSerializer 
 		return psSerializer
 	}
 	return &ProcessSerializer{
-		Pid:        ps.Pid,
-		Tid:        ps.Tid,
-		IsKworker:  ps.IsKworker,
-		IsExecExec: ps.IsExecExec,
-		Source:     model.ProcessSourceToString(ps.Source),
+		Pid:             ps.Pid,
+		Tid:             ps.Tid,
+		IsKworker:       ps.IsKworker,
+		IsExec:          ps.IsExec,
+		IsExecExec:      ps.IsExecExec,
+		IsParentMissing: ps.IsParentMissing,
+		Source:          model.ProcessSourceToString(ps.Source),
 		Credentials: &ProcessCredentialsSerializer{
 			CredentialsSerializer: &CredentialsSerializer{},
 		},

--- a/pkg/security/serializers/serializers_linux_easyjson.go
+++ b/pkg/security/serializers/serializers_linux_easyjson.go
@@ -2488,11 +2488,23 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(
 			} else {
 				out.IsKworker = bool(in.Bool())
 			}
+		case "is_exec":
+			if in.IsNull() {
+				in.Skip()
+			} else {
+				out.IsExec = bool(in.Bool())
+			}
 		case "is_exec_child":
 			if in.IsNull() {
 				in.Skip()
 			} else {
 				out.IsExecExec = bool(in.Bool())
+			}
+		case "is_parent_missing":
+			if in.IsNull() {
+				in.Skip()
+			} else {
+				out.IsParentMissing = bool(in.Bool())
 			}
 		case "source":
 			if in.IsNull() {
@@ -2796,10 +2808,20 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(
 		out.RawString(prefix)
 		out.Bool(bool(in.IsKworker))
 	}
+	if in.IsExec {
+		const prefix string = ",\"is_exec\":"
+		out.RawString(prefix)
+		out.Bool(bool(in.IsExec))
+	}
 	if in.IsExecExec {
 		const prefix string = ",\"is_exec_child\":"
 		out.RawString(prefix)
 		out.Bool(bool(in.IsExecExec))
+	}
+	if in.IsParentMissing {
+		const prefix string = ",\"is_parent_missing\":"
+		out.RawString(prefix)
+		out.Bool(bool(in.IsParentMissing))
 	}
 	if in.Source != "" {
 		const prefix string = ",\"source\":"

--- a/pkg/security/serializers/serializers_linux_test.go
+++ b/pkg/security/serializers/serializers_linux_test.go
@@ -8,16 +8,46 @@
 package serializers
 
 import (
+	"encoding/json"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/xeipuuv/gojsonschema"
 
 	"github.com/DataDog/datadog-agent/pkg/security/events"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/schemas"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
+
+// validateProcessSchemaFields validates that the given JSON document's boolean fields
+// conform to the process schema. It only reports errors for the fields under test,
+// ignoring issues with other fields (executable, credentials) that require full event setup.
+func validateProcessSchemaFields(t *testing.T, jsonStr string) {
+	t.Helper()
+
+	fs := http.FS(schemas.AssetFS)
+	schemaLoader := gojsonschema.NewReferenceLoaderFileSystem("file:///process.schema.json", fs)
+	documentLoader := gojsonschema.NewStringLoader(jsonStr)
+
+	result, err := gojsonschema.Validate(schemaLoader, documentLoader)
+	require.NoError(t, err)
+
+	for _, desc := range result.Errors() {
+		if desc.Type() == "additional_property_not_allowed" {
+			continue
+		}
+		// Only fail on errors related to our fields under test.
+		field := desc.Field()
+		switch field {
+		case "is_thread", "is_exec", "is_exec_child", "is_parent_missing":
+			t.Errorf("schema validation error for %s: %s", field, desc)
+		}
+	}
+}
 
 func newTestScrubber(t *testing.T) *utils.Scrubber {
 	t.Helper()
@@ -255,4 +285,147 @@ func TestCustomEventVariables_SECLVariablesExcluded(t *testing.T) {
 		_, found := s.EventContextSerializer.Variables[name]
 		assert.False(t, found, "SECLVariable %q should not be serialized", name)
 	}
+}
+
+func TestProcessSerializer_IsExecFields(t *testing.T) {
+	event := model.NewFakeEvent()
+	event.Type = uint32(model.ExecEventType)
+
+	proc := &event.ProcessContext.Process
+	proc.Pid = 1234
+	proc.Tid = 1234
+	proc.PPid = 1
+	proc.Comm = "test"
+	proc.FileEvent.PathnameStr = "/usr/bin/test"
+	proc.FileEvent.BasenameStr = "test"
+	proc.FileEvent.Inode = 12345
+	proc.FileEvent.MountID = 1
+	proc.FileEvent.FileFields.Mode = 0o755
+	proc.IsThread = false
+	proc.IsExec = true
+	proc.IsExecExec = false
+	proc.IsParentMissing = false
+
+	ps := newProcessSerializer(proc, event)
+
+	assert.False(t, ps.IsThread)
+	assert.True(t, ps.IsExec)
+	assert.False(t, ps.IsExecExec)
+	assert.False(t, ps.IsParentMissing)
+
+	data, err := json.Marshal(ps)
+	require.NoError(t, err)
+
+	// Verify the JSON keys exist with expected values.
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &raw))
+
+	assert.Equal(t, true, raw["is_exec"], "is_exec should be true in JSON")
+	// omitempty means false booleans are absent
+	_, hasIsThread := raw["is_thread"]
+	assert.False(t, hasIsThread, "is_thread should be omitted when false")
+	_, hasIsExecExec := raw["is_exec_child"]
+	assert.False(t, hasIsExecExec, "is_exec_child should be omitted when false")
+	_, hasIsParentMissing := raw["is_parent_missing"]
+	assert.False(t, hasIsParentMissing, "is_parent_missing should be omitted when false")
+
+	// Validate against the JSON schema.
+	validateProcessSchemaFields(t, string(data))
+}
+
+func TestProcessSerializer_IsExecFields_AllTrue(t *testing.T) {
+	event := model.NewFakeEvent()
+	event.Type = uint32(model.ExecEventType)
+
+	proc := &event.ProcessContext.Process
+	proc.Pid = 1234
+	proc.Tid = 1234
+	proc.PPid = 1
+	proc.Comm = "test"
+	proc.FileEvent.PathnameStr = "/usr/bin/test"
+	proc.FileEvent.BasenameStr = "test"
+	proc.FileEvent.Inode = 12345
+	proc.FileEvent.MountID = 1
+	proc.FileEvent.FileFields.Mode = 0o755
+	proc.IsThread = true
+	proc.IsExec = true
+	proc.IsExecExec = true
+	proc.IsParentMissing = true
+
+	ps := newProcessSerializer(proc, event)
+
+	assert.True(t, ps.IsThread)
+	assert.True(t, ps.IsExec)
+	assert.True(t, ps.IsExecExec)
+	assert.True(t, ps.IsParentMissing)
+
+	data, err := json.Marshal(ps)
+	require.NoError(t, err)
+
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &raw))
+
+	assert.Equal(t, true, raw["is_thread"])
+	assert.Equal(t, true, raw["is_exec"])
+	assert.Equal(t, true, raw["is_exec_child"])
+	assert.Equal(t, true, raw["is_parent_missing"])
+
+	// Validate against the JSON schema.
+	validateProcessSchemaFields(t, string(data))
+}
+
+func TestProcessSerializer_IsExecFields_Ancestors(t *testing.T) {
+	event := model.NewFakeEvent()
+	event.Type = uint32(model.ExecEventType)
+
+	// Set up main process.
+	proc := &event.ProcessContext.Process
+	proc.Pid = 1234
+	proc.Tid = 1234
+	proc.PPid = 100
+	proc.Comm = "child"
+	proc.FileEvent.PathnameStr = "/usr/bin/child"
+	proc.FileEvent.BasenameStr = "child"
+	proc.FileEvent.Inode = 12345
+	proc.FileEvent.MountID = 1
+	proc.FileEvent.FileFields.Mode = 0o755
+	proc.IsExec = true
+	proc.IsExecExec = true
+
+	// Set up ancestor.
+	ancestor := &model.ProcessCacheEntry{}
+	ancestor.Process.Pid = 100
+	ancestor.Process.Tid = 100
+	ancestor.Process.PPid = 1
+	ancestor.Process.Comm = "parent"
+	ancestor.Process.FileEvent.PathnameStr = "/usr/bin/parent"
+	ancestor.Process.FileEvent.BasenameStr = "parent"
+	ancestor.Process.FileEvent.Inode = 67890
+	ancestor.Process.FileEvent.MountID = 1
+	ancestor.Process.FileEvent.FileFields.Mode = 0o755
+	ancestor.Process.IsExec = true
+	ancestor.Process.IsParentMissing = true
+	event.ProcessContext.Ancestor = ancestor
+	event.ProcessContext.Parent = &ancestor.ProcessContext.Process
+
+	pcs := newProcessContextSerializer(event.ProcessContext, event)
+	require.NotNil(t, pcs)
+
+	// Verify main process fields.
+	assert.True(t, pcs.IsExec)
+	assert.True(t, pcs.IsExecExec)
+
+	// Verify ancestor fields.
+	require.NotNil(t, pcs.Parent)
+	assert.True(t, pcs.Parent.IsExec)
+	assert.True(t, pcs.Parent.IsParentMissing)
+
+	require.NotEmpty(t, pcs.Ancestors)
+	assert.True(t, pcs.Ancestors[0].IsExec)
+	assert.True(t, pcs.Ancestors[0].IsParentMissing)
+
+	// Validate ancestor serialization against the JSON schema.
+	data, err := json.Marshal(pcs.Ancestors[0])
+	require.NoError(t, err)
+	validateProcessSchemaFields(t, string(data))
 }


### PR DESCRIPTION
### What does this PR do?

  - Serialize `IsExec` and `IsParentMissing` from the `Process` struct into the event JSON for both the main process context and ancestor processes. `IsThread` and `IsExecExec` were already serialized.
  - Add the new fields (`is_exec`, `is_parent_missing`) to the JSON schema (`process.schema.json`) and backend documentation schemas.                                                                                                                          
  - Add unit tests validating the serialization of all four fields against the JSON schema, including ancestor propagation.
                                                                                                                                                                                                                                                               
  ## Motivation                                             
  These fields provide useful context about process lineage in serialized CWS events:
  - `is_exec` — whether the process entry is from a new binary execution
  - `is_parent_missing` — whether the direct parent process is missing from the process tree
  - `is_thread` / `is_exec_child` — already serialized, now also declared in the validation schema

  ## Changes
  | File | Change |
  |---|---|
  | `pkg/security/serializers/serializers_linux.go` | Added `IsExec` and `IsParentMissing` to `ProcessSerializer` struct and both code paths in `newProcessSerializer` |
  | `pkg/security/serializers/serializers_linux_easyjson.go` | Added marshal/unmarshal support for `is_exec` and `is_parent_missing` |
  | `pkg/security/serializers/serializers_linux_test.go` | Added 3 tests: single-field, all-true, and ancestor propagation with JSON schema validation |
  | `pkg/security/secl/schemas/process.schema.json` | Added `is_thread`, `is_exec`, `is_exec_child`, `is_parent_missing` boolean properties |
  | `docs/cloud-workload-security/backend_linux.schema.json` | Added `is_exec` and `is_parent_missing` to both ProcessSerializer definitions |
  | `docs/cloud-workload-security/backend.schema.json` | Same |
  | `docs/cloud-workload-security/backend_linux.md` | Added fields to schema blocks and reference tables |

  ## Test plan
  - [x] Unit tests pass: `go test -run TestProcessSerializer -v ./pkg/security/serializers/`
  - [x] All existing serializer tests still pass: `go test ./pkg/security/serializers/`
  - [x] Existing functional tests (`functionaltests` build tag) should continue to pass with the updated schema
