### PR TITLE
Add test scenarios for true/false builtins

### DIFF
--- a/pkg/shell/e2e_tests/scenarios/commands/false/false_basic_behavior/false_after_true.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/false/false_basic_behavior/false_after_true.yaml
@@ -1,0 +1,12 @@
+description: The false builtin sets exit code to 1 after true.
+input:
+  # language=bash
+  script: |+
+    true
+    false
+    echo $?
+expected:
+  stdout: |+
+    1
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/commands/false/false_basic_behavior/false_after_true.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/false/false_basic_behavior/false_after_true.yaml
@@ -5,7 +5,7 @@ input:
     true
     false
     echo $?
-expected:
+expect:
   stdout: |+
     1
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/commands/false/false_basic_behavior/false_exit_code_one.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/false/false_basic_behavior/false_exit_code_one.yaml
@@ -4,7 +4,7 @@ input:
   script: |+
     false
     echo $?
-expected:
+expect:
   stdout: |+
     1
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/commands/false/false_basic_behavior/false_exit_code_one.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/false/false_basic_behavior/false_exit_code_one.yaml
@@ -1,0 +1,11 @@
+description: The false builtin always returns exit code 1.
+input:
+  # language=bash
+  script: |+
+    false
+    echo $?
+expected:
+  stdout: |+
+    1
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/commands/false/false_basic_behavior/false_multiple.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/false/false_basic_behavior/false_multiple.yaml
@@ -6,7 +6,7 @@ input:
     false
     false
     echo $?
-expected:
+expect:
   stdout: |+
     1
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/commands/false/false_basic_behavior/false_multiple.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/false/false_basic_behavior/false_multiple.yaml
@@ -1,0 +1,13 @@
+description: Multiple false commands all fail with exit code 1.
+input:
+  # language=bash
+  script: |+
+    false
+    false
+    false
+    echo $?
+expected:
+  stdout: |+
+    1
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/commands/false/false_basic_behavior/false_no_stderr.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/false/false_basic_behavior/false_no_stderr.yaml
@@ -1,0 +1,9 @@
+description: The false builtin produces no stderr output.
+input:
+  # language=bash
+  script: |+
+    false
+expected:
+  stdout: ""
+  stderr: ""
+  exit_code: 1

--- a/pkg/shell/e2e_tests/scenarios/commands/false/false_basic_behavior/false_no_stderr.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/false/false_basic_behavior/false_no_stderr.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     false
-expected:
+expect:
   stdout: ""
   stderr: ""
   exit_code: 1

--- a/pkg/shell/e2e_tests/scenarios/commands/false/false_basic_behavior/false_no_stdout.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/false/false_basic_behavior/false_no_stdout.yaml
@@ -4,7 +4,7 @@ input:
   script: |+
     false
     echo done
-expected:
+expect:
   stdout: |+
     done
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/commands/false/false_basic_behavior/false_no_stdout.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/false/false_basic_behavior/false_no_stdout.yaml
@@ -1,0 +1,11 @@
+description: The false builtin produces no stdout output.
+input:
+  # language=bash
+  script: |+
+    false
+    echo done
+expected:
+  stdout: |+
+    done
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/commands/false/false_basic_behavior/false_standalone.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/false/false_basic_behavior/false_standalone.yaml
@@ -1,0 +1,9 @@
+description: The false builtin exits with code 1 and no output.
+input:
+  # language=bash
+  script: |+
+    false
+expected:
+  stdout: ""
+  stderr: ""
+  exit_code: 1

--- a/pkg/shell/e2e_tests/scenarios/commands/false/false_basic_behavior/false_standalone.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/false/false_basic_behavior/false_standalone.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     false
-expected:
+expect:
   stdout: ""
   stderr: ""
   exit_code: 1

--- a/pkg/shell/e2e_tests/scenarios/commands/false/false_control_flow/false_and_chain.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/false/false_control_flow/false_and_chain.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     false && echo a && echo b
-expected:
+expect:
   stdout: ""
   stderr: ""
   exit_code: 1

--- a/pkg/shell/e2e_tests/scenarios/commands/false/false_control_flow/false_and_chain.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/false/false_control_flow/false_and_chain.yaml
@@ -1,0 +1,9 @@
+description: Chained && with false short-circuits at the first false.
+input:
+  # language=bash
+  script: |+
+    false && echo a && echo b
+expected:
+  stdout: ""
+  stderr: ""
+  exit_code: 1

