### PR TITLE
Add logical operator test scenarios for pkg/shell

### DIFF
--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/and_basic_behavior/and_both_succeed.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/and_basic_behavior/and_both_succeed.yaml
@@ -1,0 +1,11 @@
+description: Both commands succeed with && operator.
+input:
+  # language=bash
+  script: |+
+    echo first && echo second
+expected:
+  stdout: |+
+    first
+    second
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/and_basic_behavior/and_chain_all_succeed.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/and_basic_behavior/and_chain_all_succeed.yaml
@@ -1,0 +1,12 @@
+description: A chain of && commands all succeed and all execute.
+input:
+  # language=bash
+  script: |+
+    echo one && echo two && echo three
+expected:
+  stdout: |+
+    one
+    two
+    three
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/and_basic_behavior/and_chain_middle_fails.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/and_basic_behavior/and_chain_middle_fails.yaml
@@ -1,0 +1,10 @@
+description: A && chain stops when a middle command fails.
+input:
+  # language=bash
+  script: |+
+    echo one && false && echo three
+expected:
+  stdout: |+
+    one
+  stderr: ""
+  exit_code: 1

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/and_basic_behavior/and_first_fails_skips_rest.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/and_basic_behavior/and_first_fails_skips_rest.yaml
@@ -1,0 +1,9 @@
+description: When first command in a long && chain fails, all subsequent commands are skipped.
+input:
+  # language=bash
+  script: |+
+    false && echo two && echo three && echo four
+expected:
+  stdout: ""
+  stderr: ""
+  exit_code: 1

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/and_basic_behavior/and_left_fails.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/and_basic_behavior/and_left_fails.yaml
@@ -1,0 +1,9 @@
+description: When left side of && fails, right side is skipped.
+input:
+  # language=bash
+  script: |+
+    false && echo skipped
+expected:
+  stdout: ""
+  stderr: ""
+  exit_code: 1

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/and_basic_behavior/and_right_fails.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/and_basic_behavior/and_right_fails.yaml
@@ -1,0 +1,10 @@
+description: When left side succeeds but right side fails, exit code is from right.
+input:
+  # language=bash
+  script: |+
+    echo ok && false
+expected:
+  stdout: |+
+    ok
+  stderr: ""
+  exit_code: 1

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/and_basic_behavior/and_with_true.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/and_basic_behavior/and_with_true.yaml
@@ -1,0 +1,10 @@
+description: The true builtin succeeds so && continues.
+input:
+  # language=bash
+  script: |+
+    true && echo reached
+expected:
+  stdout: |+
+    reached
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/exit_code_semantics/and_custom_exit_codes.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/exit_code_semantics/and_custom_exit_codes.yaml
@@ -1,0 +1,9 @@
+description: Custom exit codes propagate correctly through && chains.
+input:
+  # language=bash
+  script: |+
+    exit 2 && echo skipped
+expected:
+  stdout: ""
+  stderr: ""
+  exit_code: 2

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/exit_code_semantics/and_exit_code_from_right.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/exit_code_semantics/and_exit_code_from_right.yaml
@@ -1,0 +1,9 @@
+description: When both sides of && run, exit code is from the right.
+input:
+  # language=bash
+  script: |+
+    true && exit 7
+expected:
+  stdout: ""
+  stderr: ""
+  exit_code: 7

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/exit_code_semantics/and_preserves_left_exit_code.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/exit_code_semantics/and_preserves_left_exit_code.yaml
@@ -1,0 +1,9 @@
+description: The && operator preserves the failing left exit code.
+input:
+  # language=bash
+  script: |+
+    exit 42 && echo skipped
+expected:
+  stdout: ""
+  stderr: ""
+  exit_code: 42

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/exit_code_semantics/mixed_exit_code_recovery.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/exit_code_semantics/mixed_exit_code_recovery.yaml
@@ -1,0 +1,9 @@
+description: The exit builtin terminates the script immediately so || cannot recover.
+input:
+  # language=bash
+  script: |+
+    exit 99 || true
+expected:
+  stdout: ""
+  stderr: ""
+  exit_code: 99

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/exit_code_semantics/or_both_custom_exit.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/exit_code_semantics/or_both_custom_exit.yaml
@@ -1,0 +1,9 @@
+description: The exit builtin terminates the script immediately so || right side never runs.
+input:
+  # language=bash
+  script: |+
+    exit 2 || exit 5
+expected:
+  stdout: ""
+  stderr: ""
+  exit_code: 2

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/exit_code_semantics/or_exit_code_from_right.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/exit_code_semantics/or_exit_code_from_right.yaml
@@ -1,0 +1,9 @@
+description: When left fails in ||, exit code is from the right side.
+input:
+  # language=bash
+  script: |+
+    false || exit 3
+expected:
+  stdout: ""
+  stderr: ""
+  exit_code: 3

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/exit_code_semantics/or_exit_code_left_success.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/exit_code_semantics/or_exit_code_left_success.yaml
@@ -1,0 +1,9 @@
+description: When left succeeds in ||, exit code is from the left side.
+input:
+  # language=bash
+  script: |+
+    true || exit 5
+expected:
+  stdout: ""
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/mixed_operators/all_fail_chain.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/mixed_operators/all_fail_chain.yaml
@@ -1,0 +1,9 @@
+description: Mixed chain where every path fails.
+input:
+  # language=bash
+  script: |+
+    false && echo no || false && echo no
+expected:
+  stdout: ""
+  stderr: ""
+  exit_code: 1

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/mixed_operators/and_or_and_chain.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/mixed_operators/and_or_and_chain.yaml
@@ -1,0 +1,11 @@
+description: A complex chain mixing && and || operators.
+input:
+  # language=bash
+  script: |+
+    true && false || echo recovered && echo final
+expected:
+  stdout: |+
+    recovered
+    final
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/mixed_operators/and_then_or_failure.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/mixed_operators/and_then_or_failure.yaml
@@ -1,0 +1,10 @@
+description: Failed && triggers the || fallback.
+input:
+  # language=bash
+  script: |+
+    false && echo skipped || echo fallback
+expected:
+  stdout: |+
+    fallback
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/mixed_operators/and_then_or_success.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/mixed_operators/and_then_or_success.yaml
@@ -1,0 +1,11 @@
+description: Successful && followed by || skips the fallback.
+input:
+  # language=bash
+  script: |+
+    echo ok && echo done || echo fallback
+expected:
+  stdout: |+
+    ok
+    done
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/mixed_operators/or_and_or_chain.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/mixed_operators/or_and_or_chain.yaml
@@ -1,0 +1,10 @@
+description: Alternating || and && operators evaluate left to right.
+input:
+  # language=bash
+  script: |+
+    false || true && echo yes || echo no
+expected:
+  stdout: |+
+    yes
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/mixed_operators/or_then_and_failure.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/mixed_operators/or_then_and_failure.yaml
@@ -1,0 +1,11 @@
+description: Failed || fallback result feeds into &&.
+input:
+  # language=bash
+  script: |+
+    false || echo recovered && echo continued
+expected:
+  stdout: |+
+    recovered
+    continued
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/mixed_operators/or_then_and_success.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/mixed_operators/or_then_and_success.yaml
@@ -1,0 +1,11 @@
+description: Successful || left side followed by && continues.
+input:
+  # language=bash
+  script: |+
+    echo ok || echo fallback && echo continued
+expected:
+  stdout: |+
+    ok
+    continued
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/or_basic_behavior/or_both_fail.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/or_basic_behavior/or_both_fail.yaml
@@ -1,0 +1,9 @@
+description: When both sides of || fail, exit code is from right side.
+input:
+  # language=bash
+  script: |+
+    false || false
+expected:
+  stdout: ""
+  stderr: ""
+  exit_code: 1

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/or_basic_behavior/or_chain_all_fail.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/or_basic_behavior/or_chain_all_fail.yaml
@@ -1,0 +1,9 @@
+description: In a || chain, when all commands fail the exit code is from the last.
+input:
+  # language=bash
+  script: |+
+    false || false || false
+expected:
+  stdout: ""
+  stderr: ""
+  exit_code: 1

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/or_basic_behavior/or_chain_first_succeeds.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/or_basic_behavior/or_chain_first_succeeds.yaml
@@ -1,0 +1,10 @@
+description: In a || chain, when first command succeeds the rest are skipped.
+input:
+  # language=bash
+  script: |+
+    echo one || echo two || echo three
+expected:
+  stdout: |+
+    one
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/or_basic_behavior/or_chain_last_succeeds.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/or_basic_behavior/or_chain_last_succeeds.yaml
@@ -1,0 +1,10 @@
+description: In a || chain, commands execute until one succeeds.
+input:
+  # language=bash
+  script: |+
+    false || false || echo reached
+expected:
+  stdout: |+
+    reached
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/or_basic_behavior/or_left_fails.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/or_basic_behavior/or_left_fails.yaml
@@ -1,0 +1,10 @@
+description: When left side of || fails, right side executes.
+input:
+  # language=bash
+  script: |+
+    false || echo fallback
+expected:
+  stdout: |+
+    fallback
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/or_basic_behavior/or_left_succeeds.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/or_basic_behavior/or_left_succeeds.yaml
@@ -1,0 +1,10 @@
+description: When left side of || succeeds, right side is skipped.
+input:
+  # language=bash
+  script: |+
+    echo ok || echo skipped
+expected:
+  stdout: |+
+    ok
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/or_basic_behavior/or_with_true.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/or_basic_behavior/or_with_true.yaml
@@ -1,0 +1,9 @@
+description: The true builtin succeeds so || skips the right side.
+input:
+  # language=bash
+  script: |+
+    true || echo skipped
+expected:
+  stdout: ""
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/output_behavior/and_no_output_on_skip.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/output_behavior/and_no_output_on_skip.yaml
@@ -1,0 +1,10 @@
+description: Skipped commands after failed && produce no output.
+input:
+  # language=bash
+  script: |+
+    echo before && false && echo skipped
+expected:
+  stdout: |+
+    before
+  stderr: ""
+  exit_code: 1

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/output_behavior/and_output_accumulates.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/output_behavior/and_output_accumulates.yaml
@@ -1,0 +1,12 @@
+description: Output accumulates across && when both sides succeed.
+input:
+  # language=bash
+  script: |+
+    echo first && echo second && echo third
+expected:
+  stdout: |+
+    first
+    second
+    third
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/output_behavior/mixed_output_partial.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/output_behavior/mixed_output_partial.yaml
@@ -1,0 +1,12 @@
+description: Only executed commands in a mixed chain produce output.
+input:
+  # language=bash
+  script: |+
+    echo a && false || echo c && echo d
+expected:
+  stdout: |+
+    a
+    c
+    d
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/output_behavior/or_no_output_on_skip.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/output_behavior/or_no_output_on_skip.yaml
@@ -1,0 +1,10 @@
+description: Skipped commands after successful || produce no output.
+input:
+  # language=bash
+  script: |+
+    echo ok || echo skipped
+expected:
+  stdout: |+
+    ok
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/output_behavior/or_output_on_fallback.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/output_behavior/or_output_on_fallback.yaml
@@ -1,0 +1,10 @@
+description: The fallback command after || produces output when left fails.
+input:
+  # language=bash
+  script: |+
+    false || echo fallback
+expected:
+  stdout: |+
+    fallback
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/variable_interaction/and_exit_status_variable.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/variable_interaction/and_exit_status_variable.yaml
@@ -1,0 +1,10 @@
+description: The $? variable reflects exit status within && chains.
+input:
+  # language=bash
+  script: |+
+    true && echo $?
+expected:
+  stdout: |+
+    0
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/variable_interaction/and_variable_visible.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/variable_interaction/and_variable_visible.yaml
@@ -1,0 +1,10 @@
+description: Variable set before && is visible in the right side.
+input:
+  # language=bash
+  script: |+
+    X=hello && echo $X
+expected:
+  stdout: |+
+    hello
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/variable_interaction/or_exit_status_variable.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/variable_interaction/or_exit_status_variable.yaml
@@ -1,0 +1,10 @@
+description: The $? variable reflects the failed exit status in || fallback.
+input:
+  # language=bash
+  script: |+
+    false || echo $?
+expected:
+  stdout: |+
+    1
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/variable_interaction/or_variable_visible_on_fallback.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/variable_interaction/or_variable_visible_on_fallback.yaml
@@ -1,0 +1,10 @@
+description: Variable set before || is visible in the fallback.
+input:
+  # language=bash
+  script: |+
+    X=world; false || echo $X
+expected:
+  stdout: |+
+    world
+  stderr: ""
+  exit_code: 0


