### PR TITLE
[WP] Use OTEL service tag

### DIFF
--- a/pkg/security/probe/field_handlers.go
+++ b/pkg/security/probe/field_handlers.go
@@ -54,6 +54,9 @@ func getProcessService(config *config.Config, entry *model.ProcessCacheEntry) (s
 		if service := entry.EnvsEntry.Get(ServiceEnvVar); service != "" {
 			serviceValues = append(serviceValues, service)
 		}
+		if service := entry.EnvsEntry.Get(OTELServiceEnvVar); service != "" {
+			serviceValues = append(serviceValues, service)
+		}
 	}
 
 	inContainer := entry.ProcessContext.ContainerContext.ContainerID != ""
@@ -66,6 +69,9 @@ func getProcessService(config *config.Config, entry *model.ProcessCacheEntry) (s
 
 		if ancestor.EnvsEntry != nil {
 			if service := ancestor.EnvsEntry.Get(ServiceEnvVar); service != "" {
+				serviceValues = append(serviceValues, service)
+			}
+			if service := ancestor.EnvsEntry.Get(OTELServiceEnvVar); service != "" {
 				serviceValues = append(serviceValues, service)
 			}
 		}

--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -11,4 +11,6 @@ package probe
 const (
 	// ServiceEnvVar environment variable used to report service
 	ServiceEnvVar = "DD_SERVICE"
+	// OTELServiceEnvVar environment variable used to report service
+	OTELServiceEnvVar = "OTEL_SERVICE_NAME"
 )


### PR DESCRIPTION
### What does this PR do?

This PR ensures we're also using the `OTEL_SERVICE_NAME` tag key to resolve a process service from the env variables.

### Motivation

We're currently using on `DD_SERVICE` but both are equally important now.
