### PR TITLE
[CWS] Add DD_SERVICE and OTEL_SERVICE_NAME to default captured envs

### DIFF
--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -306,7 +306,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.event_stream.use_kprobe_fallback", true)
 	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.event_stream.buffer_size", 0)
 	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.event_stream.kretprobe_max_active", 512)
-	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.envs_with_value", []string{"LD_PRELOAD", "LD_LIBRARY_PATH", "PATH", "HISTSIZE", "HISTFILESIZE", "GLIBC_TUNABLES", "SSH_CLIENT"})
+	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.envs_with_value", []string{"LD_PRELOAD", "LD_LIBRARY_PATH", "PATH", "HISTSIZE", "HISTFILESIZE", "GLIBC_TUNABLES", "SSH_CLIENT", "DD_SERVICE", "OTEL_SERVICE_NAME"})
 	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.runtime_compilation.enabled", false)
 	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.network.enabled", true)
 	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.network.ingress.enabled", true)

--- a/pkg/config/system-probe_template.yaml
+++ b/pkg/config/system-probe_template.yaml
@@ -169,7 +169,7 @@
 #   # @env DD_RUNTIME_SECURITY_CONFIG_ENVS_WITH_VALUE - space separated list of strings - optional
 #   # Define your own list of non-sensitive environment variable names whose value will not be
 #   # concealed by the runtime security module.
-#   # Default: LD_PRELOAD, LD_LIBRARY_PATH, PATH, HISTSIZE, HISTFILESIZE, GLIBC_TUNABLES
+#   # Default: LD_PRELOAD, LD_LIBRARY_PATH, PATH, HISTSIZE, HISTFILESIZE, GLIBC_TUNABLES, OTEL_SERVICE_NAME, DD_SERVICE
 #
 #   envs_with_value:
 #     - LD_PRELOAD
@@ -177,6 +177,8 @@
 #     - PATH
 #     - HISTSIZE
 #     - HISTFILESIZE
+#     - OTEL_SERVICE_NAME
+#     - DD_SERVICE
 
 #   # @param activity_dump - custom object - optional
 #   # Activity dump section configures if/how the Agent sends activity dumps to Datadog

--- a/pkg/security/resolvers/envvars/resolver.go
+++ b/pkg/security/resolvers/envvars/resolver.go
@@ -26,12 +26,8 @@ func NewEnvVarsResolver(cfg *config.Config) *Resolver {
 		envsWithValue = cfg.EnvsWithValue
 	}
 
-	pe := make([]string, 0, len(envsWithValue)+1)
-	pe = append(pe, "DD_SERVICE")
-	pe = append(pe, envsWithValue...)
-
 	return &Resolver{
-		priorityEnvs: pe,
+		priorityEnvs: envsWithValue,
 	}
 }
 


### PR DESCRIPTION
Add DD_SERVICE and OTEL_SERVICE_NAME to the default list of environment variables captured with their values in event_monitoring_config.envs_with_value.

This allows CWS to associate security events with the service name set via the Datadog unified service tagging convention or OpenTelemetry, enabling better correlation between security events and services.

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
