### PR TITLE
Rename expected to expect in shell scenarios

### DIFF
--- a/pkg/shell/e2e_tests/scenarios/commands/cat/cat_basic_behavior/cat_dash_no_stdin.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/cat/cat_basic_behavior/cat_dash_no_stdin.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     cat -
-expected:
+expect:
   stdout: ""
   stderr: ""
   exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/commands/cat/cat_basic_behavior/cat_file.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/cat/cat_basic_behavior/cat_file.yaml
@@ -14,7 +14,7 @@ input:
   script: |+
     cat mydir/myfile1.txt
     cat mydir/myfile2.txt
-expected:
+expect:
   stdout: |+
     hello world1
     hello world2

--- a/pkg/shell/e2e_tests/scenarios/commands/cat/cat_basic_behavior/cat_no_stdin.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/cat/cat_basic_behavior/cat_no_stdin.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     cat
-expected:
+expect:
   stdout: ""
   stderr: ""
   exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/commands/cat/cat_error_handling/cat_is_directory.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/cat/cat_error_handling/cat_is_directory.yaml
@@ -8,7 +8,7 @@ input:
   # language=bash
   script: |+
     cat mydir
-expected:
+expect:
   stdout: ""
   stderr_contains:
     - "cat: mydir:"

--- a/pkg/shell/e2e_tests/scenarios/commands/cat/cat_error_handling/cat_multiple_all_fail.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/cat/cat_error_handling/cat_multiple_all_fail.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     cat missing1.txt missing2.txt
-expected:
+expect:
   stdout: ""
   stderr_contains:
     - "cat: missing1.txt:"

--- a/pkg/shell/e2e_tests/scenarios/commands/cat/cat_error_handling/cat_multiple_first_fails.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/cat/cat_error_handling/cat_multiple_first_fails.yaml
@@ -9,7 +9,7 @@ input:
   # language=bash
   script: |+
     cat nonexistent.txt existing.txt
-expected:
+expect:
   stdout: ""
   stderr_contains:
     - "cat: nonexistent.txt:"

--- a/pkg/shell/e2e_tests/scenarios/commands/cat/cat_error_handling/cat_multiple_second_fails.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/cat/cat_error_handling/cat_multiple_second_fails.yaml
@@ -9,7 +9,7 @@ input:
   # language=bash
   script: |+
     cat existing.txt nonexistent.txt
-expected:
+expect:
   stdout: |+
     hello world
   stderr_contains:

--- a/pkg/shell/e2e_tests/scenarios/commands/cat/cat_error_handling/cat_nonexistent_continues.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/cat/cat_error_handling/cat_nonexistent_continues.yaml
@@ -4,7 +4,7 @@ input:
   script: |+
     cat nonexistent.txt
     echo hello
-expected:
+expect:
   stdout: |+
     hello
   stderr_contains:

--- a/pkg/shell/e2e_tests/scenarios/commands/cat/cat_error_handling/cat_nonexistent_file.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/cat/cat_error_handling/cat_nonexistent_file.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     cat nonexistent.txt
-expected:
+expect:
   stdout: ""
   stderr_contains:
     - "cat: nonexistent.txt:"

--- a/pkg/shell/e2e_tests/scenarios/commands/cat/cat_error_handling/cat_redirect_nonexistent.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/cat/cat_error_handling/cat_redirect_nonexistent.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     cat < nonexistent.txt
-expected:
+expect:
   stdout: ""
   stderr_contains:
     - "nonexistent.txt"

--- a/pkg/shell/e2e_tests/scenarios/commands/echo/echo_basic_behavior/echo_empty_string.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/echo/echo_basic_behavior/echo_empty_string.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo ""
-expected:
+expect:
   stdout: |+
 
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/commands/echo/echo_basic_behavior/echo_exit_code.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/echo/echo_basic_behavior/echo_exit_code.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo hello
-expected:
+expect:
   stdout: |+
     hello
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/commands/echo/echo_basic_behavior/echo_multiple_args.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/echo/echo_basic_behavior/echo_multiple_args.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo hello world foo
-expected:
+expect:
   stdout: |+
     hello world foo
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/commands/echo/echo_basic_behavior/echo_multiple_calls.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/echo/echo_basic_behavior/echo_multiple_calls.yaml
@@ -5,7 +5,7 @@ input:
     echo first
     echo second
     echo third
-expected:
+expect:
   stdout: |+
     first
     second

--- a/pkg/shell/e2e_tests/scenarios/commands/echo/echo_basic_behavior/echo_no_args.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/echo/echo_basic_behavior/echo_no_args.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo
-expected:
+expect:
   stdout: |+
 
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/commands/echo/echo_basic_behavior/echo_simple.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/echo/echo_basic_behavior/echo_simple.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo abc
-expected:
+expect:
   stdout: |+
     abc
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/commands/echo/echo_literal_output/echo_dash_e_is_literal.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/echo/echo_literal_output/echo_dash_e_is_literal.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo -e hello
-expected:
+expect:
   stdout: |+
     -e hello
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/commands/echo/echo_literal_output/echo_dash_n_is_literal.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/echo/echo_literal_output/echo_dash_n_is_literal.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo -n hello
-expected:
+expect:
   stdout: |+
     -n hello
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/commands/echo/echo_literal_output/echo_special_chars.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/echo/echo_literal_output/echo_special_chars.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo 'hello\nworld\ttab'
-expected:
+expect:
   stdout: |+
     hello\nworld\ttab
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/commands/echo/echo_with_shell_features/echo_pipe.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/echo/echo_with_shell_features/echo_pipe.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo hello world | cat
-expected:
+expect:
   stdout: |+
     hello world
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/commands/echo/echo_with_shell_features/echo_variable_expansion.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/echo/echo_with_shell_features/echo_variable_expansion.yaml
@@ -4,7 +4,7 @@ input:
   script: |+
     MY_VAR=hello
     echo $MY_VAR world
-expected:
+expect:
   stdout: |+
     hello world
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_basic_behavior/separator_empty_lines.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_basic_behavior/separator_empty_lines.yaml
@@ -7,7 +7,7 @@ input:
     echo second
 
     echo third
-expected:
+expect:
   stdout: |+
     first
     second

--- a/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_basic_behavior/separator_mixed.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_basic_behavior/separator_mixed.yaml
@@ -4,7 +4,7 @@ input:
   script: |+
     echo one; echo two
     echo three; echo four
-expected:
+expect:
   stdout: |+
     one
     two

--- a/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_basic_behavior/separator_newline_multiple.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_basic_behavior/separator_newline_multiple.yaml
@@ -6,7 +6,7 @@ input:
     echo two
     echo three
     echo four
-expected:
+expect:
   stdout: |+
     one
     two

--- a/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_basic_behavior/separator_newline_simple.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_basic_behavior/separator_newline_simple.yaml
@@ -4,7 +4,7 @@ input:
   script: |+
     echo first
     echo second
-expected:
+expect:
   stdout: |+
     first
     second

--- a/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_basic_behavior/separator_semicolon_multiple.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_basic_behavior/separator_semicolon_multiple.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo one; echo two; echo three; echo four
-expected:
+expect:
   stdout: |+
     one
     two

