### PR TITLE
Add AllowedPaths config to shell interpreter

### DIFF
--- a/pkg/shell/interp/allowed_paths_test.go
+++ b/pkg/shell/interp/allowed_paths_test.go
@@ -1,0 +1,186 @@
+// Copyright (c) Datadog, Inc.
+// See LICENSE for licensing information
+
+package interp_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"mvdan.cc/sh/v3/syntax"
+
+	"github.com/DataDog/datadog-agent/pkg/shell/interp"
+)
+
+func runScript(t *testing.T, script string, opts ...interp.RunnerOption) (stdout, stderr string, exitCode int) {
+	t.Helper()
+	parser := syntax.NewParser()
+	prog, err := parser.Parse(strings.NewReader(script), "")
+	require.NoError(t, err)
+
+	var outBuf, errBuf bytes.Buffer
+	allOpts := append([]interp.RunnerOption{
+		interp.StdIO(nil, &outBuf, &errBuf),
+	}, opts...)
+	runner, err := interp.New(allOpts...)
+	require.NoError(t, err)
+	defer runner.Close()
+
+	err = runner.Run(context.Background(), prog)
+	exitCode = 0
+	if err != nil {
+		var es interp.ExitStatus
+		if errors.As(err, &es) {
+			exitCode = int(es)
+		} else {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+	return outBuf.String(), errBuf.String(), exitCode
+}
+
+func TestAllowedPaths_CatAllowed(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "hello.txt"), []byte("hello\n"), 0644))
+
+	stdout, _, exitCode := runScript(t, `cat hello.txt`,
+		interp.Dir(dir),
+		interp.AllowedPaths([]string{dir}),
+	)
+	assert.Equal(t, 0, exitCode)
+	assert.Equal(t, "hello\n", stdout)
+}
+
+func TestAllowedPaths_CatBlocked(t *testing.T) {
+	allowed := t.TempDir()
+	blocked := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(blocked, "secret.txt"), []byte("secret\n"), 0644))
+
+	_, stderr, exitCode := runScript(t,
+		`cat `+filepath.Join(blocked, "secret.txt"),
+		interp.Dir(allowed),
+		interp.AllowedPaths([]string{allowed}),
+	)
+	assert.NotEqual(t, 0, exitCode)
+	assert.Contains(t, stderr, "outside allowed directories")
+}
+
+func TestAllowedPaths_RedirectAllowed(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "input.txt"), []byte("from redirect\n"), 0644))
+
+	stdout, _, exitCode := runScript(t, `cat < input.txt`,
+		interp.Dir(dir),
+		interp.AllowedPaths([]string{dir}),
+	)
+	assert.Equal(t, 0, exitCode)
+	assert.Equal(t, "from redirect\n", stdout)
+}
+
+func TestAllowedPaths_RedirectBlocked(t *testing.T) {
+	allowed := t.TempDir()
+	blocked := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(blocked, "input.txt"), []byte("secret\n"), 0644))
+
+	_, stderr, exitCode := runScript(t,
+		`cat < `+filepath.Join(blocked, "input.txt"),
+		interp.Dir(allowed),
+		interp.AllowedPaths([]string{allowed}),
+	)
+	assert.NotEqual(t, 0, exitCode)
+	assert.Contains(t, stderr, "outside allowed directories")
+}
+
+func TestAllowedPaths_MultipleRoots(t *testing.T) {
+	dir1 := t.TempDir()
+	dir2 := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir1, "a.txt"), []byte("aaa\n"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir2, "b.txt"), []byte("bbb\n"), 0644))
+
+	stdout, _, exitCode := runScript(t,
+		`cat `+filepath.Join(dir1, "a.txt")+"\n"+`cat `+filepath.Join(dir2, "b.txt"),
+		interp.Dir(dir1),
+		interp.AllowedPaths([]string{dir1, dir2}),
+	)
+	assert.Equal(t, 0, exitCode)
+	assert.Equal(t, "aaa\nbbb\n", stdout)
+}
+
+func TestAllowedPaths_SymlinkEscape(t *testing.T) {
+	allowed := t.TempDir()
+	outside := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(outside, "secret.txt"), []byte("secret\n"), 0644))
+	require.NoError(t, os.Symlink(filepath.Join(outside, "secret.txt"), filepath.Join(allowed, "link.txt")))
+
+	_, stderr, exitCode := runScript(t, `cat link.txt`,
+		interp.Dir(allowed),
+		interp.AllowedPaths([]string{allowed}),
+	)
+	assert.NotEqual(t, 0, exitCode)
+	assert.Contains(t, stderr, "link.txt")
+}
+
+func TestAllowedPaths_DotDotTraversal(t *testing.T) {
+	parent := t.TempDir()
+	child := filepath.Join(parent, "child")
+	require.NoError(t, os.MkdirAll(child, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(parent, "secret.txt"), []byte("secret\n"), 0644))
+
+	_, stderr, exitCode := runScript(t, `cat ../secret.txt`,
+		interp.Dir(child),
+		interp.AllowedPaths([]string{child}),
+	)
+	assert.NotEqual(t, 0, exitCode)
+	assert.Contains(t, stderr, "outside allowed directories")
+}
+
+func TestAllowedPaths_SubdirAllowed(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "sub")
+	require.NoError(t, os.MkdirAll(sub, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(sub, "file.txt"), []byte("nested\n"), 0644))
+
+	stdout, _, exitCode := runScript(t, `cat sub/file.txt`,
+		interp.Dir(dir),
+		interp.AllowedPaths([]string{dir}),
+	)
+	assert.Equal(t, 0, exitCode)
+	assert.Equal(t, "nested\n", stdout)
+}
+
+func TestAllowedPaths_NoRestriction(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "hello.txt"), []byte("hello\n"), 0644))
+
+	stdout, _, exitCode := runScript(t, `cat hello.txt`,
+		interp.Dir(dir),
+	)
+	assert.Equal(t, 0, exitCode)
+	assert.Equal(t, "hello\n", stdout)
+}
+
+func TestAllowedPaths_InvalidPath(t *testing.T) {
+	_, err := interp.New(
+		interp.AllowedPaths([]string{"/nonexistent/path/that/does/not/exist"}),
+	)
+	assert.Error(t, err)
+}
+
+func TestAllowedPaths_EmptySliceNoRestriction(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "hello.txt"), []byte("hello\n"), 0644))
+
+	stdout, _, exitCode := runScript(t, `cat hello.txt`,
+		interp.Dir(dir),
+		interp.AllowedPaths([]string{}),
+	)
+	assert.Equal(t, 0, exitCode)
+	assert.Equal(t, "hello\n", stdout)
+}

