### PR TITLE
fix(release): Handle missing Jira project in chase_for_qa_cards

### DIFF
--- a/tasks/release.py
+++ b/tasks/release.py
@@ -1206,7 +1206,15 @@ def chase_for_qa_cards(_, version):
     client = WebClient(os.environ["SLACK_DATADOG_AGENT_BOT_TOKEN"])
     print(f"Found {len(cards)} QA cards to chase")
     for project, cards in grouped_cards.items():
-        team = next(team for team, jira_project in GITHUB_JIRA_MAP.items() if project == jira_project)
+        try:
+            team = next(team for team, jira_project in GITHUB_JIRA_MAP.items() if project == jira_project)
+        except StopIteration:
+            client.chat_postMessage(
+                channel="#agent-devx-ops",
+                text=f"Issue in qa_card chase, no team found for project {project} for cards {', '.join([card['key'] for card in cards])}",
+            )
+            print(f"No team found for project {project}")
+            continue
         channel = GITHUB_SLACK_MAP[team]
         print(f" - {channel} for {[card['key'] for card in cards]}")
         card_links = ", ".join(


### PR DESCRIPTION
### What does this PR do?

Adds error handling in `chase_for_qa_cards` when a Jira project from QA cards has no matching team in `GITHUB_JIRA_MAP`. Instead of crashing with a `StopIteration` exception, the function now:
- Posts an alert message to `#agent-devx-ops` Slack channel identifying the unmapped project and affected cards
- Logs the issue to stdout
- Continues processing the remaining cards

### Motivation

If a new Jira project appears in QA cards but hasn't been added to `GITHUB_JIRA_MAP` yet, the entire chase task crashes and no team gets notified. This fix ensures the task is resilient to unmapped projects while making the gap visible via Slack alerting.

### Describe how you validated your changes

Reviewed the code path and confirmed the `StopIteration` scenario when `next()` finds no match.

### Additional Notes

None.