### PR TITLE
[NETPATH-656] Downgrade network ID fetch failure log from Error to Warn

### DIFF
--- a/pkg/networkpath/traceroute/runner/runner.go
+++ b/pkg/networkpath/traceroute/runner/runner.go
@@ -93,7 +93,7 @@ func New(telemetryComp telemetryComponent.Component) (*Runner, error) {
 		networkID: funcs.MemoizeNoError(func() string {
 			nid, err := retryGetNetworkID()
 			if err != nil {
-				log.Errorf("failed to get network ID: %s", err.Error())
+				log.Warnf("failed to get network ID: %s", err.Error())
 			}
 			return nid
 		}),


### PR DESCRIPTION
https://datadoghq.atlassian.net/browse/NETPATH-656
# Plan: Reduce Log Level for Network ID Fetch Failure

## Problem

In `runner.go`, when `retryGetNetworkID()` exhausts all retries, the failure is
logged at `Error` level:

```go
// runner.go:96
log.Errorf("failed to get network ID: %s", err.Error())
```

This is misleading to customers because:

- The network ID is **enrichment-only metadata** — it populates `Source.NetworkID`
  in the traceroute payload but does not affect the correctness or completeness of
  the traceroute itself.
- The underlying function (`retryGetNetworkID`) already retries 4 times with
  backoff and logs each attempt at `Debug`, so there is already adequate
  observability for debugging.
- The docstring on `retryGetNetworkID` acknowledges that the cloud provider
  metadata endpoint "is sometimes unavailable during host startup", indicating
  this is a known transient condition rather than a hard failure.

## Code Path

```
New() (runner.go:80)
  └─ MemoizeNoError closure (runner.go:93)
       └─ retryGetNetworkID() (runner.go:265)
            └─ cloudprovidersnetwork.GetNetworkID() — retried 4x with backoff
            └─ on failure: returns ("", error)
       └─ log.Errorf(...) ← misleading  (runner.go:96)
       └─ returns ""
  └─ networkID stored as memoized func on Runner

Run() (runner.go:114)
  └─ r.networkID() called once, result set on payload.NetworkPath.Source.NetworkID
```

## Proposed Fix

Change line 96 from `Errorf` to `Warnf`:

```go
// Before
log.Errorf("failed to get network ID: %s", err.Error())

// After
log.Warnf("failed to get network ID: %s", err.Error())
```

## Rationale for `Warn` over `Info`

- `Warn` reflects a genuinely degraded state: network path data will be missing
  `NetworkID`, which can affect enrichment and correlation in the Datadog backend.
- `Info` would be too quiet — a customer debugging missing network ID enrichment
  would likely overlook it.
- `Warn` is consistent with the adjacent log at line 86, which uses `Warnf` for
  a similarly non-fatal `gatewayLookup` issue.

## Affected File

- `pkg/networkpath/traceroute/runner/runner.go` — line 96, one-line change
