### PR TITLE
NCM: Fix ssh timeout parsing

### DIFF
--- a/pkg/networkconfigmanagement/config/config.go
+++ b/pkg/networkconfigmanagement/config/config.go
@@ -319,6 +319,14 @@ func (sc *SSHConfig) validate() error {
 	if sc.Timeout <= 0 {
 		log.Debugf("no or invalid SSH timeout specified in config, applying default: %d", defaultSSHTimeout)
 		sc.Timeout = defaultSSHTimeout
+	} else if sc.Timeout < time.Millisecond {
+		// bug - we released this as time.Duration, which when customers inserted values as integers like "30" for 30 seconds,
+		// it was being interpreted as 30 nanoseconds which caused connection timeout issues. Some customers migrated
+		// to duration formats like "30s" - but we generally don't want this to be the standard behavior or to document this.
+		// To maintain backwards compatibility, we will apply a transform for any values that are less than
+		// 1 Millisecond (1,000,000 nanoseconds) to be interpreted as seconds and convert them to the appropriate duration value.
+		log.Debugf("SSH timeout value %d is too low, applying transform to interpret as seconds: %d", sc.Timeout, sc.Timeout*time.Second)
+		sc.Timeout = sc.Timeout * time.Second
 	}
 	if err := sc.hasRequiredFields(); err != nil {
 		return err

--- a/pkg/networkconfigmanagement/config/config_test.go
+++ b/pkg/networkconfigmanagement/config/config_test.go
@@ -219,3 +219,40 @@ func TestAuthCredentials_DefaultValues(t *testing.T) {
 	assert.Equal(t, "22", config.Auth.Port)
 	assert.Equal(t, "tcp", config.Auth.Protocol)
 }
+
+func TestParsingYamlFields(t *testing.T) {
+	t.Run("ssh timeouts are parsed from duration strings", func(t *testing.T) {
+		initConfig := `
+namespace: default
+ssh:
+  insecure_skip_verify: true
+  timeout: 1m30s
+`
+		instanceConfig := `
+ip_address: 192.168.0.1
+auth:
+  password: 'password'
+  username: 'admin'
+`
+		cfg, err := NewNcmCheckContext([]byte(instanceConfig), []byte(initConfig))
+		require.NoError(t, err)
+		assert.Equal(t, 90*time.Second, cfg.Device.Auth.SSH.Timeout, "it should parse the timeout duration correctly with units")
+
+		initConfig = `
+namespace: default
+ssh:
+  insecure_skip_verify: true
+  timeout: 60
+`
+		instanceConfig = `
+ip_address: 192.168.0.1
+auth:
+  password: 'password'
+  username: 'admin'
+`
+		cfg, err = NewNcmCheckContext([]byte(instanceConfig), []byte(initConfig))
+		require.NoError(t, err)
+		assert.Equal(t, 60*time.Nanosecond, cfg.Device.Auth.SSH.Timeout, "when there is no unit, it assumes nanoseconds")
+	})
+
+}

--- a/pkg/networkconfigmanagement/config/config_test.go
+++ b/pkg/networkconfigmanagement/config/config_test.go
@@ -220,13 +220,51 @@ func TestAuthCredentials_DefaultValues(t *testing.T) {
 	assert.Equal(t, "tcp", config.Auth.Protocol)
 }
 
-func TestParsingYamlFields(t *testing.T) {
-	t.Run("ssh timeouts are parsed from duration strings", func(t *testing.T) {
+func TestParsingSSHTimeoutFromYAML(t *testing.T) {
+	var tests = []struct {
+		name     string
+		timeout  string
+		expected time.Duration
+	}{
+		{
+			// we directed customers to specify this option as a timeout string, and want to maintain backwards compatibility for now.
+			name:     "duration string with units",
+			timeout:  "1m30s",
+			expected: 90 * time.Second,
+		},
+		{
+			name:     "duration string without units",
+			timeout:  "60",
+			expected: 60 * time.Second,
+		},
+		{
+			name:     "duration string with only seconds unit",
+			timeout:  "45s",
+			expected: 45 * time.Second,
+		},
+		{
+			name:     "upper boundary for conversion",
+			timeout:  "999999",
+			expected: 999999 * time.Second,
+		},
+		{
+			name:     "upper boundary for conversion",
+			timeout:  "1000000",
+			expected: time.Millisecond,
+		},
+		{
+			name:     "negative duration string",
+			timeout:  "-30s",
+			expected: defaultSSHTimeout, // should fall back to default on error
+		},
+	}
+
+	var newConfigs = func(timeout string) ([]byte, []byte) {
 		initConfig := `
 namespace: default
 ssh:
   insecure_skip_verify: true
-  timeout: 1m30s
+  timeout: ` + timeout + `
 `
 		instanceConfig := `
 ip_address: 192.168.0.1
@@ -234,25 +272,15 @@ auth:
   password: 'password'
   username: 'admin'
 `
-		cfg, err := NewNcmCheckContext([]byte(instanceConfig), []byte(initConfig))
-		require.NoError(t, err)
-		assert.Equal(t, 90*time.Second, cfg.Device.Auth.SSH.Timeout, "it should parse the timeout duration correctly with units")
+		return []byte(initConfig), []byte(instanceConfig)
+	}
 
-		initConfig = `
-namespace: default
-ssh:
-  insecure_skip_verify: true
-  timeout: 60
-`
-		instanceConfig = `
-ip_address: 192.168.0.1
-auth:
-  password: 'password'
-  username: 'admin'
-`
-		cfg, err = NewNcmCheckContext([]byte(instanceConfig), []byte(initConfig))
-		require.NoError(t, err)
-		assert.Equal(t, 60*time.Nanosecond, cfg.Device.Auth.SSH.Timeout, "when there is no unit, it assumes nanoseconds")
-	})
-
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			initConfig, instanceConfig := newConfigs(tt.timeout)
+			cfg, err := NewNcmCheckContext(instanceConfig, initConfig)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, cfg.Device.Auth.SSH.Timeout)
+		})
+	}
 }