--- a/pkg/shell/e2e_tests/scenarios/commands/false/false_control_flow/false_and_skips.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/false/false_control_flow/false_and_skips.yaml
@@ -1,0 +1,9 @@
+description: The false builtin fails so && skips the next command.
+input:
+  # language=bash
+  script: |+
+    false && echo skipped
+expected:
+  stdout: ""
+  stderr: ""
+  exit_code: 1

--- a/pkg/shell/e2e_tests/scenarios/commands/false/false_control_flow/false_and_skips.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/false/false_control_flow/false_and_skips.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     false && echo skipped
-expected:
+expect:
   stdout: ""
   stderr: ""
   exit_code: 1

--- a/pkg/shell/e2e_tests/scenarios/commands/false/false_control_flow/false_in_for_loop.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/false/false_control_flow/false_in_for_loop.yaml
@@ -6,7 +6,7 @@ input:
       false
       echo $x
     done
-expected:
+expect:
   stdout: |+
     a
     b

--- a/pkg/shell/e2e_tests/scenarios/commands/false/false_control_flow/false_in_for_loop.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/false/false_control_flow/false_in_for_loop.yaml
@@ -1,0 +1,14 @@
+description: The false builtin does not stop a for loop from iterating.
+input:
+  # language=bash
+  script: |+
+    for x in a b; do
+      false
+      echo $x
+    done
+expected:
+  stdout: |+
+    a
+    b
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/commands/false/false_control_flow/false_or_chain.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/false/false_control_flow/false_or_chain.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     false || false || echo reached
-expected:
+expect:
   stdout: |+
     reached
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/commands/false/false_control_flow/false_or_chain.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/false/false_control_flow/false_or_chain.yaml
@@ -1,0 +1,10 @@
+description: Chained || with false keeps falling through until success.
+input:
+  # language=bash
+  script: |+
+    false || false || echo reached
+expected:
+  stdout: |+
+    reached
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/commands/false/false_control_flow/false_or_continues.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/false/false_control_flow/false_or_continues.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     false || echo fallback
-expected:
+expect:
   stdout: |+
     fallback
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/commands/false/false_control_flow/false_or_continues.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/false/false_control_flow/false_or_continues.yaml
@@ -1,0 +1,10 @@
+description: The false builtin fails so || executes the fallback command.
+input:
+  # language=bash
+  script: |+
+    false || echo fallback
+expected:
+  stdout: |+
+    fallback
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/commands/false/false_control_flow/false_pipe_left.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/false/false_control_flow/false_pipe_left.yaml
@@ -1,0 +1,10 @@
+description: The false builtin on the left side of a pipe does not affect the right side exit code.
+input:
+  # language=bash
+  script: |+
+    false | echo piped
+expected:
+  stdout: |+
+    piped
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/commands/false/false_control_flow/false_pipe_left.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/false/false_control_flow/false_pipe_left.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     false | echo piped
-expected:
+expect:
   stdout: |+
     piped
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/commands/false/false_control_flow/false_pipe_right.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/false/false_control_flow/false_pipe_right.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo hello | false
-expected:
+expect:
   stdout: ""
   stderr: ""
   exit_code: 1

--- a/pkg/shell/e2e_tests/scenarios/commands/false/false_control_flow/false_pipe_right.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/false/false_control_flow/false_pipe_right.yaml
@@ -1,0 +1,9 @@
+description: The false builtin on the right side of a pipe results in exit code 1.
+input:
+  # language=bash
+  script: |+
+    echo hello | false
+expected:
+  stdout: ""
+  stderr: ""
+  exit_code: 1

--- a/pkg/shell/e2e_tests/scenarios/commands/false/false_control_flow/false_semicolon_chain.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/false/false_control_flow/false_semicolon_chain.yaml
@@ -1,0 +1,10 @@
+description: Commands after false separated by semicolons still execute.
+input:
+  # language=bash
+  script: |+
+    false; echo after
+expected:
+  stdout: |+
+    after
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/commands/false/false_control_flow/false_semicolon_chain.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/false/false_control_flow/false_semicolon_chain.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     false; echo after
-expected:
+expect:
   stdout: |+
     after
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/commands/false/false_exit_status/false_exit_status_captured.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/false/false_exit_status/false_exit_status_captured.yaml
@@ -4,7 +4,7 @@ input:
   script: |+
     false
     echo $?