--- a/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_basic_behavior/separator_semicolon_simple.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_basic_behavior/separator_semicolon_simple.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo first; echo second
-expected:
+expect:
   stdout: |+
     first
     second

--- a/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_basic_behavior/separator_trailing_semicolon.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_basic_behavior/separator_trailing_semicolon.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo hello;
-expected:
+expect:
   stdout: |+
     hello
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_basic_behavior/separator_whitespace_around.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_basic_behavior/separator_whitespace_around.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo one ;  echo two  ;  echo three
-expected:
+expect:
   stdout: |+
     one
     two

--- a/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_control_flow/separator_after_for_loop.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_control_flow/separator_after_for_loop.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     for i in a b; do echo $i; done; echo after
-expected:
+expect:
   stdout: |+
     a
     b

--- a/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_control_flow/separator_braces_then_command.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_control_flow/separator_braces_then_command.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     { echo inside; }; echo outside
-expected:
+expect:
   stdout: |+
     inside
     outside

--- a/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_control_flow/separator_for_loop_body.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_control_flow/separator_for_loop_body.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     for i in a b; do echo start $i; echo end $i; done
-expected:
+expect:
   stdout: |+
     start a
     end a

--- a/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_control_flow/separator_for_loop_newline.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_control_flow/separator_for_loop_newline.yaml
@@ -6,7 +6,7 @@ input:
       echo $i
     done
     echo after
-expected:
+expect:
   stdout: |+
     x
     y

--- a/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_control_flow/separator_in_braces.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_control_flow/separator_in_braces.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     { echo one; echo two; echo three; }
-expected:
+expect:
   stdout: |+
     one
     two

--- a/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_control_flow/separator_with_exit.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_control_flow/separator_with_exit.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo before; exit 0; echo after
-expected:
+expect:
   stdout: |+
     before
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_control_flow/separator_with_exit_nonzero.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_control_flow/separator_with_exit_nonzero.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo before; exit 7; echo after
-expected:
+expect:
   stdout: |+
     before
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_exit_code_semantics/separator_continues_after_failure.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_exit_code_semantics/separator_continues_after_failure.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     false; echo still running; echo done
-expected:
+expect:
   stdout: |+
     still running
     done

--- a/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_exit_code_semantics/separator_exit_code_custom.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_exit_code_semantics/separator_exit_code_custom.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo hello; exit 42
-expected:
+expect:
   stdout: |+
     hello
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_exit_code_semantics/separator_exit_code_first_fails.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_exit_code_semantics/separator_exit_code_first_fails.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     false; echo ok
-expected:
+expect:
   stdout: |+
     ok
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_exit_code_semantics/separator_exit_code_last.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_exit_code_semantics/separator_exit_code_last.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo hello; true
-expected:
+expect:
   stdout: |+
     hello
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_exit_code_semantics/separator_exit_code_middle_fails.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_exit_code_semantics/separator_exit_code_middle_fails.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo first; false; echo third
-expected:
+expect:
   stdout: |+
     first
     third

--- a/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_exit_code_semantics/separator_exit_code_second_fails.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_exit_code_semantics/separator_exit_code_second_fails.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo ok; false
-expected:
+expect:
   stdout: |+
     ok
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_exit_code_semantics/separator_newline_continues_after_failure.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_exit_code_semantics/separator_newline_continues_after_failure.yaml
@@ -5,7 +5,7 @@ input:
     false
     echo still running
     echo done
-expected:
+expect:
   stdout: |+
     still running
     done

--- a/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_exit_code_semantics/separator_unknown_command_continues.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_exit_code_semantics/separator_unknown_command_continues.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     nonexistent_cmd; echo after
-expected:
+expect:
   stdout: |+
     after
   stderr: |+

--- a/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_variable_sharing/separator_exit_status_variable.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_variable_sharing/separator_exit_status_variable.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     false; echo $?; true; echo $?
-expected:
+expect:
   stdout: |+
     1
     0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_variable_sharing/separator_variable_accumulate.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_variable_sharing/separator_variable_accumulate.yaml
@@ -4,7 +4,7 @@ input:
   script: |+
     a=1; b=2
     c=3; echo "$a $b $c"
-expected:
+expect:
   stdout: |+
     1 2 3
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_variable_sharing/separator_variable_newline.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_variable_sharing/separator_variable_newline.yaml
@@ -4,7 +4,7 @@ input:
   script: |+
     x=hello
     echo $x
-expected:
+expect:
   stdout: |+
     hello
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_variable_sharing/separator_variable_override.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_variable_sharing/separator_variable_override.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     x=first; echo $x; x=second; echo $x
-expected:
+expect:
   stdout: |+
     first
     second

--- a/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_variable_sharing/separator_variable_set_then_use.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_variable_sharing/separator_variable_set_then_use.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     x=hello; echo $x
-expected:
+expect:
   stdout: |+
     hello
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_with_operators/separator_and_fails_then_semicolon.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_with_operators/separator_and_fails_then_semicolon.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     false && echo skipped; echo runs
-expected:
+expect:
   stdout: |+
     runs
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_with_operators/separator_and_then_semicolon.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_with_operators/separator_and_then_semicolon.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo one && echo two; echo three
-expected:
+expect:
   stdout: |+
     one
     two

--- a/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_with_operators/separator_complex_chain.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_with_operators/separator_complex_chain.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo a | cat; echo b && echo c; false || echo d
-expected:
+expect:
   stdout: |+
     a
     b

--- a/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_with_operators/separator_or_then_semicolon.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_with_operators/separator_or_then_semicolon.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     true || echo skipped; echo after
-expected:
+expect:
   stdout: |+
     after
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_with_operators/separator_pipe_then_semicolon.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_with_operators/separator_pipe_then_semicolon.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo hello | cat; echo world
-expected:
+expect:
   stdout: |+
     hello
     world

--- a/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_with_operators/separator_with_and.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_with_operators/separator_with_and.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo first; echo second && echo third
-expected:
+expect:
   stdout: |+
     first
     second

--- a/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_with_operators/separator_with_or.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_with_operators/separator_with_or.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo first; false || echo fallback
-expected:
+expect:
   stdout: |+
     first
     fallback

--- a/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_with_operators/separator_with_pipe.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/command_separator/separator_with_operators/separator_with_pipe.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo first; echo piped | cat; echo last
-expected:
+expect:
   stdout: |+
     first
     piped

--- a/pkg/shell/e2e_tests/scenarios/interpreter/environment/env_builtin_ifs_set.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/environment/env_builtin_ifs_set.yaml
@@ -5,7 +5,7 @@ input:
     IFS=,
     A="a,b,c"
     echo $A
-expected:
+expect:
   stdout: |+
     a b c
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/environment/env_empty_by_default.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/environment/env_empty_by_default.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo "val=$SOME_RANDOM_VAR"
-expected:
+expect:
   stdout: |+
     val=
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/environment/env_inline_assignment.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/environment/env_inline_assignment.yaml
@@ -4,7 +4,7 @@ input:
   script: |+
     MY_VAR=hello
     echo "$MY_VAR"
