### PR TITLE
Reapply #47007 with job-scoped repository caches

### DIFF
--- a/.gitlab/build/bazel/defs.yml
+++ b/.gitlab/build/bazel/defs.yml
@@ -16,9 +16,16 @@
       policy: pull$BAZEL_CACHE_POLICY_SUFFIX
       when: on_success
     - &bazel_cache
-      key: bazel-$CI_RUNNER_DESCRIPTION
+      # TODO(agent-build): revert key prefix to bazel-$CI_RUNNER_DESCRIPTION after switching to Go 1.26+:
+      # - issue: https://github.com/microsoft/go/issues/1994
+      # - fix: https://github.com/microsoft/go/pull/1998
+      key:
+        prefix: bazel-$CI_JOB_NAME
+        files: [ .go-version, .python-version ]
       paths:
         - .cache/bazel/*/cache
+        - .cache/go*
+        - .cache/ms-go*
         - .cache/pip
       policy: pull$BAZEL_CACHE_POLICY_SUFFIX
       when: on_success

--- a/tools/bazel
+++ b/tools/bazel
@@ -26,6 +26,9 @@ if [ -n "${XDG_CACHE_HOME:-}" ]; then
     >&2 echo "🔴 XDG_CACHE_HOME ($XDG_CACHE_HOME) must denote an absolute path!"
     exit 2
   fi
+  unset GOCACHE                               # https://pkg.go.dev/os#UserCacheDir
+  export GOMODCACHE="$XDG_CACHE_HOME"/go/mod  # https://wiki.archlinux.org/title/XDG_Base_Directory#Partial
+  unset PIP_CACHE_DIR                         # https://pip.pypa.io/en/stable/topics/caching/#default-paths
   if [[ -n "${CI:-}" && -z "${GITHUB_ACTIONS:-}" ]]; then
     exec "$BAZEL_REAL" ${1:+"$1" --config=ci} "${@:2}"
   fi

--- a/tools/bazel
+++ b/tools/bazel
@@ -26,7 +26,7 @@ if [ -n "${XDG_CACHE_HOME:-}" ]; then
     >&2 echo "🔴 XDG_CACHE_HOME ($XDG_CACHE_HOME) must denote an absolute path!"
     exit 2
   fi
-  unset GOCACHE                               # https://pkg.go.dev/os#UserCacheDir
+  unset GOCACHE                               # https://pkg.go.dev/cmd/go#hdr-Build_and_test_caching
   export GOMODCACHE="$XDG_CACHE_HOME"/go/mod  # https://wiki.archlinux.org/title/XDG_Base_Directory#Partial
   unset PIP_CACHE_DIR                         # https://pip.pypa.io/en/stable/topics/caching/#default-paths
   if [[ -n "${CI:-}" && -z "${GITHUB_ACTIONS:-}" ]]; then

--- a/tools/bazel.bat
+++ b/tools/bazel.bat
@@ -21,13 +21,20 @@ if not exist "%XDG_CACHE_HOME%" (
   )
 )
 
-:: Ensure `bazel` & managed toolchains honor `XDG_CACHE_HOME` if set: https://github.com/bazelbuild/bazel/issues/27808
+:: Ensure `bazel` & managed toolchains honor `XDG_CACHE_HOME` as per https://wiki.archlinux.org/title/XDG_Base_Directory
 if defined XDG_CACHE_HOME (
   set "XDG_CACHE_HOME=!XDG_CACHE_HOME:/=\!"
   if "!XDG_CACHE_HOME:~1,2!" neq ":\" if "!XDG_CACHE_HOME:~0,2!" neq "\\" (
     >&2 echo 🔴 XDG_CACHE_HOME ^(!XDG_CACHE_HOME!^) must denote an absolute path!
     exit /b 2
   )
+  :: https://pkg.go.dev/os#UserCacheDir
+  set "GOCACHE=%XDG_CACHE_HOME%\go-build"
+  :: https://wiki.archlinux.org/title/XDG_Base_Directory#Partial
+  set "GOMODCACHE=%XDG_CACHE_HOME%\go\mod"
+  :: https://pip.pypa.io/en/stable/topics/caching/#default-paths
+  set "PIP_CACHE_DIR=%XDG_CACHE_HOME%\pip"
+  :: https://github.com/bazelbuild/bazel/issues/27808
   set "bazel_home=%XDG_CACHE_HOME%\bazel"
   set bazel_home_startup_option="--output_user_root=!bazel_home!"
 ) else (

--- a/tools/bazel.bat
+++ b/tools/bazel.bat
@@ -28,7 +28,7 @@ if defined XDG_CACHE_HOME (
     >&2 echo 🔴 XDG_CACHE_HOME ^(!XDG_CACHE_HOME!^) must denote an absolute path!
     exit /b 2
   )
-  :: https://pkg.go.dev/os#UserCacheDir
+  :: https://pkg.go.dev/cmd/go#hdr-Build_and_test_caching
   set "GOCACHE=%XDG_CACHE_HOME%\go-build"
   :: https://wiki.archlinux.org/title/XDG_Base_Directory#Partial
   set "GOMODCACHE=%XDG_CACHE_HOME%\go\mod"


### PR DESCRIPTION
### What does this PR do?
Reapply #47007, reverted in #47083 following #incident-50242, but with the following adjustments:
1. scope repository caches to individual jobs (`$CI_JOB_NAME`) rather than runner types (`$CI_RUNNER_DESCRIPTION`),
2. add `.cache/ms-go*` to the cached paths (neutral until `msgo` 1.26+).

### Motivation
#incident-50242 traced to FIPS and non-FIPS omnibus jobs racing to write incompatible Go build artifacts to the same cache key: `msgo` tags indeed compile objects with `X:systemcrypto` while upstream Go does not.

It turns out to be a **known issue**: microsoft/go#1994.

Until the corresponding fix (microsoft/go#1998) is available, that is when bumping the Go SDK version to 1.26+, the main adjustment consists in temporarily scoping repository caches to jobs.
Per-job cache keys naturally segregate the two without requiring an explicit FIPS discriminator (we couldn't rely on `$FLAVOR` because it's not expanding consistently across jobs).

### Additional Notes
When switching to Go SDK 1.26+, we'll revert `$CI_RUNNER_DESCRIPTION` because `msgo` 1.26+ will eliminate the conflict at the toolchain level thanks to microsoft/go#1998.