-expected:
+expect:
   stdout: |+
     1
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/commands/false/false_exit_status/false_exit_status_captured.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/false/false_exit_status/false_exit_status_captured.yaml
@@ -1,0 +1,11 @@
+description: The $? variable captures 1 after false.
+input:
+  # language=bash
+  script: |+
+    false
+    echo $?
+expected:
+  stdout: |+
+    1
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/commands/false/false_exit_status/false_exit_status_in_chain.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/false/false_exit_status/false_exit_status_in_chain.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo first; false
-expected:
+expect:
   stdout: |+
     first
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/commands/false/false_exit_status/false_exit_status_in_chain.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/false/false_exit_status/false_exit_status_in_chain.yaml
@@ -1,0 +1,10 @@
+description: The exit status is 1 when false is the last command in a chain.
+input:
+  # language=bash
+  script: |+
+    echo first; false
+expected:
+  stdout: |+
+    first
+  stderr: ""
+  exit_code: 1

--- a/pkg/shell/e2e_tests/scenarios/commands/false/false_exit_status/false_overrides_success.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/false/false_exit_status/false_overrides_success.yaml
@@ -1,0 +1,14 @@
+description: The false builtin sets $? to 1 after a successful command.
+input:
+  # language=bash
+  script: |+
+    true
+    echo $?
+    false
+    echo $?
+expected:
+  stdout: |+
+    0
+    1
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/commands/false/false_exit_status/false_overrides_success.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/false/false_exit_status/false_overrides_success.yaml
@@ -6,7 +6,7 @@ input:
     echo $?
     false
     echo $?
-expected:
+expect:
   stdout: |+
     0
     1

--- a/pkg/shell/e2e_tests/scenarios/commands/true/true_basic_behavior/true_after_false.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/true/true_basic_behavior/true_after_false.yaml
@@ -1,0 +1,12 @@
+description: The true builtin resets exit code to 0 after false.
+input:
+  # language=bash
+  script: |+
+    false
+    true
+    echo $?
+expected:
+  stdout: |+
+    0
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/commands/true/true_basic_behavior/true_after_false.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/true/true_basic_behavior/true_after_false.yaml
@@ -5,7 +5,7 @@ input:
     false
     true
     echo $?
-expected:
+expect:
   stdout: |+
     0
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/commands/true/true_basic_behavior/true_exit_code_zero.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/true/true_basic_behavior/true_exit_code_zero.yaml
@@ -1,0 +1,11 @@
+description: The true builtin always returns exit code 0.
+input:
+  # language=bash
+  script: |+
+    true
+    echo $?
+expected:
+  stdout: |+
+    0
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/commands/true/true_basic_behavior/true_exit_code_zero.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/true/true_basic_behavior/true_exit_code_zero.yaml
@@ -4,7 +4,7 @@ input:
   script: |+
     true
     echo $?
-expected:
+expect:
   stdout: |+
     0
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/commands/true/true_basic_behavior/true_multiple.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/true/true_basic_behavior/true_multiple.yaml
@@ -6,7 +6,7 @@ input:
     true
     true
     echo $?
-expected:
+expect:
   stdout: |+
     0
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/commands/true/true_basic_behavior/true_multiple.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/true/true_basic_behavior/true_multiple.yaml
@@ -1,0 +1,13 @@
+description: Multiple true commands all succeed.
+input:
+  # language=bash
+  script: |+
+    true
+    true
+    true
+    echo $?
+expected:
+  stdout: |+
+    0
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/commands/true/true_basic_behavior/true_no_stderr.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/true/true_basic_behavior/true_no_stderr.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     true
-expected:
+expect:
   stdout: ""
   stderr: ""
   exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/commands/true/true_basic_behavior/true_no_stderr.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/true/true_basic_behavior/true_no_stderr.yaml
