### PR TITLE
Add for clause test scenarios for shell

### DIFF
--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_basic_behavior/for_commands_after.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_basic_behavior/for_commands_after.yaml
@@ -1,0 +1,13 @@
+description: Commands after a for loop execute normally.
+input:
+  # language=bash
+  script: |+
+    for i in a b; do echo $i; done
+    echo after
+expected:
+  stdout: |+
+    a
+    b
+    after
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_basic_behavior/for_commands_before.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_basic_behavior/for_commands_before.yaml
@@ -1,0 +1,13 @@
+description: Commands before a for loop execute normally.
+input:
+  # language=bash
+  script: |+
+    echo before
+    for i in a b; do echo $i; done
+expected:
+  stdout: |+
+    before
+    a
+    b
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_basic_behavior/for_empty_list.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_basic_behavior/for_empty_list.yaml
@@ -1,0 +1,11 @@
+description: For loop with empty list executes zero iterations.
+input:
+  # language=bash
+  script: |+
+    for i in; do echo $i; done
+    echo done
+expected:
+  stdout: |+
+    done
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_basic_behavior/for_iterate_words.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_basic_behavior/for_iterate_words.yaml
@@ -1,0 +1,12 @@
+description: For loop iterates over a list of words.
+input:
+  # language=bash
+  script: |+
+    for i in a b c; do echo $i; done
+expected:
+  stdout: |+
+    a
+    b
+    c
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_basic_behavior/for_many_items.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_basic_behavior/for_many_items.yaml
@@ -1,0 +1,14 @@
+description: For loop iterates over many items in order.
+input:
+  # language=bash
+  script: |+
+    for n in 1 2 3 4 5; do echo $n; done
+expected:
+  stdout: |+
+    1
+    2
+    3
+    4
+    5
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_basic_behavior/for_multiline_body.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_basic_behavior/for_multiline_body.yaml
@@ -1,0 +1,16 @@
+description: For loop body can span multiple lines.
+input:
+  # language=bash
+  script: |+
+    for i in a b; do
+      echo start $i
+      echo end $i
+    done
+expected:
+  stdout: |+
+    start a
+    end a
+    start b
+    end b
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_basic_behavior/for_single_item.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_basic_behavior/for_single_item.yaml
@@ -1,0 +1,10 @@
+description: For loop with a single item iterates once.
+input:
+  # language=bash
+  script: |+
+    for x in hello; do echo $x; done
+expected:
+  stdout: |+
+    hello
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_basic_behavior/for_special_characters_in_items.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_basic_behavior/for_special_characters_in_items.yaml
@@ -1,0 +1,11 @@
+description: For loop items can contain special characters when quoted.
+input:
+  # language=bash
+  script: |+
+    for f in "hello world" "foo bar"; do echo "$f"; done
+expected:
+  stdout: |+
+    hello world
+    foo bar
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_break_continue/for_break_mid_body.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_break_continue/for_break_mid_body.yaml
@@ -1,0 +1,14 @@
+description: Break in the middle of the loop body stops execution.
+input:
+  # language=bash
+  script: |+
+    for i in a b c; do
+      echo "start $i"
+      break
+      echo "end $i"
+    done
+expected:
+  stdout: |+
+    start a
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_break_continue/for_break_outside_loop.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_break_continue/for_break_outside_loop.yaml
@@ -1,0 +1,12 @@
+description: Break outside a loop produces an error message.
+input:
+  # language=bash
+  script: |+
+    break
+    echo after
+expected:
+  stdout: |+
+    after
+  stderr_contains:
+    - "break is only useful in a loop"
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_break_continue/for_break_simple.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_break_continue/for_break_simple.yaml
@@ -1,0 +1,15 @@
+description: Break exits the for loop early.
+input:
+  # language=bash
+  script: |+
+    for i in a b c d; do
+      echo $i
+      break
+    done
+    echo after
+expected:
+  stdout: |+
+    a
+    after
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_break_continue/for_break_with_arg.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_break_continue/for_break_with_arg.yaml
@@ -1,0 +1,15 @@
+description: Break with argument 1 breaks one level (same as simple break).
+input:
+  # language=bash
+  script: |+
+    for i in a b c; do
+      echo $i
+      break 1
+    done
+    echo done
+expected:
+  stdout: |+
+    a
+    done
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_break_continue/for_continue_outside_loop.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_break_continue/for_continue_outside_loop.yaml
@@ -1,0 +1,12 @@
+description: Continue outside a loop produces an error message.
+input:
+  # language=bash
+  script: |+
+    continue
+    echo after
+expected:
+  stdout: |+
+    after
+  stderr_contains:
+    - "continue is only useful in a loop"
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_break_continue/for_continue_simple.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_break_continue/for_continue_simple.yaml
@@ -1,0 +1,16 @@
+description: Continue skips the rest of the loop body and goes to the next iteration.
+input:
+  # language=bash
+  script: |+
+    for i in a b c; do
+      echo "before $i"
+      continue
+      echo "after $i"
+    done
+expected:
+  stdout: |+
+    before a
+    before b
+    before c
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_break_continue/for_continue_with_arg.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_break_continue/for_continue_with_arg.yaml
@@ -1,0 +1,14 @@
+description: Continue with argument 1 continues one level (same as simple continue).
+input:
+  # language=bash
+  script: |+
+    for i in a b c; do
+      continue 1
+      echo $i
+    done
+    echo done
+expected:
+  stdout: |+
+    done
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_exit_code/for_exit_code_after_break.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_exit_code/for_exit_code_after_break.yaml
@@ -1,0 +1,11 @@
+description: Exit code after break is 0.
+input:
+  # language=bash
+  script: |+
+    for i in a b c; do
+      break
+    done
+expected:
+  stdout: ""
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_exit_code/for_exit_code_empty_list.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_exit_code/for_exit_code_empty_list.yaml
@@ -1,0 +1,9 @@
+description: For loop with empty list exits with code 0.
+input:
+  # language=bash
+  script: |+
+    for i in; do false; done
+expected:
+  stdout: ""
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_exit_code/for_exit_code_last_cmd.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_exit_code/for_exit_code_last_cmd.yaml
@@ -1,0 +1,9 @@
+description: For loop exit code reflects the last command in the body.
+input:
+  # language=bash
+  script: |+
+    for i in a; do false; done
+expected:
+  stdout: ""
+  stderr: ""
+  exit_code: 1

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_exit_code/for_exit_code_success.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_exit_code/for_exit_code_success.yaml
@@ -1,0 +1,11 @@
+description: For loop with successful body exits with code 0.
+input:
+  # language=bash
+  script: |+
+    for i in a b; do echo $i; done
+expected:
+  stdout: |+
+    a
+    b
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_exit_code/for_unknown_cmd_in_body.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_exit_code/for_unknown_cmd_in_body.yaml
@@ -1,0 +1,10 @@
+description: Unknown command in for loop body produces error on stderr.
+input:
+  # language=bash
+  script: |+
+    for i in a; do nonexistent_cmd; done
+expected:
+  stdout: ""
+  stderr_contains:
+    - "not found"
+  exit_code: 127

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_nested/for_nested_basic.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_nested/for_nested_basic.yaml
@@ -1,0 +1,17 @@
+description: Nested for loops iterate correctly over all combinations.
+input:
+  # language=bash
+  script: |+
+    for i in a b; do
+      for j in 1 2; do
+        echo "$i$j"
+      done
+    done
+expected:
+  stdout: |+
+    a1
+    a2
+    b1
+    b2
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_nested/for_nested_break_inner.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_nested/for_nested_break_inner.yaml
@@ -1,0 +1,16 @@
+description: Break in inner nested loop only breaks the inner loop.
+input:
+  # language=bash
+  script: |+
+    for i in a b; do
+      for j in 1 2 3; do
+        echo "$i$j"
+        break
+      done
+    done
+expected:
+  stdout: |+
+    a1
+    b1
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_nested/for_nested_break_outer.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_nested/for_nested_break_outer.yaml
@@ -1,0 +1,17 @@
+description: Break 2 in inner loop breaks both inner and outer loops.
+input:
+  # language=bash
+  script: |+
+    for i in a b c; do
+      for j in 1 2 3; do
+        echo "$i$j"
+        break 2
+      done
+    done
+    echo done
+expected:
+  stdout: |+
+    a1
+    done
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_nested/for_nested_continue_inner.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_nested/for_nested_continue_inner.yaml
@@ -1,0 +1,17 @@
+description: Continue in inner nested loop only continues the inner loop.
+input:
+  # language=bash
+  script: |+
+    for i in a b; do
+      for j in 1 2; do
+        continue
+        echo "skipped"
+      done
+      echo "outer $i"
+    done
+expected:
+  stdout: |+
+    outer a
+    outer b
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_variable_scoping/for_env_var_in_items.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_variable_scoping/for_env_var_in_items.yaml
@@ -1,0 +1,15 @@
+description: For loop iterates over items built from variable expansion.
+input:
+  # language=bash
+  script: |+
+    A=one
+    B=two
+    C=three
+    for i in $A $B $C; do echo $i; done
+expected:
+  stdout: |+
+    one
+    two
+    three
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_variable_scoping/for_var_assigned_in_body.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_variable_scoping/for_var_assigned_in_body.yaml
@@ -1,0 +1,13 @@
+description: Variable assigned in loop body is visible after the loop.
+input:
+  # language=bash
+  script: |+
+    for i in a b c; do
+      LAST=$i
+    done
+    echo $LAST
+expected:
+  stdout: |+
+    c
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_variable_scoping/for_var_expansion_in_items.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_variable_scoping/for_var_expansion_in_items.yaml
@@ -1,0 +1,13 @@
+description: For loop items can reference variables via expansion.
+input:
+  # language=bash
+  script: |+
+    ITEMS="x y z"
+    for i in $ITEMS; do echo $i; done
+expected:
+  stdout: |+
+    x
+    y
+    z
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_variable_scoping/for_var_from_outer_scope.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_variable_scoping/for_var_from_outer_scope.yaml
@@ -1,0 +1,11 @@
+description: Variables defined before the loop are accessible inside the body.
+input:
+  # language=bash
+  script: |+
+    PREFIX=hello
+    for i in world; do echo "$PREFIX $i"; done
+expected:
+  stdout: |+
+    hello world
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_variable_scoping/for_var_no_clobber_outer.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_variable_scoping/for_var_no_clobber_outer.yaml
@@ -1,0 +1,14 @@
+description: Loop variable does not clobber a different-named outer variable.
+input:
+  # language=bash
+  script: |+
+    X=original
+    for i in a b; do echo $i; done
+    echo $X
+expected:
+  stdout: |+
+    a
+    b
+    original
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_variable_scoping/for_var_persists_after_loop.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_variable_scoping/for_var_persists_after_loop.yaml
@@ -1,0 +1,14 @@
+description: Loop variable retains value from last iteration after loop.
+input:
+  # language=bash
+  script: |+
+    for i in a b c; do echo $i; done
+    echo "after: $i"
+expected:
+  stdout: |+
+    a
+    b
+    c
+    after: c
+  stderr: ""
+  exit_code: 0


