### PR TITLE
[WP] Serialize ancestor variables

### DIFF
--- a/docs/cloud-workload-security/backend_linux.md
+++ b/docs/cloud-workload-security/backend_linux.md
@@ -230,7 +230,7 @@ Workload Protection events for Linux systems have the following JSON schema:
                 },
                 "variables": {
                     "$ref": "#/$defs/Variables",
-                    "description": "Variables values"
+                    "description": "Variable values"
                 }
             },
             "additionalProperties": false,
@@ -310,7 +310,7 @@ Workload Protection events for Linux systems have the following JSON schema:
                 },
                 "variables": {
                     "$ref": "#/$defs/Variables",
-                    "description": "Variables values"
+                    "description": "Variable values"
                 }
             },
             "additionalProperties": false,
@@ -436,7 +436,7 @@ Workload Protection events for Linux systems have the following JSON schema:
                 },
                 "variables": {
                     "$ref": "#/$defs/Variables",
-                    "description": "Variables values"
+                    "description": "Variable values"
                 },
                 "rule_context": {
                     "$ref": "#/$defs/RuleContext",
@@ -1482,6 +1482,10 @@ Workload Protection events for Linux systems have the following JSON schema:
                     },
                     "type": "object",
                     "description": "Tags from an APM tracer instrumentation"
+                },
+                "variables": {
+                    "$ref": "#/$defs/Variables",
+                    "description": "Variable values"
                 }
             },
             "additionalProperties": false,
@@ -1655,6 +1659,10 @@ Workload Protection events for Linux systems have the following JSON schema:
                     "type": "object",
                     "description": "Tags from an APM tracer instrumentation"
                 },
+                "variables": {
+                    "$ref": "#/$defs/Variables",
+                    "description": "Variable values"
+                },
                 "parent": {
                     "$ref": "#/$defs/Process",
                     "description": "Parent process"
@@ -1665,10 +1673,6 @@ Workload Protection events for Linux systems have the following JSON schema:
                     },
                     "type": "array",
                     "description": "Ancestor processes"
-                },
-                "variables": {
-                    "$ref": "#/$defs/Variables",
-                    "description": "Variables values"
                 },
                 "truncated_ancestors": {
                     "type": "boolean",
@@ -2819,7 +2823,7 @@ Workload Protection events for Linux systems have the following JSON schema:
         },
         "variables": {
             "$ref": "#/$defs/Variables",
-            "description": "Variables values"
+            "description": "Variable values"
         }
     },
     "additionalProperties": false,
@@ -2833,7 +2837,7 @@ Workload Protection events for Linux systems have the following JSON schema:
 | ----- | ----------- |
 | `id` | CGroup ID |
 | `manager` | CGroup manager |
-| `variables` | Variables values |
+| `variables` | Variable values |
 
 | References |
 | ---------- |
@@ -2957,7 +2961,7 @@ Workload Protection events for Linux systems have the following JSON schema:
         },
         "variables": {
             "$ref": "#/$defs/Variables",
-            "description": "Variables values"
+            "description": "Variable values"
         }
     },
     "additionalProperties": false,
@@ -2971,7 +2975,7 @@ Workload Protection events for Linux systems have the following JSON schema:
 | ----- | ----------- |
 | `id` | Container ID |
 | `created_at` | Creation time of the container |
-| `variables` | Variables values |
+| `variables` | Variable values |
 
 | References |
 | ---------- |
@@ -3160,7 +3164,7 @@ Workload Protection events for Linux systems have the following JSON schema:
         },
         "variables": {
             "$ref": "#/$defs/Variables",
-            "description": "Variables values"
+            "description": "Variable values"
         },
         "rule_context": {
             "$ref": "#/$defs/RuleContext",
@@ -3185,7 +3189,7 @@ Workload Protection events for Linux systems have the following JSON schema:
 | `outcome` | Event outcome |
 | `async` | True if the event was asynchronous |
 | `matched_rules` | The list of rules that the event matched (only valid in the context of an anomaly) |
-| `variables` | Variables values |
+| `variables` | Variable values |
 | `rule_context` | RuleContext rule context |
 | `source` | Source of the event |
 
@@ -4624,6 +4628,10 @@ Workload Protection events for Linux systems have the following JSON schema:
             },
             "type": "object",
             "description": "Tags from an APM tracer instrumentation"