### PR DESCRIPTION
<!-- dd-meta {"pullId":"7abede32-b356-49b3-9e16-cb880b7dfd4e","source":"chat","resourceId":"f7336983-611c-46e2-bbb4-cf11e044a417","workflowId":"d7be2cc4-e36a-4598-9b2f-0f7ec6f1471e","codeChangeId":"d7be2cc4-e36a-4598-9b2f-0f7ec6f1471e","sourceType":"chat"} -->
PR by Bits
[View session in Datadog](https://app.datadoghq.com/code/f7336983-611c-46e2-bbb4-cf11e044a417)

Comment @datadog to request changes

Feedback (especially what can be better) welcome in [#code-gen-aka-bits-dev-feedback](https://dd.enterprise.slack.com/archives/C07JA5N2D25)!

---

### What does this PR do?

Adds 37 comprehensive YAML test scenarios for logical operators (`&&` and `||`) in the `pkg/shell` interpreter, organized under `pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/`.

### Motivation

The shell interpreter's logical operator support had limited dedicated test coverage. This adds a structured test suite covering:

- **and_basic_behavior** (7 tests): `&&` success/failure, chaining, short-circuit evaluation
- **or_basic_behavior** (7 tests): `||` success/failure, chaining, fallback behavior
- **mixed_operators** (7 tests): Combined `&&`/`||` chains, left-to-right evaluation
- **exit_code_semantics** (7 tests): Exit code propagation through `&&` and `||`
- **output_behavior** (5 tests): stdout correctness for executed/skipped commands
- **variable_interaction** (4 tests): Variable visibility and `$?` across operators

### Describe how you validated your changes

All 37 new scenarios pass via `go test ./pkg/shell/e2e_tests/ -run "TestShellScenarios/interpreter/logical_operators"`.

### Additional Notes

Test-only change. No production code modified.