@@ -1,0 +1,9 @@
+description: The true builtin produces no stderr output.
+input:
+  # language=bash
+  script: |+
+    true
+expected:
+  stdout: ""
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/commands/true/true_basic_behavior/true_no_stdout.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/true/true_basic_behavior/true_no_stdout.yaml
@@ -4,7 +4,7 @@ input:
   script: |+
     true
     echo done
-expected:
+expect:
   stdout: |+
     done
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/commands/true/true_basic_behavior/true_no_stdout.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/true/true_basic_behavior/true_no_stdout.yaml
@@ -1,0 +1,11 @@
+description: The true builtin produces no stdout output.
+input:
+  # language=bash
+  script: |+
+    true
+    echo done
+expected:
+  stdout: |+
+    done
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/commands/true/true_basic_behavior/true_standalone.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/true/true_basic_behavior/true_standalone.yaml
@@ -1,0 +1,9 @@
+description: The true builtin exits successfully with no output.
+input:
+  # language=bash
+  script: |+
+    true
+expected:
+  stdout: ""
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/commands/true/true_basic_behavior/true_standalone.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/true/true_basic_behavior/true_standalone.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     true
-expected:
+expect:
   stdout: ""
   stderr: ""
   exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/commands/true/true_control_flow/true_and_chain.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/true/true_control_flow/true_and_chain.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     true && true && echo end
-expected:
+expect:
   stdout: |+
     end
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/commands/true/true_control_flow/true_and_chain.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/true/true_control_flow/true_and_chain.yaml
@@ -1,0 +1,10 @@
+description: Chained && with true allows all commands to execute.
+input:
+  # language=bash
+  script: |+
+    true && true && echo end
+expected:
+  stdout: |+
+    end
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/commands/true/true_control_flow/true_and_continues.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/true/true_control_flow/true_and_continues.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     true && echo reached
-expected:
+expect:
   stdout: |+
     reached
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/commands/true/true_control_flow/true_and_continues.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/true/true_control_flow/true_and_continues.yaml
@@ -1,0 +1,10 @@
+description: The true builtin succeeds so && executes the next command.
+input:
+  # language=bash
+  script: |+
+    true && echo reached
+expected:
+  stdout: |+
+    reached
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/commands/true/true_control_flow/true_in_for_loop.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/true/true_control_flow/true_in_for_loop.yaml
@@ -6,7 +6,7 @@ input:
       true
       echo $x
     done
-expected:
+expect:
   stdout: |+
     a
     b

--- a/pkg/shell/e2e_tests/scenarios/commands/true/true_control_flow/true_in_for_loop.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/true/true_control_flow/true_in_for_loop.yaml
@@ -1,0 +1,14 @@
+description: The true builtin works correctly inside a for loop body.
+input:
+  # language=bash
+  script: |+
+    for x in a b; do
+      true
+      echo $x
+    done
+expected:
+  stdout: |+
+    a
+    b
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/commands/true/true_control_flow/true_or_skips.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/true/true_control_flow/true_or_skips.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     true || echo fallback
-expected:
+expect:
   stdout: ""
   stderr: ""
   exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/commands/true/true_control_flow/true_or_skips.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/true/true_control_flow/true_or_skips.yaml
@@ -1,0 +1,9 @@
+description: The true builtin succeeds so || skips the fallback command.
+input:
+  # language=bash
+  script: |+
+    true || echo fallback
+expected:
+  stdout: ""
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/commands/true/true_control_flow/true_pipe_left.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/true/true_control_flow/true_pipe_left.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     true | echo piped
-expected:
+expect:
   stdout: |+
     piped
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/commands/true/true_control_flow/true_pipe_left.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/true/true_control_flow/true_pipe_left.yaml
@@ -1,0 +1,10 @@
+description: The true builtin on the left side of a pipe produces no input.
+input:
+  # language=bash
+  script: |+
+    true | echo piped
+expected:
+  stdout: |+
+    piped
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/commands/true/true_control_flow/true_pipe_right.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/true/true_control_flow/true_pipe_right.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo hello | true
-expected:
+expect:
   stdout: ""
   stderr: ""
   exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/commands/true/true_control_flow/true_pipe_right.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/true/true_control_flow/true_pipe_right.yaml