+        },
+        "variables": {
+            "$ref": "#/$defs/Variables",
+            "description": "Variable values"
         }
     },
     "additionalProperties": false,
@@ -4674,6 +4682,7 @@ Workload Protection events for Linux systems have the following JSON schema:
 | `syscalls` | List of syscalls captured to generate the event |
 | `aws_security_credentials` | List of AWS Security Credentials that the process had access to |
 | `tracer` | Tags from an APM tracer instrumentation |
+| `variables` | Variable values |
 
 | References |
 | ---------- |
@@ -4683,6 +4692,7 @@ Workload Protection events for Linux systems have the following JSON schema:
 | [CGroupContext](#cgroupcontext) |
 | [ContainerContext](#containercontext) |
 | [SyscallsEvent](#syscallsevent) |
+| [Variables](#variables) |
 
 ## `ProcessContext`
 
@@ -4851,6 +4861,10 @@ Workload Protection events for Linux systems have the following JSON schema:
             "type": "object",
             "description": "Tags from an APM tracer instrumentation"
         },
+        "variables": {
+            "$ref": "#/$defs/Variables",
+            "description": "Variable values"
+        },
         "parent": {
             "$ref": "#/$defs/Process",
             "description": "Parent process"
@@ -4861,10 +4875,6 @@ Workload Protection events for Linux systems have the following JSON schema:
             },
             "type": "array",
             "description": "Ancestor processes"
-        },
-        "variables": {
-            "$ref": "#/$defs/Variables",
-            "description": "Variables values"
         },
         "truncated_ancestors": {
             "type": "boolean",
@@ -4919,9 +4929,9 @@ Workload Protection events for Linux systems have the following JSON schema:
 | `syscalls` | List of syscalls captured to generate the event |
 | `aws_security_credentials` | List of AWS Security Credentials that the process had access to |
 | `tracer` | Tags from an APM tracer instrumentation |
+| `variables` | Variable values |
 | `parent` | Parent process |
 | `ancestors` | Ancestor processes |
-| `variables` | Variables values |
 | `truncated_ancestors` | True if the ancestors list was truncated because it was too big |
 
 | References |
@@ -4932,8 +4942,8 @@ Workload Protection events for Linux systems have the following JSON schema:
 | [CGroupContext](#cgroupcontext) |
 | [ContainerContext](#containercontext) |
 | [SyscallsEvent](#syscallsevent) |
-| [Process](#process) |
 | [Variables](#variables) |
+| [Process](#process) |
 
 ## `ProcessCredentials`
 

--- a/docs/cloud-workload-security/backend_linux.schema.json
+++ b/docs/cloud-workload-security/backend_linux.schema.json
@@ -219,7 +219,7 @@
         },
         "variables": {
           "$ref": "#/$defs/Variables",
-          "description": "Variables values"
+          "description": "Variable values"
         }
       },
       "additionalProperties": false,
@@ -299,7 +299,7 @@
         },
         "variables": {
           "$ref": "#/$defs/Variables",
-          "description": "Variables values"
+          "description": "Variable values"
         }
       },
       "additionalProperties": false,
@@ -425,7 +425,7 @@
         },
         "variables": {
           "$ref": "#/$defs/Variables",
-          "description": "Variables values"
+          "description": "Variable values"
         },
         "rule_context": {
           "$ref": "#/$defs/RuleContext",
@@ -1471,6 +1471,10 @@
           },
           "type": "object",
           "description": "Tags from an APM tracer instrumentation"
+        },
+        "variables": {
+          "$ref": "#/$defs/Variables",
+          "description": "Variable values"
         }
       },
       "additionalProperties": false,
@@ -1644,6 +1648,10 @@
           "type": "object",
           "description": "Tags from an APM tracer instrumentation"
         },
+        "variables": {
+          "$ref": "#/$defs/Variables",
+          "description": "Variable values"
+        },
         "parent": {
           "$ref": "#/$defs/Process",
           "description": "Parent process"
@@ -1654,10 +1662,6 @@
           },
           "type": "array",
           "description": "Ancestor processes"
-        },
-        "variables": {
-          "$ref": "#/$defs/Variables",
-          "description": "Variables values"
         },
         "truncated_ancestors": {
           "type": "boolean",

--- a/pkg/security/serializers/serializers_base.go
+++ b/pkg/security/serializers/serializers_base.go
@@ -32,7 +32,7 @@ type ContainerContextSerializer struct {
 	ID string `json:"id,omitempty"`
 	// Creation time of the container
 	CreatedAt *utils.EasyjsonTime `json:"created_at,omitempty"`
-	// Variables values
+	// Variable values
 	Variables Variables `json:"variables,omitempty"`
 }
 
@@ -43,7 +43,7 @@ type CGroupContextSerializer struct {
 	ID string `json:"id,omitempty"`
 	// CGroup manager
 	Manager string `json:"manager,omitempty"`
-	// Variables values
+	// Variable values
 	Variables Variables `json:"variables,omitempty"`
 }
 
@@ -79,7 +79,7 @@ type EventContextSerializer struct {
 	Async bool `json:"async,omitempty"`
 	// The list of rules that the event matched (only valid in the context of an anomaly)
 	MatchedRules []MatchedRuleSerializer `json:"matched_rules,omitempty"`
-	// Variables values
+	// Variable values
 	Variables Variables `json:"variables,omitempty"`
 	// RuleContext rule context
 	RuleContext RuleContext `json:"rule_context,omitempty"`
@@ -95,8 +95,6 @@ type ProcessContextSerializer struct {
 	Parent *ProcessSerializer `json:"parent,omitempty"`
 	// Ancestor processes
 	Ancestors []*ProcessSerializer `json:"ancestors,omitempty"`
-	// Variables values
-	Variables Variables `json:"variables,omitempty"`
 	// True if the ancestors list was truncated because it was too big
 	TruncatedAncestors bool `json:"truncated_ancestors,omitempty"`
 }
@@ -478,11 +476,8 @@ func NewBaseEventSerializer(event *model.Event, rule *rules.Rule, scrubber *util
 			RuleContext: newRuleContext(event, rule, scrubber),
 			Source:      event.Source,
 		},
-		ProcessContextSerializer: newProcessContextSerializer(pc, event),
+		ProcessContextSerializer: newProcessContextSerializer(pc, event, rule),
 		Date:                     utils.NewEasyjsonTime(event.ResolveEventTime()),
-	}
-	if s.ProcessContextSerializer != nil {
-		s.ProcessContextSerializer.Variables = newVariablesContext(event, rule, "process.")
 	}
 
 	if event.IsAnomalyDetectionEvent() && len(event.Rules) > 0 {

--- a/pkg/security/serializers/serializers_base_linux_easyjson.go
+++ b/pkg/security/serializers/serializers_base_linux_easyjson.go
@@ -803,12 +803,6 @@ func easyjsonA1e47abeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers6(i
 				}
 				in.Delim(']')
 			}
-		case "variables":
-			if in.IsNull() {
-				in.Skip()
-			} else {
-				(out.Variables).UnmarshalEasyJSON(in)
-			}
 		case "truncated_ancestors":
 			if in.IsNull() {
 				in.Skip()
@@ -1267,6 +1261,12 @@ func easyjsonA1e47abeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers6(i
 				}
 				in.Delim('}')
 			}
+		case "variables":
+			if in.IsNull() {
+				in.Skip()
+			} else {
+				(out.Variables).UnmarshalEasyJSON(in)
+			}
 		default:
 			in.SkipRecursive()
 		}
