### PR TITLE
dyninst/module: fix buffer accounting with duplicate entries

### DIFF
--- a/pkg/dyninst/module/message_buffer.go
+++ b/pkg/dyninst/module/message_buffer.go
@@ -144,7 +144,8 @@ func (bt *bufferTree) addEvent(key eventKey, event dispatcher.Message) (ok bool)
 			)
 		}
 		bt.mb.release(len(prev.event.Event()))
-		return false
+		prev.event.Release()
+		return true
 	}
 	return true
 }

--- a/pkg/dyninst/module/message_buffer_test.go
+++ b/pkg/dyninst/module/message_buffer_test.go
@@ -1,0 +1,168 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package module
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/dyninst/dispatcher"
+)
+
+func trackerUsed(mb *bufferedMessageTracker) int {
+	mb.mu.Lock()
+	defer mb.mu.Unlock()
+	return mb.mu.used
+}
+
+func makeMsg(size int) dispatcher.Message {
+	return dispatcher.MakeTestingMessage(make([]byte, size))
+}
+
+func TestBufferTreeAddAndPop(t *testing.T) {
+	mb := newBufferedMessageTracker(1024)
+	bt := mb.newTree()
+	defer bt.close()
+
+	key := eventKey{goid: 1, stackByteDepth: 100, probeID: 5}
+
+	ok := bt.addEvent(key, makeMsg(64))
+	require.True(t, ok)
+	assert.Equal(t, 64, trackerUsed(mb))
+
+	msg, ok := bt.popMatchingEvent(key)
+	require.True(t, ok)
+	assert.Equal(t, 64, len(msg.Event()))
+	assert.Equal(t, 0, trackerUsed(mb))
+}
+
+func TestBufferTreePopMissing(t *testing.T) {
+	mb := newBufferedMessageTracker(1024)
+	bt := mb.newTree()
+	defer bt.close()
+
+	key := eventKey{goid: 1, stackByteDepth: 100, probeID: 5}
+	_, ok := bt.popMatchingEvent(key)
+	assert.False(t, ok)
+	assert.Equal(t, 0, trackerUsed(mb))
+}
+
+func TestBufferTreeBufferFull(t *testing.T) {
+	mb := newBufferedMessageTracker(100)
+	bt := mb.newTree()
+	defer bt.close()
+
+	key1 := eventKey{goid: 1, stackByteDepth: 100, probeID: 5}
+	ok := bt.addEvent(key1, makeMsg(80))
+	require.True(t, ok)
+	assert.Equal(t, 80, trackerUsed(mb))
+
+	// This should fail: 80 + 80 > 100.
+	key2 := eventKey{goid: 2, stackByteDepth: 100, probeID: 5}
+	ok = bt.addEvent(key2, makeMsg(80))
+	assert.False(t, ok)
+	assert.Equal(t, 80, trackerUsed(mb))
+}
+
+// TestBufferTreeDuplicateAccounting verifies that inserting a duplicate
+// event returns true, properly accounts for the size change, and that
+// popping the entry afterwards leaves used at zero. This is a
+// regression test for an invariant violation where the duplicate path
+// returned false, causing the caller to release a record still held
+// by the tree.
+func TestBufferTreeDuplicateAccounting(t *testing.T) {
+	mb := newBufferedMessageTracker(1024)
+	bt := mb.newTree()
+	defer bt.close()
+
+	key := eventKey{goid: 1, stackByteDepth: 100, probeID: 5}
+
+	ok := bt.addEvent(key, makeMsg(64))
+	require.True(t, ok)
+	assert.Equal(t, 64, trackerUsed(mb))
+
+	// Insert a duplicate with a different size.
+	ok = bt.addEvent(key, makeMsg(48))
+	require.True(t, ok, "duplicate should return true")
+	assert.Equal(t, 48, trackerUsed(mb),
+		"used should reflect the replacement event size")
+
+	// Pop should return the replacement and bring used back to zero.
+	msg, ok := bt.popMatchingEvent(key)
+	require.True(t, ok)
+	assert.Equal(t, 48, len(msg.Event()))
+	assert.Equal(t, 0, trackerUsed(mb),
+		"used must be zero after popping the only event")
+}
+
+func TestBufferTreeDuplicateSameSize(t *testing.T) {
+	mb := newBufferedMessageTracker(1024)
+	bt := mb.newTree()
+	defer bt.close()
+
+	key := eventKey{goid: 1, stackByteDepth: 100, probeID: 5}
+
+	ok := bt.addEvent(key, makeMsg(64))
+	require.True(t, ok)
+
+	ok = bt.addEvent(key, makeMsg(64))
+	require.True(t, ok)
+	assert.Equal(t, 64, trackerUsed(mb))
+
+	msg, ok := bt.popMatchingEvent(key)
+	require.True(t, ok)
+	assert.Equal(t, 64, len(msg.Event()))
+	assert.Equal(t, 0, trackerUsed(mb))
+}
+
+func TestBufferTreeCloseReleasesAccounting(t *testing.T) {
+	mb := newBufferedMessageTracker(1024)
+	bt := mb.newTree()
+
+	keys := []eventKey{
+		{goid: 1, stackByteDepth: 10, probeID: 1},
+		{goid: 2, stackByteDepth: 20, probeID: 2},
+		{goid: 3, stackByteDepth: 30, probeID: 3},
+	}
+	for _, k := range keys {
+		require.True(t, bt.addEvent(k, makeMsg(32)))
+	}
+	assert.Equal(t, 96, trackerUsed(mb))
+
+	bt.close()
+	assert.Equal(t, 0, trackerUsed(mb),
+		"close must release all tracked bytes")
+}
+
+func TestBufferTreeMultipleTreesShareTracker(t *testing.T) {
+	mb := newBufferedMessageTracker(128)
+	bt1 := mb.newTree()
+	bt2 := mb.newTree()
+	defer bt1.close()
+	defer bt2.close()
+
+	key1 := eventKey{goid: 1, stackByteDepth: 10, probeID: 1}
+	key2 := eventKey{goid: 2, stackByteDepth: 20, probeID: 2}
+
+	require.True(t, bt1.addEvent(key1, makeMsg(64)))
+	require.True(t, bt2.addEvent(key2, makeMsg(64)))
+	assert.Equal(t, 128, trackerUsed(mb))
+
+	// Tracker is full; a third add on either tree should fail.
+	key3 := eventKey{goid: 3, stackByteDepth: 30, probeID: 3}
+	assert.False(t, bt1.addEvent(key3, makeMsg(1)))
+
+	// Releasing from one tree frees space for the other.
+	_, ok := bt1.popMatchingEvent(key1)
+	require.True(t, ok)
+	assert.Equal(t, 64, trackerUsed(mb))
+	require.True(t, bt1.addEvent(key3, makeMsg(32)))
+	assert.Equal(t, 96, trackerUsed(mb))
+}


### PR DESCRIPTION
### What does this PR do?

Duplicate entries can occur for the same goroutine when we miss a panic-recover. Such an incident is likely to lead to the user having a bad experience when the buffer in eBPF fills up (nothing currently cleans up after that, alas).

Anyway, the bug was that before this change we used to tell the caller of add that their message wasn't added when there was a duplicate, but  it was! So, we'd end up releasing the entry back into the pool while it's still in the tree. This was wrong and is now fixed. Also, we release the event that we do pop out of the tree back to the pool (though it wasn't a problem we weren't doing that before).

We also added lots of tests (thanks Claude!)

### Motivation

We saw some logs about the invariant violation, and we never want to see that!

### Describe how you validated your changes

There's some tests.
