### PR TITLE
[OTAGENT-889] group AgentPayloads by tracer hostname in gateway mode

### DIFF
--- a/comp/trace/config/setup.go
+++ b/comp/trace/config/setup.go
@@ -683,6 +683,7 @@ func applyDatadogConfig(c *config.AgentConfig, core corecompcfg.Component) error
 	if k := "apm_config.mode"; core.IsConfigured(k) {
 		c.APMMode = normalizeAPMMode(core.GetString(k))
 	}
+	c.GatewayMode = core.GetBool("otelcollector.gateway.mode")
 	c.SendAllInternalStats = core.GetBool("apm_config.send_all_internal_stats") // default is false
 	c.DebugServerPort = core.GetInt("apm_config.debug.port")
 	c.ContainerTagsBuffer = core.GetBool("apm_config.enable_container_tags_buffer")

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -558,6 +558,10 @@ type AgentConfig struct {
 	// APMMode specifies whether using "edge" APM mode. May support other modes in the future. If unset, it has no impact.
 	APMMode string
 
+	// GatewayMode specifies whether the agent is running in OTel collector gateway mode.
+	// In gateway mode the agent forwards traffic and does not claim a host identity.
+	GatewayMode bool
+
 	// SecretsRefreshFn is called when a 403 response is received to trigger
 	// API key refresh from the secrets backend. It blocks until the refresh
 	// completes and returns a message and any error encountered.

--- a/pkg/trace/writer/trace.go
+++ b/pkg/trace/writer/trace.go
@@ -88,6 +88,9 @@ type TraceWriter struct {
 	compressor compression.Component
 	// apmMode exists here to propagate the value to the AgentPayload
 	apmMode string
+	// gatewayMode, when true, causes flushPayloads to group TracerPayloads by
+	// their Hostname and emit a separate AgentPayload per unique hostname.
+	gatewayMode bool
 }
 
 // NewTraceWriter returns a new TraceWriter. It is created for the given agent configuration and
@@ -121,6 +124,7 @@ func NewTraceWriter(
 		timing:             timing,
 		compressor:         compressor,
 		apmMode:            cfg.APMMode,
+		gatewayMode:        cfg.GatewayMode,
 	}
 	climit := cfg.TraceWriter.ConnectionLimit
 	if climit == 0 {
@@ -269,6 +273,33 @@ func (w *TraceWriter) flushPayloads(payloads []*pb.TracerPayload) {
 	}
 
 	defer w.timing.Since("datadog.trace_agent.trace_writer.encode_ms", time.Now())
+
+	if w.gatewayMode {
+		// In gateway mode the agent has no host identity. Group payloads by the
+		// tracer-reported hostname and emit a separate AgentPayload per host so
+		// the backend can attribute traces to the correct originating host.
+		groups := make(map[string][]*pb.TracerPayload, len(payloads))
+		for _, tp := range payloads {
+			groups[tp.Hostname] = append(groups[tp.Hostname], tp)
+		}
+		for hostname, group := range groups {
+			log.Debugf("Serializing %d tracer payloads for hostname %q.", len(group), hostname)
+			p := pb.AgentPayload{
+				AgentVersion:       w.agentVersion,
+				HostName:           hostname,
+				Env:                w.env,
+				TargetTPS:          w.prioritySampler.GetTargetTPS(),
+				ErrorTPS:           w.errorsSampler.GetTargetTPS(),
+				RareSamplerEnabled: w.rareSampler.IsEnabled(),
+				TracerPayloads:     group,
+			}
+			if w.apmMode != "" {
+				p.Tags = map[string]string{tagAPMMode: w.apmMode}
+			}
+			w.serialize(&p)
+		}
+		return
+	}
 
 	log.Debugf("Serializing %d tracer payloads.", len(payloads))
 	p := pb.AgentPayload{

--- a/pkg/trace/writer/trace_test.go
+++ b/pkg/trace/writer/trace_test.go
@@ -445,6 +445,49 @@ func TestTraceWriterAPMMode(t *testing.T) {
 	}
 }
 
+func TestTraceWriterGatewayMode(t *testing.T) {
+	srv := newTestServer()
+	defer srv.Close()
+	cfg := &config.AgentConfig{
+		Hostname:   "",
+		DefaultEnv: testEnv,
+		Endpoints: []*config.Endpoint{{
+			APIKey: "123",
+			Host:   srv.URL,
+		}},
+		TraceWriter:         &config.WriterConfig{ConnectionLimit: 200, QueueSize: 40},
+		SynchronousFlushing: true,
+		GatewayMode:         true,
+	}
+	tw := NewTraceWriter(cfg, mockSampler, mockSampler, mockSampler, telemetry.NewNoopCollector(), &statsd.NoOpClient{}, &timing.NoopReporter{}, gzip.NewComponent())
+	defer tw.Stop()
+
+	// Send two payloads from different hosts
+	chunkA := randomSampledSpans(5, 0)
+	chunkA.TracerPayload.Hostname = "host-a"
+	chunkB := randomSampledSpans(5, 0)
+	chunkB.TracerPayload.Hostname = "host-b"
+	tw.WriteChunks(chunkA)
+	tw.WriteChunks(chunkB)
+	err := tw.FlushSync()
+	require.Nil(t, err)
+
+	// Expect two separate AgentPayloads, one per unique tracer hostname
+	require.Len(t, srv.payloads, 2)
+	hostnames := make(map[string]bool)
+	for _, p := range srv.payloads {
+		ap, err := deserializePayload(*p, tw.compressor)
+		require.Nil(t, err)
+		hostnames[ap.HostName] = true
+		// All TracerPayloads in a given AgentPayload share the same hostname
+		for _, tp := range ap.TracerPayloads {
+			assert.Equal(t, ap.HostName, tp.Hostname)
+		}
+	}
+	assert.True(t, hostnames["host-a"], "expected AgentPayload for host-a")
+	assert.True(t, hostnames["host-b"], "expected AgentPayload for host-b")
+}
+
 func TestTraceWriterUpdateAPIKey(t *testing.T) {
 	assert := assert.New(t)
 	srv := newTestServer()

--- a/releasenotes/notes/otel-gateway-hostname-grouping-153006d65b.yaml
+++ b/releasenotes/notes/otel-gateway-hostname-grouping-153006d65b.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    In OTel collector gateway mode, the trace agent now groups outgoing payloads by the tracer-reported hostname so each ``AgentPayload`` is attributed to the correct originating host instead of being sent with an empty hostname.

--- a/test/new-e2e/tests/otel/otel-agent/gateway_test.go
+++ b/test/new-e2e/tests/otel/otel-agent/gateway_test.go
@@ -76,13 +76,16 @@ func (s *gatewayTestSuite) SetupSuite() {
 func (s *gatewayTestSuite) TestOTLPTraces() {
 	utils.TestTraces(s, gatewayParams)
 
-	// In gateway mode, the agent hostname should be empty (not set)
-	// because the gateway agent acts as a forwarder and doesn't represent a specific host.
+	// In gateway mode, the agent has no host identity of its own. Instead,
+	// payloads are grouped by the tracer-reported hostname so each AgentPayload
+	// carries the hostname of the originating service rather than the gateway.
 	traces, err := s.Env().FakeIntake.Client().GetTraces()
 	require.NoError(s.T(), err)
 	require.NotEmpty(s.T(), traces)
 	for _, trace := range traces {
-		assert.Empty(s.T(), trace.HostName, "agent hostname should be empty in gateway mode")
+		require.NotEmpty(s.T(), trace.TracerPayloads)
+		assert.Equal(s.T(), trace.TracerPayloads[0].Hostname, trace.HostName,
+			"AgentPayload.HostName should match the tracer-reported hostname in gateway mode")
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?
In otelcollector.gateway.mode the trace agent acts as a forwarder with no host identity of its own (AgentConfig.Hostname is intentionally ""). Previously all TracerPayloads were wrapped in a single AgentPayload with an empty HostName, losing the originating host information.

This change groups the buffered TracerPayloads by their Hostname field and emits a separate AgentPayload per unique hostname so the backend can attribute traces to the correct originating host.

- Add AgentConfig.GatewayMode bool, populated from otelcollector.gateway.mode
- Add TraceWriter.gatewayMode bool, set from AgentConfig
- Modify flushPayloads to group by TracerPayload.Hostname when gatewayMode is true
- Update TestOTLPTraces e2e assertion to match new behavior

### Motivation
Fix the APM under-billing issue in DDOT gateway. Follow up of https://github.com/DataDog/datadog-agent/pull/46466.

### Describe how you validated your changes
Will deploy & test the rc image in my test cluster and org

### Additional Notes