@@ -1309,16 +1309,6 @@ func easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers6(o
 			}
 			out.RawByte(']')
 		}
-	}
-	if len(in.Variables) != 0 {
-		const prefix string = ",\"variables\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		(in.Variables).MarshalEasyJSON(out)
 	}
 	if in.TruncatedAncestors {
 		const prefix string = ",\"truncated_ancestors\":"
@@ -1598,6 +1588,11 @@ func easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers6(o
 			}
 			out.RawByte('}')
 		}
+	}
+	if len(in.Variables) != 0 {
+		const prefix string = ",\"variables\":"
+		out.RawString(prefix)
+		(in.Variables).MarshalEasyJSON(out)
 	}
 	out.RawByte('}')
 }

--- a/pkg/security/serializers/serializers_linux.go
+++ b/pkg/security/serializers/serializers_linux.go
@@ -332,6 +332,8 @@ type ProcessSerializer struct {
 	AWSSecurityCredentials []*AWSSecurityCredentialsSerializer `json:"aws_security_credentials,omitempty"`
 	// Tags from an APM tracer instrumentation
 	Tracer map[string]string `json:"tracer,omitempty"`
+	// Variable values
+	Variables Variables `json:"variables,omitempty"`
 }
 
 // FileEventSerializer serializes a file event to JSON