-expected:
+expect:
   stdout: |+
     hello
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/environment/env_no_parent_propagation.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/environment/env_no_parent_propagation.yaml
@@ -7,7 +7,7 @@ input:
   script: |+
     echo "key=$MY_SECRET_KEY"
     echo "token=$MY_API_TOKEN"
-expected:
+expect:
   stdout: |+
     key=
     token=

--- a/pkg/shell/e2e_tests/scenarios/interpreter/environment/env_override_provided.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/environment/env_override_provided.yaml
@@ -7,7 +7,7 @@ input:
     echo "$MY_VAR"
     MY_VAR=script_value
     echo "$MY_VAR"
-expected:
+expect:
   stdout: |+
 
     script_value

--- a/pkg/shell/e2e_tests/scenarios/interpreter/environment/env_provided_vars_accessible.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/environment/env_provided_vars_accessible.yaml
@@ -7,7 +7,7 @@ input:
   script: |+
     echo "path=$PATH"
     echo "user=$USER"
-expected:
+expect:
   stdout: |+
     path=
     user=

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_basic_behavior/for_commands_after.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_basic_behavior/for_commands_after.yaml
@@ -4,7 +4,7 @@ input:
   script: |+
     for i in a b; do echo $i; done
     echo after
-expected:
+expect:
   stdout: |+
     a
     b

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_basic_behavior/for_commands_before.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_basic_behavior/for_commands_before.yaml
@@ -4,7 +4,7 @@ input:
   script: |+
     echo before
     for i in a b; do echo $i; done
-expected:
+expect:
   stdout: |+
     before
     a

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_basic_behavior/for_empty_list.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_basic_behavior/for_empty_list.yaml
@@ -4,7 +4,7 @@ input:
   script: |+
     for i in; do echo $i; done
     echo done
-expected:
+expect:
   stdout: |+
     done
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_basic_behavior/for_iterate_words.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_basic_behavior/for_iterate_words.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     for i in a b c; do echo $i; done
-expected:
+expect:
   stdout: |+
     a
     b

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_basic_behavior/for_many_items.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_basic_behavior/for_many_items.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     for n in 1 2 3 4 5; do echo $n; done
-expected:
+expect:
   stdout: |+
     1
     2

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_basic_behavior/for_multiline_body.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_basic_behavior/for_multiline_body.yaml
@@ -6,7 +6,7 @@ input:
       echo start $i
       echo end $i
     done
-expected:
+expect:
   stdout: |+
     start a
     end a

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_basic_behavior/for_single_item.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_basic_behavior/for_single_item.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     for x in hello; do echo $x; done
-expected:
+expect:
   stdout: |+
     hello
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_basic_behavior/for_special_characters_in_items.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_basic_behavior/for_special_characters_in_items.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     for f in "hello world" "foo bar"; do echo "$f"; done
-expected:
+expect:
   stdout: |+
     hello world
     foo bar

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_break_continue/for_break_mid_body.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_break_continue/for_break_mid_body.yaml
@@ -7,7 +7,7 @@ input:
       break
       echo "end $i"
     done
-expected:
+expect:
   stdout: |+
     start a
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_break_continue/for_break_outside_loop.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_break_continue/for_break_outside_loop.yaml
@@ -4,7 +4,7 @@ input:
   script: |+
     break
     echo after
-expected:
+expect:
   stdout: |+
     after
   stderr: |+

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_break_continue/for_break_simple.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_break_continue/for_break_simple.yaml
@@ -7,7 +7,7 @@ input:
       break
     done
     echo after
-expected:
+expect:
   stdout: |+
     a
     after

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_break_continue/for_break_with_arg.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_break_continue/for_break_with_arg.yaml
@@ -7,7 +7,7 @@ input:
       break 1
     done
     echo done
-expected:
+expect:
   stdout: |+
     a
     done

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_break_continue/for_continue_outside_loop.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_break_continue/for_continue_outside_loop.yaml
@@ -4,7 +4,7 @@ input:
   script: |+
     continue
     echo after
-expected:
+expect:
   stdout: |+
     after
   stderr: |+

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_break_continue/for_continue_simple.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_break_continue/for_continue_simple.yaml
@@ -7,7 +7,7 @@ input:
       continue
       echo "after $i"
     done
-expected:
+expect:
   stdout: |+
     before a
     before b

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_break_continue/for_continue_with_arg.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_break_continue/for_continue_with_arg.yaml
@@ -7,7 +7,7 @@ input:
       echo $i
     done
     echo done
-expected:
+expect:
   stdout: |+
     done
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_exit_code/for_exit_code_after_break.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_exit_code/for_exit_code_after_break.yaml
@@ -5,7 +5,7 @@ input:
     for i in a b c; do
       break
     done
-expected:
+expect:
   stdout: ""
   stderr: ""
   exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_exit_code/for_exit_code_empty_list.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_exit_code/for_exit_code_empty_list.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     for i in; do false; done
-expected:
+expect:
   stdout: ""
   stderr: ""
   exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_exit_code/for_exit_code_last_cmd.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_exit_code/for_exit_code_last_cmd.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     for i in a; do false; done
-expected:
+expect:
   stdout: ""
   stderr: ""
   exit_code: 1

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_exit_code/for_exit_code_success.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_exit_code/for_exit_code_success.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     for i in a b; do echo $i; done
-expected:
+expect:
   stdout: |+
     a
     b

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_exit_code/for_unknown_cmd_in_body.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_exit_code/for_unknown_cmd_in_body.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     for i in a; do nonexistent_cmd; done
-expected:
+expect:
   stdout: ""
   stderr: |+
     nonexistent_cmd: not found

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_nested/for_nested_basic.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_nested/for_nested_basic.yaml
@@ -7,7 +7,7 @@ input:
         echo "$i$j"
       done
     done
-expected:
+expect:
   stdout: |+
     a1
     a2

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_nested/for_nested_break_inner.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_nested/for_nested_break_inner.yaml
@@ -8,7 +8,7 @@ input:
         break
       done
     done
-expected:
+expect:
   stdout: |+
     a1
     b1

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_nested/for_nested_break_outer.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_nested/for_nested_break_outer.yaml
@@ -9,7 +9,7 @@ input:
       done
     done
     echo done
-expected:
+expect:
   stdout: |+
     a1
     done

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_nested/for_nested_continue_inner.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_nested/for_nested_continue_inner.yaml
@@ -9,7 +9,7 @@ input:
       done
       echo "outer $i"
     done
-expected:
+expect:
   stdout: |+
     outer a
     outer b

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_variable_scoping/for_env_var_in_items.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_variable_scoping/for_env_var_in_items.yaml
@@ -6,7 +6,7 @@ input:
     B=two
     C=three
     for i in $A $B $C; do echo $i; done
-expected:
+expect:
   stdout: |+
     one
     two

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_variable_scoping/for_var_assigned_in_body.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_variable_scoping/for_var_assigned_in_body.yaml
@@ -6,7 +6,7 @@ input:
       LAST=$i
     done
     echo $LAST