@@ -1,0 +1,9 @@
+description: The true builtin on the right side of a pipe results in exit code 0.
+input:
+  # language=bash
+  script: |+
+    echo hello | true
+expected:
+  stdout: ""
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/commands/true/true_control_flow/true_semicolon_chain.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/true/true_control_flow/true_semicolon_chain.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     true; echo after
-expected:
+expect:
   stdout: |+
     after
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/commands/true/true_control_flow/true_semicolon_chain.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/true/true_control_flow/true_semicolon_chain.yaml
@@ -1,0 +1,10 @@
+description: The true builtin works correctly in semicolon-separated chains.
+input:
+  # language=bash
+  script: |+
+    true; echo after
+expected:
+  stdout: |+
+    after
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/commands/true/true_exit_status/true_exit_status_captured.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/true/true_exit_status/true_exit_status_captured.yaml
@@ -1,0 +1,11 @@
+description: The $? variable captures 0 after true.
+input:
+  # language=bash
+  script: |+
+    true
+    echo $?
+expected:
+  stdout: |+
+    0
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/commands/true/true_exit_status/true_exit_status_captured.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/true/true_exit_status/true_exit_status_captured.yaml
@@ -4,7 +4,7 @@ input:
   script: |+
     true
     echo $?
-expected:
+expect:
   stdout: |+
     0
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/commands/true/true_exit_status/true_exit_status_in_chain.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/true/true_exit_status/true_exit_status_in_chain.yaml
@@ -3,7 +3,7 @@ input:
   # language=bash
   script: |+
     echo first; true
-expected:
+expect:
   stdout: |+
     first
   stderr: ""

--- a/pkg/shell/e2e_tests/scenarios/commands/true/true_exit_status/true_exit_status_in_chain.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/true/true_exit_status/true_exit_status_in_chain.yaml
@@ -1,0 +1,10 @@
+description: The exit status is 0 when true is the last command in a chain.
+input:
+  # language=bash
+  script: |+
+    echo first; true
+expected:
+  stdout: |+
+    first
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/commands/true/true_exit_status/true_resets_failure.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/true/true_exit_status/true_resets_failure.yaml
@@ -1,0 +1,14 @@
+description: The true builtin resets $? to 0 after a failed command.
+input:
+  # language=bash
+  script: |+
+    false
+    echo $?
+    true
+    echo $?
+expected:
+  stdout: |+
+    1
+    0
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/commands/true/true_exit_status/true_resets_failure.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/true/true_exit_status/true_resets_failure.yaml
@@ -6,7 +6,7 @@ input:
     echo $?
     true
     echo $?
-expected:
+expect:
   stdout: |+
     1
     0


### PR DESCRIPTION
<!-- dd-meta {"pullId":"b7e40b65-c265-4605-a911-6ef81be9f034","source":"chat","resourceId":"13d85225-38d2-4519-8d37-b26953690b33","workflowId":"9ad90ddf-1ade-4973-aef1-3756493d5339","codeChangeId":"9ad90ddf-1ade-4973-aef1-3756493d5339","sourceType":"chat"} -->
PR by Bits
[View session in Datadog](https://app.datadoghq.com/code/13d85225-38d2-4519-8d37-b26953690b33)

Comment @datadog to request changes

Feedback (especially what can be better) welcome in [#code-gen-aka-bits-dev-feedback](https://dd.enterprise.slack.com/archives/C07JA5N2D25)!

---

### What does this PR do?
Adds comprehensive YAML-based e2e test scenarios for the `true` and `false` shell built-in commands in `pkg/shell`.

33 new scenario files organized into three categories each:
- **basic_behavior** (6 per command): standalone execution, no stdout/stderr output, exit codes, multiple invocations, interaction between true/false
- **control_flow** (7 per command): `&&` chains, `||` fallbacks, semicolon sequences, pipe left/right sides, for loop bodies
- **exit_status** (3 per command): `$?` capture, reset/override after the other builtin, final exit code in chains

### Motivation
The `true` and `false` builtins had no dedicated test scenarios despite being fundamental shell commands used throughout other test scenarios.

### Describe how you validated your changes
All 33 new scenarios pass via `go test ./pkg/shell/e2e_tests/ -run "TestShellScenarios/commands/(true|false)"`.

### Additional Notes
Follows the existing YAML scenario conventions established for `echo` and `cat` commands.