@@ -1184,7 +1186,7 @@ func newPTraceEventSerializer(e *model.Event) *PTraceEventSerializer {
 	return &PTraceEventSerializer{
 		Request: model.PTraceRequest(e.PTrace.Request).String(),
 		Address: fmt.Sprintf("0x%x", e.PTrace.Address),
-		Tracee:  newProcessContextSerializer(e.PTrace.Tracee, fakeTraceeEvent),
+		Tracee:  newProcessContextSerializer(e.PTrace.Tracee, fakeTraceeEvent, nil),
 	}
 }
 
@@ -1209,7 +1211,7 @@ func newSignalEventSerializer(e *model.Event) *SignalEventSerializer {
 	ses := &SignalEventSerializer{
 		Type:   model.Signal(e.Signal.Type).String(),
 		PID:    e.Signal.PID,
-		Target: newProcessContextSerializer(e.Signal.Target, e),
+		Target: newProcessContextSerializer(e.Signal.Target, e, nil),
 	}
 	return ses
 }
@@ -1378,7 +1380,7 @@ func serializeOutcome(retval int64) string {
 	}
 }
 
-func newProcessContextSerializer(pc *model.ProcessContext, e *model.Event) *ProcessContextSerializer {
+func newProcessContextSerializer(pc *model.ProcessContext, e *model.Event, rule *rules.Rule) *ProcessContextSerializer {
 	if pc == nil || pc.Pid == 0 || e == nil {
 		return nil
 	}
@@ -1386,6 +1388,8 @@ func newProcessContextSerializer(pc *model.ProcessContext, e *model.Event) *Proc
 	ps := ProcessContextSerializer{
 		ProcessSerializer: newProcessSerializer(&pc.Process, e),
 	}
+
+	ps.Variables = newVariablesContext(e, rule, "process.")
 
 	// add the syscalls from the event only for the top level parent
 	if e.GetEventType() == model.SyscallsEventType {
@@ -1402,9 +1406,17 @@ func newProcessContextSerializer(pc *model.ProcessContext, e *model.Event) *Proc
 
 	first := true
 
+	originalPCE := e.ProcessCacheEntry
+
 	for ptr != nil {
 		pce := (*model.ProcessCacheEntry)(ptr)
 		s := newProcessSerializer(&pce.Process, e)
+
+		// evaluate variables scoped to this ancestor
+		e.ProcessCacheEntry = pce
+		s.Variables = newVariablesContext(e, rule, "process.")
+		e.ProcessCacheEntry = originalPCE
+
 		ps.Ancestors = append(ps.Ancestors, s)
 
 		if first {
@@ -1544,7 +1556,7 @@ func newSetrlimitEventSerializer(e *model.Event) *SetrlimitEventSerializer {
 		Resource: model.RlimitResource(e.Setrlimit.Resource).String(),
 		Current:  e.Setrlimit.RlimCur,
 		Max:      e.Setrlimit.RlimMax,
-		Target:   newProcessContextSerializer(e.Setrlimit.Target, fakeTargetEvent),
+		Target:   newProcessContextSerializer(e.Setrlimit.Target, fakeTargetEvent, nil),
 	}
 }
 

--- a/pkg/security/serializers/serializers_linux_easyjson.go
+++ b/pkg/security/serializers/serializers_linux_easyjson.go
@@ -2602,6 +2602,12 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(
 				}
 				in.Delim('}')
 			}
+		case "variables":
+			if in.IsNull() {
+				in.Skip()
+			} else {
+				(out.Variables).UnmarshalEasyJSON(in)
+			}
 		default:
 			in.SkipRecursive()
 		}
@@ -2880,6 +2886,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(
 			}
 			out.RawByte('}')
 		}
+	}
+	if len(in.Variables) != 0 {
+		const prefix string = ",\"variables\":"
+		out.RawString(prefix)
+		(in.Variables).MarshalEasyJSON(out)
 	}
 	out.RawByte('}')
 }