### PR DESCRIPTION
<!-- dd-meta {"pullId":"96f1fd4b-f872-474f-9f45-4a53a1d61242","source":"chat","resourceId":"3760fec5-bf7e-4fc4-955a-1a048944c035","workflowId":"20aee782-089e-479e-a0b7-eafb00d3808f","codeChangeId":"20aee782-089e-479e-a0b7-eafb00d3808f","sourceType":"chat"} -->
PR by Bits
[View session in Datadog](https://app.datadoghq.com/code/3760fec5-bf7e-4fc4-955a-1a048944c035)

Comment @datadog to request changes

Feedback (especially what can be better) welcome in [#code-gen-aka-bits-dev-feedback](https://dd.enterprise.slack.com/archives/C07JA5N2D25)!

---

### What does this PR do?

Adds 30 comprehensive YAML-based test scenarios for the `for` clause in the shell interpreter under `pkg/shell/e2e_tests/scenarios/interpreter/for_clause/`.

Scenarios are organized into 5 groups:
- **for_basic_behavior** (8 scenarios): word iteration, single/empty/many items, quoted items, multiline body, commands before/after
- **for_variable_scoping** (6 scenarios): loop variable persistence, body assignments, outer scope access, variable expansion in items
- **for_break_continue** (7 scenarios): break/continue basic usage, mid-body break, break/continue with numeric argument, break/continue outside loop
- **for_exit_code** (5 scenarios): success, last-command exit code, empty list, break exit code, unknown command
- **for_nested** (4 scenarios): nested iteration, break/continue inner only, break 2 for outer

### Motivation

The `for` clause had no dedicated test coverage. Existing for-loop references in the test suite only appeared incidentally in separator and pipe test groups. This adds focused, comprehensive coverage for all supported for-loop behaviors.

### Describe how you validated your changes

All 30 new scenarios pass via `go test ./pkg/shell/e2e_tests/ -run "TestShellScenarios/interpreter/for_clause" -v`.

### Additional Notes

Test-only change; no production code modified.