### PR TITLE
Fix disk check label tags missing when blkid lacks permissions

### DIFF
--- a/pkg/collector/corechecks/system/disk/diskv2/disk.go
+++ b/pkg/collector/corechecks/system/disk/diskv2/disk.go
@@ -714,7 +714,16 @@ func (c *Check) fetchAllDeviceLabels() error {
 	if c.instanceConfig.BlkidCacheFile != "" {
 		return c.fetchAllDeviceLabelsFromBlkidCache()
 	}
-	return c.fetchAllDeviceLabelsFromBlkid()
+	err := c.fetchAllDeviceLabelsFromBlkid()
+	if err != nil {
+		log.Debugf("blkid failed (%s), falling back to lsblk", err)
+		return c.fetchAllDeviceLabelsFromLsblk()
+	}
+	if len(c.deviceLabels) == 0 {
+		log.Debugf("blkid returned no labels, falling back to lsblk")
+		return c.fetchAllDeviceLabelsFromLsblk()
+	}
+	return nil
 }
 
 // Factory creates a new check factory

--- a/pkg/collector/corechecks/system/disk/diskv2/disk_nix_test.go
+++ b/pkg/collector/corechecks/system/disk/diskv2/disk_nix_test.go
@@ -693,7 +693,7 @@ tag_by_label: true
 	m.AssertMetricTaggedWith(t, "Gauge", "system.disk.free", []string{"device:/dev/sda2", "device_name:sda2", "label:MYLABEL2", "device_label:MYLABEL2"})
 }
 
