### PR TITLE
[SUSM-146] Disable TLS context fallback to fix endpoint misattribution

### DIFF
--- a/pkg/network/ebpf/c/protocols/tls/https.h
+++ b/pkg/network/ebpf/c/protocols/tls/https.h
@@ -275,18 +275,12 @@ static __always_inline conn_tuple_t* tup_from_ssl_ctx(void *ssl_ctx, u64 pid_tgi
     };
     ssl_sock_t *ssl_sock = bpf_map_lookup_elem(&ssl_sock_by_ctx, &key);
     if (ssl_sock == NULL) {
-        // Best-effort fallback mechanism to guess the socket address without
-        // intercepting the SSL socket initialization. This improves the the quality
-        // of data for TLS connections started *prior* to system-probe
-        // initialization. Here we simply store the pid_tgid along with its
-        // corresponding ssl_ctx pointer. In another probe (tcp_sendmsg), we
-        // query again this map and if there is a match we assume that the *sock
-        // object is the the TCP socket being used by this SSL connection. The
-        // whole thing works based on the assumption that SSL_read/SSL_write is
-        // then followed by the execution of tcp_sendmsg within the same CPU
-        // context. This is not necessarily true for all cases (such as when
-        // using the async SSL API) but seems to work on most-cases.
-        bpf_map_update_with_telemetry(ssl_ctx_by_pid_tgid, &pid_tgid, &ssl_ctx, BPF_ANY);
+        // SUSM-146: Disable the fallback mechanism that guesses socket address
+        // by storing ssl_ctx keyed by pid_tgid then consuming it in tcp_sendmsg.
+        // In single-threaded proxies (HAProxy, Nginx) this causes TLS context
+        // from frontend connections to be misassociated with plaintext backend
+        // sockets, leading to endpoint misattribution between services.
+        // bpf_map_update_with_telemetry(ssl_ctx_by_pid_tgid, &pid_tgid, &ssl_ctx, BPF_ANY);
         return NULL;
     }
 

--- a/pkg/network/ebpf/c/protocols/tls/native-tls.h
+++ b/pkg/network/ebpf/c/protocols/tls/native-tls.h
@@ -9,9 +9,7 @@
 
 SEC("uprobe/SSL_do_handshake")
 int BPF_BYPASSABLE_UPROBE(uprobe__SSL_do_handshake, void *ssl_ctx) {
-    u64 pid_tgid = bpf_get_current_pid_tgid();
-    log_debug("uprobe/SSL_do_handshake: pid_tgid=%llx ssl_ctx=%p", pid_tgid, ssl_ctx);
-    bpf_map_update_with_telemetry(ssl_ctx_by_pid_tgid, &pid_tgid, &ssl_ctx, BPF_ANY);
+    // SUSM-146: Disable fallback — see tup_from_ssl_ctx comment in https.h
     return 0;
 }
 
@@ -25,9 +23,7 @@ int BPF_BYPASSABLE_URETPROBE(uretprobe__SSL_do_handshake) {
 
 SEC("uprobe/SSL_connect")
 int BPF_BYPASSABLE_UPROBE(uprobe__SSL_connect, void *ssl_ctx) {
-    u64 pid_tgid = bpf_get_current_pid_tgid();
-    log_debug("uprobe/SSL_connect: pid_tgid=%llx ssl_ctx=%p", pid_tgid, ssl_ctx);
-    bpf_map_update_with_telemetry(ssl_ctx_by_pid_tgid, &pid_tgid, &ssl_ctx, BPF_ANY);
+    // SUSM-146: Disable fallback — see tup_from_ssl_ctx comment in https.h
     return 0;
 }
 
@@ -378,8 +374,7 @@ int BPF_BYPASSABLE_UPROBE(uprobe__SSL_shutdown, void *ssl_ctx) {
 
 SEC("uprobe/gnutls_handshake")
 int BPF_BYPASSABLE_UPROBE(uprobe__gnutls_handshake, void *ssl_ctx) {
-    u64 pid_tgid = bpf_get_current_pid_tgid();
-    bpf_map_update_with_telemetry(ssl_ctx_by_pid_tgid, &pid_tgid, &ssl_ctx, BPF_ANY);
+    // SUSM-146: Disable fallback — see tup_from_ssl_ctx comment in https.h
     return 0;
 }
 


### PR DESCRIPTION
## Summary

- Disables the `ssl_ctx_by_pid_tgid` fallback mechanism in `tup_from_ssl_ctx` that causes endpoint misattribution in single-threaded TLS-terminating proxies (HAProxy, Nginx)
- When system-probe restarts, pre-existing TLS connections miss `SSL_set_fd`, so the fallback stores `ssl_ctx` keyed by `pid_tgid`. In a single-threaded proxy, the next `tcp_sendmsg` (on a plaintext backend socket) consumes this entry, incorrectly associating the TLS context with the backend connection
- Pre-existing TLS connections will no longer be tracked after restart (no data instead of wrong data)

## Test plan

- [x] Local reproduction with HAProxy on 7.68.x: misattribution 10.5% → 0% after restart
- [x] Local reproduction with Nginx on 7.68.x: misattribution 4.8% → 0% after restart
- [ ] Build custom agent image for customer validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)