--- a/pkg/security/serializers/serializers_linux_test.go
+++ b/pkg/security/serializers/serializers_linux_test.go
@@ -287,6 +287,64 @@ func TestCustomEventVariables_SECLVariablesExcluded(t *testing.T) {
 	}
 }
 
+func TestCustomEventVariables_AncestorVariables(t *testing.T) {
+	// Build a process scoper that returns event.ProcessCacheEntry.
+	scopedVars := eval.NewScopedVariables("process", func(ctx *eval.Context) eval.VariableScope {
+		if pce := ctx.Event.(*model.Event).ProcessCacheEntry; pce != nil {
+			return pce
+		}
+		return nil
+	})
+
+	// Create a scoped boolean variable named "process.is_suspicious".
+	seclVar, err := scopedVars.NewSECLVariable("process.is_suspicious", false, "process", eval.VariableOpts{})
+	require.NoError(t, err)
+
+	store := &eval.VariableStore{}
+	store.Add("process.is_suspicious", seclVar)
+
+	rule := events.NewCustomRule(
+		events.AnomalyDetectionRuleID,
+		events.AnomalyDetectionRuleDesc,
+		&eval.Opts{VariableStore: store},
+	)
+
+	// Create an event with a process and one ancestor.
+	event := newAnomalyEvent()
+	event.ProcessContext.Pid = 42
+
+	ancestorPCE := &model.ProcessCacheEntry{}
+	ancestorPCE.Process.Pid = 1
+	event.ProcessContext.Ancestor = ancestorPCE
+
+	mainPCE := &model.ProcessCacheEntry{}
+	mainPCE.Process.Pid = 42
+	event.ProcessCacheEntry = mainPCE
+
+	// Set the variable value for the ancestor's scope.
+	event.ProcessCacheEntry = ancestorPCE
+	ctx := eval.NewContext(event)
+	err = seclVar.(eval.MutableVariable).Set(ctx, true)
+	require.NoError(t, err)
+
+	// Restore the main process PCE.
+	event.ProcessCacheEntry = mainPCE
+
+	s := NewEventSerializer(event, rule, newTestScrubber(t))
+
+	require.NotNil(t, s.ProcessContextSerializer)
+	require.Len(t, s.ProcessContextSerializer.Ancestors, 1)
+
+	// The ancestor should have the variable set to true.
+	require.NotNil(t, s.ProcessContextSerializer.Ancestors[0].Variables)
+	assert.Equal(t, true, s.ProcessContextSerializer.Ancestors[0].Variables["is_suspicious"])
+
+	// The main process should have the variable's zero value (false), since
+	// the scoped variable evaluator returns the zero value when not explicitly set.
+	require.NotNil(t, s.ProcessContextSerializer.Variables)
+	assert.Equal(t, false, s.ProcessContextSerializer.Variables["is_suspicious"])
+}
+
 func TestProcessSerializer_IsExecFields(t *testing.T) {
 	event := model.NewFakeEvent()
 	event.Type = uint32(model.ExecEventType)
@@ -408,7 +466,12 @@ func TestProcessSerializer_IsExecFields_Ancestors(t *testing.T) {
 	event.ProcessContext.Ancestor = ancestor
 	event.ProcessContext.Parent = &ancestor.ProcessContext.Process
 
-	pcs := newProcessContextSerializer(event.ProcessContext, event)
+	rule := events.NewCustomRule(
+		events.AnomalyDetectionRuleID,
+		events.AnomalyDetectionRuleDesc,
+		&eval.Opts{},
+	)
+	pcs := newProcessContextSerializer(event.ProcessContext, event, rule)
 	require.NotNil(t, pcs)
 
 	// Verify main process fields.

--- a/pkg/security/serializers/serializers_windows.go
+++ b/pkg/security/serializers/serializers_windows.go
@@ -83,6 +83,8 @@ type ProcessSerializer struct {
 	CmdLine string `json:"cmdline,omitempty"`
 	// User name
 	User string `json:"user,omitempty"`
+	// Variable values
+	Variables Variables `json:"variables,omitempty"`
 }
 
 // FileEventSerializer serializes a file event to JSON
@@ -171,7 +173,7 @@ func newProcessSerializer(ps *model.Process, e *model.Event) *ProcessSerializer 
 	return psSerializer
 }
 
-func newProcessContextSerializer(pc *model.ProcessContext, e *model.Event) *ProcessContextSerializer {
+func newProcessContextSerializer(pc *model.ProcessContext, e *model.Event, rule *rules.Rule) *ProcessContextSerializer {
 	if pc == nil || pc.Pid == 0 || e == nil {
 		return nil
 	}
@@ -180,17 +182,26 @@ func newProcessContextSerializer(pc *model.ProcessContext, e *model.Event) *Proc
 		ProcessSerializer: newProcessSerializer(&pc.Process, e),
 	}
 
+	ps.Variables = newVariablesContext(e, rule, "process.")
+
 	ctx := eval.NewContext(e)
 
 	it := &model.ProcessAncestorsIterator{}
 	ptr := it.Front(ctx)
 
+	originalPCE := e.ProcessCacheEntry
 	first := true
 
 	for ptr != nil {
 		pce := (*model.ProcessCacheEntry)(ptr)
 
 		s := newProcessSerializer(&pce.Process, e)
+
+		// evaluate variables scoped to this ancestor
+		e.ProcessCacheEntry = pce
+		s.Variables = newVariablesContext(e, rule, "process.")
+		e.ProcessCacheEntry = originalPCE
+
 		ps.Ancestors = append(ps.Ancestors, s)
 
 		if first {


### PR DESCRIPTION
## What does this PR do?

  Adds per-ancestor variable serialization to CWS event JSON output. Previously, process-scoped variables (`process.*`) were only serialized on the top-level `ProcessContextSerializer`. Now each ancestor `ProcessSerializer` in the `ancestors` array
  carries its own `variables` map, evaluated against that specific ancestor's `ProcessCacheEntry` scope.

  Key changes:
  - Added a `Variables` field to `ProcessSerializer` (Linux and Windows)
  - Updated `newProcessContextSerializer` to accept a `rule` parameter and evaluate scoped variables per ancestor by temporarily swapping `event.ProcessCacheEntry` to each ancestor's PCE
  - Moved process-level variable assignment from `NewBaseEventSerializer` into `newProcessContextSerializer` to co-locate all process variable logic
  - Regenerated easyjson marshalers and backend schema

  ## Motivation

  Process-scoped variables are stored per-`ProcessCacheEntry` in the eval engine's `ScopedVariables` map, keyed by each process's unique scope hash. When a rule's `set` action writes a variable with `scope: process`, the value is tied to the specific
  process that triggered the rule. However, during serialization only the current process's variables were included — ancestor processes with their own distinct variable values were silently dropped. This meant downstream consumers had no visibility into
  per-ancestor variable state.

  ## Describe how you validated your changes

  - Added `TestCustomEventVariables_AncestorVariables` which sets up a `ScopedVariables` instance with a process scoper, registers a boolean variable, sets it to `true` for an ancestor's scope, serializes the event, and asserts:
    - The ancestor's `Variables["is_suspicious"]` is `true`
    - The main process's `Variables["is_suspicious"]` is `false` (zero value, since it was never explicitly set for that scope)
  - All existing `TestCustomEventVariables_*` tests continue to pass
  - `go test -tags linux ./pkg/security/serializers/` passes