-expected:
+expect:
   stdout: |+
     c
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_variable_scoping/for_var_expansion_in_items.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_variable_scoping/for_var_expansion_in_items.yaml
@@ -4,7 +4,7 @@ input:
   script: |+
     ITEMS="x y z"
     for i in $ITEMS; do echo $i; done
-expected:
+expect:
   stdout: |+
     x
     y

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_variable_scoping/for_var_from_outer_scope.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_variable_scoping/for_var_from_outer_scope.yaml
@@ -4,7 +4,7 @@ input:
   script: |+
     PREFIX=hello
     for i in world; do echo "$PREFIX $i"; done
-expected:
+expect:
   stdout: |+
     hello world
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_variable_scoping/for_var_no_clobber_outer.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_variable_scoping/for_var_no_clobber_outer.yaml
@@ -5,7 +5,7 @@ input:
     X=original
     for i in a b; do echo $i; done
     echo $X
-expected:
+expect:
   stdout: |+
     a
     b

--- a/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_variable_scoping/for_var_persists_after_loop.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/for_clause/for_variable_scoping/for_var_persists_after_loop.yaml
@@ -4,7 +4,7 @@ input:
   script: |+
     for i in a b c; do echo $i; done
     echo "after: $i"
-expected:
+expect:
   stdout: |+
     a
     b

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/and_basic_behavior/and_both_succeed.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/and_basic_behavior/and_both_succeed.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo first && echo second
-expected:
+expect:
   stdout: |+
     first
     second

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/and_basic_behavior/and_chain_all_succeed.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/and_basic_behavior/and_chain_all_succeed.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo one && echo two && echo three
-expected:
+expect:
   stdout: |+
     one
     two

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/and_basic_behavior/and_chain_middle_fails.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/and_basic_behavior/and_chain_middle_fails.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo one && false && echo three
-expected:
+expect:
   stdout: |+
     one
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/and_basic_behavior/and_first_fails_skips_rest.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/and_basic_behavior/and_first_fails_skips_rest.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     false && echo two && echo three && echo four
-expected:
+expect:
   stdout: ""
   stderr: ""
   exit_code: 1

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/and_basic_behavior/and_left_fails.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/and_basic_behavior/and_left_fails.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     false && echo skipped
-expected:
+expect:
   stdout: ""
   stderr: ""
   exit_code: 1

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/and_basic_behavior/and_right_fails.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/and_basic_behavior/and_right_fails.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo ok && false
-expected:
+expect:
   stdout: |+
     ok
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/and_basic_behavior/and_with_true.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/and_basic_behavior/and_with_true.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     true && echo reached
-expected:
+expect:
   stdout: |+
     reached
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/exit_code_semantics/and_custom_exit_codes.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/exit_code_semantics/and_custom_exit_codes.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     exit 2 && echo skipped
-expected:
+expect:
   stdout: ""
   stderr: ""
   exit_code: 2

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/exit_code_semantics/and_exit_code_from_right.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/exit_code_semantics/and_exit_code_from_right.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     true && exit 7
-expected:
+expect:
   stdout: ""
   stderr: ""
   exit_code: 7

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/exit_code_semantics/and_preserves_left_exit_code.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/exit_code_semantics/and_preserves_left_exit_code.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     exit 42 && echo skipped
-expected:
+expect:
   stdout: ""
   stderr: ""
   exit_code: 42

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/exit_code_semantics/mixed_exit_code_recovery.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/exit_code_semantics/mixed_exit_code_recovery.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     exit 99 || true
-expected:
+expect:
   stdout: ""
   stderr: ""
   exit_code: 99

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/exit_code_semantics/or_both_custom_exit.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/exit_code_semantics/or_both_custom_exit.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     exit 2 || exit 5
-expected:
+expect:
   stdout: ""
   stderr: ""
   exit_code: 2

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/exit_code_semantics/or_exit_code_from_right.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/exit_code_semantics/or_exit_code_from_right.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     false || exit 3
-expected:
+expect:
   stdout: ""
   stderr: ""
   exit_code: 3

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/exit_code_semantics/or_exit_code_left_success.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/exit_code_semantics/or_exit_code_left_success.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     true || exit 5
-expected:
+expect:
   stdout: ""
   stderr: ""
   exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/mixed_operators/all_fail_chain.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/mixed_operators/all_fail_chain.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     false && echo no || false && echo no
-expected:
+expect:
   stdout: ""
   stderr: ""
   exit_code: 1

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/mixed_operators/and_or_and_chain.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/mixed_operators/and_or_and_chain.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     true && false || echo recovered && echo final
-expected:
+expect:
   stdout: |+
     recovered
     final

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/mixed_operators/and_then_or_failure.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/mixed_operators/and_then_or_failure.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     false && echo skipped || echo fallback
-expected:
+expect:
   stdout: |+
     fallback
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/mixed_operators/and_then_or_success.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/mixed_operators/and_then_or_success.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo ok && echo done || echo fallback
-expected:
+expect:
   stdout: |+
     ok
     done

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/mixed_operators/or_and_or_chain.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/mixed_operators/or_and_or_chain.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     false || true && echo yes || echo no
-expected:
+expect:
   stdout: |+
     yes
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/mixed_operators/or_then_and_failure.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/mixed_operators/or_then_and_failure.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     false || echo recovered && echo continued
-expected:
+expect:
   stdout: |+
     recovered
     continued

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/mixed_operators/or_then_and_success.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/mixed_operators/or_then_and_success.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo ok || echo fallback && echo continued
-expected:
+expect:
   stdout: |+
     ok
     continued

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/or_basic_behavior/or_both_fail.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/or_basic_behavior/or_both_fail.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     false || false
-expected:
+expect:
   stdout: ""
   stderr: ""
   exit_code: 1

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/or_basic_behavior/or_chain_all_fail.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/or_basic_behavior/or_chain_all_fail.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     false || false || false
-expected:
+expect:
   stdout: ""
   stderr: ""
   exit_code: 1

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/or_basic_behavior/or_chain_first_succeeds.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/or_basic_behavior/or_chain_first_succeeds.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo one || echo two || echo three
-expected:
+expect:
   stdout: |+
     one
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/or_basic_behavior/or_chain_last_succeeds.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/or_basic_behavior/or_chain_last_succeeds.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     false || false || echo reached
-expected:
+expect:
   stdout: |+
     reached
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/or_basic_behavior/or_left_fails.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/or_basic_behavior/or_left_fails.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     false || echo fallback
-expected:
+expect:
   stdout: |+
     fallback
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/or_basic_behavior/or_left_succeeds.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/or_basic_behavior/or_left_succeeds.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo ok || echo skipped
-expected:
+expect:
   stdout: |+
     ok
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/or_basic_behavior/or_with_true.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/or_basic_behavior/or_with_true.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     true || echo skipped
-expected:
+expect:
   stdout: ""
   stderr: ""
   exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/output_behavior/and_no_output_on_skip.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/output_behavior/and_no_output_on_skip.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo before && false && echo skipped
