### PR TITLE
[OTAGENT-889] attach a special tag to agent payload in DDOT gateway

### DIFF
--- a/cmd/otel-agent/config/agent_config.go
+++ b/cmd/otel-agent/config/agent_config.go
@@ -194,13 +194,6 @@ func NewConfigComponent(ctx context.Context, ddCfg string, uris []string) (confi
 	pkgconfig.Set("apm_config.debug.port", 0, pkgconfigmodel.SourceDefault)      // Disabled in the otel-agent
 	pkgconfig.Set(pkgconfigsetup.OTLPTracePort, 0, pkgconfigmodel.SourceDefault) // Disabled in the otel-agent
 
-	if pkgconfig.GetBool("otelcollector.gateway.mode") {
-		// Use SourceAgentRuntime to override DD_HOSTNAME env var (SourceEnvVar), which the
-		// Helm chart sets to spec.nodeName for the gateway deployment. In gateway mode the
-		// trace agent forwards traffic and should not claim any host identity.
-		pkgconfig.Set("hostname", "", pkgconfigmodel.SourceAgentRuntime)
-	}
-
 	pkgconfig.Set("otlp_config.traces.span_name_as_resource_name", ddc.Traces.SpanNameAsResourceName, pkgconfigmodel.SourceFile)
 	pkgconfig.Set("otlp_config.traces.span_name_remappings", ddc.Traces.SpanNameRemappings, pkgconfigmodel.SourceFile)
 

--- a/cmd/otel-agent/config/agent_config_test.go
+++ b/cmd/otel-agent/config/agent_config_test.go
@@ -503,62 +503,6 @@ func TestLogsEnabledViaDatadogConfig(t *testing.T) {
 	assert.True(t, c.GetBool("logs_enabled"), "logs_enabled should be true from datadog config")
 }
 
-func (suite *ConfigTestSuite) TestGatewayModeHostnameEmpty() {
-	t := suite.T()
-	fileName := "testdata/config_default.yaml"
-	ddFileName := "testdata/datadog_gateway_mode.yaml"
-	c, err := NewConfigComponent(context.Background(), ddFileName, []string{fileName})
-	require.NoError(t, err, "NewConfigComponent should succeed with gateway mode enabled")
-
-	// When gateway mode is enabled, hostname should be set to empty string
-	assert.True(t, c.GetBool("otelcollector.gateway.mode"), "gateway mode should be enabled")
-	assert.Equal(t, "", c.GetString("hostname"), "hostname should be empty when gateway mode is enabled")
-}
-
-func (suite *ConfigTestSuite) TestGatewayModeDisabledHostnameNotEmpty() {
-	t := suite.T()
-	fileName := "testdata/config_default.yaml"
-	// Using datadog.yaml which doesn't have gateway mode set
-	ddFileName := "testdata/datadog.yaml"
-	c, err := NewConfigComponent(context.Background(), ddFileName, []string{fileName})
-	require.NoError(t, err, "NewConfigComponent should succeed without gateway mode")
-
-	// When gateway mode is not enabled, hostname should not be forced to empty
-	assert.False(t, c.GetBool("otelcollector.gateway.mode"), "gateway mode should be disabled")
-	// The hostname might be empty by default, but the key difference is that
-	// it wasn't explicitly set to empty via the gateway mode logic
-	// We verify the config was loaded without the gateway mode setting
-	assert.False(t, c.IsConfigured("otelcollector.gateway.mode") && c.GetBool("otelcollector.gateway.mode"),
-		"gateway mode should not be enabled")
-}
-
-func (suite *ConfigTestSuite) TestGatewayModeViaEnvVarHostnameEmpty() {
-	t := suite.T()
-	fileName := "testdata/config_default.yaml"
-	// Set gateway mode via environment variable
-	t.Setenv("DD_OTELCOLLECTOR_GATEWAY_MODE", "true")
-	c, err := NewConfigComponent(context.Background(), "", []string{fileName})
-	require.NoError(t, err, "NewConfigComponent should succeed with gateway mode env var set")
-
-	// When gateway mode is enabled via env var, hostname should be set to empty string
-	assert.True(t, c.GetBool("otelcollector.gateway.mode"), "gateway mode should be enabled from env var")
-	assert.Equal(t, "", c.GetString("hostname"), "hostname should be empty when gateway mode is enabled via env var")
-}
-
-func (suite *ConfigTestSuite) TestGatewayModeOverridesDDHostnameEnvVar() {
-	t := suite.T()
-	fileName := "testdata/config_default.yaml"
-	ddFileName := "testdata/datadog_gateway_mode.yaml"
-	// Simulate the Helm chart setting DD_HOSTNAME to the Kubernetes node name
-	t.Setenv("DD_HOSTNAME", "k8s-node-name")
-	c, err := NewConfigComponent(context.Background(), ddFileName, []string{fileName})
-	require.NoError(t, err, "NewConfigComponent should succeed with gateway mode enabled")
-
-	// Gateway mode should override DD_HOSTNAME and set hostname to empty
-	assert.True(t, c.GetBool("otelcollector.gateway.mode"), "gateway mode should be enabled")
-	assert.Equal(t, "", c.GetString("hostname"), "hostname should be empty in gateway mode even when DD_HOSTNAME is set")
-}
-
 // TestSuite runs the CalculatorTestSuite
 func TestSuite(t *testing.T) {
 	suite.Run(t, new(ConfigTestSuite))

--- a/cmd/otel-agent/config/testdata/datadog_gateway_mode.yaml
+++ b/cmd/otel-agent/config/testdata/datadog_gateway_mode.yaml
@@ -1,3 +1,0 @@
-otelcollector:
-  gateway:
-    mode: true

--- a/cmd/otel-agent/subcommands/run/command.go
+++ b/cmd/otel-agent/subcommands/run/command.go
@@ -175,14 +175,7 @@ func runOTelAgentCommand(ctx context.Context, params *cliParams, opts ...fx.Opti
 			InitHelper: workloadmetainit.GetWorkloadmetaInit(),
 		}),
 		fx.Supply(uris),
-		fx.Provide(func(h hostnameinterface.Component, cfg coreconfig.Component) (serializerexporter.SourceProviderFunc, error) {
-			if cfg.GetBool("otelcollector.gateway.mode") {
-				// In gateway mode the agent does not represent a specific host, so return an empty
-				// hostname without error instead of failing when hostname resolution is not available.
-				return func(_ context.Context) (string, error) {
-					return "", nil
-				}, nil
-			}
+		fx.Provide(func(h hostnameinterface.Component) (serializerexporter.SourceProviderFunc, error) {
 			return h.Get, nil
 		}),
 		remotehostnameimpl.Module(),

--- a/comp/otelcol/otlp/components/exporter/datadogexporter/traces_exporter_test.go
+++ b/comp/otelcol/otlp/components/exporter/datadogexporter/traces_exporter_test.go
@@ -6,9 +6,7 @@
 package datadogexporter
 
 import (
-	"bytes"
 	"context"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -38,7 +36,6 @@ import (
 	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	"google.golang.org/protobuf/proto"
 )
 
 type testComponent struct {
@@ -244,97 +241,4 @@ func TestNoPanicSendTraceAfterTraceAgentStop(t *testing.T) {
 
 	err = exporter.ConsumeTraces(ctx, simpleTraces())
 	assert.ErrorContains(t, err, "OTLPReceiver in trace agent is already stopped")
-}
-
-func TestNoAgenthost(t *testing.T) {
-	payloadChan := make(chan []byte, 1)
-	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		assert.Equal(t, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", req.Header.Get("DD-Api-Key"))
-		assert.Equal(t, "application/x-protobuf", req.Header.Get("Content-Type"))
-
-		// Read and store the request body
-		body, err := io.ReadAll(req.Body)
-		assert.NoError(t, err)
-		payloadChan <- body
-
-		rw.WriteHeader(http.StatusAccepted)
-	}))
-
-	defer server.Close()
-	cfg := datadogconfig.Config{
-		API: datadogconfig.APIConfig{
-			Key: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-		},
-		Traces: datadogconfig.TracesExporterConfig{
-			TCPAddrConfig: confignet.TCPAddrConfig{
-				Endpoint: server.URL,
-			},
-			TracesConfig: datadogconfig.TracesConfig{
-				IgnoreResources: []string{},
-			},
-		},
-	}
-
-	params := exportertest.NewNopSettings(Type)
-	tcfg := config.New()
-	tcfg.ReceiverEnabled = false
-	tcfg.TraceWriter.FlushPeriodSeconds = 0.1
-	tcfg.Endpoints[0].APIKey = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-	tcfg.Endpoints[0].Host = server.URL
-	tcfg.Hostname = "" // Set hostname to empty string
-	ctx := context.Background()
-	traceagent := pkgagent.NewAgent(ctx, tcfg, telemetry.NewNoopCollector(), &ddgostatsd.NoOpClient{}, gzip.NewComponent())
-
-	telemetryComp := fxutil.Test[coretelemetry.Mock](t, telemetryimpl.MockModule())
-	store := serializerexporter.TelemetryStore{
-		DDOTTraces: telemetryComp.NewGauge(
-			"runtime",
-			"datadog_agent_ddot_traces",
-			[]string{"version", "command", "host", "task_arn"},
-			"Usage metric of OTLP traces in DDOT",
-		),
-
-		DDOTGWUsage: telemetryComp.NewGauge(
-			"runtime",
-			"datadog_agent_ddot_gateway_usage",
-			[]string{"version", "command"},
-			"Usage metric for GW deployments with DDOT",
-		),
-	}
-	f := NewFactory(testComponent{traceagent, nil}, nil, nil, nil, metricsclient.NewStatsdClientWrapper(&ddgostatsd.NoOpClient{}), otel.NewDisabledGatewayUsage(), store)
-	exporter, err := f.CreateTraces(ctx, params, &cfg)
-	assert.NoError(t, err)
-
-	go traceagent.Run()
-
-	err = exporter.ConsumeTraces(ctx, simpleTraces())
-	assert.NoError(t, err)
-
-	// Wait for payload to be received
-	timeout := time.After(2 * time.Second)
-	var payloadBytes []byte
-	select {
-	case payloadBytes = <-payloadChan:
-		// Got the payload
-	case <-timeout:
-		t.Fatal("Timed out waiting for payload")
-	}
-
-	// Decompress and parse the payload
-	reader, err := gzip.NewComponent().NewReader(io.NopCloser(bytes.NewReader(payloadBytes)))
-	require.NoError(t, err)
-	defer reader.Close()
-
-	decompressed, err := io.ReadAll(reader)
-	require.NoError(t, err)
-
-	var agentPayload pb.AgentPayload
-	err = proto.Unmarshal(decompressed, &agentPayload)
-	require.NoError(t, err)
-
-	assert.Empty(t, agentPayload.HostName, "agent hostname should be empty")
-	assert.Len(t, agentPayload.TracerPayloads, 1)
-	assert.Equal(t, "test-host", agentPayload.TracerPayloads[0].Hostname)
-
-	require.NoError(t, exporter.Shutdown(ctx))
 }

--- a/comp/trace/config/setup.go
+++ b/comp/trace/config/setup.go
@@ -683,6 +683,7 @@ func applyDatadogConfig(c *config.AgentConfig, core corecompcfg.Component) error
 	if k := "apm_config.mode"; core.IsConfigured(k) {
 		c.APMMode = normalizeAPMMode(core.GetString(k))
 	}
+	c.OTelGateway = core.GetBool("otelcollector.gateway.mode")
 	c.SendAllInternalStats = core.GetBool("apm_config.send_all_internal_stats") // default is false
 	c.DebugServerPort = core.GetInt("apm_config.debug.port")
 	c.ContainerTagsBuffer = core.GetBool("apm_config.enable_container_tags_buffer")

--- a/comp/trace/config/setup.go
+++ b/comp/trace/config/setup.go
@@ -848,7 +848,7 @@ func validate(c *config.AgentConfig, core corecompcfg.Component) error {
 		return errors.New("agent binary path not set")
 	}
 
-	if c.Hostname == "" && !core.GetBool("serverless.enabled") && !core.GetBool("otelcollector.gateway.mode") {
+	if c.Hostname == "" && !core.GetBool("serverless.enabled") {
 		if err := hostname(c); err != nil {
 			return err
 		}

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -558,6 +558,10 @@ type AgentConfig struct {
 	// APMMode specifies whether using "edge" APM mode. May support other modes in the future. If unset, it has no impact.
 	APMMode string
 
+	// OTelGateway indicates whether the agent is configured as an OTel gateway.
+	// When true, the tag "_dd.otel.gateway" will be attached to the AgentPayload.
+	OTelGateway bool
+
 	// SecretsRefreshFn is called when a 403 response is received to trigger
 	// API key refresh from the secrets backend. It blocks until the refresh
 	// completes and returns a message and any error encountered.

--- a/pkg/trace/writer/trace.go
+++ b/pkg/trace/writer/trace.go
@@ -30,6 +30,9 @@ const defaultConnectionLimit = 5
 // tagAPMMode specifies whether running APM in "edge" mode (may support other modes in the future)
 const tagAPMMode = "_dd.apm_mode"
 
+// tagOTelGateway is attached to the AgentPayload when the agent is configured as an OTel gateway.
+const tagOTelGateway = "_dd.otel.gateway"
+
 // MaxPayloadSize specifies the maximum accumulated payload size that is allowed before
 // a flush is triggered; replaced in tests.
 var MaxPayloadSize = 3200000 // 3.2MB is the maximum allowed by the Datadog API
@@ -88,6 +91,8 @@ type TraceWriter struct {
 	compressor compression.Component
 	// apmMode exists here to propagate the value to the AgentPayload
 	apmMode string
+	// otelGateway indicates whether the agent is configured as an OTel gateway
+	otelGateway bool
 }
 
 // NewTraceWriter returns a new TraceWriter. It is created for the given agent configuration and
@@ -121,6 +126,7 @@ func NewTraceWriter(
 		timing:             timing,
 		compressor:         compressor,
 		apmMode:            cfg.APMMode,
+		otelGateway:        cfg.OTelGateway,
 	}
 	climit := cfg.TraceWriter.ConnectionLimit
 	if climit == 0 {
@@ -280,8 +286,14 @@ func (w *TraceWriter) flushPayloads(payloads []*pb.TracerPayload) {
 		RareSamplerEnabled: w.rareSampler.IsEnabled(),
 		TracerPayloads:     payloads,
 	}
-	if w.apmMode != "" {
-		p.Tags = map[string]string{tagAPMMode: w.apmMode}
+	if w.apmMode != "" || w.otelGateway {
+		p.Tags = make(map[string]string)
+		if w.apmMode != "" {
+			p.Tags[tagAPMMode] = w.apmMode
+		}
+		if w.otelGateway {
+			p.Tags[tagOTelGateway] = "true"
+		}
 	}
 	log.Debugf("Reported agent rates: target_tps=%v errors_tps=%v rare_sampling=%v", p.TargetTPS, p.ErrorTPS, p.RareSamplerEnabled)
 

--- a/pkg/trace/writer/trace_test.go
+++ b/pkg/trace/writer/trace_test.go
@@ -445,6 +445,58 @@ func TestTraceWriterAPMMode(t *testing.T) {
 	}
 }
 
+func TestTraceWriterOTelGateway(t *testing.T) {
+	testCases := []struct {
+		name        string
+		otelGateway bool
+	}{
+		{
+			name:        "gateway-disabled",
+			otelGateway: false,
+		},
+		{
+			name:        "gateway-enabled",
+			otelGateway: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newTestServer()
+			defer srv.Close()
+			cfg := &config.AgentConfig{
+				Hostname:   testHostname,
+				DefaultEnv: testEnv,
+				Endpoints: []*config.Endpoint{{
+					APIKey: "123",
+					Host:   srv.URL,
+				}},
+				TraceWriter:         &config.WriterConfig{ConnectionLimit: 200, QueueSize: 40},
+				SynchronousFlushing: true,
+				OTelGateway:         tc.otelGateway,
+			}
+			tw := NewTraceWriter(cfg, mockSampler, mockSampler, mockSampler, telemetry.NewNoopCollector(), &statsd.NoOpClient{}, &timing.NoopReporter{}, gzip.NewComponent())
+			defer tw.Stop()
+
+			tw.WriteChunks(randomSampledSpans(20, 8))
+			err := tw.FlushSync()
+			assert.Nil(t, err)
+
+			require.Len(t, srv.payloads, 1)
+			ap, err := deserializePayload(*srv.payloads[0], tw.compressor)
+			assert.Nil(t, err)
+			v, ok := ap.Tags[tagOTelGateway]
+			if tc.otelGateway {
+				assert.True(t, ok)
+				assert.Equal(t, "true", v)
+			} else {
+				assert.False(t, ok)
+				assert.Empty(t, v)
+			}
+		})
+	}
+}
+
 func TestTraceWriterUpdateAPIKey(t *testing.T) {
 	assert := assert.New(t)
 	srv := newTestServer()

--- a/releasenotes/notes/ddot-gw-host-2c343fc849eabcb7.yaml
+++ b/releasenotes/notes/ddot-gw-host-2c343fc849eabcb7.yaml
@@ -1,4 +1,0 @@
----
-fixes:
-  - |
-    Set Agent hostname to empty in DDOT when DDOT is in gateway mode. 

--- a/test/new-e2e/tests/otel/otel-agent/gateway_test.go
+++ b/test/new-e2e/tests/otel/otel-agent/gateway_test.go
@@ -10,6 +10,9 @@ import (
 	_ "embed"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/kubernetesagentparams"
 	scenkindvm "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/kindvm"
@@ -72,6 +75,14 @@ func (s *gatewayTestSuite) SetupSuite() {
 
 func (s *gatewayTestSuite) TestOTLPTraces() {
 	utils.TestTraces(s, gatewayParams)
+
+	traces, err := s.Env().FakeIntake.Client().GetTraces()
+	require.NoError(s.T(), err)
+	require.NotEmpty(s.T(), traces)
+	for _, trace := range traces {
+		assert.NotEmpty(s.T(), trace.HostName, "agent hostname should not be empty in gateway mode")
+		assert.Equal(s.T(), "true", trace.Tags["_dd.otel.gateway"], "gateway tag should be set on AgentPayload")
+	}
 }
 
 func (s *gatewayTestSuite) TestOTLPMetrics() {

--- a/test/new-e2e/tests/otel/otel-agent/gateway_test.go
+++ b/test/new-e2e/tests/otel/otel-agent/gateway_test.go
@@ -10,9 +10,6 @@ import (
 	_ "embed"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/kubernetesagentparams"
 	scenkindvm "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/kindvm"
@@ -75,15 +72,6 @@ func (s *gatewayTestSuite) SetupSuite() {
 
 func (s *gatewayTestSuite) TestOTLPTraces() {
 	utils.TestTraces(s, gatewayParams)
-
-	// In gateway mode, the agent hostname should be empty (not set)
-	// because the gateway agent acts as a forwarder and doesn't represent a specific host.
-	traces, err := s.Env().FakeIntake.Client().GetTraces()
-	require.NoError(s.T(), err)
-	require.NotEmpty(s.T(), traces)
-	for _, trace := range traces {
-		assert.Empty(s.T(), trace.HostName, "agent hostname should be empty in gateway mode")
-	}
 }
 
 func (s *gatewayTestSuite) TestOTLPMetrics() {


### PR DESCRIPTION
### What does this PR do?
Attach tag "_dd.otel.gateway": "true" at the agent payload level in DDOT gateway. 
As part of the change, https://github.com/DataDog/datadog-agent/commit/38f74d37f6e2312ba57d2c79187e0c924992b7f5 is reverted, so that the agent hostname in agent payloads is still the gateway hostname.

### Motivation
This is another attempt to resolve the APM under-billing issue in gateway. The backend will use the new tag to apply correct billing in gateway setups.

### Describe how you validated your changes
Deploy the new RC to my test cluster & org. This needs to wait for the backend changes to roll out.

### Additional Notes
