### PR TITLE
Add comprehensive exit builtin test scenarios

### DIFF
--- a/pkg/shell/e2e_tests/scenarios/commands/exit/exit_basic_behavior/exit_no_args.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/exit/exit_basic_behavior/exit_no_args.yaml
@@ -1,0 +1,9 @@
+description: Exit with no arguments returns 0 when no previous command has run.
+input:
+  # language=bash
+  script: |+
+    exit
+expect:
+  stdout: ""
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/commands/exit/exit_basic_behavior/exit_no_args_last_code.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/exit/exit_basic_behavior/exit_no_args_last_code.yaml
@@ -1,0 +1,10 @@
+description: Exit with no arguments returns the last command's exit code.
+input:
+  # language=bash
+  script: |+
+    false
+    exit
+expect:
+  stdout: ""
+  stderr: ""
+  exit_code: 1

--- a/pkg/shell/e2e_tests/scenarios/commands/exit/exit_basic_behavior/exit_nonzero.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/exit/exit_basic_behavior/exit_nonzero.yaml
@@ -1,0 +1,9 @@
+description: Exit 1 terminates with a non-zero exit code.
+input:
+  # language=bash
+  script: |+
+    exit 1
+expect:
+  stdout: ""
+  stderr: ""
+  exit_code: 1

--- a/pkg/shell/e2e_tests/scenarios/commands/exit/exit_basic_behavior/exit_preserves_stdout.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/exit/exit_basic_behavior/exit_preserves_stdout.yaml
@@ -1,0 +1,14 @@
+description: Output produced before exit is preserved.
+input:
+  # language=bash
+  script: |+
+    echo first
+    echo second
+    exit 0
+    echo third
+expect:
+  stdout: |+
+    first
+    second
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/commands/exit/exit_basic_behavior/exit_stops_execution.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/exit/exit_basic_behavior/exit_stops_execution.yaml
@@ -1,0 +1,12 @@
+description: Exit stops execution; subsequent commands do not run.
+input:
+  # language=bash
+  script: |+
+    echo before
+    exit 0
+    echo after
+expect:
+  stdout: |+
+    before
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/commands/exit/exit_basic_behavior/exit_zero.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/exit/exit_basic_behavior/exit_zero.yaml
@@ -1,0 +1,9 @@
+description: Exit 0 explicitly terminates with success.
+input:
+  # language=bash
+  script: |+
+    exit 0
+expect:
+  stdout: ""
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/commands/exit/exit_code_values/exit_code_127.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/exit/exit_code_values/exit_code_127.yaml
@@ -1,0 +1,9 @@
+description: Exit with code 127 returns the conventional "command not found" code.
+input:
+  # language=bash
+  script: |+
+    exit 127
+expect:
+  stdout: ""
+  stderr: ""
+  exit_code: 127

--- a/pkg/shell/e2e_tests/scenarios/commands/exit/exit_code_values/exit_code_255.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/exit/exit_code_values/exit_code_255.yaml
@@ -1,0 +1,9 @@
+description: Exit with code 255, the maximum single-byte value.
+input:
+  # language=bash
+  script: |+
+    exit 255
+expect:
+  stdout: ""
+  stderr: ""
+  exit_code: 255

--- a/pkg/shell/e2e_tests/scenarios/commands/exit/exit_code_values/exit_code_256_wraps.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/exit/exit_code_values/exit_code_256_wraps.yaml
@@ -1,0 +1,9 @@
+description: Exit with code 256 wraps to 0 via uint8 overflow.
+input:
+  # language=bash
+  script: |+
+    exit 256
+expect:
+  stdout: ""
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/commands/exit/exit_code_values/exit_code_42.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/exit/exit_code_values/exit_code_42.yaml
@@ -1,0 +1,9 @@
+description: Exit with code 42 returns that specific code.
+input:
+  # language=bash
+  script: |+
+    exit 42
+expect:
+  stdout: ""
+  stderr: ""
+  exit_code: 42

--- a/pkg/shell/e2e_tests/scenarios/commands/exit/exit_code_values/exit_code_large_wraps.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/exit/exit_code_values/exit_code_large_wraps.yaml
@@ -1,0 +1,9 @@
+description: Exit with large number wraps via uint8 conversion (513 mod 256 = 1).
+input:
+  # language=bash
+  script: |+
+    exit 513
+expect:
+  stdout: ""
+  stderr: ""
+  exit_code: 1

--- a/pkg/shell/e2e_tests/scenarios/commands/exit/exit_code_values/exit_code_negative.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/exit/exit_code_values/exit_code_negative.yaml
@@ -1,0 +1,9 @@
+description: Exit with negative number wraps via uint8 conversion.
+input:
+  # language=bash
+  script: |+
+    exit -1
+expect:
+  stdout: ""
+  stderr: ""
+  exit_code: 255

--- a/pkg/shell/e2e_tests/scenarios/commands/exit/exit_error_handling/exit_float.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/exit/exit_error_handling/exit_float.yaml
@@ -1,0 +1,10 @@
+description: Exit with a floating-point argument is invalid.
+input:
+  # language=bash
+  script: |+
+    exit 1.5
+expect:
+  stdout: ""
+  stderr: |+
+    invalid exit status code: "1.5"
+  exit_code: 2

--- a/pkg/shell/e2e_tests/scenarios/commands/exit/exit_error_handling/exit_invalid_continues.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/exit/exit_error_handling/exit_invalid_continues.yaml
@@ -1,0 +1,11 @@
+description: An invalid exit argument does not stop execution; subsequent commands still run.
+input:
+  # language=bash
+  script: |+
+    exit abc; echo still running
+expect:
+  stdout: |+
+    still running
+  stderr: |+
+    invalid exit status code: "abc"
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/commands/exit/exit_error_handling/exit_invalid_string.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/exit/exit_error_handling/exit_invalid_string.yaml
@@ -1,0 +1,10 @@
+description: Exit with a non-numeric string argument produces an error.
+input:
+  # language=bash
+  script: |+
+    exit abc
+expect:
+  stdout: ""
+  stderr: |+
+    invalid exit status code: "abc"
+  exit_code: 2

