### PR TITLE
remove system-probe module config namespaces

### DIFF
--- a/.cursor/rules/system_probe_modules.mdc
+++ b/.cursor/rules/system_probe_modules.mdc
@@ -187,7 +187,6 @@ func (t *Tracer) GetAndFlush() model.Stats {
 ```go
 var MyModule = &module.Factory{
     Name:             config.MyModuleName,
-    ConfigNamespaces: []string{},
     Fn: func(_ *sysconfigtypes.Config, _ module.FactoryDependencies) (module.Module, error) {
         t, err := probe.NewTracer(ebpf.NewConfig())
         if err != nil {

--- a/cmd/system-probe/api/config.go
+++ b/cmd/system-probe/api/config.go
@@ -8,27 +8,15 @@ package api
 import (
 	"github.com/gorilla/mux"
 
-	"github.com/DataDog/datadog-agent/cmd/system-probe/modules"
 	"github.com/DataDog/datadog-agent/comp/core/settings"
-	"github.com/DataDog/datadog-agent/pkg/system-probe/config"
 )
 
 // setupConfigHandlers adds the specific handlers for /config endpoints
 func setupConfigHandlers(r *mux.Router, settings settings.Component) {
-	r.HandleFunc("/config", settings.GetFullConfig(getAggregatedNamespaces()...)).Methods("GET")
-	r.HandleFunc("/config/without-defaults", settings.GetFullConfigWithoutDefaults(getAggregatedNamespaces()...)).Methods("GET")
+	r.HandleFunc("/config", settings.GetFullConfig("")).Methods("GET")
+	r.HandleFunc("/config/without-defaults", settings.GetFullConfigWithoutDefaults("")).Methods("GET")
 	r.HandleFunc("/config/by-source", settings.GetFullConfigBySource()).Methods("GET")
 	r.HandleFunc("/config/list-runtime", settings.ListConfigurable).Methods("GET")
 	r.HandleFunc("/config/{setting}", settings.GetValue).Methods("GET")
 	r.HandleFunc("/config/{setting}", settings.SetValue).Methods("POST")
-}
-
-func getAggregatedNamespaces() []string {
-	namespaces := []string{
-		config.Namespace,
-	}
-	for _, m := range modules.All() {
-		namespaces = append(namespaces, m.ConfigNamespaces...)
-	}
-	return namespaces
 }

--- a/cmd/system-probe/modules/AGENTS.md
+++ b/cmd/system-probe/modules/AGENTS.md
@@ -13,7 +13,6 @@ Each module is a `module.Factory` registered in `init()` with the following fiel
 ```go
 var MyModule = &module.Factory{
     Name:             config.MyModuleName,           // Unique identifier
-    ConfigNamespaces: []string{},                     // Config sections to load
     Fn:               createModule,                   // Constructor function
     NeedsEBPF:        func() bool { return true },    // eBPF requirement indicator
 }
@@ -28,10 +27,6 @@ func init() {
 - **Name**: Unique module identifier (type `types.ModuleName`)
   - Defined as constant in `pkg/system-probe/config/config.go`
   - Used to route HTTP requests to the module
-
-- **ConfigNamespaces**: List of configuration namespaces this module needs
-  - Empty list means no special config loading
-  - Module-specific configs are typically accessed via module name
 
 - **Fn**: Constructor function signature:
   ```go

--- a/cmd/system-probe/modules/compliance.go
+++ b/cmd/system-probe/modules/compliance.go
@@ -28,8 +28,6 @@ import (
 
 func init() { registerModule(ComplianceModule) }
 
-var complianceConfigNamespaces = []string{"compliance_config", "runtime_security_config"}
-
 // ComplianceModule is a system-probe module that exposes an HTTP api to
 // perform compliance checks that require more privileges than security-agent
 // can offer.
@@ -37,9 +35,8 @@ var complianceConfigNamespaces = []string{"compliance_config", "runtime_security
 // For instance, being able to run cross-container checks at runtime by directly
 // accessing the /proc/<pid>/root mount point.
 var ComplianceModule = &module.Factory{
-	Name:             config.ComplianceModule,
-	ConfigNamespaces: complianceConfigNamespaces,
-	Fn:               newComplianceModule,
+	Name: config.ComplianceModule,
+	Fn:   newComplianceModule,
 	NeedsEBPF: func() bool {
 		return false
 	},

--- a/cmd/system-probe/modules/crashdetect_windows.go
+++ b/cmd/system-probe/modules/crashdetect_windows.go
@@ -23,8 +23,7 @@ func init() { registerModule(WinCrashProbe) }
 
 // WinCrashProbe Factory
 var WinCrashProbe = &module.Factory{
-	Name:             config.WindowsCrashDetectModule,
-	ConfigNamespaces: []string{"windows_crash_detection"},
+	Name: config.WindowsCrashDetectModule,
 	Fn: func(cfg *sysconfigtypes.Config, _ module.FactoryDependencies) (module.Module, error) {
 		log.Infof("Starting the WinCrashProbe probe")
 		cp, err := probe.NewWinCrashProbe(cfg)

--- a/cmd/system-probe/modules/discovery_linux.go
+++ b/cmd/system-probe/modules/discovery_linux.go
@@ -15,9 +15,8 @@ func init() { registerModule(DiscoveryModule) }
 
 // DiscoveryModule is the discovery module factory.
 var DiscoveryModule = &module.Factory{
-	Name:             config.DiscoveryModule,
-	ConfigNamespaces: []string{"discovery"},
-	Fn:               discoverymodule.NewDiscoveryModule,
+	Name: config.DiscoveryModule,
+	Fn: discoverymodule.NewDiscoveryModule,
 	NeedsEBPF: func() bool {
 		return false
 	},

--- a/cmd/system-probe/modules/discovery_linux.go
+++ b/cmd/system-probe/modules/discovery_linux.go
@@ -16,7 +16,7 @@ func init() { registerModule(DiscoveryModule) }
 // DiscoveryModule is the discovery module factory.
 var DiscoveryModule = &module.Factory{
 	Name: config.DiscoveryModule,
-	Fn: discoverymodule.NewDiscoveryModule,
+	Fn:   discoverymodule.NewDiscoveryModule,
 	NeedsEBPF: func() bool {
 		return false
 	},

--- a/cmd/system-probe/modules/dynamic_instrumentation.go
+++ b/cmd/system-probe/modules/dynamic_instrumentation.go
@@ -28,8 +28,7 @@ func init() { registerModule(DynamicInstrumentation) }
 // DynamicInstrumentation is a system probe module which allows you to add instrumentation into
 // running Go services without restarts.
 var DynamicInstrumentation = &module.Factory{
-	Name:             config.DynamicInstrumentationModule,
-	ConfigNamespaces: []string{"dynamic_instrumentation"},
+	Name: config.DynamicInstrumentationModule,
 	Fn: func(agentConfiguration *sysconfigtypes.Config, deps module.FactoryDependencies) (module.Module, error) {
 		config, err := dimod.NewConfig(agentConfiguration)
 		if err != nil {

--- a/cmd/system-probe/modules/ebpf.go
+++ b/cmd/system-probe/modules/ebpf.go
@@ -26,8 +26,7 @@ func init() { registerModule(EBPFProbe) }
 
 // EBPFProbe Factory
 var EBPFProbe = &module.Factory{
-	Name:             config.EBPFModule,
-	ConfigNamespaces: []string{"ebpf_check"},
+	Name: config.EBPFModule,
 	Fn: func(_ *sysconfigtypes.Config, _ module.FactoryDependencies) (module.Module, error) {
 		log.Infof("Starting the ebpf probe")
 		okp, err := ebpfcheck.NewProbe(ebpf.NewConfig())

--- a/cmd/system-probe/modules/ebpf.go
+++ b/cmd/system-probe/modules/ebpf.go
@@ -27,7 +27,7 @@ func init() { registerModule(EBPFProbe) }
 // EBPFProbe Factory
 var EBPFProbe = &module.Factory{
 	Name:             config.EBPFModule,
-	ConfigNamespaces: []string{},
+	ConfigNamespaces: []string{"ebpf_check"},
 	Fn: func(_ *sysconfigtypes.Config, _ module.FactoryDependencies) (module.Module, error) {
 		log.Infof("Starting the ebpf probe")
 		okp, err := ebpfcheck.NewProbe(ebpf.NewConfig())

--- a/cmd/system-probe/modules/eventmonitor.go
+++ b/cmd/system-probe/modules/eventmonitor.go
@@ -26,8 +26,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-var eventMonitorModuleConfigNamespaces = []string{"event_monitoring_config", "runtime_security_config"}
-
 func createEventMonitorModule(_ *sysconfigtypes.Config, deps module.FactoryDependencies) (module.Module, error) {
 	emconfig := emconfig.NewConfig()
 

--- a/cmd/system-probe/modules/eventmonitor_linux.go
+++ b/cmd/system-probe/modules/eventmonitor_linux.go
@@ -24,9 +24,8 @@ func init() { registerModule(EventMonitor) }
 
 // EventMonitor - Event monitor Factory
 var EventMonitor = &module.Factory{
-	Name:             config.EventMonitorModule,
-	ConfigNamespaces: eventMonitorModuleConfigNamespaces,
-	Fn:               createEventMonitorModule,
+	Name: config.EventMonitorModule,
+	Fn:   createEventMonitorModule,
 	NeedsEBPF: func() bool {
 		return !secconfig.IsEBPFLessModeEnabled()
 	},

--- a/cmd/system-probe/modules/eventmonitor_windows.go
+++ b/cmd/system-probe/modules/eventmonitor_windows.go
@@ -18,9 +18,8 @@ func init() { registerModule(EventMonitor) }
 
 // EventMonitor - Event monitor Factory
 var EventMonitor = &module.Factory{
-	Name:             config.EventMonitorModule,
-	ConfigNamespaces: eventMonitorModuleConfigNamespaces,
-	Fn:               createEventMonitorModule,
+	Name: config.EventMonitorModule,
+	Fn:   createEventMonitorModule,
 }
 
 func createProcessMonitorConsumer(_ *eventmonitor.EventMonitor, _ *netconfig.Config) error {

--- a/cmd/system-probe/modules/gpu.go
+++ b/cmd/system-probe/modules/gpu.go
@@ -37,7 +37,6 @@ import (
 func init() { registerModule(GPUMonitoring) }
 
 var _ module.Module = &GPUMonitoringModule{}
-var gpuMonitoringConfigNamespaces = []string{gpuconfigconsts.GPUNS}
 
 // processEventConsumer is a global variable that holds the process event consumer, created in the eventmonitor module
 // Note: In the future we should have a better way to handle dependencies between modules
@@ -53,8 +52,7 @@ var processConsumerEventTypes = []consumers.ProcessConsumerEventTypes{consumers.
 
 // GPUMonitoring Factory
 var GPUMonitoring = &module.Factory{
-	Name:             config.GPUMonitoringModule,
-	ConfigNamespaces: gpuMonitoringConfigNamespaces,
+	Name: config.GPUMonitoringModule,
 	Fn: func(_ *sysconfigtypes.Config, deps module.FactoryDependencies) (module.Module, error) {
 		if processEventConsumer == nil {
 			return nil, errors.New("process event consumer not initialized")

--- a/cmd/system-probe/modules/injector_windows.go
+++ b/cmd/system-probe/modules/injector_windows.go
@@ -35,8 +35,7 @@ var _ module.Module = &injectorModule{}
 
 // Injector Factory
 var Injector = &module.Factory{
-	Name:             config.InjectorModule,
-	ConfigNamespaces: []string{"injector"},
+	Name: config.InjectorModule,
 	Fn: func(_ *sysconfigtypes.Config, deps module.FactoryDependencies) (module.Module, error) {
 		log.Infof("Creating Windows Injector module")
 

--- a/cmd/system-probe/modules/injector_windows.go
+++ b/cmd/system-probe/modules/injector_windows.go
@@ -13,6 +13,8 @@ import (
 
 	"go.uber.org/atomic"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/system-probe/api/module"
@@ -20,7 +22,6 @@ import (
 	sysconfigtypes "github.com/DataDog/datadog-agent/pkg/system-probe/config/types"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/windowsdriver/ddinjector"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 const (
@@ -35,7 +36,7 @@ var _ module.Module = &injectorModule{}
 // Injector Factory
 var Injector = &module.Factory{
 	Name:             config.InjectorModule,
-	ConfigNamespaces: []string{},
+	ConfigNamespaces: []string{"injector"},
 	Fn: func(_ *sysconfigtypes.Config, deps module.FactoryDependencies) (module.Module, error) {
 		log.Infof("Creating Windows Injector module")
 

--- a/cmd/system-probe/modules/language_detection.go
+++ b/cmd/system-probe/modules/language_detection.go
@@ -27,8 +27,8 @@ func init() { registerModule(LanguageDetectionModule) }
 
 // LanguageDetectionModule is the language detection module factory
 var LanguageDetectionModule = &module.Factory{
-	Name:             config.LanguageDetectionModule,
-	ConfigNamespaces: []string{"language_detection"},
+	Name: config.LanguageDetectionModule,
+
 	Fn: func(_ *sysconfigtypes.Config, _ module.FactoryDependencies) (module.Module, error) {
 		return &languageDetectionModule{
 			languageDetector: privileged.NewLanguageDetector(),

--- a/cmd/system-probe/modules/language_detection.go
+++ b/cmd/system-probe/modules/language_detection.go
@@ -28,7 +28,6 @@ func init() { registerModule(LanguageDetectionModule) }
 // LanguageDetectionModule is the language detection module factory
 var LanguageDetectionModule = &module.Factory{
 	Name: config.LanguageDetectionModule,
-
 	Fn: func(_ *sysconfigtypes.Config, _ module.FactoryDependencies) (module.Module, error) {
 		return &languageDetectionModule{
 			languageDetector: privileged.NewLanguageDetector(),

--- a/cmd/system-probe/modules/logon_duration_darwin.go
+++ b/cmd/system-probe/modules/logon_duration_darwin.go
@@ -22,8 +22,7 @@ func init() { registerModule(LogonDuration) }
 
 // LogonDuration Factory
 var LogonDuration = &module.Factory{
-	Name:             config.LogonDurationModule,
-	ConfigNamespaces: []string{"logon_duration"},
+	Name: config.LogonDurationModule,
 	Fn: func(_ *sysconfigtypes.Config, _ module.FactoryDependencies) (module.Module, error) {
 		return &logonDurationModule{}, nil
 	},

--- a/cmd/system-probe/modules/network_tracer.go
+++ b/cmd/system-probe/modules/network_tracer.go
@@ -33,9 +33,6 @@ var ErrSysprobeUnsupported = errors.New("system-probe unsupported")
 
 const inactivityLogDuration = 10 * time.Minute
 const inactivityRestartDuration = 20 * time.Minute
-
-var networkTracerModuleConfigNamespaces = []string{"network_config", "service_monitoring_config"}
-
 const maxConntrackDumpSize = 3000
 
 func createNetworkTracerModule(_ *sysconfigtypes.Config, deps module.FactoryDependencies) (module.Module, error) {

--- a/cmd/system-probe/modules/network_tracer_linux.go
+++ b/cmd/system-probe/modules/network_tracer_linux.go
@@ -26,10 +26,9 @@ func init() { registerModule(NetworkTracer) }
 
 // NetworkTracer is a factory for NPM's tracer
 var NetworkTracer = &module.Factory{
-	Name:             config.NetworkTracerModule,
-	ConfigNamespaces: networkTracerModuleConfigNamespaces,
-	Fn:               createNetworkTracerModule,
-	NeedsEBPF:        tracer.NeedsEBPF,
+	Name:      config.NetworkTracerModule,
+	Fn:        createNetworkTracerModule,
+	NeedsEBPF: tracer.NeedsEBPF,
 }
 
 func (nt *networkTracer) platformRegister(httpMux *module.Router) error {

--- a/cmd/system-probe/modules/network_tracer_windows.go
+++ b/cmd/system-probe/modules/network_tracer_windows.go
@@ -22,9 +22,8 @@ func init() { registerModule(NetworkTracer) }
 
 // NetworkTracer is a factory for NPM's tracer
 var NetworkTracer = &module.Factory{
-	Name:             config.NetworkTracerModule,
-	ConfigNamespaces: networkTracerModuleConfigNamespaces,
-	Fn:               createNetworkTracerModule,
+	Name: config.NetworkTracerModule,
+	Fn:   createNetworkTracerModule,
 }
 
 func (nt *networkTracer) platformRegister(httpMux *module.Router) error {

--- a/cmd/system-probe/modules/noisy_neighbor.go
+++ b/cmd/system-probe/modules/noisy_neighbor.go
@@ -26,8 +26,7 @@ func init() { registerModule(NoisyNeighbor) }
 
 // NoisyNeighbor Factory
 var NoisyNeighbor = &module.Factory{
-	Name:             config.NoisyNeighborModule,
-	ConfigNamespaces: []string{"noisy_neighbor"},
+	Name: config.NoisyNeighborModule,
 	Fn: func(_ *sysconfigtypes.Config, _ module.FactoryDependencies) (module.Module, error) {
 		log.Infof("Starting the noisy neighbor module")
 		p, err := noisyneighbor.NewProbe(ebpf.NewConfig())

--- a/cmd/system-probe/modules/oom_kill_probe.go
+++ b/cmd/system-probe/modules/oom_kill_probe.go
@@ -26,8 +26,7 @@ func init() { registerModule(OOMKillProbe) }
 
 // OOMKillProbe Factory
 var OOMKillProbe = &module.Factory{
-	Name:             config.OOMKillProbeModule,
-	ConfigNamespaces: []string{},
+	Name: config.OOMKillProbeModule,
 	Fn: func(_ *sysconfigtypes.Config, _ module.FactoryDependencies) (module.Module, error) {
 		log.Infof("Starting the OOM Kill probe")
 		okp, err := oomkill.NewProbe(ebpf.NewConfig())

--- a/cmd/system-probe/modules/ping.go
+++ b/cmd/system-probe/modules/ping.go
@@ -36,8 +36,8 @@ type pinger struct{}
 
 // Pinger is a factory for NDMs Ping module
 var Pinger = &module.Factory{
-	Name:             config.PingModule,
-	ConfigNamespaces: []string{"ping"},
+	Name: config.PingModule,
+
 	Fn: func(_ *sysconfigtypes.Config, _ module.FactoryDependencies) (module.Module, error) {
 		return &pinger{}, nil
 	},

--- a/cmd/system-probe/modules/ping.go
+++ b/cmd/system-probe/modules/ping.go
@@ -37,7 +37,6 @@ type pinger struct{}
 // Pinger is a factory for NDMs Ping module
 var Pinger = &module.Factory{
 	Name: config.PingModule,
-
 	Fn: func(_ *sysconfigtypes.Config, _ module.FactoryDependencies) (module.Module, error) {
 		return &pinger{}, nil
 	},

--- a/cmd/system-probe/modules/privileged_logs_linux.go
+++ b/cmd/system-probe/modules/privileged_logs_linux.go
@@ -17,7 +17,7 @@ func init() { registerModule(PrivilegedLogs) }
 // PrivilegedLogs is a module that provides privileged logs access capabilities
 var PrivilegedLogs = &module.Factory{
 	Name:             config.PrivilegedLogsModule,
-	ConfigNamespaces: []string{},
+	ConfigNamespaces: []string{"privileged_logs"},
 	Fn: func(_ *sysconfigtypes.Config, _ module.FactoryDependencies) (module.Module, error) {
 		return privilegedlogsmodule.NewPrivilegedLogsModule(), nil
 	},

--- a/cmd/system-probe/modules/privileged_logs_linux.go
+++ b/cmd/system-probe/modules/privileged_logs_linux.go
@@ -16,8 +16,7 @@ func init() { registerModule(PrivilegedLogs) }
 
 // PrivilegedLogs is a module that provides privileged logs access capabilities
 var PrivilegedLogs = &module.Factory{
-	Name:             config.PrivilegedLogsModule,
-	ConfigNamespaces: []string{"privileged_logs"},
+	Name: config.PrivilegedLogsModule,
 	Fn: func(_ *sysconfigtypes.Config, _ module.FactoryDependencies) (module.Module, error) {
 		return privilegedlogsmodule.NewPrivilegedLogsModule(), nil
 	},

--- a/cmd/system-probe/modules/process.go
+++ b/cmd/system-probe/modules/process.go
@@ -28,8 +28,7 @@ func init() { registerModule(Process) }
 
 // Process is a module that fetches process level data
 var Process = &module.Factory{
-	Name:             config.ProcessModule,
-	ConfigNamespaces: []string{},
+	Name: config.ProcessModule,
 	Fn: func(_ *sysconfigtypes.Config, _ module.FactoryDependencies) (module.Module, error) {
 		log.Infof("Creating process module for: %s", filepath.Base(os.Args[0]))
 

--- a/cmd/system-probe/modules/software_inventory.go
+++ b/cmd/system-probe/modules/software_inventory.go
@@ -24,7 +24,6 @@ func init() { registerModule(SoftwareInventory) }
 // SoftwareInventory Factory
 var SoftwareInventory = &module.Factory{
 	Name: config.SoftwareInventoryModule,
-
 	Fn: func(_ *sysconfigtypes.Config, _ module.FactoryDependencies) (module.Module, error) {
 		return &softwareInventoryModule{}, nil
 	},

--- a/cmd/system-probe/modules/software_inventory.go
+++ b/cmd/system-probe/modules/software_inventory.go
@@ -23,8 +23,8 @@ func init() { registerModule(SoftwareInventory) }
 
 // SoftwareInventory Factory
 var SoftwareInventory = &module.Factory{
-	Name:             config.SoftwareInventoryModule,
-	ConfigNamespaces: []string{"software_inventory"},
+	Name: config.SoftwareInventoryModule,
+
 	Fn: func(_ *sysconfigtypes.Config, _ module.FactoryDependencies) (module.Module, error) {
 		return &softwareInventoryModule{}, nil
 	},

--- a/cmd/system-probe/modules/tcp_queue_tracer.go
+++ b/cmd/system-probe/modules/tcp_queue_tracer.go
@@ -25,8 +25,8 @@ func init() { registerModule(TCPQueueLength) }
 
 // TCPQueueLength Factory
 var TCPQueueLength = &module.Factory{
-	Name:             config.TCPQueueLengthTracerModule,
-	ConfigNamespaces: []string{},
+	Name: config.TCPQueueLengthTracerModule,
+
 	Fn: func(_ *sysconfigtypes.Config, _ module.FactoryDependencies) (module.Module, error) {
 		t, err := tcpqueuelength.NewTracer(ebpf.NewConfig())
 		if err != nil {

--- a/cmd/system-probe/modules/tcp_queue_tracer.go
+++ b/cmd/system-probe/modules/tcp_queue_tracer.go
@@ -26,7 +26,6 @@ func init() { registerModule(TCPQueueLength) }
 // TCPQueueLength Factory
 var TCPQueueLength = &module.Factory{
 	Name: config.TCPQueueLengthTracerModule,
-
 	Fn: func(_ *sysconfigtypes.Config, _ module.FactoryDependencies) (module.Module, error) {
 		t, err := tcpqueuelength.NewTracer(ebpf.NewConfig())
 		if err != nil {

--- a/cmd/system-probe/modules/traceroute.go
+++ b/cmd/system-probe/modules/traceroute.go
@@ -34,8 +34,6 @@ type traceroute struct {
 
 var (
 	_ module.Module = &traceroute{}
-
-	tracerouteConfigNamespaces = []string{"traceroute"}
 )
 
 func createTracerouteModule(_ *sysconfigtypes.Config, deps module.FactoryDependencies) (module.Module, error) {

--- a/cmd/system-probe/modules/traceroute_darwin.go
+++ b/cmd/system-probe/modules/traceroute_darwin.go
@@ -12,9 +12,8 @@ import (
 
 // Traceroute is a factory for NDMs Traceroute module
 var Traceroute = &module.Factory{
-	Name:             config.TracerouteModule,
-	ConfigNamespaces: tracerouteConfigNamespaces,
-	Fn:               createTracerouteModule,
+	Name: config.TracerouteModule,
+	Fn:   createTracerouteModule,
 }
 
 // startPlatformDriver is a no-op on Darwin

--- a/cmd/system-probe/modules/traceroute_linux.go
+++ b/cmd/system-probe/modules/traceroute_linux.go
@@ -12,9 +12,8 @@ import (
 
 // Traceroute is a factory for NDMs Traceroute module
 var Traceroute = &module.Factory{
-	Name:             config.TracerouteModule,
-	ConfigNamespaces: tracerouteConfigNamespaces,
-	Fn:               createTracerouteModule,
+	Name: config.TracerouteModule,
+	Fn:   createTracerouteModule,
 	NeedsEBPF: func() bool {
 		return false
 	},

--- a/cmd/system-probe/modules/traceroute_windows.go
+++ b/cmd/system-probe/modules/traceroute_windows.go
@@ -14,9 +14,8 @@ import (
 
 // Traceroute is a factory for NDMs Traceroute module
 var Traceroute = &module.Factory{
-	Name:             config.TracerouteModule,
-	ConfigNamespaces: tracerouteConfigNamespaces,
-	Fn:               createTracerouteModule,
+	Name: config.TracerouteModule,
+	Fn:   createTracerouteModule,
 }
 
 // startPlatformDriver starts the Windows network driver for traceroute

--- a/pkg/system-probe/api/module/factory_linux.go
+++ b/pkg/system-probe/api/module/factory_linux.go
@@ -13,9 +13,8 @@ import (
 
 // Factory encapsulates the initialization of a Module
 type Factory struct {
-	Name             sysconfigtypes.ModuleName
-	ConfigNamespaces []string
-	Fn               func(cfg *sysconfigtypes.Config, deps FactoryDependencies) (Module, error)
-	NeedsEBPF        func() bool
-	OptionalEBPF     bool
+	Name         sysconfigtypes.ModuleName
+	Fn           func(cfg *sysconfigtypes.Config, deps FactoryDependencies) (Module, error)
+	NeedsEBPF    func() bool
+	OptionalEBPF bool
 }

--- a/pkg/system-probe/api/module/factory_others.go
+++ b/pkg/system-probe/api/module/factory_others.go
@@ -13,7 +13,6 @@ import (
 
 // Factory encapsulates the initialization of a Module
 type Factory struct {
-	Name             sysconfigtypes.ModuleName
-	ConfigNamespaces []string
-	Fn               func(cfg *sysconfigtypes.Config, deps FactoryDependencies) (Module, error)
+	Name sysconfigtypes.ModuleName
+	Fn   func(cfg *sysconfigtypes.Config, deps FactoryDependencies) (Module, error)
 }


### PR DESCRIPTION
### What does this PR do?

Removes config namespaces for system-probe modules

### Motivation

Missing information in `system-probe config` output. We no longer need to explicitly list the config namespaces for the system-probe config.

### Describe how you validated your changes

### Additional Notes