--- a/releasenotes/notes/network-configuration-management-ssh-timeouts-config-a054d003b7a074fb.yaml
+++ b/releasenotes/notes/network-configuration-management-ssh-timeouts-config-a054d003b7a074fb.yaml
@@ -10,6 +10,6 @@ fixes:
   - |
     Fixes a bug in the Network Configuration Management (NCM) module where the SSH Timeout settings were parsed as
     nanoseconds instead of seconds. This issue caused SSH sessions to time out prematurely, leading to errors like:
-    ```
-    Error running check: failed to connect to 192.168.0.1:22: dial tcp 192.168.0.1:22: i/o timeout
-    ```
+      ```
+      Error running check: failed to connect to 192.168.0.1:22: dial tcp 192.168.0.1:22: i/o timeout
+      ```

--- a/releasenotes/notes/network-configuration-management-ssh-timeouts-config-a054d003b7a074fb.yaml
+++ b/releasenotes/notes/network-configuration-management-ssh-timeouts-config-a054d003b7a074fb.yaml
@@ -1,0 +1,15 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes a bug in the Network Configuration Management (NCM) module where the SSH Timeout settings were parsed as
+    nanoseconds instead of seconds. This issue caused SSH sessions to time out prematurely, leading to errors like:
+    ```
+    Error running check: failed to connect to 192.168.0.1:22: dial tcp 192.168.0.1:22: i/o timeout
+    ```


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue reported by customers where our timeout was being parsed as nanoseconds. Because some customers have already migrated to use the string representation, I'd like to avoid having to re-migrate them when this patch hits them

### Motivation
A couple customers have reported seeing I/O timeouts, and it looks like the root cause is bad ssh timeouts from their conf.yaml. This PR adds tests to validate how we parse from yaml, and also specifically around this SSH timeout value.

Because customers have already started putting strings in this value, it is hard for us to replace this with int. It leads to an error:
```
failed to unmarshal init config: yaml: unmarshal errors:
  line 5: cannot unmarshal !!str `1m30s` into int
```