--- a/pkg/shell/interp/api.go
+++ b/pkg/shell/interp/api.go
@@ -18,9 +18,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 
 	"mvdan.cc/sh/v3/expand"
 	"mvdan.cc/sh/v3/syntax"
@@ -76,6 +78,12 @@ type Runner struct {
 	// readDirHandler is a function responsible for reading directories during
 	// glob expansion. It must be non-nil.
 	readDirHandler ReadDirHandlerFunc2
+
+	// allowedRoots restricts all file access to the given directory trees.
+	// When non-nil, openHandler and readDirHandler are wrapped so that
+	// only paths under these roots are reachable.  Each *os.Root is
+	// opened once via AllowedPaths and shared across Reset/Subshell.
+	allowedRoots []*os.Root
 
 	stdin  *os.File // e.g. the read end of a pipe
 	stdout io.Writer
@@ -392,6 +400,112 @@ func ReadDirHandler2(f ReadDirHandlerFunc2) RunnerOption {
 	}
 }
 
+// AllowedPaths restricts all file access performed by the shell interpreter
+// to the given directory trees.  Each path is opened as an [os.Root], which
+// provides kernel-level enforcement against symlink escapes and ".."
+// traversal.  When set, the open and readdir handlers are wrapped so that
+// any file operation outside these directories is rejected.
+//
+// Passing an empty slice removes any restriction (the default).
+// The caller must call [Runner.Close] when done to release the open roots.
+func AllowedPaths(paths []string) RunnerOption {
+	return func(r *Runner) error {
+		for _, root := range r.allowedRoots {
+			root.Close()
+		}
+		r.allowedRoots = nil
+
+		for _, p := range paths {
+			abs, err := filepath.Abs(p)
+			if err != nil {
+				return fmt.Errorf("allowed path %q: %w", p, err)
+			}
+			root, err := os.OpenRoot(abs)
+			if err != nil {
+				for _, prev := range r.allowedRoots {
+					prev.Close()
+				}
+				r.allowedRoots = nil
+				return fmt.Errorf("allowed path %q: %w", p, err)
+			}
+			r.allowedRoots = append(r.allowedRoots, root)
+		}
+		return nil
+	}
+}
+
+// Close releases resources held by the Runner, including any [os.Root]
+// handles opened by [AllowedPaths].  It is safe to call Close multiple
+// times.
+func (r *Runner) Close() error {
+	for _, root := range r.allowedRoots {
+		root.Close()
+	}
+	r.allowedRoots = nil
+	return nil
+}
+
+// resolveAllowedPath converts path (which may be relative to the runner's Dir)
+// into a (root, relPath) pair that can be used with os.Root methods.
+// It returns an *os.PathError if the path does not fall under any allowed root.
+func (r *Runner) resolveAllowedPath(path string) (*os.Root, string, error) {
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(r.Dir, path)
+	}
+	path = filepath.Clean(path)
+
+	for _, root := range r.allowedRoots {
+		rootName := root.Name()
+		rel, err := filepath.Rel(rootName, path)
+		if err != nil {
+			continue
+		}
+		if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			continue
+		}
+		return root, rel, nil
+	}
+	return nil, "", &os.PathError{
+		Op:   "open",
+		Path: path,
+		Err:  fmt.Errorf("path is outside allowed directories"),
+	}
+}
+
+// allowedOpenHandler wraps next so that only paths under the allowed roots
+// can be opened.  Paths that resolve into a root are opened via [os.Root.OpenFile];
+// all others are rejected with an [*os.PathError].
+func (r *Runner) allowedOpenHandler(next OpenHandlerFunc) OpenHandlerFunc {
+	return func(ctx context.Context, path string, flag int, perm os.FileMode) (io.ReadWriteCloser, error) {
+		mc := HandlerCtx(ctx)
+		absPath := path
+		if absPath != "" && !filepath.IsAbs(absPath) {
+			absPath = filepath.Join(mc.Dir, absPath)
+		}
+		root, rel, err := r.resolveAllowedPath(absPath)
+		if err != nil {
+			return nil, err
+		}
+		return root.OpenFile(rel, flag, perm)
+	}
+}
+
+// allowedReadDirHandler wraps next so that only directories under the allowed
+// roots can be listed during glob expansion.
+func (r *Runner) allowedReadDirHandler(next ReadDirHandlerFunc2) ReadDirHandlerFunc2 {
+	return func(ctx context.Context, path string) ([]fs.DirEntry, error) {
+		root, rel, err := r.resolveAllowedPath(path)
+		if err != nil {
+			return nil, err
+		}
+		f, err := root.Open(rel)
+		if err != nil {
+			return nil, err
+		}
+		defer f.Close()
+		return f.ReadDir(-1)
+	}
+}
 
 func stdinFile(r io.Reader) (*os.File, error) {
 	switch r := r.(type) {
@@ -562,14 +676,20 @@ func (r *Runner) Reset() {
 		}
 		// Clean it as we will later do a string prefix match.
 		r.tempDir = filepath.Clean(r.tempDir)
+
+		if len(r.allowedRoots) > 0 {
+			r.openHandler = r.allowedOpenHandler(r.openHandler)
+			r.readDirHandler = r.allowedReadDirHandler(r.readDirHandler)
+		}
 	}
 	// reset the internal state
 	*r = Runner{
-		Env:             r.Env,
-		tempDir:         r.tempDir,
-		execHandler:     r.execHandler,
-		openHandler:     r.openHandler,
-		readDirHandler:  r.readDirHandler,
+		Env:            r.Env,
+		tempDir:        r.tempDir,
+		execHandler:    r.execHandler,
+		openHandler:    r.openHandler,
+		readDirHandler: r.readDirHandler,
+		allowedRoots:   r.allowedRoots,
 
 		// These can be set by functions like [Dir] or [Params], but
 		// builtins can overwrite them; reset the fields to whatever the
@@ -687,22 +807,22 @@ func (r *Runner) subshell(background bool) *Runner {
 	// Keep in sync with the Runner type. Manually copy fields, to not copy
 	// sensitive ones like [errgroup.Group], and to do deep copies of slices.
 	r2 := &Runner{
-		Dir:             r.Dir,
-		tempDir:         r.tempDir,
-		Params:          r.Params,
-		execHandler:     r.execHandler,
-		openHandler:     r.openHandler,
-		readDirHandler:  r.readDirHandler,
+		Dir:            r.Dir,
+		tempDir:        r.tempDir,
+		Params:         r.Params,
+		execHandler:    r.execHandler,
+		openHandler:    r.openHandler,
+		readDirHandler: r.readDirHandler,
+		allowedRoots:   r.allowedRoots,
 
-		stdin:          r.stdin,
-		stdout:         r.stdout,
-		stderr:         r.stderr,
-		filename:       r.filename,
-		opts:           r.opts,
-		usedNew:        r.usedNew,
-		exit:           r.exit,
-		lastExit:       r.lastExit,
-
+		stdin:    r.stdin,
+		stdout:   r.stdout,
+		stderr:   r.stderr,
+		filename: r.filename,
+		opts:     r.opts,
+		usedNew:  r.usedNew,
+		exit:     r.exit,
+		lastExit: r.lastExit,
 	}
 	r2.writeEnv = newOverlayEnviron(r.writeEnv, background)
 	r2.fillExpandConfig(r.ectx)


### PR DESCRIPTION
<!-- dd-meta {"pullId":"e9894c45-3d83-43ed-9d82-6f0d12ac85d7","source":"chat","resourceId":"a3cf5f87-7501-46e2-9051-c061b164eebd","workflowId":"04366922-e198-4e79-a6b8-b49664796f49","codeChangeId":"04366922-e198-4e79-a6b8-b49664796f49","sourceType":"chat"} -->
PR by Bits
[View session in Datadog](https://app.datadoghq.com/code/a3cf5f87-7501-46e2-9051-c061b164eebd)

Comment @datadog to request changes

Feedback (especially what can be better) welcome in [#code-gen-aka-bits-dev-feedback](https://dd.enterprise.slack.com/archives/C07JA5N2D25)!

---

### What does this PR do?

Adds an `AllowedPaths([]string)` `RunnerOption` to `pkg/shell/interp` that restricts all file access (reads, redirects, glob expansion) to the specified directory trees.

- Adds `allowedRoots []*os.Root` field to `Runner`, leveraging Go's `os.Root` for kernel-level path enforcement
- Adds `AllowedPaths(paths []string) RunnerOption` that opens an `*os.Root` per path
- Wraps `openHandler` and `readDirHandler` at `Reset()` time to reject any path outside allowed roots
- Adds `Runner.Close()` to release `os.Root` handles
- Propagates `allowedRoots` through `Reset()` and `Subshell()`

### Motivation

The shell interpreter is used by AI Agents and needs to restrict file system access to specific directories for safety. `os.Root` provides OS-level enforcement against symlink escapes and `..` traversal, making this more secure than string-prefix matching.

### Describe how you validated your changes

- 11 new unit tests covering: allowed/blocked cat, allowed/blocked redirects, multiple roots, symlink escape, `..` traversal, subdirectory access, no-restriction default, invalid path error, empty slice no-op
- All existing scenario tests pass with no regressions

### Additional Notes

Requires Go 1.24+ for `os.Root` / `os.OpenRoot`.