### PR TITLE
Stop generating/installing libcurl's pc fle

### DIFF
--- a/deps/curl/overlay/overlay.BUILD.bazel
+++ b/deps/curl/overlay/overlay.BUILD.bazel
@@ -1,6 +1,5 @@
 """ Agent specific curl build."""
 
-load("@@//bazel/rules:dd_agent_expand_template.bzl", "dd_agent_expand_template")
 load("@@//bazel/rules:so_symlink.bzl", "so_symlink")
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
@@ -234,28 +233,6 @@ cc_shared_library(
     ],
 )
 
-dd_agent_expand_template(
-    name = "gen_pkgconfig",
-    out = "libcurl.pc",
-    substitutions = {
-        "@prefix@": "{install_dir}",
-        "@exec_prefix@": "${prefix}",
-        "@libdir@": "${prefix}/embedded/lib",
-        "@includedir@": "${prefix}/embedded/include",
-        "@CURLVERSION@": VERSION,
-        "@SUPPORT_PROTOCOLS@": "",
-        "@SUPPORT_FEATURES@": "",
-        "@LIBCURL_PC_REQUIRES@": "",
-        "@LIBCURL_PC_REQUIRES_PRIVATE@": "",
-        "@LIBCURL_PC_LIBS@": "",
-        "@LIBCURL_PC_LDFLAGS_PRIVATE@": "",
-        "@LIBCURL_PC_LIBS_PRIVATE@": "",
-        "@LIBCURL_PC_CFLAGS@": "",
-        "@LIBCURL_PC_CFLAGS_PRIVATE@": "",
-    },
-    template = ":libcurl.pc.in",
-)
-
 pkg_files(
     name = "bin_files",
     srcs = [
@@ -283,19 +260,12 @@ pkg_files(
     prefix = "embedded/include/curl",
 )
 
-pkg_files(
-    name = "pc_files",
-    srcs = [":gen_pkgconfig"],
-    prefix = "embedded/lib/pkgconfig",
-)
-
 pkg_filegroup(
     name = "all_files",
     srcs = [
         ":bin_files",
         ":hdr_files",
         ":lib_files",
-        ":pc_files",
     ],
 )
 

--- a/deps/curl/overlay/overlay.BUILD.bazel
+++ b/deps/curl/overlay/overlay.BUILD.bazel
@@ -2,10 +2,10 @@
 
 load("@@//bazel/rules:dd_agent_expand_template.bzl", "dd_agent_expand_template")
 load("@@//bazel/rules:so_symlink.bzl", "so_symlink")
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_shared_library.bzl", "cc_shared_library")
-load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@rules_license//rules:license.bzl", "license")
 load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_filegroup", "pkg_files")
@@ -92,25 +92,21 @@ cc_binary(
         "@platforms//os:linux": LIB_CURLTOOL_SRCS_LINUX,
         "@platforms//os:macos": LIB_CURLTOOL_SRCS_DARWIN,
     }),
-    defines = LOCAL_DEFINES,
-    includes = [
-        ".",
-        "include",
-        "lib",
-    ],
     copts = [
         "-I.",
     ],
+    defines = LOCAL_DEFINES,
     dynamic_deps = [
         ":curl",
         "@nghttp2//:nghttp2_shared",
         "@openssl//:openssl_shared",
         "@zlib//:z",
     ],
-    deps = [
-        ":config_h",
+    includes = [
+        ".",
+        "include",
+        "lib",
     ],
-    linkstatic = False,
     linkopts = select({
         "@platforms//os:macos": [
             "-Wl,-framework,CoreFoundation",
@@ -118,7 +114,11 @@ cc_binary(
         ],
         "//conditions:default": [],
     }),
+    linkstatic = False,
     visibility = ["//visibility:public"],
+    deps = [
+        ":config_h",
+    ],
 )
 
 cc_library(
@@ -128,6 +128,16 @@ cc_library(
         "@platforms//os:macos": LIB_CURLU_SRCS_DARWIN,
     }),
     hdrs = PUBLIC_HEADERS,
+    copts = [
+        "-Wno-implicit-function-declaration",
+        "-Wno-int-conversion",
+        "-Wno-system-headers",
+        "-I.",
+        "-O2",
+    ],
+    implementation_deps = [
+        ":config_h",
+    ],
     # Using includes because -I just does not work with bzlmod.
     # But yuch. What we need is to  port local_incudes concept from Google out
     # to rules_cc.
@@ -144,27 +154,17 @@ cc_library(
         ],
         "//conditions:default": [],
     }),