-expected:
+expect:
   stdout: |+
     before
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/output_behavior/and_output_accumulates.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/output_behavior/and_output_accumulates.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo first && echo second && echo third
-expected:
+expect:
   stdout: |+
     first
     second

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/output_behavior/mixed_output_partial.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/output_behavior/mixed_output_partial.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo a && false || echo c && echo d
-expected:
+expect:
   stdout: |+
     a
     c

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/output_behavior/or_no_output_on_skip.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/output_behavior/or_no_output_on_skip.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo ok || echo skipped
-expected:
+expect:
   stdout: |+
     ok
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/output_behavior/or_output_on_fallback.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/output_behavior/or_output_on_fallback.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     false || echo fallback
-expected:
+expect:
   stdout: |+
     fallback
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/variable_interaction/and_exit_status_variable.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/variable_interaction/and_exit_status_variable.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     true && echo $?
-expected:
+expect:
   stdout: |+
     0
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/variable_interaction/and_variable_visible.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/variable_interaction/and_variable_visible.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     X=hello && echo $X
-expected:
+expect:
   stdout: |+
     hello
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/variable_interaction/or_exit_status_variable.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/variable_interaction/or_exit_status_variable.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     false || echo $?
-expected:
+expect:
   stdout: |+
     1
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/variable_interaction/or_variable_visible_on_fallback.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/logical_operators/variable_interaction/or_variable_visible_on_fallback.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     X=world; false || echo $X
-expected:
+expect:
   stdout: |+
     world
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/pipe/pipe_all/pipe_all_both.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/pipe/pipe_all/pipe_all_both.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     { echo hello; break; } |& cat
-expected:
+expect:
   stdout: |+
     hello
     break is only useful in a loop

--- a/pkg/shell/e2e_tests/scenarios/interpreter/pipe/pipe_all/pipe_all_stderr_only.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/pipe/pipe_all/pipe_all_stderr_only.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     break |& cat
-expected:
+expect:
   stdout: |+
     break is only useful in a loop
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/pipe/pipe_all/pipe_stderr_passthrough.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/pipe/pipe_all/pipe_stderr_passthrough.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     { echo hello; break; } | cat
-expected:
+expect:
   stdout: |+
     hello
   stderr: |+

--- a/pkg/shell/e2e_tests/scenarios/interpreter/pipe/pipe_basic_behavior/pipe_cat_file.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/pipe/pipe_basic_behavior/pipe_cat_file.yaml
@@ -9,7 +9,7 @@ input:
   # language=bash
   script: |+
     cat data.txt | cat
-expected:
+expect:
   stdout: |+
     line one
     line two

--- a/pkg/shell/e2e_tests/scenarios/interpreter/pipe/pipe_basic_behavior/pipe_chain.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/pipe/pipe_basic_behavior/pipe_chain.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo abc | cat | cat
-expected:
+expect:
   stdout: |+
     abc
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/pipe/pipe_basic_behavior/pipe_echo_ignores_stdin.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/pipe/pipe_basic_behavior/pipe_echo_ignores_stdin.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo hello | echo world
-expected:
+expect:
   stdout: |+
     world
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/pipe/pipe_basic_behavior/pipe_for_loop.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/pipe/pipe_basic_behavior/pipe_for_loop.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     for i in a b c; do echo $i; done | cat
-expected:
+expect:
   stdout: |+
     a
     b

--- a/pkg/shell/e2e_tests/scenarios/interpreter/pipe/pipe_basic_behavior/pipe_multiline.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/pipe/pipe_basic_behavior/pipe_multiline.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     { echo a; echo b; echo c; } | cat
-expected:
+expect:
   stdout: |+
     a
     b

--- a/pkg/shell/e2e_tests/scenarios/interpreter/pipe/pipe_basic_behavior/pipe_no_output_left.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/pipe/pipe_basic_behavior/pipe_no_output_left.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     true | cat
-expected:
+expect:
   stdout: ""
   stderr: ""
   exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/pipe/pipe_basic_behavior/pipe_sequential.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/pipe/pipe_basic_behavior/pipe_sequential.yaml
@@ -4,7 +4,7 @@ input:
   script: |+
     echo first | cat
     echo second | cat
-expected:
+expect:
   stdout: |+
     first
     second

--- a/pkg/shell/e2e_tests/scenarios/interpreter/pipe/pipe_basic_behavior/pipe_simple.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/pipe/pipe_basic_behavior/pipe_simple.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo abc | cat
-expected:
+expect:
   stdout: |+
     abc
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/pipe/pipe_basic_behavior/pipe_variable_expansion.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/pipe/pipe_basic_behavior/pipe_variable_expansion.yaml
@@ -4,7 +4,7 @@ input:
   script: |+
     X=hello
     echo $X world | cat
-expected:
+expect:
   stdout: |+
     hello world
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/pipe/pipe_error_handling/pipe_unknown_left.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/pipe/pipe_error_handling/pipe_unknown_left.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     foo | echo ok
-expected:
+expect:
   stdout: |+
     ok
   stderr: |+

--- a/pkg/shell/e2e_tests/scenarios/interpreter/pipe/pipe_error_handling/pipe_unknown_right.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/pipe/pipe_error_handling/pipe_unknown_right.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo ok | foo
-expected:
+expect:
   stdout: ""
   stderr: |+
     foo: not found

--- a/pkg/shell/e2e_tests/scenarios/interpreter/pipe/pipe_exit_code_semantics/pipe_exit_code_from_right.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/pipe/pipe_exit_code_semantics/pipe_exit_code_from_right.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo ok | false
-expected:
+expect:
   stdout: ""
   stderr: ""
   exit_code: 1

--- a/pkg/shell/e2e_tests/scenarios/interpreter/pipe/pipe_exit_code_semantics/pipe_exit_left.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/pipe/pipe_exit_code_semantics/pipe_exit_left.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     exit 42 | echo ok
-expected:
+expect:
   stdout: |+
     ok
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/pipe/pipe_exit_code_semantics/pipe_exit_right.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/pipe/pipe_exit_code_semantics/pipe_exit_right.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo ok | exit 42
-expected:
+expect:
   stdout: ""
   stderr: ""
   exit_code: 42

--- a/pkg/shell/e2e_tests/scenarios/interpreter/pipe/pipe_exit_code_semantics/pipe_false_true.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/pipe/pipe_exit_code_semantics/pipe_false_true.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     false | true
-expected:
+expect:
   stdout: ""
   stderr: ""
   exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/interpreter/pipe/pipe_exit_code_semantics/pipe_left_fails_right_succeeds.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/pipe/pipe_exit_code_semantics/pipe_left_fails_right_succeeds.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     false | echo ok
-expected:
+expect:
   stdout: |+
     ok
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/pipe/pipe_exit_code_semantics/pipe_true_false.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/pipe/pipe_exit_code_semantics/pipe_true_false.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     true | false
-expected:
+expect:
   stdout: ""
   stderr: ""
   exit_code: 1

--- a/pkg/shell/e2e_tests/scenarios/interpreter/pipe/pipe_logical_operators/pipe_and_failure.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/pipe/pipe_logical_operators/pipe_and_failure.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo abc | false && echo done
-expected:
+expect:
   stdout: ""
   stderr: ""
   exit_code: 1

--- a/pkg/shell/e2e_tests/scenarios/interpreter/pipe/pipe_logical_operators/pipe_and_success.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/pipe/pipe_logical_operators/pipe_and_success.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo abc | cat && echo done
-expected:
+expect:
   stdout: |+
     abc
     done