-func TestGivenADiskCheckWithTagByLabelConfiguredTrue_WhenCheckRunsAndBlkidReturnsError_ThenBlkidLabelsAreNotReportedAsTags(t *testing.T) {
+func TestGivenADiskCheckWithTagByLabelConfiguredTrue_WhenCheckRunsAndBlkidReturnsError_ThenFallsBackToLsblk(t *testing.T) {
 	setupDefaultMocks()
 	diskv2.BlkidCommand = func() (string, error) {
 		return "", errors.New("error calling blkid")
@@ -703,6 +703,45 @@ func TestGivenADiskCheckWithTagByLabelConfiguredTrue_WhenCheckRunsAndBlkidReturn
 tag_by_label: true
 `))
 	m := configureCheck(t, diskCheck, config, nil)
+	err := diskCheck.Run()
+
+	assert.Nil(t, err)
+	m.AssertMetricTaggedWith(t, "Gauge", "system.disk.total", []string{"device:/dev/sda1", "device_name:sda1", "label:MYLABEL1", "device_label:MYLABEL1"})
+	m.AssertMetricTaggedWith(t, "Gauge", "system.disk.used", []string{"device:/dev/sda1", "device_name:sda1", "label:MYLABEL1", "device_label:MYLABEL1"})
+	m.AssertMetricTaggedWith(t, "Gauge", "system.disk.free", []string{"device:/dev/sda1", "device_name:sda1", "label:MYLABEL1", "device_label:MYLABEL1"})
+	m.AssertMetricTaggedWith(t, "Gauge", "system.disk.total", []string{"device:/dev/sda2", "device_name:sda2", "label:MYLABEL2", "device_label:MYLABEL2"})
+	m.AssertMetricTaggedWith(t, "Gauge", "system.disk.used", []string{"device:/dev/sda2", "device_name:sda2", "label:MYLABEL2", "device_label:MYLABEL2"})
+	m.AssertMetricTaggedWith(t, "Gauge", "system.disk.free", []string{"device:/dev/sda2", "device_name:sda2", "label:MYLABEL2", "device_label:MYLABEL2"})
+}
+
+func TestGivenADiskCheckWithDefaultConfig_WhenBlkidReturnsNoLabels_ThenFallsBackToLsblk(t *testing.T) {
+	setupDefaultMocks()
+	diskv2.BlkidCommand = func() (string, error) {
+		return "", nil
+	}
+	diskCheck := createDiskCheck(t)
+	m := configureCheck(t, diskCheck, nil, nil)
+	err := diskCheck.Run()
+
+	assert.Nil(t, err)
+	m.AssertMetricTaggedWith(t, "Gauge", "system.disk.total", []string{"device:/dev/sda1", "device_name:sda1", "label:MYLABEL1", "device_label:MYLABEL1"})
+	m.AssertMetricTaggedWith(t, "Gauge", "system.disk.used", []string{"device:/dev/sda1", "device_name:sda1", "label:MYLABEL1", "device_label:MYLABEL1"})
+	m.AssertMetricTaggedWith(t, "Gauge", "system.disk.free", []string{"device:/dev/sda1", "device_name:sda1", "label:MYLABEL1", "device_label:MYLABEL1"})
+	m.AssertMetricTaggedWith(t, "Gauge", "system.disk.total", []string{"device:/dev/sda2", "device_name:sda2", "label:MYLABEL2", "device_label:MYLABEL2"})
+	m.AssertMetricTaggedWith(t, "Gauge", "system.disk.used", []string{"device:/dev/sda2", "device_name:sda2", "label:MYLABEL2", "device_label:MYLABEL2"})
+	m.AssertMetricTaggedWith(t, "Gauge", "system.disk.free", []string{"device:/dev/sda2", "device_name:sda2", "label:MYLABEL2", "device_label:MYLABEL2"})
+}
+
+func TestGivenADiskCheckWithDefaultConfig_WhenBlkidAndLsblkBothFail_ThenLabelsAreNotReportedAsTags(t *testing.T) {
+	setupDefaultMocks()
+	diskv2.BlkidCommand = func() (string, error) {
+		return "", errors.New("error calling blkid")
+	}
+	diskv2.LsblkCommand = func() (string, error) {
+		return "", errors.New("error calling lsblk")
+	}
+	diskCheck := createDiskCheck(t)
+	m := configureCheck(t, diskCheck, nil, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)

--- a/releasenotes/notes/disk-label-tags-blkid-lsblk-fallback-290b723e07deff2b.yaml
+++ b/releasenotes/notes/disk-label-tags-blkid-lsblk-fallback-290b723e07deff2b.yaml
@@ -1,0 +1,8 @@
+---
+enhancements:
+  - |
+    The disk check now falls back to ``lsblk`` when ``blkid`` fails or
+    returns no labels for disk label tagging. This ensures ``label`` and
+    ``device_label`` tags are present on disk metrics even when the agent
+    runs as a non-root user, since ``lsblk`` reads from sysfs and does
+    not require elevated privileges.


### PR DESCRIPTION
### What does this PR do?

When neither `use_lsblk` nor `blkid_cache_file` is explicitly configured, the disk check's `fetchAllDeviceLabels()` now falls back to `lsblk` if `blkid` errors or returns no labels. Previously it only tried `blkid` and silently dropped labels on failure.

### Motivation

Fixes #6460.

When the agent runs as a non-root user (e.g. `dd-agent`), `blkid` may fail or return empty output because it cannot probe block devices without an existing cache file (`/run/blkid/blkid.tab`). This causes disk metrics to be missing `label:` and `device_label:` tags. The tags only appear after a user manually runs `datadog-agent check disk` as root, which creates the blkid cache as a side effect.

`lsblk` reads from sysfs and does not require root privileges, making it a reliable fallback.

### Describe how you validated your changes

- Updated existing test to verify fallback from blkid error to lsblk (`TestGivenADiskCheckWithTagByLabelConfiguredTrue_WhenCheckRunsAndBlkidReturnsError_ThenFallsBackToLsblk`)
- Added new test for fallback when blkid succeeds but returns empty output (`TestGivenADiskCheckWithDefaultConfig_WhenBlkidReturnsNoLabels_ThenFallsBackToLsblk`)
- Added new test for graceful degradation when both blkid and lsblk fail (`TestGivenADiskCheckWithDefaultConfig_WhenBlkidAndLsblkBothFail_ThenLabelsAreNotReportedAsTags`)
- All 15 label-related tests pass, along with the full disk check test suite

### Additional Notes

- When `use_lsblk` or `blkid_cache_file` is explicitly configured, behavior is unchanged — the user's explicit choice is respected.
- The fallback only applies in the default code path (neither option configured).
- This is minimally disruptive: users where `blkid` works (e.g. agent running as root) see no behavior change.