### PR TITLE
[AGENTCFG-652] Fix flaky TestAgentConfigRefresh secret refresh test

### DIFF
--- a/test/new-e2e/tests/agent-subcommands/secret/secret_nix_test.go
+++ b/test/new-e2e/tests/agent-subcommands/secret/secret_nix_test.go
@@ -112,8 +112,8 @@ api_key: ENC[api_key]
 	secretRefreshOutput := v.Env().Agent.Client.Secret(agentclient.WithArgs([]string{"refresh"}))
 	require.Contains(v.T(), secretRefreshOutput, "api_key")
 
-	status = v.Env().Agent.Client.Status()
 	assert.EventuallyWithT(v.T(), func(t *assert.CollectT) {
+		status = v.Env().Agent.Client.Status()
 		assert.Contains(t, status.Content, "API key ending with vwxyz")
 	}, 1*time.Minute, 10*time.Second)
 }

--- a/test/new-e2e/tests/agent-subcommands/secret/secret_win_test.go
+++ b/test/new-e2e/tests/agent-subcommands/secret/secret_win_test.go
@@ -124,8 +124,8 @@ api_key: ENC[api_key]
 	secretRefreshOutput := v.Env().Agent.Client.Secret(agentclient.WithArgs([]string{"refresh"}))
 	require.Contains(v.T(), secretRefreshOutput, "api_key")
 
-	status = v.Env().Agent.Client.Status()
 	assert.EventuallyWithT(v.T(), func(t *assert.CollectT) {
+		status = v.Env().Agent.Client.Status()
 		assert.Contains(t, status.Content, "API key ending with vwxyz")
 	}, 1*time.Minute, 10*time.Second)
 }


### PR DESCRIPTION
## Summary
- Fix flaky `TestAgentConfigRefresh` in both Windows and Linux secret test suites
- The `Status()` call was outside the `EventuallyWithT` retry callback, so retries kept checking stale data instead of re-querying the agent for updated secret values after `secret refresh`
- Move the `Status()` call inside the retry loop so each iteration gets fresh status output

## Jira
[AGENTCFG-652](https://datadoghq.atlassian.net/browse/AGENTCFG-652)

## Test plan
- [ ] CI passes for `new-e2e-agent-subcommands-windows` job
- [ ] CI passes for `new-e2e-agent-subcommands` (Linux) job
- [ ] `TestAgentConfigRefresh` no longer flakes on secret refresh verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AGENTCFG-652]: https://datadoghq.atlassian.net/browse/AGENTCFG-652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