--- a/pkg/shell/e2e_tests/scenarios/interpreter/pipe/pipe_logical_operators/pipe_or_failure.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/pipe/pipe_logical_operators/pipe_or_failure.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo abc | false || echo fallback
-expected:
+expect:
   stdout: |+
     fallback
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/pipe/pipe_logical_operators/pipe_or_success.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/pipe/pipe_logical_operators/pipe_or_success.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo abc | cat || echo fallback
-expected:
+expect:
   stdout: |+
     abc
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_basic/unknown_after_echo.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_basic/unknown_after_echo.yaml
@@ -4,7 +4,7 @@ input:
   script: |+
     echo hello
     foo
-expected:
+expect:
   stdout: |+
     hello
   stderr: |+

--- a/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_basic/unknown_before_echo.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_basic/unknown_before_echo.yaml
@@ -4,7 +4,7 @@ input:
   script: |+
     foo
     echo hello
-expected:
+expect:
   stdout: |+
     hello
   stderr: |+

--- a/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_basic/unknown_multiple_consecutive.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_basic/unknown_multiple_consecutive.yaml
@@ -5,7 +5,7 @@ input:
     foo
     bar
     baz
-expected:
+expect:
   stdout: ""
   stderr: |+
     foo: not found

--- a/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_basic/unknown_multiword_name.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_basic/unknown_multiword_name.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     my-unknown-command
-expected:
+expect:
   stdout: ""
   stderr: |+
     my-unknown-command: not found

--- a/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_basic/unknown_simple.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_basic/unknown_simple.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     foo
-expected:
+expect:
   stdout: ""
   stderr: |+
     foo: not found

--- a/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_basic/unknown_underscore_name.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_basic/unknown_underscore_name.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     my_unknown_command
-expected:
+expect:
   stdout: ""
   stderr: |+
     my_unknown_command: not found

--- a/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_common_programs/unknown_bash.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_common_programs/unknown_bash.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     bash -c "echo hello"
-expected:
+expect:
   stdout: ""
   stderr: |+
     bash: not found

--- a/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_common_programs/unknown_chmod.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_common_programs/unknown_chmod.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     chmod 755 file.txt
-expected:
+expect:
   stdout: ""
   stderr: |+
     chmod: not found

--- a/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_common_programs/unknown_cp.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_common_programs/unknown_cp.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     cp source.txt dest.txt
-expected:
+expect:
   stdout: ""
   stderr: |+
     cp: not found

--- a/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_common_programs/unknown_curl.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_common_programs/unknown_curl.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     curl http://example.com
-expected:
+expect:
   stdout: ""
   stderr: |+
     curl: not found

--- a/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_common_programs/unknown_grep.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_common_programs/unknown_grep.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     grep pattern file.txt
-expected:
+expect:
   stdout: ""
   stderr: |+
     grep: not found

--- a/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_common_programs/unknown_ls.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_common_programs/unknown_ls.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     ls
-expected:
+expect:
   stdout: ""
   stderr: |+
     ls: not found

--- a/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_common_programs/unknown_mv.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_common_programs/unknown_mv.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     mv old.txt new.txt
-expected:
+expect:
   stdout: ""
   stderr: |+
     mv: not found

--- a/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_common_programs/unknown_python.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_common_programs/unknown_python.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     python -c "print('hello')"
-expected:
+expect:
   stdout: ""
   stderr: |+
     python: not found

--- a/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_common_programs/unknown_rm.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_common_programs/unknown_rm.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     rm file.txt
-expected:
+expect:
   stdout: ""
   stderr: |+
     rm: not found

--- a/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_common_programs/unknown_sed.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_common_programs/unknown_sed.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     sed s/foo/bar/ file.txt
-expected:
+expect:
   stdout: ""
   stderr: |+
     sed: not found

--- a/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_common_programs/unknown_sh.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_common_programs/unknown_sh.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     sh -c "echo hello"
-expected:
+expect:
   stdout: ""
   stderr: |+
     sh: not found

--- a/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_common_programs/unknown_wget.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_common_programs/unknown_wget.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     wget http://example.com
-expected:
+expect:
   stdout: ""
   stderr: |+
     wget: not found

--- a/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_exit_code/unknown_and_operator_skips.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_exit_code/unknown_and_operator_skips.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     foo && echo should_not_run
-expected:
+expect:
   stdout: ""
   stderr: |+
     foo: not found

--- a/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_exit_code/unknown_and_or_chain.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_exit_code/unknown_and_or_chain.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     foo && echo no || echo yes
-expected:
+expect:
   stdout: |+
     yes
   stderr: |+

--- a/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_exit_code/unknown_exit_code_127.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_exit_code/unknown_exit_code_127.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     nonexistent
-expected:
+expect:
   stdout: ""
   stderr: |+
     nonexistent: not found

--- a/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_exit_code/unknown_exit_code_captured.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_exit_code/unknown_exit_code_captured.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     nonexistent; echo $?
-expected:
+expect:
   stdout: |+
     127
   stderr: |+

--- a/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_exit_code/unknown_or_chain.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_exit_code/unknown_or_chain.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     foo || bar || echo reached
-expected:
+expect:
   stdout: |+
     reached
   stderr: |+

--- a/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_exit_code/unknown_or_operator_continues.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_exit_code/unknown_or_operator_continues.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     foo || echo fallback
-expected:
+expect:
   stdout: |+
     fallback
   stderr: |+

--- a/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_exit_code/unknown_semicolon_continues.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_exit_code/unknown_semicolon_continues.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     foo; echo after
-expected:
+expect:
   stdout: |+
     after
   stderr: |+

--- a/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_with_args/unknown_with_args.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_with_args/unknown_with_args.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     foo arg1 arg2 arg3
-expected:
+expect:
   stdout: ""
   stderr: |+
     foo: not found

--- a/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_with_args/unknown_with_flags.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_with_args/unknown_with_flags.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     foo --verbose -n 5
-expected:
+expect:
   stdout: ""
   stderr: |+
     foo: not found

--- a/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_with_args/unknown_with_quoted_args.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_with_args/unknown_with_quoted_args.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     foo "hello world" 'single quoted'
-expected:
+expect:
   stdout: ""
   stderr: |+
     foo: not found

--- a/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_with_args/unknown_with_variable_arg.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/unknown_command/unknown_command_with_args/unknown_with_variable_arg.yaml
@@ -4,7 +4,7 @@ input:
   script: |+
     MY_VAR=hello
     foo $MY_VAR
-expected:
+expect:
   stdout: ""
   stderr: |+
     foo: not found

--- a/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/basic/var_adjacent_text.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/basic/var_adjacent_text.yaml
@@ -4,7 +4,7 @@ input:
   script: |+
     FRUIT=apple
     echo "${FRUIT}sauce"
-expected:
+expect:
   stdout: |+
     applesauce
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/basic/var_braces.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/basic/var_braces.yaml
@@ -4,7 +4,7 @@ input:
   script: |+
     GREETING=hello
     echo ${GREETING}
