### PR TITLE
[WP] Fix root domain resolution and add tests

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -2351,6 +2351,7 @@ core,github.com/vmihailenco/tagparser/v2/internal,BSD-2-Clause,Copyright (c) 201
 core,github.com/vmihailenco/tagparser/v2/internal/parser,BSD-2-Clause,Copyright (c) 2019 The github.com/vmihailenco/tagparser Authors
 core,github.com/vultr/govultr/v2,MIT,Copyright (c) 2019 Vultr
 core,github.com/wI2L/jsondiff,MIT,Copyright (c) 2020-2025 William Poussier <william.poussier@gmail.com>
+core,github.com/weppos/publicsuffix-go/publicsuffix,MIT,Copyright (c) 2016-2026 Simone Carletti
 core,github.com/wk8/go-ordered-map/v2,Apache-2.0,Copyright 2023 Jean Rougé <wk8.github@gmail.com>
 core,github.com/x448/float16,MIT,Copyright (c) 2019 Montgomery Edwards⁴⁴⁸ and Faye Amacker
 core,github.com/xanzy/ssh-agent,Apache-2.0,"Copyright (c) 2014 David Mzareulyan | Copyright 2015, Sander van Harmelen"

--- a/go.mod
+++ b/go.mod
@@ -1195,6 +1195,7 @@ require (
 	github.com/tink-crypto/tink-go/v2 v2.4.0 // indirect
 	github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c // indirect
 	github.com/vmware/govmomi v0.18.0 // indirect
+	github.com/weppos/publicsuffix-go v0.50.3 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	gopkg.in/neurosnap/sentences.v1 v1.0.7 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2570,6 +2570,8 @@ github.com/vultr/govultr/v2 v2.17.2 h1:gej/rwr91Puc/tgh+j33p/BLR16UrIPnSr+AIwYWZ
 github.com/vultr/govultr/v2 v2.17.2/go.mod h1:ZFOKGWmgjytfyjeyAdhQlSWwTjh2ig+X49cAp50dzXI=
 github.com/wI2L/jsondiff v0.7.0 h1:1lH1G37GhBPqCfp/lrs91rf/2j3DktX6qYAKZkLuCQQ=
 github.com/wI2L/jsondiff v0.7.0/go.mod h1:KAEIojdQq66oJiHhDyQez2x+sRit0vIzC9KeK0yizxM=
+github.com/weppos/publicsuffix-go v0.50.3 h1:eT5dcjHQcVDNc0igpFEsGHKIip30feuB2zuuI9eJxiE=
+github.com/weppos/publicsuffix-go v0.50.3/go.mod h1:/rOa781xBykZhHK/I3QeHo92qdDKVmKZKF7s8qAEM/4=
 github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=
 github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
 github.com/wsxiaoys/terminal v0.0.0-20160513160801-0940f3fc43a0 h1:3UeQBvD0TFrlVjOeLOBz+CPAI8dnbqNSVwUwRrkp7vQ=

--- a/pkg/security/secl/compiler/eval/strings_linux.go
+++ b/pkg/security/secl/compiler/eval/strings_linux.go
@@ -11,26 +11,37 @@ package eval
 import (
 	"slices"
 
-	"golang.org/x/net/publicsuffix"
+	"github.com/weppos/publicsuffix-go/publicsuffix"
 )
+
+// EffectiveTLDPlusOneWithFallback returns the effective top level domain plus one more
+// label. It calls the publicsuffix.DomainFromListWithOptions function.
+// Fallback: if the publicsuffix.DomainFromListWithOptions function returns an error or an empty
+// string, it will return the full domain.
+func EffectiveTLDPlusOneWithFallback(domain string) string {
+	rootDomain, err := publicsuffix.DomainFromListWithOptions(publicsuffix.DefaultList, domain, &publicsuffix.FindOptions{IgnorePrivate: true})
+
+	if err != nil || rootDomain == "" {
+		// Fallback, can't get the root domain, return full domain
+		return domain
+	}
+	return rootDomain
+}
 
 // GetPublicTLD returns the public top-level domain (eTLD+1) from an FQDN.
 // For example: "www.google.com" returns "google.com", "www.abc.co.uk" returns "abc.co.uk".
-// If the input is invalid or cannot be parsed, it returns the input unchanged.
 func GetPublicTLD(fqdn string) string {
-	etldPlusOne, err := publicsuffix.EffectiveTLDPlusOne(fqdn)
-	if err != nil {
-		return fqdn
-	}
-	return etldPlusOne
+	return EffectiveTLDPlusOneWithFallback(fqdn)
 }
 
 // GetPublicTLDs returns the public top-level domains (eTLD+1) from a slice of FQDNs.
+// For example: ["www.google.com", "www.abc.co.uk"] returns ["google.com", "abc.co.uk"].
+// Removes duplicates.
 func GetPublicTLDs(fqdns []string) []string {
 	var etldPlusOnes []string
 	for _, fqdn := range fqdns {
-		etldPlusOne, err := publicsuffix.EffectiveTLDPlusOne(fqdn)
-		if err == nil && !slices.Contains(etldPlusOnes, etldPlusOne) {
+		etldPlusOne := EffectiveTLDPlusOneWithFallback(fqdn)
+		if !slices.Contains(etldPlusOnes, etldPlusOne) {
 			etldPlusOnes = append(etldPlusOnes, etldPlusOne)
 		}
 	}

--- a/pkg/security/secl/compiler/eval/strings_linux_test.go
+++ b/pkg/security/secl/compiler/eval/strings_linux_test.go
@@ -7,21 +7,69 @@
 package eval
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/weppos/publicsuffix-go/publicsuffix"
 )
 
 func TestGetPublicTLD(t *testing.T) {
 	t.Run("valid-fqdn", func(t *testing.T) {
-		etldPlusOne := GetPublicTLD("www.yahoo.com")
+		domainTested := "www.yahoo.com"
+		etldPlusOne := GetPublicTLD(domainTested)
 		assert.Equal(t, "yahoo.com", etldPlusOne)
+		// Check we did not hit the fallback //
+		rootDomain, err := publicsuffix.DomainFromListWithOptions(publicsuffix.DefaultList, domainTested, &publicsuffix.FindOptions{IgnorePrivate: true})
+		assert.True(t, err == nil, "Should not have failed to get root domain, got %q err=%v", rootDomain, err)
+	})
+	t.Run("dont-return-private", func(t *testing.T) {
+		domainTested := "elb.us-east-1.amazonaws.com"
+		etldPlusOne := GetPublicTLD(domainTested)
+		fmt.Printf("etldPlusOne: %s\n", etldPlusOne)
+		assert.Equal(t, "amazonaws.com", etldPlusOne)
+		// Check we did not hit the fallback
+		rootDomain, err := publicsuffix.DomainFromListWithOptions(publicsuffix.DefaultList, domainTested, &publicsuffix.FindOptions{IgnorePrivate: true})
+		assert.True(t, err == nil, "Should not have failed to get root domain, got %q err=%v", rootDomain, err)
+	})
+	t.Run("longer-fqdn", func(t *testing.T) {
+		domainTested := "www.abc.gov.uk"
+		etldPlusOne := GetPublicTLD(domainTested)
+		assert.Equal(t, "abc.gov.uk", etldPlusOne)
+		// Check we did not hit the fallback
+		rootDomain, err := publicsuffix.DomainFromListWithOptions(publicsuffix.DefaultList, domainTested, &publicsuffix.FindOptions{IgnorePrivate: true})
+		assert.True(t, err == nil, "Should not have failed to get root domain, got %q err=%v", rootDomain, err)
+
+	})
+	t.Run("domain-is-root-domain", func(t *testing.T) {
+		domainTested := "abc.gov.uk"
+		etldPlusOne := GetPublicTLD(domainTested)
+		assert.Equal(t, "abc.gov.uk", etldPlusOne)
+		// Check we did not hit the fallback
+		rootDomain, err := publicsuffix.DomainFromListWithOptions(publicsuffix.DefaultList, domainTested, &publicsuffix.FindOptions{IgnorePrivate: true})
+		assert.True(t, err == nil, "Should not have failed to get root domain, got %q err=%v", rootDomain, err)
+	})
+	t.Run("invalid-fqdn", func(t *testing.T) {
+		domainTested := "no-dot"
+		etldPlusOne := GetPublicTLD(domainTested)
+		assert.Equal(t, "no-dot", etldPlusOne)
+		// Check we hit the fallback
+		rootDomain, err := publicsuffix.DomainFromListWithOptions(publicsuffix.DefaultList, domainTested, &publicsuffix.FindOptions{IgnorePrivate: true})
+		assert.True(t, err != nil || rootDomain == "", "Should have failed to get root domain, got %q err=%v", rootDomain, err)
 	})
 }
 
 func TestGetPublicTLDs(t *testing.T) {
 	t.Run("valid-fqdns", func(t *testing.T) {
-		etldPlusOnes := GetPublicTLDs([]string{"www.yahoo.com", "www.google.com", "ftp.yahoo.com"})
-		assert.Equal(t, []string{"yahoo.com", "google.com"}, etldPlusOnes)
+		etldPlusOnes := GetPublicTLDs([]string{"www.yahoo.com", "elb.us-east-1.amazonaws.com", "ftp.yahoo.com", "s3.us-east-1.amazonaws.com"})
+		assert.Equal(t, []string{"yahoo.com", "amazonaws.com"}, etldPlusOnes)
+	})
+	t.Run("invalid-fqdn", func(t *testing.T) {
+		etldPlusOnes := GetPublicTLDs([]string{"no-dot"})
+		assert.Equal(t, []string{"no-dot"}, etldPlusOnes)
+	})
+	t.Run("invalid-multiple-fqdns", func(t *testing.T) {
+		etldPlusOnes := GetPublicTLDs([]string{"no-dot", "one-dot.com"})
+		assert.Equal(t, []string{"no-dot", "one-dot.com"}, etldPlusOnes)
 	})
 }

--- a/pkg/security/secl/go.mod
+++ b/pkg/security/secl/go.mod
@@ -15,10 +15,10 @@ require (
 	github.com/skydive-project/go-debouncer v1.0.1
 	github.com/spf13/cast v1.10.0
 	github.com/stretchr/testify v1.11.1
+	github.com/weppos/publicsuffix-go v0.50.3
 	github.com/xeipuuv/gojsonschema v1.2.0
 	go.uber.org/atomic v1.11.0
 	go.yaml.in/yaml/v3 v3.0.4
-	golang.org/x/net v0.51.0
 	golang.org/x/sys v0.41.0
 	golang.org/x/text v0.34.0
 	sigs.k8s.io/yaml v1.6.0
@@ -32,6 +32,7 @@ require (
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
+	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/pkg/security/secl/go.sum
+++ b/pkg/security/secl/go.sum
@@ -47,6 +47,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/weppos/publicsuffix-go v0.50.3 h1:eT5dcjHQcVDNc0igpFEsGHKIip30feuB2zuuI9eJxiE=
+github.com/weppos/publicsuffix-go v0.50.3/go.mod h1:/rOa781xBykZhHK/I3QeHo92qdDKVmKZKF7s8qAEM/4=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb h1:zGWFAtiMcyryUHoUjUJX0/lt1H2+i2Ka2n+D3DImSNo=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=

--- a/pkg/security/seclwin/go.mod
+++ b/pkg/security/seclwin/go.mod
@@ -8,9 +8,11 @@ require (
 	github.com/alecthomas/participle v0.7.1 // indirect
 	github.com/charlievieth/strcase v0.0.5 // indirect
 	github.com/jellydator/ttlcache/v3 v3.4.0 // indirect
+	github.com/weppos/publicsuffix-go v0.50.3 // indirect
 	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
+	golang.org/x/text v0.34.0 // indirect
 )
 
 // This section was automatically added by 'dda inv modules.add-all-replace' command, do not edit manually

--- a/pkg/security/seclwin/go.sum
+++ b/pkg/security/seclwin/go.sum
@@ -16,6 +16,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/weppos/publicsuffix-go v0.50.3 h1:eT5dcjHQcVDNc0igpFEsGHKIip30feuB2zuuI9eJxiE=
+github.com/weppos/publicsuffix-go v0.50.3/go.mod h1:/rOa781xBykZhHK/I3QeHo92qdDKVmKZKF7s8qAEM/4=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 golang.org/x/net v0.51.0 h1:94R/GTO7mt3/4wIKpcR5gkGmRLOuE/2hNGeWq/GBIFo=


### PR DESCRIPTION
### What does this PR do?

- Replaces the current library used for root domain resolution by https://github.com/weppos/publicsuffix-go
- Ensures private domains are no longer taken into account during resolution.
- Harmonizes the resolution logic so it behaves consistently whether the input is a single string (DNS) or a list (connect, accept).
- Adds comprehensive tests to validate the behavior.
- Introduces a fallback mechanism that returns the full domain when the root domain cannot be resolved.

### Motivation

- Domain resolution could previously fail silently due to the lack of test coverage.
- The absence of a fallback mechanism could result in empty strings being added.
- The behavior was inconsistent depending on the input format, which could lead to unexpected results
- The result was inconsistent due to the incomplete private domain list that was used