-    copts = [
-        "-Wno-implicit-function-declaration",
-        "-Wno-int-conversion",
-        "-Wno-system-headers",
-        "-I.",
-        "-O2",
-    ],
-    visibility = ["//visibility:public"],
-    deps = [
-        "@nghttp2//:nghttp2",
-        "@openssl//:openssl",
-        "@zlib//:zlib",
-    ],
-    implementation_deps = [
-        ":config_h",
-    ],
     # Do not build in ... expansion. It triggers an incompatiblity between
     # the toolchain decls, rules_cc, and the compiler we use.  rules_cc
     # ends up using --start-lib/--end-lib options, which are not recognize
     # by the compiler we use as of 2026-02-03.
     tags = ["manual"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@nghttp2",
+        "@openssl",
+        "@zlib",
+    ],
 )
 
 cc_library(
@@ -174,12 +174,29 @@ cc_library(
         "@platforms//os:macos": LIB_CURLU_SRCS_DARWIN,
     }),
     hdrs = PUBLIC_HEADERS,
+    copts = [
+        "-Wno-implicit-function-declaration",
+        "-Wno-int-conversion",
+        "-Wno-system-headers",
+        "-I.",
+        "-O2",
+    ],
+    implementation_deps = [
+        ":config_h",
+    ],
     # Using includes because -I just does not work with bzlmod.
     # But yuch. What we need is to  port local_incudes concept from Google out
     # to rules_cc.
     includes = [
         "include",
     ],
+    linkopts = select({
+        "@platforms//os:macos": [
+            "-Wl,-framework,CoreFoundation",
+            "-Wl,-framework,SystemConfiguration",
+        ],
+        "//conditions:default": [],
+    }),
     local_defines = LOCAL_DEFINES + [
         "BUILDING_LIBCURL",
         "NDEBUG",
@@ -189,55 +206,37 @@ cc_library(
         ],
         "//conditions:default": [],
     }),
-    copts = [
-        "-Wno-implicit-function-declaration",
-        "-Wno-int-conversion",
-        "-Wno-system-headers",
-        "-I.",
-        "-O2",
-    ],
-    linkopts = select({
-        "@platforms//os:macos": [
-            "-Wl,-framework,CoreFoundation",
-            "-Wl,-framework,SystemConfiguration",
-        ],
-        "//conditions:default": [],
-    }),
-    visibility = ["//visibility:public"],
-    implementation_deps = [
-        ":config_h",
-    ],
-    deps = [
-        ":curl_static",
-        "@nghttp2//:nghttp2",
-        "@openssl//:openssl",
-        "@zlib//:zlib",
-    ],
     # Do not build in ... expansion. It triggers an incompatiblity between
     # the toolchain decls, rules_cc, and the compiler we use.  rules_cc
     # ends up using --start-lib/--end-lib options, which are not recognize
     # by the compiler we use as of 2026-02-03.
     tags = ["manual"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":curl_static",
+        "@nghttp2",
+        "@openssl",
+        "@zlib",
+    ],
 )
 
 cc_shared_library(
     name = "curl",
-    deps = [
-        ":curl_static",
-        ":curlu_static",
-    ],
     dynamic_deps = [
         "@nghttp2//:nghttp2_shared",
         "@openssl//:openssl_shared",
         "@zlib//:z",
     ],
     visibility = ["//visibility:public"],
+    deps = [
+        ":curl_static",
+        ":curlu_static",
+    ],
 )
 
 dd_agent_expand_template(
     name = "gen_pkgconfig",
     out = "libcurl.pc",
-    template = ":libcurl.pc.in",
     substitutions = {
         "@prefix@": "{install_dir}",
         "@exec_prefix@": "${prefix}",
@@ -254,6 +253,7 @@ dd_agent_expand_template(
         "@LIBCURL_PC_CFLAGS@": "",
         "@LIBCURL_PC_CFLAGS_PRIVATE@": "",
     },
+    template = ":libcurl.pc.in",
 )
 
 pkg_files(
@@ -262,19 +262,19 @@ pkg_files(
         ":curl_bin",
     ],
     attributes = pkg_attributes(mode = "0755"),
+    prefix = "embedded/bin",
     renames = {
         "curl_bin": "curl",
     },
-    prefix = "embedded/bin",
 )
 
 so_symlink(
     name = "lib_files",
     src = ":curl",
-    libname = "libcurl",
-    version = SO_VERSION,
-    prefix = "embedded",
     attributes = pkg_attributes(mode = "0755"),
+    libname = "libcurl",
+    prefix = "embedded",
+    version = SO_VERSION,
 )
 
 pkg_files(

--- a/omnibus/config/software/curl.rb
+++ b/omnibus/config/software/curl.rb
@@ -29,7 +29,6 @@ build do
 
   command_on_repo_root "bazelisk run -- @curl//:install --destdir='#{install_dir}'"
   command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
-    " #{install_dir}/embedded/lib/pkgconfig/libcurl.pc" \
     " #{install_dir}/embedded/lib/libcurl.so" \
     " #{install_dir}/embedded/bin/curl"
 end


### PR DESCRIPTION
### What does this PR do?

Stop generating libcurl's .pc file

### Motivation

We don't need it anymore since all dependencies depending on curl are built with bazel, which doesn't use pkgconfig.

### Describe how you validated your changes

### Additional Notes

I (actually, my editor) also ran buildifier and I guess it makes sense to also include the cleanup here