-expected:
+expect:
   stdout: |+
     hello
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/basic/var_case_sensitive.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/basic/var_case_sensitive.yaml
@@ -5,7 +5,7 @@ input:
     foo=lower
     FOO=upper
     echo $foo $FOO
-expected:
+expect:
   stdout: |+
     lower upper
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/basic/var_chain_assignment.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/basic/var_chain_assignment.yaml
@@ -5,7 +5,7 @@ input:
     A=hello
     B=$A
     echo $B
-expected:
+expect:
   stdout: |+
     hello
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/basic/var_empty_value.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/basic/var_empty_value.yaml
@@ -4,7 +4,7 @@ input:
   script: |+
     EMPTY=""
     echo "value=${EMPTY}end"
-expected:
+expect:
   stdout: |+
     value=end
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/basic/var_multiple.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/basic/var_multiple.yaml
@@ -5,7 +5,7 @@ input:
     A=hello
     B=world
     echo $A $B
-expected:
+expect:
   stdout: |+
     hello world
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/basic/var_reassignment.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/basic/var_reassignment.yaml
@@ -6,7 +6,7 @@ input:
     echo $X
     X=second
     echo $X
-expected:
+expect:
   stdout: |+
     first
     second

--- a/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/basic/var_simple_assignment.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/basic/var_simple_assignment.yaml
@@ -4,7 +4,7 @@ input:
   script: |+
     MY_VAR=hello
     echo $MY_VAR
-expected:
+expect:
   stdout: |+
     hello
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/basic/var_unset_expands_empty.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/basic/var_unset_expands_empty.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo "before${UNSET_VAR}after"
-expected:
+expect:
   stdout: |+
     beforeafter
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/basic/var_with_spaces_in_value.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/basic/var_with_spaces_in_value.yaml
@@ -4,7 +4,7 @@ input:
   script: |+
     MSG="hello world"
     echo "$MSG"
-expected:
+expect:
   stdout: |+
     hello world
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_features/var_blocked_all_params.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_features/var_blocked_all_params.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo $@
-expected:
+expect:
   stdout: ""
   stderr: |+
     $@ is not supported

--- a/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_features/var_blocked_alternative.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_features/var_blocked_alternative.yaml
@@ -4,7 +4,7 @@ input:
   script: |+
     X=set
     echo ${X:+alt}
-expected:
+expect:
   stdout: ""
   stderr: |+
     ${var} operations (defaults, pattern removal, case conversion) are not supported

--- a/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_features/var_blocked_append.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_features/var_blocked_append.yaml
@@ -4,7 +4,7 @@ input:
   script: |+
     X=hello
     X+=world
-expected:
+expect:
   stdout: ""
   stderr: |+
     += is not supported

--- a/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_features/var_blocked_arithmetic.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_features/var_blocked_arithmetic.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo $((1+2))
-expected:
+expect:
   stdout: ""
   stderr: |+
     arithmetic expansion is not supported

--- a/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_features/var_blocked_array.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_features/var_blocked_array.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     ARR=(a b c)
-expected:
+expect:
   stdout: ""
   stderr: |+
     array assignment is not supported

--- a/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_features/var_blocked_array_index.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_features/var_blocked_array_index.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo ${PATH[0]}
-expected:
+expect:
   stdout: ""
   stderr: |+
     array indexing is not supported

--- a/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_features/var_blocked_assign_default.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_features/var_blocked_assign_default.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo ${UNSET:=fallback}
-expected:
+expect:
   stdout: ""
   stderr: |+
     ${var} operations (defaults, pattern removal, case conversion) are not supported

--- a/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_features/var_blocked_case_conversion.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_features/var_blocked_case_conversion.yaml
@@ -4,7 +4,7 @@ input:
   script: |+
     X=hello
     echo ${X^^}
-expected:
+expect:
   stdout: ""
   stderr: |+
     ${var} operations (defaults, pattern removal, case conversion) are not supported

--- a/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_features/var_blocked_command_sub.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_features/var_blocked_command_sub.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo $(echo hello)
-expected:
+expect:
   stdout: ""
   stderr: |+
     command substitution is not supported

--- a/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_features/var_blocked_default_value.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_features/var_blocked_default_value.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo ${UNSET:-fallback}
-expected:
+expect:
   stdout: ""
   stderr: |+
     ${var} operations (defaults, pattern removal, case conversion) are not supported

--- a/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_features/var_blocked_error_unset.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_features/var_blocked_error_unset.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo ${UNSET:?message}
-expected:
+expect:
   stdout: ""
   stderr: |+
     ${var} operations (defaults, pattern removal, case conversion) are not supported

--- a/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_features/var_blocked_indirect.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_features/var_blocked_indirect.yaml
@@ -4,7 +4,7 @@ input:
   script: |+
     X=HOME
     echo ${!X}
-expected:
+expect:
   stdout: ""
   stderr: |+
     ${!var} is not supported

--- a/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_features/var_blocked_param_count.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_features/var_blocked_param_count.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo $#
-expected:
+expect:
   stdout: ""
   stderr: |+
     $# is not supported

--- a/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_features/var_blocked_positional_params.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_features/var_blocked_positional_params.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo $1
-expected:
+expect:
   stdout: ""
   stderr: |+
     $1 is not supported