--- a/pkg/shell/e2e_tests/scenarios/commands/exit/exit_error_handling/exit_multiple_args.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/exit/exit_error_handling/exit_multiple_args.yaml
@@ -1,0 +1,10 @@
+description: Exit with multiple arguments produces an error.
+input:
+  # language=bash
+  script: |+
+    exit 1 2
+expect:
+  stdout: ""
+  stderr: |+
+    exit cannot take multiple arguments
+  exit_code: 1

--- a/pkg/shell/e2e_tests/scenarios/commands/exit/exit_error_handling/exit_multiple_args_continues.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/exit/exit_error_handling/exit_multiple_args_continues.yaml
@@ -1,0 +1,11 @@
+description: Exit with multiple arguments does not stop execution; subsequent commands still run.
+input:
+  # language=bash
+  script: |+
+    exit 1 2; echo still running
+expect:
+  stdout: |+
+    still running
+  stderr: |+
+    exit cannot take multiple arguments
+  exit_code: 0

--- a/pkg/shell/e2e_tests/scenarios/commands/exit/exit_with_shell_features/exit_after_failed_command.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/exit/exit_with_shell_features/exit_after_failed_command.yaml
@@ -1,0 +1,12 @@
+description: Exit with no arguments after a failed command propagates the failure code.
+input:
+  # language=bash
+  script: |+
+    echo before
+    false
+    exit
+expect:
+  stdout: |+
+    before
+  stderr: ""
+  exit_code: 1

--- a/pkg/shell/e2e_tests/scenarios/commands/exit/exit_with_shell_features/exit_in_and_chain.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/exit/exit_with_shell_features/exit_in_and_chain.yaml
@@ -1,0 +1,10 @@
+description: Exit executes when reached via && after a successful command.
+input:
+  # language=bash
+  script: |+
+    true && exit 3
+    echo unreachable
+expect:
+  stdout: ""
+  stderr: ""
+  exit_code: 3

--- a/pkg/shell/e2e_tests/scenarios/commands/exit/exit_with_shell_features/exit_in_for_loop.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/exit/exit_with_shell_features/exit_in_for_loop.yaml
@@ -1,0 +1,14 @@
+description: Exit inside a for loop terminates the entire script.
+input:
+  # language=bash
+  script: |+
+    for x in a b c; do
+      echo $x
+      exit 3
+    done
+    echo unreachable
+expect:
+  stdout: |+
+    a
+  stderr: ""
+  exit_code: 3

--- a/pkg/shell/e2e_tests/scenarios/commands/exit/exit_with_shell_features/exit_in_or_chain.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/exit/exit_with_shell_features/exit_in_or_chain.yaml
@@ -1,0 +1,10 @@
+description: Exit executes when reached via || after a failed command.
+input:
+  # language=bash
+  script: |+
+    false || exit 3
+    echo unreachable
+expect:
+  stdout: ""
+  stderr: ""
+  exit_code: 3

--- a/pkg/shell/e2e_tests/scenarios/commands/exit/exit_with_shell_features/exit_with_variable.yaml
+++ b/pkg/shell/e2e_tests/scenarios/commands/exit/exit_with_shell_features/exit_with_variable.yaml
@@ -1,0 +1,10 @@
+description: Exit code can be provided via variable expansion.
+input:
+  # language=bash
+  script: |+
+    CODE=5
+    exit $CODE
+expect:
+  stdout: ""
+  stderr: ""
+  exit_code: 5


### PR DESCRIPTION
<!-- dd-meta {"pullId":"5d8009ab-ab46-4081-9b8e-ab9b52937bb1","source":"chat","resourceId":"1ce771d5-1c87-44a8-a7dd-0dbb3b16a81f","workflowId":"7bbce641-3b5a-4326-a8c0-09d589822cb6","codeChangeId":"7bbce641-3b5a-4326-a8c0-09d589822cb6","sourceType":"chat"} -->
PR by Bits
[View session in Datadog](https://app.datadoghq.com/code/1ce771d5-1c87-44a8-a7dd-0dbb3b16a81f)

Comment @datadog to request changes

Feedback (especially what can be better) welcome in [#code-gen-aka-bits-dev-feedback](https://dd.enterprise.slack.com/archives/C07JA5N2D25)!

---

### What does this PR do?

Adds 22 YAML-based e2e test scenarios for the `exit` built-in command in `pkg/shell`, organized into four categories:

- **exit_basic_behavior** (6 tests): no-args default, explicit zero/nonzero, stops execution, preserves stdout, inherits last exit code
- **exit_code_values** (6 tests): codes 42/127/255, uint8 overflow wrapping (256→0, 513→1), negative wrapping (-1→255)
- **exit_error_handling** (5 tests): invalid string arg, multiple args, float arg, and verification that invalid exit calls do not halt execution
- **exit_with_shell_features** (5 tests): variable expansion, for-loop termination, post-failure propagation, `&&`/`||` chains

### Motivation

The `exit` builtin had no dedicated test coverage. These scenarios exercise all code paths in `builtin.go`'s exit handling including success, error, overflow, and interaction with other shell features.

### Describe how you validated your changes

All 22 new scenarios pass via `go test ./pkg/shell/e2e_tests/ -run "TestShellScenarios/commands/exit"`.

### Additional Notes

No code changes; test-only addition.