--- a/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_features/var_blocked_prefix_removal.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_features/var_blocked_prefix_removal.yaml
@@ -4,7 +4,7 @@ input:
   script: |+
     X=/a/b/c
     echo ${X#*/}
-expected:
+expect:
   stdout: ""
   stderr: |+
     ${var} operations (defaults, pattern removal, case conversion) are not supported

--- a/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_features/var_blocked_replace.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_features/var_blocked_replace.yaml
@@ -4,7 +4,7 @@ input:
   script: |+
     X=hello
     echo ${X/l/L}
-expected:
+expect:
   stdout: ""
   stderr: |+
     ${var/pattern/replacement} is not supported

--- a/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_features/var_blocked_script_name.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_features/var_blocked_script_name.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo $0
-expected:
+expect:
   stdout: ""
   stderr: |+
     $0 is not supported

--- a/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_features/var_blocked_string_length.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_features/var_blocked_string_length.yaml
@@ -4,7 +4,7 @@ input:
   script: |+
     X=hello
     echo ${#X}
-expected:
+expect:
   stdout: ""
   stderr: |+
     ${#var} is not supported

--- a/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_features/var_blocked_substring.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_features/var_blocked_substring.yaml
@@ -4,7 +4,7 @@ input:
   script: |+
     X=hello
     echo ${X:1:3}
-expected:
+expect:
   stdout: ""
   stderr: |+
     ${var:offset} is not supported

--- a/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_features/var_blocked_suffix_removal.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_features/var_blocked_suffix_removal.yaml
@@ -4,7 +4,7 @@ input:
   script: |+
     X=file.txt
     echo ${X%.txt}
-expected:
+expect:
   stdout: ""
   stderr: |+
     ${var} operations (defaults, pattern removal, case conversion) are not supported

--- a/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_variables/var_blocked_assignment.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_variables/var_blocked_assignment.yaml
@@ -4,7 +4,7 @@ input:
   script: |+
     RANDOM=42
     echo $RANDOM
-expected:
+expect:
   stdout: |+
     42
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_variables/var_blocked_background_pid.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_variables/var_blocked_background_pid.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo "[$!]"
-expected:
+expect:
   stdout: |+
     []
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_variables/var_blocked_euid.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_variables/var_blocked_euid.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo "[$EUID]"
-expected:
+expect:
   stdout: |+
     []
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_variables/var_blocked_gid.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_variables/var_blocked_gid.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo "[$GID]"
-expected:
+expect:
   stdout: |+
     []
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_variables/var_blocked_in_braces.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_variables/var_blocked_in_braces.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo "[${RANDOM}]"
-expected:
+expect:
   stdout: |+
     []
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_variables/var_blocked_pid.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_variables/var_blocked_pid.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo "$$"
-expected:
+expect:
   stdout: |+
 
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_variables/var_blocked_ppid.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_variables/var_blocked_ppid.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo "[$PPID]"
-expected:
+expect:
   stdout: |+
     []
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_variables/var_blocked_random.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_variables/var_blocked_random.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo "[$RANDOM]"
-expected:
+expect:
   stdout: |+
     []
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_variables/var_blocked_srandom.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_variables/var_blocked_srandom.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo "[$SRANDOM]"
-expected:
+expect:
   stdout: |+
     []
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_variables/var_blocked_stops_execution.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_variables/var_blocked_stops_execution.yaml
@@ -5,7 +5,7 @@ input:
     echo "before"
     echo "$$"
     echo "after"
-expected:
+expect:
   stdout: |+
     before
 

--- a/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_variables/var_blocked_uid.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/blocked_variables/var_blocked_uid.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo "[$UID]"
-expected:
+expect:
   stdout: |+
     []
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/quoting/var_braces_in_double_quotes.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/quoting/var_braces_in_double_quotes.yaml
@@ -4,7 +4,7 @@ input:
   script: |+
     ANIMAL=cat
     echo "the ${ANIMAL}s"
-expected:
+expect:
   stdout: |+
     the cats
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/quoting/var_double_quotes_expand.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/quoting/var_double_quotes_expand.yaml
@@ -4,7 +4,7 @@ input:
   script: |+
     NAME=world
     echo "hello $NAME"
-expected:
+expect:
   stdout: |+
     hello world
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/quoting/var_double_quotes_preserve_spaces.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/quoting/var_double_quotes_preserve_spaces.yaml
@@ -4,7 +4,7 @@ input:
   script: |+
     VAR="hello    world"
     echo "$VAR"
-expected:
+expect:
   stdout: |+
     hello    world
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/quoting/var_mixed_quoting.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/quoting/var_mixed_quoting.yaml
@@ -4,7 +4,7 @@ input:
   script: |+
     NAME=world
     echo 'literal '"$NAME"' literal'
-expected:
+expect:
   stdout: |+
     literal world literal
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/quoting/var_single_quotes_no_expand.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/quoting/var_single_quotes_no_expand.yaml
@@ -4,7 +4,7 @@ input:
   script: |+
     NAME=world
     echo 'hello $NAME'
-expected:
+expect:
   stdout: |+
     hello $NAME
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/special_variables/var_exit_status.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/special_variables/var_exit_status.yaml
@@ -6,7 +6,7 @@ input:
     echo $?
     false
     echo $?
-expected:
+expect:
   stdout: |+
     0
     1

--- a/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/special_variables/var_exit_status_chained.yaml
+++ b/pkg/shell/e2e_tests/scenarios/interpreter/variable_expansion/special_variables/var_exit_status_chained.yaml
@@ -9,7 +9,7 @@ input:
     true
     C=$?
     echo $A $B $C
-expected:
+expect:
   stdout: |+
     0 1 0
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios_test.go
+++ b/pkg/shell/e2e_tests/scenarios_test.go
@@ -27,7 +27,7 @@ type scenario struct {
 	Description string   `yaml:"description"`
 	Setup       setup    `yaml:"setup"`
 	Input       input    `yaml:"input"`
-	Expected    expected `yaml:"expected"`
+	Expect      expected `yaml:"expect"`
 }
 
 // setup holds optional pre-test configuration such as files to create.
@@ -51,6 +51,7 @@ type input struct {
 // expected holds the expected output for a scenario.
 type expected struct {
 	Stdout         string   `yaml:"stdout"`
+	StdoutContains []string `yaml:"stdout_contains"`
 	Stderr         string   `yaml:"stderr"`
 	StderrContains []string `yaml:"stderr_contains"`
 	ExitCode       int      `yaml:"exit_code"`
@@ -146,14 +147,20 @@ func runScenario(t *testing.T, sc scenario) {
 		}
 	}
 
-	assert.Equal(t, sc.Expected.ExitCode, exitCode, "exit code mismatch")
-	assert.Equal(t, sc.Expected.Stdout, stdout.String(), "stdout mismatch")
-	if len(sc.Expected.StderrContains) > 0 {
-		for _, substr := range sc.Expected.StderrContains {
+	assert.Equal(t, sc.Expect.ExitCode, exitCode, "exit code mismatch")
+	if len(sc.Expect.StdoutContains) > 0 {
+		for _, substr := range sc.Expect.StdoutContains {
+			assert.Contains(t, stdout.String(), substr, "stdout should contain %q", substr)
+		}
+	} else {
+		assert.Equal(t, sc.Expect.Stdout, stdout.String(), "stdout mismatch")
+	}
+	if len(sc.Expect.StderrContains) > 0 {
+		for _, substr := range sc.Expect.StderrContains {
 			assert.Contains(t, stderr.String(), substr, "stderr should contain %q", substr)
 		}
 	} else {
-		assert.Equal(t, sc.Expected.Stderr, stderr.String(), "stderr mismatch")
+		assert.Equal(t, sc.Expect.Stderr, stderr.String(), "stderr mismatch")
 	}
 }
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"21d08097-f67f-4e19-98f0-a25590bb0e6d","source":"chat","resourceId":"9b1ba54d-5339-496c-8d9a-f8921124bdd6","workflowId":"3c794482-a0f6-4fe9-bf76-ae1f39ec2503","codeChangeId":"3c794482-a0f6-4fe9-bf76-ae1f39ec2503","sourceType":"chat"} -->
PR by Bits
[View session in Datadog](https://app.datadoghq.com/code/9b1ba54d-5339-496c-8d9a-f8921124bdd6)

Comment @datadog to request changes

Feedback (especially what can be better) welcome in [#code-gen-aka-bits-dev-feedback](https://dd.enterprise.slack.com/archives/C07JA5N2D25)!

---

### What does this PR do?

Updates the shell scenario test format in `pkg/shell`:
- Renames the `expected` YAML key to `expect` across all 231 scenario files and the Go test harness.
- Adds support for `expect.stdout_contains` (substring matching for stdout, mirroring the existing `stderr_contains`).

### Motivation

Shorter, more consistent naming (`expect` vs `expected`) and parity between stdout/stderr assertion modes.

### Describe how you validated your changes

Ran `go test ./pkg/shell/e2e_tests/` — all 231 scenarios pass.

### Additional Notes