### PR TITLE
dyninst: fix template expressions showing same value for multiple fields

### DIFF
--- a/pkg/dyninst/compiler/generate.go
+++ b/pkg/dyninst/compiler/generate.go
@@ -682,34 +682,41 @@ func (g *generator) EncodeLocationOp(pc uint64, op *ir.LocationOp, ops []Op) ([]
 			if layoutIdx >= len(layoutPieces) {
 				return nil, fmt.Errorf("mismatch between loclist pieces and type memory layout for %s : %s", op.Variable.Name, op.Variable.Type.GetName())
 			}
-			paddedOffset := layoutPieces[layoutIdx].PaddedOffset
+			startPaddedOffset := layoutPieces[layoutIdx].PaddedOffset
 			nextLayoutIdx := layoutIdx
-			for nextLayoutIdx < len(layoutPieces) && layoutPieces[nextLayoutIdx].PaddedOffset-paddedOffset < uint32(piece.Size) {
+			for nextLayoutIdx < len(layoutPieces) && layoutPieces[nextLayoutIdx].PaddedOffset-startPaddedOffset < uint32(piece.Size) {
 				nextLayoutIdx++
 			}
 			// Layout pieces in [layoutIdx, nextLayoutIdx) range correspond to current locPiece.
-			layoutIdx = nextLayoutIdx
-			if op.Offset <= paddedOffset && paddedOffset < op.Offset+op.ByteSize {
-				switch p := piece.Op.(type) {
-				case ir.Register:
-					if piece.Size > 8 {
-						return nil, fmt.Errorf("unsupported register size: %d", piece.Size)
+			// We need to iterate over each layout piece to check if it's within our target range,
+			// because a single loclist piece may cover multiple layout pieces (e.g., a struct on stack).
+			for i := layoutIdx; i < nextLayoutIdx; i++ {
+				paddedOffset := layoutPieces[i].PaddedOffset
+				if op.Offset <= paddedOffset && paddedOffset < op.Offset+op.ByteSize {
+					switch p := piece.Op.(type) {
+					case ir.Register:
+						if piece.Size > 8 {
+							return nil, fmt.Errorf("unsupported register size: %d", piece.Size)
+						}
+						ops = append(ops, ExprReadRegisterOp{
+							Register:     p.RegNo,
+							Size:         uint8(piece.Size),
+							OutputOffset: paddedOffset - op.Offset,
+						})
+					case ir.Cfa:
+						// Calculate the offset within the CFA piece for this layout piece.
+						pieceInternalOffset := int32(paddedOffset - startPaddedOffset)
+						ops = append(ops, ExprDereferenceCfaOp{
+							Offset:       p.CfaOffset + pieceInternalOffset,
+							Len:          layoutPieces[i].Size,
+							OutputOffset: paddedOffset - op.Offset,
+						})
+					case ir.Addr:
+						return nil, errUnsupportedAddrLocationOp
 					}
-					ops = append(ops, ExprReadRegisterOp{
-						Register:     p.RegNo,
-						Size:         uint8(piece.Size),
-						OutputOffset: paddedOffset - op.Offset,
-					})
-				case ir.Cfa:
-					ops = append(ops, ExprDereferenceCfaOp{
-						Offset:       p.CfaOffset,
-						Len:          piece.Size,
-						OutputOffset: paddedOffset - op.Offset,
-					})
-				case ir.Addr:
-					return nil, errUnsupportedAddrLocationOp
 				}
 			}
+			layoutIdx = nextLayoutIdx
 		}
 		return ops, nil
 	}

--- a/pkg/dyninst/compiler/generate_test.go
+++ b/pkg/dyninst/compiler/generate_test.go
@@ -75,6 +75,86 @@ func testCorruptedLocationRecovery(t *testing.T, cfg testprogs.Config) {
 	)
 }
 
+// TestMultiFieldStructExpressionEncoding tests that when a template like
+// "{a.a} {a.b} {a.c}" references multiple fields of a struct, the compiler
+// emits read ops for every field — not just the first one. This is the
+// regression test for DEBUG-5245 where EncodeLocationOp only processed the
+// first layout piece when a single CFA loclist piece covered multiple fields.
+func TestMultiFieldStructExpressionEncoding(t *testing.T) {
+	cfgs := testprogs.MustGetCommonConfigs(t)
+	for _, cfg := range cfgs {
+		t.Run(cfg.String(), func(t *testing.T) {
+			testMultiFieldStructExpressionEncoding(t, cfg)
+		})
+	}
+}
+
+func testMultiFieldStructExpressionEncoding(t *testing.T, cfg testprogs.Config) {
+	binPath := testprogs.MustGetBinary(t, "sample", cfg)
+	probeDefs := testprogs.MustGetProbeDefinitions(t, "sample")
+	probeDefs = slices.DeleteFunc(probeDefs, testprogs.HasIssueTag)
+
+	// Keep only the testThreeStringsInStructExpr probe.
+	probeDefs = slices.DeleteFunc(probeDefs, func(p ir.ProbeDefinition) bool {
+		return p.GetID() != "testThreeStringsInStructExpr"
+	})
+	require.Len(t, probeDefs, 1, "expected exactly one probe definition for testThreeStringsInStructExpr")
+
+	obj, err := object.OpenElfFileWithDwarf(binPath)
+	require.NoError(t, err)
+	defer func() { _ = obj.Close() }()
+
+	irProg, err := irgen.GenerateIR(1, obj, probeDefs)
+	require.NoError(t, err)
+
+	compiled, err := GenerateProgram(irProg)
+	require.NoError(t, err)
+
+	// Collect ProcessExpression functions for this probe (one per expression: a.a, a.b, a.c).
+	var exprFuncs []Function
+	for _, fn := range compiled.Functions {
+		if _, ok := fn.ID.(ProcessExpression); ok {
+			exprFuncs = append(exprFuncs, fn)
+		}
+	}
+	require.Len(t, exprFuncs, 3, "expected 3 ProcessExpression functions for {a.a} {a.b} {a.c}")
+
+	// For each expression function, collect the read ops (CFA dereference or register read)
+	// that occur between ExprPrepareOp and ExprSaveOp.
+	outputOffsets := make([]uint32, 0, 3)
+	for i, fn := range exprFuncs {
+		var readOps []Op
+		for _, op := range fn.Ops {
+			switch op.(type) {
+			case ExprDereferenceCfaOp, ExprReadRegisterOp:
+				readOps = append(readOps, op)
+			}
+		}
+		assert.NotEmpty(t, readOps,
+			"expression %d has no read ops — field would be silently dropped (DEBUG-5245 regression)", i)
+
+		// Record the OutputOffset of the first read op for distinctness check.
+		if len(readOps) > 0 {
+			switch op := readOps[0].(type) {
+			case ExprDereferenceCfaOp:
+				outputOffsets = append(outputOffsets, op.OutputOffset)
+			case ExprReadRegisterOp:
+				outputOffsets = append(outputOffsets, op.OutputOffset)
+			}
+		}
+	}
+
+	// The three expressions should write to distinct output offsets since
+	// they capture different struct fields at different positions.
+	require.Len(t, outputOffsets, 3, "expected 3 output offsets")
+	assert.NotEqual(t, outputOffsets[0], outputOffsets[1],
+		"expressions 0 and 1 should have different OutputOffset values")
+	assert.NotEqual(t, outputOffsets[1], outputOffsets[2],
+		"expressions 1 and 2 should have different OutputOffset values")
+	assert.NotEqual(t, outputOffsets[0], outputOffsets[2],
+		"expressions 0 and 2 should have different OutputOffset values")
+}
+
 // corruptRegisterPieceSize walks the IR program to find a Register location
 // piece and sets its Size to an invalid value (> 8). Returns true if a piece
 // was corrupted.

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.sm.txt
@@ -7,13 +7,13 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call b8 03 00 00 // ProcessType[*****int]
+	Call 54 04 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessExpression[Probe[main.PointerChainArg]@0x4a6046.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call b8 03 00 00 // ProcessType[*****int]
+	Call 54 04 00 00 // ProcessType[*****int]
 	Return 
 // 0x39: ProcessEvent[Probe[main.PointerChainArg]@4a6046]
 	PrepareEventRoot bc 00 00 00 11 00 00 00 
@@ -24,7 +24,7 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call ca 03 00 00 // ProcessType[**int]
+	Call 66 04 00 00 // ProcessType[**int]
 	Return 
 // 0x68: ProcessEvent[Probe[main.PointerSmallChainArg]@4a6090]
 	PrepareEventRoot bd 00 00 00 09 00 00 00 
@@ -34,13 +34,13 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call f8 05 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 94 06 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x92: ProcessExpression[Probe[main.bigMapArg]@0x4a6553.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call f8 05 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 94 06 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0xad: ProcessEvent[Probe[main.bigMapArg]@4a6553]
 	PrepareEventRoot b4 00 00 00 11 00 00 00 
@@ -85,433 +85,445 @@
 	Return 
 // 0x148: ProcessExpression[Probe[main.intArrayArg]@0x4a628a.expr[0]]
 	ExprPrepare 
-	ExprDereferenceCfa 00 00 00 00 18 00 00 00 00 00 00 00 
+	ExprDereferenceCfa 00 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferenceCfa 08 00 00 00 08 00 00 00 08 00 00 00 
+	ExprDereferenceCfa 10 00 00 00 08 00 00 00 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
-// 0x164: ProcessEvent[Probe[main.intArrayArg]@4a628a]
+// 0x17e: ProcessEvent[Probe[main.intArrayArg]@4a628a]
 	PrepareEventRoot ab 00 00 00 19 00 00 00 
 	Call 48 01 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4a628a.expr[0]]
 	Return 
-// 0x173: ProcessEvent[Probe[main.intArrayArg]Return@4a62d6]
+// 0x18d: ProcessEvent[Probe[main.intArrayArg]Return@4a62d6]
 	PrepareEventRoot ac 00 00 00 00 00 00 00 
 	Return 
-// 0x17d: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a6400.expr[0]]
+// 0x197: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a6400.expr[0]]
 	ExprPrepare 
-	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
+	ExprDereferenceCfa 00 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferenceCfa 08 00 00 00 08 00 00 00 08 00 00 00 
+	ExprDereferenceCfa 10 00 00 00 08 00 00 00 10 00 00 00 
+	ExprDereferenceCfa 18 00 00 00 08 00 00 00 18 00 00 00 
+	ExprDereferenceCfa 20 00 00 00 08 00 00 00 20 00 00 00 
+	ExprDereferenceCfa 28 00 00 00 08 00 00 00 28 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 9a 04 00 00 // ProcessType[[3]string]
+	Call 36 05 00 00 // ProcessType[[3]string]
 	Return 
-// 0x19e: ProcessEvent[Probe[main.stringArrayArgFrameless]@4a6400]
+// 0x1f9: ProcessEvent[Probe[main.stringArrayArgFrameless]@4a6400]
 	PrepareEventRoot b1 00 00 00 31 00 00 00 
-	Call 7d 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a6400.expr[0]]
+	Call 97 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a6400.expr[0]]
 	Return 
-// 0x1ad: ProcessExpression[Probe[main.intSliceArg]@0x4a620a.expr[0]]
+// 0x208: ProcessExpression[Probe[main.intSliceArg]@0x4a620a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call e6 04 00 00 // ProcessType[[]int]
+	Call 82 05 00 00 // ProcessType[[]int]
 	Return 
-// 0x1d6: ProcessEvent[Probe[main.intSliceArg]@4a620a]
+// 0x231: ProcessEvent[Probe[main.intSliceArg]@4a620a]
 	PrepareEventRoot a9 00 00 00 19 00 00 00 
-	Call ad 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4a620a.expr[0]]
+	Call 08 02 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4a620a.expr[0]]
 	Return 
-// 0x1e5: ProcessEvent[Probe[main.intSliceArg]Return@4a624f]
+// 0x240: ProcessEvent[Probe[main.intSliceArg]Return@4a624f]
 	PrepareEventRoot aa 00 00 00 00 00 00 00 
 	Return 
-// 0x1ef: ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
+// 0x24a: ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e0 06 00 00 // ProcessType[string]
+	Call 7c 07 00 00 // ProcessType[string]
 	Return 
-// 0x211: ProcessEvent[Probe[main.stringArg]@4a618a]
+// 0x26c: ProcessEvent[Probe[main.stringArg]@4a618a]
 	PrepareEventRoot a3 00 00 00 11 00 00 00 
-	Call ef 01 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
+	Call 4a 02 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
 	Return 
-// 0x220: ProcessEvent[Probe[main.stringArg]Return@4a61cf]
+// 0x27b: ProcessEvent[Probe[main.stringArg]Return@4a61cf]
 	PrepareEventRoot a4 00 00 00 00 00 00 00 
 	Return 
-// 0x22a: ProcessEvent[Probe[main.stringArg]@4a618a]
+// 0x285: ProcessEvent[Probe[main.stringArg]@4a618a]
 	PrepareEventRoot a5 00 00 00 00 00 00 00 
 	Return 
-// 0x234: ProcessEvent[Probe[main.stringArg]Return@4a61cf]
+// 0x28f: ProcessEvent[Probe[main.stringArg]Return@4a61cf]
 	PrepareEventRoot a6 00 00 00 00 00 00 00 
 	Return 
-// 0x23e: ProcessExpression[Probe[main.mapArg]@0x4a64ea.expr[0]]
+// 0x299: ProcessExpression[Probe[main.mapArg]@0x4a64ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call f2 05 00 00 // ProcessType[map[string]int]
+	Call 8e 06 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x259: ProcessExpression[Probe[main.mapArg]@0x4a64ea.expr[1]]
+// 0x2b4: ProcessExpression[Probe[main.mapArg]@0x4a64ea.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call f2 05 00 00 // ProcessType[map[string]int]
+	Call 8e 06 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x274: ProcessEvent[Probe[main.mapArg]@4a64ea]
+// 0x2cf: ProcessEvent[Probe[main.mapArg]@4a64ea]
 	PrepareEventRoot b2 00 00 00 11 00 00 00 
-	Call 3e 02 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a64ea.expr[0]]
-	Call 59 02 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a64ea.expr[1]]
+	Call 99 02 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a64ea.expr[0]]
+	Call b4 02 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a64ea.expr[1]]
 	Return 
-// 0x288: ProcessEvent[Probe[main.mapArg]Return@4a651f]
+// 0x2e3: ProcessEvent[Probe[main.mapArg]Return@4a651f]
 	PrepareEventRoot b3 00 00 00 00 00 00 00 
 	Return 
-// 0x292: ProcessEvent[Probe[main.noArgs]@4a660a]
+// 0x2ed: ProcessEvent[Probe[main.noArgs]@4a660a]
 	PrepareEventRoot b6 00 00 00 00 00 00 00 
 	Return 
-// 0x29c: ProcessEvent[Probe[main.noArgs]Return@4a6646]
+// 0x2f7: ProcessEvent[Probe[main.noArgs]Return@4a6646]
 	PrepareEventRoot b7 00 00 00 00 00 00 00 
 	Return 
-// 0x2a6: ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
+// 0x301: ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e0 06 00 00 // ProcessType[string]
+	Call 7c 07 00 00 // ProcessType[string]
 	Return 
-// 0x2c8: ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[1]]
+// 0x323: ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call e0 06 00 00 // ProcessType[string]
+	Call 7c 07 00 00 // ProcessType[string]
 	Return 
-// 0x2ea: ProcessEvent[Probe[main.stringArg]@4a618a]
+// 0x345: ProcessEvent[Probe[main.stringArg]@4a618a]
 	PrepareEventRoot a7 00 00 00 21 00 00 00 
-	Call a6 02 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
-	Call c8 02 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[1]]
+	Call 01 03 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
+	Call 23 03 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[1]]
 	Return 
-// 0x2fe: ProcessEvent[Probe[main.stringArg]Return@4a61cf]
+// 0x359: ProcessEvent[Probe[main.stringArg]Return@4a61cf]
 	PrepareEventRoot a8 00 00 00 00 00 00 00 
 	Return 
-// 0x308: ProcessExpression[Probe[main.stringArrayArg]@0x4a638a.expr[0]]
+// 0x363: ProcessExpression[Probe[main.stringArrayArg]@0x4a638a.expr[0]]
 	ExprPrepare 
-	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
+	ExprDereferenceCfa 00 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferenceCfa 08 00 00 00 08 00 00 00 08 00 00 00 
+	ExprDereferenceCfa 10 00 00 00 08 00 00 00 10 00 00 00 
+	ExprDereferenceCfa 18 00 00 00 08 00 00 00 18 00 00 00 
+	ExprDereferenceCfa 20 00 00 00 08 00 00 00 20 00 00 00 
+	ExprDereferenceCfa 28 00 00 00 08 00 00 00 28 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 9a 04 00 00 // ProcessType[[3]string]
+	Call 36 05 00 00 // ProcessType[[3]string]
 	Return 
-// 0x329: ProcessEvent[Probe[main.stringArrayArg]@4a638a]
+// 0x3c5: ProcessEvent[Probe[main.stringArrayArg]@4a638a]
 	PrepareEventRoot af 00 00 00 31 00 00 00 
-	Call 08 03 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4a638a.expr[0]]
+	Call 63 03 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4a638a.expr[0]]
 	Return 
-// 0x338: ProcessEvent[Probe[main.stringArrayArg]Return@4a63d6]
+// 0x3d4: ProcessEvent[Probe[main.stringArrayArg]Return@4a63d6]
 	PrepareEventRoot b0 00 00 00 00 00 00 00 
 	Return 
-// 0x342: ProcessExpression[Probe[main.stringSliceArg]@0x4a630a.expr[0]]
+// 0x3de: ProcessExpression[Probe[main.stringSliceArg]@0x4a630a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 00 05 00 00 // ProcessType[[]string]
+	Call 9c 05 00 00 // ProcessType[[]string]
 	Return 
-// 0x36b: ProcessEvent[Probe[main.stringSliceArg]@4a630a]
+// 0x407: ProcessEvent[Probe[main.stringSliceArg]@4a630a]
 	PrepareEventRoot ad 00 00 00 19 00 00 00 
-	Call 42 03 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4a630a.expr[0]]
+	Call de 03 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4a630a.expr[0]]
 	Return 
-// 0x37a: ProcessEvent[Probe[main.stringSliceArg]Return@4a634f]
+// 0x416: ProcessEvent[Probe[main.stringSliceArg]Return@4a634f]
 	PrepareEventRoot ae 00 00 00 00 00 00 00 
 	Return 
-// 0x384: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4a6676]
+// 0x420: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4a6676]
 	PrepareEventRoot b8 00 00 00 00 00 00 00 
 	Return 
-// 0x38e: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a682e.expr[0]]
+// 0x42a: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a682e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 04 06 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call a0 06 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x3a9: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4a682e]
+// 0x445: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4a682e]
 	PrepareEventRoot b9 00 00 00 09 00 00 00 
-	Call 8e 03 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a682e.expr[0]]
+	Call 2a 04 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a682e.expr[0]]
 	Return 
-// 0x3b8: ProcessType[*****int]
+// 0x454: ProcessType[*****int]
 	ProcessPointer 7e 00 00 00 
 	Return 
-// 0x3be: ProcessType[****int]
+// 0x45a: ProcessType[****int]
 	ProcessPointer 9f 00 00 00 
 	Return 
-// 0x3c4: ProcessType[***int]
+// 0x460: ProcessType[***int]
 	ProcessPointer 7f 00 00 00 
 	Return 
-// 0x3ca: ProcessType[**int]
+// 0x466: ProcessType[**int]
 	ProcessPointer 5d 00 00 00 
 	Return 
-// 0x3d0: ProcessType[*[]runtime.ancestorInfo]
+// 0x46c: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x3d6: ProcessType[*bool]
+// 0x472: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x3dc: ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
+// 0x478: ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 98 00 00 00 
 	Return 
-// 0x3e2: ProcessType[*bucket<string,int>]
+// 0x47e: ProcessType[*bucket<string,int>]
 	ProcessPointer 6b 00 00 00 
 	Return 
-// 0x3e8: ProcessType[*bucket<string,main.bigStruct>]
+// 0x484: ProcessType[*bucket<string,main.bigStruct>]
 	ProcessPointer 72 00 00 00 
 	Return 
-// 0x3ee: ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x48a: ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 7c 00 00 00 
 	Return 
-// 0x3f4: ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x490: ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 77 00 00 00 
 	Return 
-// 0x3fa: ProcessType[*error]
+// 0x496: ProcessType[*error]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x400: ProcessType[*float32]
+// 0x49c: ProcessType[*float32]
 	ProcessPointer 10 00 00 00 
 	Return 
-// 0x406: ProcessType[*float64]
+// 0x4a2: ProcessType[*float64]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x40c: ProcessType[*int]
+// 0x4a8: ProcessType[*int]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x412: ProcessType[*int32]
+// 0x4ae: ProcessType[*int32]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x418: ProcessType[*int64]
+// 0x4b4: ProcessType[*int64]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x41e: ProcessType[*main.bigStruct]
+// 0x4ba: ProcessType[*main.bigStruct]
 	ProcessPointer 90 00 00 00 
 	Return 
-// 0x424: ProcessType[*runtime._defer]
+// 0x4c0: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x42a: ProcessType[*runtime._panic]
+// 0x4c6: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x430: ProcessType[*runtime.cgoCallers]
+// 0x4cc: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 3d 00 00 00 
 	Return 
-// 0x436: ProcessType[*runtime.coro]
+// 0x4d2: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x43c: ProcessType[*runtime.g]
+// 0x4d8: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x442: ProcessType[*runtime.m]
+// 0x4de: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x448: ProcessType[*runtime.mapextra]
+// 0x4e4: ProcessType[*runtime.mapextra]
 	ProcessPointer 6d 00 00 00 
 	Return 
-// 0x44e: ProcessType[*runtime.sudog]
+// 0x4ea: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x454: ProcessType[*runtime.timer]
+// 0x4f0: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x45a: ProcessType[*runtime.traceBuf]
+// 0x4f6: ProcessType[*runtime.traceBuf]
 	ProcessPointer 49 00 00 00 
 	Return 
-// 0x460: ProcessType[*string]
+// 0x4fc: ProcessType[*string]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x466: ProcessType[*uint]
+// 0x502: ProcessType[*uint]
 	ProcessPointer 0f 00 00 00 
 	Return 
-// 0x46c: ProcessType[*uint16]
+// 0x508: ProcessType[*uint16]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x472: ProcessType[*uint32]
+// 0x50e: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x478: ProcessType[*uint64]
+// 0x514: ProcessType[*uint64]
 	ProcessPointer 0b 00 00 00 
 	Return 
-// 0x47e: ProcessType[*uint8]
+// 0x51a: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x484: ProcessType[*uintptr]
+// 0x520: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x48a: ProcessType[[2]*runtime.traceBuf]
+// 0x526: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call 5a 04 00 00 // ProcessType[*runtime.traceBuf]
+	Call f6 04 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x49a: ProcessType[[3]string]
+// 0x536: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call e0 06 00 00 // ProcessType[string]
+	Call 7c 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x4aa: ProcessType[[]bucket<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x546: ProcessType[[]bucket<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 4a 05 00 00 // ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
+	Call e6 05 00 00 // ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x4b6: ProcessType[[]bucket<string,int>.array]
+// 0x552: ProcessType[[]bucket<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 55 05 00 00 // ProcessType[bucket<string,int>]
+	Call f1 05 00 00 // ProcessType[bucket<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x4c2: ProcessType[[]bucket<string,main.bigStruct>.array]
+// 0x55e: ProcessType[[]bucket<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 6a 05 00 00 // ProcessType[bucket<string,main.bigStruct>]
+	Call 06 06 00 00 // ProcessType[bucket<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x4ce: ProcessType[[]bucket<string,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x56a: ProcessType[[]bucket<string,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 7f 05 00 00 // ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 1b 06 00 00 // ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x4da: ProcessType[[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x576: ProcessType[[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 94 05 00 00 // ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 30 06 00 00 // ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x4e6: ProcessType[[]int]
+// 0x582: ProcessType[[]int]
 	ProcessSlice 86 00 00 00 08 00 00 00 
 	Return 
-// 0x4f0: ProcessType[[]key<string>]
+// 0x58c: ProcessType[[]key<string>]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call e0 06 00 00 // ProcessType[string]
+	Call 7c 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x500: ProcessType[[]string]
+// 0x59c: ProcessType[[]string]
 	ProcessSlice 88 00 00 00 10 00 00 00 
 	Return 
-// 0x50a: ProcessType[[]string.array]
+// 0x5a6: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call e0 06 00 00 // ProcessType[string]
+	Call 7c 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x516: ProcessType[[]uint8]
+// 0x5b2: ProcessType[[]uint8]
 	ProcessSlice 82 00 00 00 01 00 00 00 
 	Return 
-// 0x520: ProcessType[[]uintptr]
+// 0x5bc: ProcessType[[]uintptr]
 	ProcessSlice 84 00 00 00 08 00 00 00 
 	Return 
-// 0x52a: ProcessType[[]val<main.bigStruct>]
+// 0x5c6: ProcessType[[]val<main.bigStruct>]
 	ProcessArrayDataPrep 40 00 00 00 
-	Call 1e 04 00 00 // ProcessType[*main.bigStruct]
+	Call ba 04 00 00 // ProcessType[*main.bigStruct]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x53a: ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+// 0x5d6: ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessArrayDataPrep 40 00 00 00 
-	Call ec 05 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 88 06 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x54a: ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
+// 0x5e6: ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 88 00 00 00 
-	Call dc 03 00 00 // ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
+	Call 78 04 00 00 // ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x555: ProcessType[bucket<string,int>]
+// 0x5f1: ProcessType[bucket<string,int>]
 	IncrementOutputOffset 08 00 00 00 
-	Call f0 04 00 00 // ProcessType[[]key<string>]
+	Call 8c 05 00 00 // ProcessType[[]key<string>]
 	IncrementOutputOffset 40 00 00 00 
-	Call e2 03 00 00 // ProcessType[*bucket<string,int>]
+	Call 7e 04 00 00 // ProcessType[*bucket<string,int>]
 	Return 
-// 0x56a: ProcessType[bucket<string,main.bigStruct>]
+// 0x606: ProcessType[bucket<string,main.bigStruct>]
 	IncrementOutputOffset 08 00 00 00 
-	Call f0 04 00 00 // ProcessType[[]key<string>]
-	Call 2a 05 00 00 // ProcessType[[]val<main.bigStruct>]
-	Call e8 03 00 00 // ProcessType[*bucket<string,main.bigStruct>]
+	Call 8c 05 00 00 // ProcessType[[]key<string>]
+	Call c6 05 00 00 // ProcessType[[]val<main.bigStruct>]
+	Call 84 04 00 00 // ProcessType[*bucket<string,main.bigStruct>]
 	Return 
-// 0x57f: ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x61b: ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 08 00 00 00 
-	Call f0 04 00 00 // ProcessType[[]key<string>]
-	Call 3a 05 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
-	Call ee 03 00 00 // ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 8c 05 00 00 // ProcessType[[]key<string>]
+	Call d6 05 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+	Call 8a 04 00 00 // ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x594: ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x630: ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 3a 05 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
-	Call f4 03 00 00 // ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call d6 05 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+	Call 90 04 00 00 // ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x5a4: ProcessType[error]
+// 0x640: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x5a6: ProcessType[hash<int,main.aStructNotUsedAsAnArgument>]
+// 0x642: ProcessType[hash<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoHmap 9e 00 00 00 90 00 00 00 08 09 10 18 
 	Return 
-// 0x5b4: ProcessType[hash<string,int>]
+// 0x650: ProcessType[hash<string,int>]
 	ProcessGoHmap 8d 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x5c2: ProcessType[hash<string,main.bigStruct>]
+// 0x65e: ProcessType[hash<string,main.bigStruct>]
 	ProcessGoHmap 91 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x5d0: ProcessType[hash<string,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x66c: ProcessType[hash<string,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoHmap 9a 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x5de: ProcessType[hash<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x67a: ProcessType[hash<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoHmap 99 00 00 00 58 00 00 00 08 09 10 18 
 	Return 
-// 0x5ec: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x688: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 96 00 00 00 
 	Return 
-// 0x5f2: ProcessType[map[string]int]
+// 0x68e: ProcessType[map[string]int]
 	ProcessPointer 69 00 00 00 
 	Return 
-// 0x5f8: ProcessType[map[string]main.bigStruct]
+// 0x694: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 70 00 00 00 
 	Return 
-// 0x5fe: ProcessType[map[string]map[int]main.aStructNotUsedAsAnArgument]
+// 0x69a: ProcessType[map[string]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 7a 00 00 00 
 	Return 
-// 0x604: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x6a0: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 75 00 00 00 
 	Return 
-// 0x60a: ProcessType[runtime.g]
+// 0x6a6: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 2a 04 00 00 // ProcessType[*runtime._panic]
+	Call c6 04 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 24 04 00 00 // ProcessType[*runtime._defer]
+	Call c0 04 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call 42 04 00 00 // ProcessType[*runtime.m]
+	Call de 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call 16 05 00 00 // ProcessType[[]uint8]
+	Call b2 05 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call d0 03 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 6c 04 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call 4e 04 00 00 // ProcessType[*runtime.sudog]
+	Call ea 04 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 20 05 00 00 // ProcessType[[]uintptr]
+	Call bc 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call 54 04 00 00 // ProcessType[*runtime.timer]
+	Call f0 04 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call 36 04 00 00 // ProcessType[*runtime.coro]
+	Call d2 04 00 00 // ProcessType[*runtime.coro]
 	Return 
-// 0x665: ProcessType[runtime.m]
-	Call 3c 04 00 00 // ProcessType[*runtime.g]
+// 0x701: ProcessType[runtime.m]
+	Call d8 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 50 00 00 00 
-	Call 3c 04 00 00 // ProcessType[*runtime.g]
+	Call d8 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call 3c 04 00 00 // ProcessType[*runtime.g]
+	Call d8 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call e0 06 00 00 // ProcessType[string]
+	Call 7c 07 00 00 // ProcessType[string]
 	IncrementOutputOffset 40 00 00 00 
-	Call 30 04 00 00 // ProcessType[*runtime.cgoCallers]
+	Call cc 04 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call 42 04 00 00 // ProcessType[*runtime.m]
+	Call de 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 28 01 00 00 
-	Call c5 06 00 00 // ProcessType[runtime.mLockProfile]
+	Call 61 07 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 38 00 00 00 
-	Call 20 05 00 00 // ProcessType[[]uintptr]
+	Call bc 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call 42 04 00 00 // ProcessType[*runtime.m]
+	Call de 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call d0 06 00 00 // ProcessType[runtime.mTraceState]
+	Call 6c 07 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x6c5: ProcessType[runtime.mLockProfile]
+// 0x761: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 20 05 00 00 // ProcessType[[]uintptr]
+	Call bc 05 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x6d0: ProcessType[runtime.mTraceState]
+// 0x76c: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call 8a 04 00 00 // ProcessType[[2]*runtime.traceBuf]
-	Call 42 04 00 00 // ProcessType[*runtime.m]
+	Call 26 05 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call de 04 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x6e0: ProcessType[string]
+// 0x77c: ProcessType[string]
 	ProcessString 80 00 00 00 
 	Return 
 // Extra illegal ops to simplify code bound checks
@@ -533,12 +545,12 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 982
-ID: 6 Len: 8 Enqueue: 1150
+ID: 5 Len: 8 Enqueue: 1138
+ID: 6 Len: 8 Enqueue: 1306
 ID: 7 Len: 2 Enqueue: 0
-ID: 8 Len: 8 Enqueue: 1156
+ID: 8 Len: 8 Enqueue: 1312
 ID: 9 Len: 8 Enqueue: 0
-ID: 10 Len: 16 Enqueue: 1760
+ID: 10 Len: 16 Enqueue: 1916
 ID: 11 Len: 8 Enqueue: 0
 ID: 12 Len: 4 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
@@ -546,18 +558,18 @@ ID: 14 Len: 1 Enqueue: 0
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 4 Enqueue: 0
 ID: 17 Len: 8 Enqueue: 0
-ID: 18 Len: 16 Enqueue: 1444
+ID: 18 Len: 16 Enqueue: 1600
 ID: 19 Len: 8 Enqueue: 0
-ID: 20 Len: 8 Enqueue: 1042
-ID: 21 Len: 8 Enqueue: 1138
-ID: 22 Len: 432 Enqueue: 1546
+ID: 20 Len: 8 Enqueue: 1198
+ID: 21 Len: 8 Enqueue: 1294
+ID: 22 Len: 432 Enqueue: 1702
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 1066
+ID: 24 Len: 8 Enqueue: 1222
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 1060
+ID: 26 Len: 8 Enqueue: 1216
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 1090
-ID: 29 Len: 1760 Enqueue: 1637
+ID: 28 Len: 8 Enqueue: 1246
+ID: 29 Len: 1760 Enqueue: 1793
 ID: 30 Len: 56 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -566,41 +578,41 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 1302
-ID: 39 Len: 8 Enqueue: 976
+ID: 38 Len: 24 Enqueue: 1458
+ID: 39 Len: 8 Enqueue: 1132
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 1102
+ID: 41 Len: 8 Enqueue: 1258
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 1312
-ID: 44 Len: 8 Enqueue: 1108
+ID: 43 Len: 24 Enqueue: 1468
+ID: 44 Len: 8 Enqueue: 1264
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 1078
+ID: 47 Len: 8 Enqueue: 1234
 ID: 48 Len: 8 Enqueue: 0
 ID: 49 Len: 32 Enqueue: 0
 ID: 50 Len: 32 Enqueue: 0
 ID: 51 Len: 12 Enqueue: 0
 ID: 52 Len: 16 Enqueue: 0
-ID: 53 Len: 8 Enqueue: 1084
+ID: 53 Len: 8 Enqueue: 1240
 ID: 54 Len: 40 Enqueue: 0
 ID: 55 Len: 8 Enqueue: 0
 ID: 56 Len: 48 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 8 Enqueue: 0
 ID: 59 Len: 4 Enqueue: 0
-ID: 60 Len: 8 Enqueue: 1072
+ID: 60 Len: 8 Enqueue: 1228
 ID: 61 Len: 8 Enqueue: 0
 ID: 62 Len: 8 Enqueue: 0
 ID: 63 Len: 256 Enqueue: 0
-ID: 64 Len: 64 Enqueue: 1733
+ID: 64 Len: 64 Enqueue: 1889
 ID: 65 Len: 8 Enqueue: 0
 ID: 66 Len: 0 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 1 Enqueue: 0
-ID: 69 Len: 32 Enqueue: 1744
+ID: 69 Len: 32 Enqueue: 1900
 ID: 70 Len: 8 Enqueue: 0
-ID: 71 Len: 16 Enqueue: 1162
-ID: 72 Len: 8 Enqueue: 1114
+ID: 71 Len: 16 Enqueue: 1318
+ID: 72 Len: 8 Enqueue: 1270
 ID: 73 Len: 8 Enqueue: 0
 ID: 74 Len: 48 Enqueue: 0
 ID: 75 Len: 0 Enqueue: 0
@@ -616,46 +628,46 @@ ID: 84 Len: 32 Enqueue: 0
 ID: 85 Len: 160 Enqueue: 0
 ID: 86 Len: 16 Enqueue: 0
 ID: 87 Len: 8 Enqueue: 0
-ID: 88 Len: 8 Enqueue: 1120
+ID: 88 Len: 8 Enqueue: 1276
 ID: 89 Len: 8 Enqueue: 0
 ID: 90 Len: 16 Enqueue: 0
-ID: 91 Len: 8 Enqueue: 1030
-ID: 92 Len: 8 Enqueue: 1048
-ID: 93 Len: 8 Enqueue: 1036
-ID: 94 Len: 8 Enqueue: 1144
-ID: 95 Len: 8 Enqueue: 1018
-ID: 96 Len: 8 Enqueue: 1024
-ID: 97 Len: 8 Enqueue: 1126
-ID: 98 Len: 8 Enqueue: 1132
-ID: 99 Len: 24 Enqueue: 1254
+ID: 91 Len: 8 Enqueue: 1186
+ID: 92 Len: 8 Enqueue: 1204
+ID: 93 Len: 8 Enqueue: 1192
+ID: 94 Len: 8 Enqueue: 1300
+ID: 95 Len: 8 Enqueue: 1174
+ID: 96 Len: 8 Enqueue: 1180
+ID: 97 Len: 8 Enqueue: 1282
+ID: 98 Len: 8 Enqueue: 1288
+ID: 99 Len: 24 Enqueue: 1410
 ID: 100 Len: 24 Enqueue: 0
-ID: 101 Len: 24 Enqueue: 1280
-ID: 102 Len: 48 Enqueue: 1178
-ID: 103 Len: 8 Enqueue: 1522
+ID: 101 Len: 24 Enqueue: 1436
+ID: 102 Len: 48 Enqueue: 1334
+ID: 103 Len: 8 Enqueue: 1678
 ID: 104 Len: 8 Enqueue: 0
-ID: 105 Len: 48 Enqueue: 1460
-ID: 106 Len: 8 Enqueue: 994
-ID: 107 Len: 208 Enqueue: 1365
-ID: 108 Len: 8 Enqueue: 1096
+ID: 105 Len: 48 Enqueue: 1616
+ID: 106 Len: 8 Enqueue: 1150
+ID: 107 Len: 208 Enqueue: 1521
+ID: 108 Len: 8 Enqueue: 1252
 ID: 109 Len: 8 Enqueue: 0
-ID: 110 Len: 8 Enqueue: 1528
+ID: 110 Len: 8 Enqueue: 1684
 ID: 111 Len: 8 Enqueue: 0
-ID: 112 Len: 48 Enqueue: 1474
-ID: 113 Len: 8 Enqueue: 1000
-ID: 114 Len: 208 Enqueue: 1386
-ID: 115 Len: 8 Enqueue: 1540
+ID: 112 Len: 48 Enqueue: 1630
+ID: 113 Len: 8 Enqueue: 1156
+ID: 114 Len: 208 Enqueue: 1542
+ID: 115 Len: 8 Enqueue: 1696
 ID: 116 Len: 8 Enqueue: 0
-ID: 117 Len: 48 Enqueue: 1502
-ID: 118 Len: 8 Enqueue: 1012
-ID: 119 Len: 88 Enqueue: 1428
-ID: 120 Len: 8 Enqueue: 1534
+ID: 117 Len: 48 Enqueue: 1658
+ID: 118 Len: 8 Enqueue: 1168
+ID: 119 Len: 88 Enqueue: 1584
+ID: 120 Len: 8 Enqueue: 1690
 ID: 121 Len: 8 Enqueue: 0
-ID: 122 Len: 48 Enqueue: 1488
-ID: 123 Len: 8 Enqueue: 1006
-ID: 124 Len: 208 Enqueue: 1407
-ID: 125 Len: 8 Enqueue: 952
-ID: 126 Len: 8 Enqueue: 958
-ID: 127 Len: 8 Enqueue: 970
+ID: 122 Len: 48 Enqueue: 1644
+ID: 123 Len: 8 Enqueue: 1162
+ID: 124 Len: 208 Enqueue: 1563
+ID: 125 Len: 8 Enqueue: 1108
+ID: 126 Len: 8 Enqueue: 1114
+ID: 127 Len: 8 Enqueue: 1126
 ID: 128 Len: 1 Enqueue: 0
 ID: 129 Len: 8 Enqueue: 0
 ID: 130 Len: 1 Enqueue: 0
@@ -664,30 +676,30 @@ ID: 132 Len: 8 Enqueue: 0
 ID: 133 Len: 8 Enqueue: 0
 ID: 134 Len: 8 Enqueue: 0
 ID: 135 Len: 8 Enqueue: 0
-ID: 136 Len: 16 Enqueue: 1290
+ID: 136 Len: 16 Enqueue: 1446
 ID: 137 Len: 8 Enqueue: 0
 ID: 138 Len: 8 Enqueue: 0
-ID: 139 Len: 128 Enqueue: 1264
+ID: 139 Len: 128 Enqueue: 1420
 ID: 140 Len: 64 Enqueue: 0
-ID: 141 Len: 208 Enqueue: 1206
-ID: 142 Len: 64 Enqueue: 1322
-ID: 143 Len: 8 Enqueue: 1054
+ID: 141 Len: 208 Enqueue: 1362
+ID: 142 Len: 64 Enqueue: 1478
+ID: 143 Len: 8 Enqueue: 1210
 ID: 144 Len: 184 Enqueue: 0
-ID: 145 Len: 208 Enqueue: 1218
+ID: 145 Len: 208 Enqueue: 1374
 ID: 146 Len: 8 Enqueue: 0
-ID: 147 Len: 64 Enqueue: 1338
-ID: 148 Len: 8 Enqueue: 1516
+ID: 147 Len: 64 Enqueue: 1494
+ID: 148 Len: 8 Enqueue: 1672
 ID: 149 Len: 8 Enqueue: 0
-ID: 150 Len: 48 Enqueue: 1446
-ID: 151 Len: 8 Enqueue: 988
-ID: 152 Len: 144 Enqueue: 1354
-ID: 153 Len: 88 Enqueue: 1242
-ID: 154 Len: 208 Enqueue: 1230
+ID: 150 Len: 48 Enqueue: 1602
+ID: 151 Len: 8 Enqueue: 1144
+ID: 152 Len: 144 Enqueue: 1510
+ID: 153 Len: 88 Enqueue: 1398
+ID: 154 Len: 208 Enqueue: 1386
 ID: 155 Len: 64 Enqueue: 0
 ID: 156 Len: 64 Enqueue: 0
 ID: 157 Len: 8 Enqueue: 0
-ID: 158 Len: 144 Enqueue: 1194
-ID: 159 Len: 8 Enqueue: 964
+ID: 158 Len: 144 Enqueue: 1350
+ID: 159 Len: 8 Enqueue: 1120
 ID: 160 Len: 128 Enqueue: 0
 ID: 161 Len: 9 Enqueue: 0
 ID: 162 Len: 0 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.sm.txt
@@ -7,13 +7,13 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call b8 03 00 00 // ProcessType[*****int]
+	Call 54 04 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessExpression[Probe[main.PointerChainArg]@0x4a8046.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call b8 03 00 00 // ProcessType[*****int]
+	Call 54 04 00 00 // ProcessType[*****int]
 	Return 
 // 0x39: ProcessEvent[Probe[main.PointerChainArg]@4a8046]
 	PrepareEventRoot cd 00 00 00 11 00 00 00 
@@ -24,7 +24,7 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call ca 03 00 00 // ProcessType[**int]
+	Call 66 04 00 00 // ProcessType[**int]
 	Return 
 // 0x68: ProcessEvent[Probe[main.PointerSmallChainArg]@4a8090]
 	PrepareEventRoot ce 00 00 00 09 00 00 00 
@@ -34,13 +34,13 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call aa 05 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 46 06 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x92: ProcessExpression[Probe[main.bigMapArg]@0x4a8553.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call aa 05 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 46 06 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0xad: ProcessEvent[Probe[main.bigMapArg]@4a8553]
 	PrepareEventRoot c5 00 00 00 11 00 00 00 
@@ -85,467 +85,479 @@
 	Return 
 // 0x148: ProcessExpression[Probe[main.intArrayArg]@0x4a828a.expr[0]]
 	ExprPrepare 
-	ExprDereferenceCfa 00 00 00 00 18 00 00 00 00 00 00 00 
+	ExprDereferenceCfa 00 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferenceCfa 08 00 00 00 08 00 00 00 08 00 00 00 
+	ExprDereferenceCfa 10 00 00 00 08 00 00 00 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
-// 0x164: ProcessEvent[Probe[main.intArrayArg]@4a828a]
+// 0x17e: ProcessEvent[Probe[main.intArrayArg]@4a828a]
 	PrepareEventRoot bc 00 00 00 19 00 00 00 
 	Call 48 01 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4a828a.expr[0]]
 	Return 
-// 0x173: ProcessEvent[Probe[main.intArrayArg]Return@4a82d6]
+// 0x18d: ProcessEvent[Probe[main.intArrayArg]Return@4a82d6]
 	PrepareEventRoot bd 00 00 00 00 00 00 00 
 	Return 
-// 0x17d: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a8400.expr[0]]
+// 0x197: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a8400.expr[0]]
 	ExprPrepare 
-	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
+	ExprDereferenceCfa 00 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferenceCfa 08 00 00 00 08 00 00 00 08 00 00 00 
+	ExprDereferenceCfa 10 00 00 00 08 00 00 00 10 00 00 00 
+	ExprDereferenceCfa 18 00 00 00 08 00 00 00 18 00 00 00 
+	ExprDereferenceCfa 20 00 00 00 08 00 00 00 20 00 00 00 
+	ExprDereferenceCfa 28 00 00 00 08 00 00 00 28 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call a4 04 00 00 // ProcessType[[3]string]
+	Call 40 05 00 00 // ProcessType[[3]string]
 	Return 
-// 0x19e: ProcessEvent[Probe[main.stringArrayArgFrameless]@4a8400]
+// 0x1f9: ProcessEvent[Probe[main.stringArrayArgFrameless]@4a8400]
 	PrepareEventRoot c2 00 00 00 31 00 00 00 
-	Call 7d 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a8400.expr[0]]
+	Call 97 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a8400.expr[0]]
 	Return 
-// 0x1ad: ProcessExpression[Probe[main.intSliceArg]@0x4a820a.expr[0]]
+// 0x208: ProcessExpression[Probe[main.intSliceArg]@0x4a820a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call e4 04 00 00 // ProcessType[[]int]
+	Call 80 05 00 00 // ProcessType[[]int]
 	Return 
-// 0x1d6: ProcessEvent[Probe[main.intSliceArg]@4a820a]
+// 0x231: ProcessEvent[Probe[main.intSliceArg]@4a820a]
 	PrepareEventRoot ba 00 00 00 19 00 00 00 
-	Call ad 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4a820a.expr[0]]
+	Call 08 02 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4a820a.expr[0]]
 	Return 
-// 0x1e5: ProcessEvent[Probe[main.intSliceArg]Return@4a824f]
+// 0x240: ProcessEvent[Probe[main.intSliceArg]Return@4a824f]
 	PrepareEventRoot bb 00 00 00 00 00 00 00 
 	Return 
-// 0x1ef: ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[0]]
+// 0x24a: ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 08 07 00 00 // ProcessType[string]
+	Call a4 07 00 00 // ProcessType[string]
 	Return 
-// 0x211: ProcessEvent[Probe[main.stringArg]@4a818a]
+// 0x26c: ProcessEvent[Probe[main.stringArg]@4a818a]
 	PrepareEventRoot b4 00 00 00 11 00 00 00 
-	Call ef 01 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[0]]
+	Call 4a 02 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[0]]
 	Return 
-// 0x220: ProcessEvent[Probe[main.stringArg]Return@4a81cf]
+// 0x27b: ProcessEvent[Probe[main.stringArg]Return@4a81cf]
 	PrepareEventRoot b5 00 00 00 00 00 00 00 
 	Return 
-// 0x22a: ProcessEvent[Probe[main.stringArg]@4a818a]
+// 0x285: ProcessEvent[Probe[main.stringArg]@4a818a]
 	PrepareEventRoot b6 00 00 00 00 00 00 00 
 	Return 
-// 0x234: ProcessEvent[Probe[main.stringArg]Return@4a81cf]
+// 0x28f: ProcessEvent[Probe[main.stringArg]Return@4a81cf]
 	PrepareEventRoot b7 00 00 00 00 00 00 00 
 	Return 
-// 0x23e: ProcessExpression[Probe[main.mapArg]@0x4a84ea.expr[0]]
+// 0x299: ProcessExpression[Probe[main.mapArg]@0x4a84ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call a4 05 00 00 // ProcessType[map[string]int]
+	Call 40 06 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x259: ProcessExpression[Probe[main.mapArg]@0x4a84ea.expr[1]]
+// 0x2b4: ProcessExpression[Probe[main.mapArg]@0x4a84ea.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call a4 05 00 00 // ProcessType[map[string]int]
+	Call 40 06 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x274: ProcessEvent[Probe[main.mapArg]@4a84ea]
+// 0x2cf: ProcessEvent[Probe[main.mapArg]@4a84ea]
 	PrepareEventRoot c3 00 00 00 11 00 00 00 
-	Call 3e 02 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a84ea.expr[0]]
-	Call 59 02 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a84ea.expr[1]]
+	Call 99 02 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a84ea.expr[0]]
+	Call b4 02 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a84ea.expr[1]]
 	Return 
-// 0x288: ProcessEvent[Probe[main.mapArg]Return@4a851f]
+// 0x2e3: ProcessEvent[Probe[main.mapArg]Return@4a851f]
 	PrepareEventRoot c4 00 00 00 00 00 00 00 
 	Return 
-// 0x292: ProcessEvent[Probe[main.noArgs]@4a860a]
+// 0x2ed: ProcessEvent[Probe[main.noArgs]@4a860a]
 	PrepareEventRoot c7 00 00 00 00 00 00 00 
 	Return 
-// 0x29c: ProcessEvent[Probe[main.noArgs]Return@4a8646]
+// 0x2f7: ProcessEvent[Probe[main.noArgs]Return@4a8646]
 	PrepareEventRoot c8 00 00 00 00 00 00 00 
 	Return 
-// 0x2a6: ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[0]]
+// 0x301: ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 08 07 00 00 // ProcessType[string]
+	Call a4 07 00 00 // ProcessType[string]
 	Return 
-// 0x2c8: ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[1]]
+// 0x323: ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call 08 07 00 00 // ProcessType[string]
+	Call a4 07 00 00 // ProcessType[string]
 	Return 
-// 0x2ea: ProcessEvent[Probe[main.stringArg]@4a818a]
+// 0x345: ProcessEvent[Probe[main.stringArg]@4a818a]
 	PrepareEventRoot b8 00 00 00 21 00 00 00 
-	Call a6 02 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[0]]
-	Call c8 02 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[1]]
+	Call 01 03 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[0]]
+	Call 23 03 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[1]]
 	Return 
-// 0x2fe: ProcessEvent[Probe[main.stringArg]Return@4a81cf]
+// 0x359: ProcessEvent[Probe[main.stringArg]Return@4a81cf]
 	PrepareEventRoot b9 00 00 00 00 00 00 00 
 	Return 
-// 0x308: ProcessExpression[Probe[main.stringArrayArg]@0x4a838a.expr[0]]
+// 0x363: ProcessExpression[Probe[main.stringArrayArg]@0x4a838a.expr[0]]
 	ExprPrepare 
-	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
+	ExprDereferenceCfa 00 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferenceCfa 08 00 00 00 08 00 00 00 08 00 00 00 
+	ExprDereferenceCfa 10 00 00 00 08 00 00 00 10 00 00 00 
+	ExprDereferenceCfa 18 00 00 00 08 00 00 00 18 00 00 00 
+	ExprDereferenceCfa 20 00 00 00 08 00 00 00 20 00 00 00 
+	ExprDereferenceCfa 28 00 00 00 08 00 00 00 28 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call a4 04 00 00 // ProcessType[[3]string]
+	Call 40 05 00 00 // ProcessType[[3]string]
 	Return 
-// 0x329: ProcessEvent[Probe[main.stringArrayArg]@4a838a]
+// 0x3c5: ProcessEvent[Probe[main.stringArrayArg]@4a838a]
 	PrepareEventRoot c0 00 00 00 31 00 00 00 
-	Call 08 03 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4a838a.expr[0]]
+	Call 63 03 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4a838a.expr[0]]
 	Return 
-// 0x338: ProcessEvent[Probe[main.stringArrayArg]Return@4a83d6]
+// 0x3d4: ProcessEvent[Probe[main.stringArrayArg]Return@4a83d6]
 	PrepareEventRoot c1 00 00 00 00 00 00 00 
 	Return 
-// 0x342: ProcessExpression[Probe[main.stringSliceArg]@0x4a830a.expr[0]]
+// 0x3de: ProcessExpression[Probe[main.stringSliceArg]@0x4a830a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 12 05 00 00 // ProcessType[[]string]
+	Call ae 05 00 00 // ProcessType[[]string]
 	Return 
-// 0x36b: ProcessEvent[Probe[main.stringSliceArg]@4a830a]
+// 0x407: ProcessEvent[Probe[main.stringSliceArg]@4a830a]
 	PrepareEventRoot be 00 00 00 19 00 00 00 
-	Call 42 03 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4a830a.expr[0]]
+	Call de 03 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4a830a.expr[0]]
 	Return 
-// 0x37a: ProcessEvent[Probe[main.stringSliceArg]Return@4a834f]
+// 0x416: ProcessEvent[Probe[main.stringSliceArg]Return@4a834f]
 	PrepareEventRoot bf 00 00 00 00 00 00 00 
 	Return 
-// 0x384: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4a8676]
+// 0x420: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4a8676]
 	PrepareEventRoot c9 00 00 00 00 00 00 00 
 	Return 
-// 0x38e: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a883c.expr[0]]
+// 0x42a: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a883c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call b0 05 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 4c 06 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x3a9: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4a883c]
+// 0x445: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4a883c]
 	PrepareEventRoot ca 00 00 00 09 00 00 00 
-	Call 8e 03 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a883c.expr[0]]
+	Call 2a 04 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a883c.expr[0]]
 	Return 
-// 0x3b8: ProcessType[*****int]
+// 0x454: ProcessType[*****int]
 	ProcessPointer 7c 00 00 00 
 	Return 
-// 0x3be: ProcessType[****int]
+// 0x45a: ProcessType[****int]
 	ProcessPointer b0 00 00 00 
 	Return 
-// 0x3c4: ProcessType[***int]
+// 0x460: ProcessType[***int]
 	ProcessPointer 7d 00 00 00 
 	Return 
-// 0x3ca: ProcessType[**int]
+// 0x466: ProcessType[**int]
 	ProcessPointer 62 00 00 00 
 	Return 
-// 0x3d0: ProcessType[*[]runtime.ancestorInfo]
+// 0x46c: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x3d6: ProcessType[*bool]
+// 0x472: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x3dc: ProcessType[*error]
+// 0x478: ProcessType[*error]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x3e2: ProcessType[*float32]
+// 0x47e: ProcessType[*float32]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x3e8: ProcessType[*float64]
+// 0x484: ProcessType[*float64]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x3ee: ProcessType[*int]
+// 0x48a: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x3f4: ProcessType[*int32]
+// 0x490: ProcessType[*int32]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x3fa: ProcessType[*int64]
+// 0x496: ProcessType[*int64]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x400: ProcessType[*main.bigStruct]
+// 0x49c: ProcessType[*main.bigStruct]
 	ProcessPointer 97 00 00 00 
 	Return 
-// 0x406: ProcessType[*runtime._defer]
+// 0x4a2: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x40c: ProcessType[*runtime._panic]
+// 0x4a8: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x412: ProcessType[*runtime.cgoCallers]
+// 0x4ae: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 3f 00 00 00 
 	Return 
-// 0x418: ProcessType[*runtime.coro]
+// 0x4b4: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x41e: ProcessType[*runtime.g]
+// 0x4ba: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x424: ProcessType[*runtime.m]
+// 0x4c0: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x42a: ProcessType[*runtime.sudog]
+// 0x4c6: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x430: ProcessType[*runtime.synctestGroup]
+// 0x4cc: ProcessType[*runtime.synctestGroup]
 	ProcessPointer 32 00 00 00 
 	Return 
-// 0x436: ProcessType[*runtime.timer]
+// 0x4d2: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x43c: ProcessType[*runtime.traceBuf]
+// 0x4d8: ProcessType[*runtime.traceBuf]
 	ProcessPointer 4d 00 00 00 
 	Return 
-// 0x442: ProcessType[*string]
+// 0x4de: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x448: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+// 0x4e4: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer a7 00 00 00 
 	Return 
-// 0x44e: ProcessType[*table<string,int>]
+// 0x4ea: ProcessType[*table<string,int>]
 	ProcessPointer 88 00 00 00 
 	Return 
-// 0x454: ProcessType[*table<string,main.bigStruct>]
+// 0x4f0: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer 90 00 00 00 
 	Return 
-// 0x45a: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x4f6: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 9a 00 00 00 
 	Return 
-// 0x460: ProcessType[*uint]
+// 0x4fc: ProcessType[*uint]
 	ProcessPointer 10 00 00 00 
 	Return 
-// 0x466: ProcessType[*uint16]
+// 0x502: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x46c: ProcessType[*uint32]
+// 0x508: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x472: ProcessType[*uint64]
+// 0x50e: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x478: ProcessType[*uint8]
+// 0x514: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x47e: ProcessType[*uintptr]
+// 0x51a: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x484: ProcessType[[2]*runtime.traceBuf]
+// 0x520: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call 3c 04 00 00 // ProcessType[*runtime.traceBuf]
+	Call d8 04 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x494: ProcessType[[2][2]*runtime.traceBuf]
+// 0x530: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call 84 04 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call 20 05 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x4a4: ProcessType[[3]string]
+// 0x540: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 08 07 00 00 // ProcessType[string]
+	Call a4 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x4b4: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x550: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 48 04 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	Call e4 04 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x4c0: ProcessType[[]*table<string,int>.array]
+// 0x55c: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 4e 04 00 00 // ProcessType[*table<string,int>]
+	Call ea 04 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x4cc: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x568: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 54 04 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call f0 04 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x4d8: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x574: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 5a 04 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call f6 04 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x4e4: ProcessType[[]int]
+// 0x580: ProcessType[[]int]
 	ProcessSlice 84 00 00 00 08 00 00 00 
 	Return 
-// 0x4ee: ProcessType[[]noalg.map.group[string]int.array]
+// 0x58a: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call e6 05 00 00 // ProcessType[noalg.map.group[string]int]
+	Call 82 06 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x4fa: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x596: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call f1 05 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call 8d 06 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x506: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+// 0x5a2: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call fc 05 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 98 06 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x512: ProcessType[[]string]
+// 0x5ae: ProcessType[[]string]
 	ProcessSlice 86 00 00 00 10 00 00 00 
 	Return 
-// 0x51c: ProcessType[[]string.array]
+// 0x5b8: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call 08 07 00 00 // ProcessType[string]
+	Call a4 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x528: ProcessType[[]uint8]
+// 0x5c4: ProcessType[[]uint8]
 	ProcessSlice 80 00 00 00 01 00 00 00 
 	Return 
-// 0x532: ProcessType[[]uintptr]
+// 0x5ce: ProcessType[[]uintptr]
 	ProcessSlice 82 00 00 00 08 00 00 00 
 	Return 
-// 0x53c: ProcessType[error]
+// 0x5d8: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x53e: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+// 0x5da: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups af 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x54a: ProcessType[groupReference<string,int>]
+// 0x5e6: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups 8f 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x556: ProcessType[groupReference<string,main.bigStruct>]
+// 0x5f2: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups 99 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x562: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x5fe: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups a6 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x56e: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+// 0x60a: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap ae 00 00 00 aa 00 00 00 10 18 
 	Return 
-// 0x57a: ProcessType[map<string,int>]
+// 0x616: ProcessType[map<string,int>]
 	ProcessGoSwissMap 8e 00 00 00 8b 00 00 00 10 18 
 	Return 
-// 0x586: ProcessType[map<string,main.bigStruct>]
+// 0x622: ProcessType[map<string,main.bigStruct>]
 	ProcessGoSwissMap 98 00 00 00 93 00 00 00 10 18 
 	Return 
-// 0x592: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x62e: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap a5 00 00 00 9d 00 00 00 10 18 
 	Return 
-// 0x59e: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x63a: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer a2 00 00 00 
 	Return 
-// 0x5a4: ProcessType[map[string]int]
+// 0x640: ProcessType[map[string]int]
 	ProcessPointer 6e 00 00 00 
 	Return 
-// 0x5aa: ProcessType[map[string]main.bigStruct]
+// 0x646: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 73 00 00 00 
 	Return 
-// 0x5b0: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x64c: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 78 00 00 00 
 	Return 
-// 0x5b6: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x652: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 07 06 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call a3 06 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x5c6: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x662: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 17 06 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call b3 06 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x5d6: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x672: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call 1d 06 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call b9 06 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x5e6: ProcessType[noalg.map.group[string]int]
+// 0x682: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call c6 05 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call 62 06 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x5f1: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x68d: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call b6 05 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call 52 06 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x5fc: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x698: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call d6 05 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 72 06 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x607: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call 08 07 00 00 // ProcessType[string]
+// 0x6a3: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call a4 07 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 00 04 00 00 // ProcessType[*main.bigStruct]
+	Call 9c 04 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x617: ProcessType[noalg.struct { key string; elem int }]
-	Call 08 07 00 00 // ProcessType[string]
+// 0x6b3: ProcessType[noalg.struct { key string; elem int }]
+	Call a4 07 00 00 // ProcessType[string]
 	Return 
-// 0x61d: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x6b9: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call 9e 05 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 3a 06 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x628: ProcessType[runtime.g]
+// 0x6c4: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 0c 04 00 00 // ProcessType[*runtime._panic]
+	Call a8 04 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 06 04 00 00 // ProcessType[*runtime._defer]
+	Call a2 04 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call 24 04 00 00 // ProcessType[*runtime.m]
+	Call c0 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call 28 05 00 00 // ProcessType[[]uint8]
+	Call c4 05 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call d0 03 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 6c 04 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call 2a 04 00 00 // ProcessType[*runtime.sudog]
+	Call c6 04 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 32 05 00 00 // ProcessType[[]uintptr]
+	Call ce 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call 36 04 00 00 // ProcessType[*runtime.timer]
+	Call d2 04 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call 18 04 00 00 // ProcessType[*runtime.coro]
+	Call b4 04 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call 30 04 00 00 // ProcessType[*runtime.synctestGroup]
+	Call cc 04 00 00 // ProcessType[*runtime.synctestGroup]
 	Return 
-// 0x68d: ProcessType[runtime.m]
-	Call 1e 04 00 00 // ProcessType[*runtime.g]
+// 0x729: ProcessType[runtime.m]
+	Call ba 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 50 00 00 00 
-	Call 1e 04 00 00 // ProcessType[*runtime.g]
+	Call ba 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call 1e 04 00 00 // ProcessType[*runtime.g]
+	Call ba 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call 08 07 00 00 // ProcessType[string]
+	Call a4 07 00 00 // ProcessType[string]
 	IncrementOutputOffset 40 00 00 00 
-	Call 12 04 00 00 // ProcessType[*runtime.cgoCallers]
+	Call ae 04 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call 24 04 00 00 // ProcessType[*runtime.m]
+	Call c0 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 28 01 00 00 
-	Call ed 06 00 00 // ProcessType[runtime.mLockProfile]
+	Call 89 07 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 38 00 00 00 
-	Call 32 05 00 00 // ProcessType[[]uintptr]
+	Call ce 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call 24 04 00 00 // ProcessType[*runtime.m]
+	Call c0 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call f8 06 00 00 // ProcessType[runtime.mTraceState]
+	Call 94 07 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x6ed: ProcessType[runtime.mLockProfile]
+// 0x789: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 32 05 00 00 // ProcessType[[]uintptr]
+	Call ce 05 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x6f8: ProcessType[runtime.mTraceState]
+// 0x794: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call 94 04 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call 24 04 00 00 // ProcessType[*runtime.m]
+	Call 30 05 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call c0 04 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x708: ProcessType[string]
+// 0x7a4: ProcessType[string]
 	ProcessString 7e 00 00 00 
 	Return 
-// 0x70e: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x7aa: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 3e 05 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call da 05 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x719: ProcessType[table<string,int>]
+// 0x7b5: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 4a 05 00 00 // ProcessType[groupReference<string,int>]
+	Call e6 05 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x724: ProcessType[table<string,main.bigStruct>]
+// 0x7c0: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 56 05 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call f2 05 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x72f: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x7cb: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 62 05 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call fe 05 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -566,31 +578,31 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 1144
+ID: 5 Len: 8 Enqueue: 1300
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 1800
+ID: 9 Len: 16 Enqueue: 1956
 ID: 10 Len: 4 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 982
+ID: 11 Len: 8 Enqueue: 1138
 ID: 12 Len: 8 Enqueue: 0
-ID: 13 Len: 16 Enqueue: 1340
+ID: 13 Len: 16 Enqueue: 1496
 ID: 14 Len: 8 Enqueue: 0
 ID: 15 Len: 1 Enqueue: 0
 ID: 16 Len: 8 Enqueue: 0
 ID: 17 Len: 4 Enqueue: 0
 ID: 18 Len: 8 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 1150
-ID: 20 Len: 8 Enqueue: 1012
-ID: 21 Len: 8 Enqueue: 1132
-ID: 22 Len: 440 Enqueue: 1576
+ID: 19 Len: 8 Enqueue: 1306
+ID: 20 Len: 8 Enqueue: 1168
+ID: 21 Len: 8 Enqueue: 1288
+ID: 22 Len: 440 Enqueue: 1732
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 1036
+ID: 24 Len: 8 Enqueue: 1192
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 1030
+ID: 26 Len: 8 Enqueue: 1186
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 1060
-ID: 29 Len: 1808 Enqueue: 1677
+ID: 28 Len: 8 Enqueue: 1216
+ID: 29 Len: 1808 Enqueue: 1833
 ID: 30 Len: 56 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -599,45 +611,45 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 1320
-ID: 39 Len: 8 Enqueue: 976
+ID: 38 Len: 24 Enqueue: 1476
+ID: 39 Len: 8 Enqueue: 1132
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 1066
+ID: 41 Len: 8 Enqueue: 1222
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 1330
-ID: 44 Len: 8 Enqueue: 1078
+ID: 43 Len: 24 Enqueue: 1486
+ID: 44 Len: 8 Enqueue: 1234
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 1048
+ID: 47 Len: 8 Enqueue: 1204
 ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 8 Enqueue: 1072
+ID: 49 Len: 8 Enqueue: 1228
 ID: 50 Len: 8 Enqueue: 0
 ID: 51 Len: 32 Enqueue: 0
 ID: 52 Len: 32 Enqueue: 0
 ID: 53 Len: 12 Enqueue: 0
 ID: 54 Len: 16 Enqueue: 0
-ID: 55 Len: 8 Enqueue: 1054
+ID: 55 Len: 8 Enqueue: 1210
 ID: 56 Len: 40 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 48 Enqueue: 0
 ID: 59 Len: 8 Enqueue: 0
 ID: 60 Len: 8 Enqueue: 0
 ID: 61 Len: 4 Enqueue: 0
-ID: 62 Len: 8 Enqueue: 1042
+ID: 62 Len: 8 Enqueue: 1198
 ID: 63 Len: 8 Enqueue: 0
 ID: 64 Len: 8 Enqueue: 0
 ID: 65 Len: 256 Enqueue: 0
 ID: 66 Len: 8 Enqueue: 0
-ID: 67 Len: 64 Enqueue: 1773
+ID: 67 Len: 64 Enqueue: 1929
 ID: 68 Len: 8 Enqueue: 0
 ID: 69 Len: 0 Enqueue: 0
 ID: 70 Len: 8 Enqueue: 0
 ID: 71 Len: 1 Enqueue: 0
-ID: 72 Len: 56 Enqueue: 1784
+ID: 72 Len: 56 Enqueue: 1940
 ID: 73 Len: 8 Enqueue: 0
-ID: 74 Len: 32 Enqueue: 1172
-ID: 75 Len: 16 Enqueue: 1156
-ID: 76 Len: 8 Enqueue: 1084
+ID: 74 Len: 32 Enqueue: 1328
+ID: 75 Len: 16 Enqueue: 1312
+ID: 76 Len: 8 Enqueue: 1240
 ID: 77 Len: 8 Enqueue: 0
 ID: 78 Len: 48 Enqueue: 0
 ID: 79 Len: 0 Enqueue: 0
@@ -654,39 +666,39 @@ ID: 89 Len: 160 Enqueue: 0
 ID: 90 Len: 16 Enqueue: 0
 ID: 91 Len: 8 Enqueue: 0
 ID: 92 Len: 0 Enqueue: 0
-ID: 93 Len: 8 Enqueue: 1090
+ID: 93 Len: 8 Enqueue: 1246
 ID: 94 Len: 8 Enqueue: 0
 ID: 95 Len: 16 Enqueue: 0
-ID: 96 Len: 8 Enqueue: 1000
-ID: 97 Len: 8 Enqueue: 1018
-ID: 98 Len: 8 Enqueue: 1006
-ID: 99 Len: 8 Enqueue: 1138
-ID: 100 Len: 8 Enqueue: 988
-ID: 101 Len: 8 Enqueue: 994
-ID: 102 Len: 8 Enqueue: 1120
-ID: 103 Len: 8 Enqueue: 1126
-ID: 104 Len: 24 Enqueue: 1252
+ID: 96 Len: 8 Enqueue: 1156
+ID: 97 Len: 8 Enqueue: 1174
+ID: 98 Len: 8 Enqueue: 1162
+ID: 99 Len: 8 Enqueue: 1294
+ID: 100 Len: 8 Enqueue: 1144
+ID: 101 Len: 8 Enqueue: 1150
+ID: 102 Len: 8 Enqueue: 1276
+ID: 103 Len: 8 Enqueue: 1282
+ID: 104 Len: 24 Enqueue: 1408
 ID: 105 Len: 24 Enqueue: 0
-ID: 106 Len: 24 Enqueue: 1298
-ID: 107 Len: 48 Enqueue: 1188
-ID: 108 Len: 8 Enqueue: 1444
+ID: 106 Len: 24 Enqueue: 1454
+ID: 107 Len: 48 Enqueue: 1344
+ID: 108 Len: 8 Enqueue: 1600
 ID: 109 Len: 8 Enqueue: 0
-ID: 110 Len: 48 Enqueue: 1402
+ID: 110 Len: 48 Enqueue: 1558
 ID: 111 Len: 8 Enqueue: 0
-ID: 112 Len: 8 Enqueue: 1102
-ID: 113 Len: 8 Enqueue: 1450
+ID: 112 Len: 8 Enqueue: 1258
+ID: 113 Len: 8 Enqueue: 1606
 ID: 114 Len: 8 Enqueue: 0
-ID: 115 Len: 48 Enqueue: 1414
+ID: 115 Len: 48 Enqueue: 1570
 ID: 116 Len: 8 Enqueue: 0
-ID: 117 Len: 8 Enqueue: 1108
-ID: 118 Len: 8 Enqueue: 1456
+ID: 117 Len: 8 Enqueue: 1264
+ID: 118 Len: 8 Enqueue: 1612
 ID: 119 Len: 8 Enqueue: 0
-ID: 120 Len: 48 Enqueue: 1426
+ID: 120 Len: 48 Enqueue: 1582
 ID: 121 Len: 8 Enqueue: 0
-ID: 122 Len: 8 Enqueue: 1114
-ID: 123 Len: 8 Enqueue: 952
-ID: 124 Len: 8 Enqueue: 958
-ID: 125 Len: 8 Enqueue: 970
+ID: 122 Len: 8 Enqueue: 1270
+ID: 123 Len: 8 Enqueue: 1108
+ID: 124 Len: 8 Enqueue: 1114
+ID: 125 Len: 8 Enqueue: 1126
 ID: 126 Len: 1 Enqueue: 0
 ID: 127 Len: 8 Enqueue: 0
 ID: 128 Len: 1 Enqueue: 0
@@ -695,49 +707,49 @@ ID: 130 Len: 8 Enqueue: 0
 ID: 131 Len: 8 Enqueue: 0
 ID: 132 Len: 8 Enqueue: 0
 ID: 133 Len: 8 Enqueue: 0
-ID: 134 Len: 16 Enqueue: 1308
+ID: 134 Len: 16 Enqueue: 1464
 ID: 135 Len: 8 Enqueue: 0
-ID: 136 Len: 32 Enqueue: 1817
-ID: 137 Len: 16 Enqueue: 1354
+ID: 136 Len: 32 Enqueue: 1973
+ID: 137 Len: 16 Enqueue: 1510
 ID: 138 Len: 8 Enqueue: 0
-ID: 139 Len: 200 Enqueue: 1510
-ID: 140 Len: 192 Enqueue: 1478
-ID: 141 Len: 24 Enqueue: 1559
-ID: 142 Len: 8 Enqueue: 1216
-ID: 143 Len: 200 Enqueue: 1262
-ID: 144 Len: 32 Enqueue: 1828
-ID: 145 Len: 16 Enqueue: 1366
+ID: 139 Len: 200 Enqueue: 1666
+ID: 140 Len: 192 Enqueue: 1634
+ID: 141 Len: 24 Enqueue: 1715
+ID: 142 Len: 8 Enqueue: 1372
+ID: 143 Len: 200 Enqueue: 1418
+ID: 144 Len: 32 Enqueue: 1984
+ID: 145 Len: 16 Enqueue: 1522
 ID: 146 Len: 8 Enqueue: 0
-ID: 147 Len: 200 Enqueue: 1521
-ID: 148 Len: 192 Enqueue: 1462
-ID: 149 Len: 24 Enqueue: 1543
-ID: 150 Len: 8 Enqueue: 1024
+ID: 147 Len: 200 Enqueue: 1677
+ID: 148 Len: 192 Enqueue: 1618
+ID: 149 Len: 24 Enqueue: 1699
+ID: 150 Len: 8 Enqueue: 1180
 ID: 151 Len: 184 Enqueue: 0
-ID: 152 Len: 8 Enqueue: 1228
-ID: 153 Len: 200 Enqueue: 1274
-ID: 154 Len: 32 Enqueue: 1839
-ID: 155 Len: 16 Enqueue: 1378
+ID: 152 Len: 8 Enqueue: 1384
+ID: 153 Len: 200 Enqueue: 1430
+ID: 154 Len: 32 Enqueue: 1995
+ID: 155 Len: 16 Enqueue: 1534
 ID: 156 Len: 8 Enqueue: 0
-ID: 157 Len: 136 Enqueue: 1532
-ID: 158 Len: 128 Enqueue: 1494
-ID: 159 Len: 16 Enqueue: 1565
-ID: 160 Len: 8 Enqueue: 1438
+ID: 157 Len: 136 Enqueue: 1688
+ID: 158 Len: 128 Enqueue: 1650
+ID: 159 Len: 16 Enqueue: 1721
+ID: 160 Len: 8 Enqueue: 1594
 ID: 161 Len: 8 Enqueue: 0
-ID: 162 Len: 48 Enqueue: 1390
+ID: 162 Len: 48 Enqueue: 1546
 ID: 163 Len: 8 Enqueue: 0
-ID: 164 Len: 8 Enqueue: 1096
-ID: 165 Len: 8 Enqueue: 1240
-ID: 166 Len: 136 Enqueue: 1286
-ID: 167 Len: 32 Enqueue: 1806
-ID: 168 Len: 16 Enqueue: 1342
+ID: 164 Len: 8 Enqueue: 1252
+ID: 165 Len: 8 Enqueue: 1396
+ID: 166 Len: 136 Enqueue: 1442
+ID: 167 Len: 32 Enqueue: 1962
+ID: 168 Len: 16 Enqueue: 1498
 ID: 169 Len: 8 Enqueue: 0
 ID: 170 Len: 136 Enqueue: 0
 ID: 171 Len: 128 Enqueue: 0
 ID: 172 Len: 16 Enqueue: 0
 ID: 173 Len: 8 Enqueue: 0
-ID: 174 Len: 8 Enqueue: 1204
+ID: 174 Len: 8 Enqueue: 1360
 ID: 175 Len: 136 Enqueue: 0
-ID: 176 Len: 8 Enqueue: 964
+ID: 176 Len: 8 Enqueue: 1120
 ID: 177 Len: 128 Enqueue: 0
 ID: 178 Len: 9 Enqueue: 0
 ID: 179 Len: 0 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.sm.txt
@@ -7,13 +7,13 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call b8 03 00 00 // ProcessType[*****int]
+	Call 54 04 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessExpression[Probe[main.PointerChainArg]@0x4ae646.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call b8 03 00 00 // ProcessType[*****int]
+	Call 54 04 00 00 // ProcessType[*****int]
 	Return 
 // 0x39: ProcessEvent[Probe[main.PointerChainArg]@4ae646]
 	PrepareEventRoot d2 00 00 00 11 00 00 00 
@@ -24,7 +24,7 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call ca 03 00 00 // ProcessType[**int]
+	Call 66 04 00 00 // ProcessType[**int]
 	Return 
 // 0x68: ProcessEvent[Probe[main.PointerSmallChainArg]@4ae690]
 	PrepareEventRoot d3 00 00 00 09 00 00 00 
@@ -34,13 +34,13 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call c6 05 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 62 06 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x92: ProcessExpression[Probe[main.bigMapArg]@0x4aeb53.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call c6 05 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 62 06 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0xad: ProcessEvent[Probe[main.bigMapArg]@4aeb53]
 	PrepareEventRoot ca 00 00 00 11 00 00 00 
@@ -85,480 +85,492 @@
 	Return 
 // 0x148: ProcessExpression[Probe[main.intArrayArg]@0x4ae88a.expr[0]]
 	ExprPrepare 
-	ExprDereferenceCfa 00 00 00 00 18 00 00 00 00 00 00 00 
+	ExprDereferenceCfa 00 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferenceCfa 08 00 00 00 08 00 00 00 08 00 00 00 
+	ExprDereferenceCfa 10 00 00 00 08 00 00 00 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
-// 0x164: ProcessEvent[Probe[main.intArrayArg]@4ae88a]
+// 0x17e: ProcessEvent[Probe[main.intArrayArg]@4ae88a]
 	PrepareEventRoot c1 00 00 00 19 00 00 00 
 	Call 48 01 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4ae88a.expr[0]]
 	Return 
-// 0x173: ProcessEvent[Probe[main.intArrayArg]Return@4ae8d6]
+// 0x18d: ProcessEvent[Probe[main.intArrayArg]Return@4ae8d6]
 	PrepareEventRoot c2 00 00 00 00 00 00 00 
 	Return 
-// 0x17d: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4aea00.expr[0]]
+// 0x197: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4aea00.expr[0]]
 	ExprPrepare 
-	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
+	ExprDereferenceCfa 00 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferenceCfa 08 00 00 00 08 00 00 00 08 00 00 00 
+	ExprDereferenceCfa 10 00 00 00 08 00 00 00 10 00 00 00 
+	ExprDereferenceCfa 18 00 00 00 08 00 00 00 18 00 00 00 
+	ExprDereferenceCfa 20 00 00 00 08 00 00 00 20 00 00 00 
+	ExprDereferenceCfa 28 00 00 00 08 00 00 00 28 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call aa 04 00 00 // ProcessType[[3]string]
+	Call 46 05 00 00 // ProcessType[[3]string]
 	Return 
-// 0x19e: ProcessEvent[Probe[main.stringArrayArgFrameless]@4aea00]
+// 0x1f9: ProcessEvent[Probe[main.stringArrayArgFrameless]@4aea00]
 	PrepareEventRoot c7 00 00 00 31 00 00 00 
-	Call 7d 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4aea00.expr[0]]
+	Call 97 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4aea00.expr[0]]
 	Return 
-// 0x1ad: ProcessExpression[Probe[main.intSliceArg]@0x4ae80a.expr[0]]
+// 0x208: ProcessExpression[Probe[main.intSliceArg]@0x4ae80a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 00 05 00 00 // ProcessType[[]int]
+	Call 9c 05 00 00 // ProcessType[[]int]
 	Return 
-// 0x1d6: ProcessEvent[Probe[main.intSliceArg]@4ae80a]
+// 0x231: ProcessEvent[Probe[main.intSliceArg]@4ae80a]
 	PrepareEventRoot bf 00 00 00 19 00 00 00 
-	Call ad 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4ae80a.expr[0]]
+	Call 08 02 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4ae80a.expr[0]]
 	Return 
-// 0x1e5: ProcessEvent[Probe[main.intSliceArg]Return@4ae84f]
+// 0x240: ProcessEvent[Probe[main.intSliceArg]Return@4ae84f]
 	PrepareEventRoot c0 00 00 00 00 00 00 00 
 	Return 
-// 0x1ef: ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[0]]
+// 0x24a: ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 2e 07 00 00 // ProcessType[string]
+	Call ca 07 00 00 // ProcessType[string]
 	Return 
-// 0x211: ProcessEvent[Probe[main.stringArg]@4ae78a]
+// 0x26c: ProcessEvent[Probe[main.stringArg]@4ae78a]
 	PrepareEventRoot b9 00 00 00 11 00 00 00 
-	Call ef 01 00 00 // ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[0]]
+	Call 4a 02 00 00 // ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[0]]
 	Return 
-// 0x220: ProcessEvent[Probe[main.stringArg]Return@4ae7cf]
+// 0x27b: ProcessEvent[Probe[main.stringArg]Return@4ae7cf]
 	PrepareEventRoot ba 00 00 00 00 00 00 00 
 	Return 
-// 0x22a: ProcessEvent[Probe[main.stringArg]@4ae78a]
+// 0x285: ProcessEvent[Probe[main.stringArg]@4ae78a]
 	PrepareEventRoot bb 00 00 00 00 00 00 00 
 	Return 
-// 0x234: ProcessEvent[Probe[main.stringArg]Return@4ae7cf]
+// 0x28f: ProcessEvent[Probe[main.stringArg]Return@4ae7cf]
 	PrepareEventRoot bc 00 00 00 00 00 00 00 
 	Return 
-// 0x23e: ProcessExpression[Probe[main.mapArg]@0x4aeaea.expr[0]]
+// 0x299: ProcessExpression[Probe[main.mapArg]@0x4aeaea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call c0 05 00 00 // ProcessType[map[string]int]
+	Call 5c 06 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x259: ProcessExpression[Probe[main.mapArg]@0x4aeaea.expr[1]]
+// 0x2b4: ProcessExpression[Probe[main.mapArg]@0x4aeaea.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call c0 05 00 00 // ProcessType[map[string]int]
+	Call 5c 06 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x274: ProcessEvent[Probe[main.mapArg]@4aeaea]
+// 0x2cf: ProcessEvent[Probe[main.mapArg]@4aeaea]
 	PrepareEventRoot c8 00 00 00 11 00 00 00 
-	Call 3e 02 00 00 // ProcessExpression[Probe[main.mapArg]@0x4aeaea.expr[0]]
-	Call 59 02 00 00 // ProcessExpression[Probe[main.mapArg]@0x4aeaea.expr[1]]
+	Call 99 02 00 00 // ProcessExpression[Probe[main.mapArg]@0x4aeaea.expr[0]]
+	Call b4 02 00 00 // ProcessExpression[Probe[main.mapArg]@0x4aeaea.expr[1]]
 	Return 
-// 0x288: ProcessEvent[Probe[main.mapArg]Return@4aeb1f]
+// 0x2e3: ProcessEvent[Probe[main.mapArg]Return@4aeb1f]
 	PrepareEventRoot c9 00 00 00 00 00 00 00 
 	Return 
-// 0x292: ProcessEvent[Probe[main.noArgs]@4aec0a]
+// 0x2ed: ProcessEvent[Probe[main.noArgs]@4aec0a]
 	PrepareEventRoot cc 00 00 00 00 00 00 00 
 	Return 
-// 0x29c: ProcessEvent[Probe[main.noArgs]Return@4aec46]
+// 0x2f7: ProcessEvent[Probe[main.noArgs]Return@4aec46]
 	PrepareEventRoot cd 00 00 00 00 00 00 00 
 	Return 
-// 0x2a6: ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[0]]
+// 0x301: ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 2e 07 00 00 // ProcessType[string]
+	Call ca 07 00 00 // ProcessType[string]
 	Return 
-// 0x2c8: ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[1]]
+// 0x323: ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call 2e 07 00 00 // ProcessType[string]
+	Call ca 07 00 00 // ProcessType[string]
 	Return 
-// 0x2ea: ProcessEvent[Probe[main.stringArg]@4ae78a]
+// 0x345: ProcessEvent[Probe[main.stringArg]@4ae78a]
 	PrepareEventRoot bd 00 00 00 21 00 00 00 
-	Call a6 02 00 00 // ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[0]]
-	Call c8 02 00 00 // ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[1]]
+	Call 01 03 00 00 // ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[0]]
+	Call 23 03 00 00 // ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[1]]
 	Return 
-// 0x2fe: ProcessEvent[Probe[main.stringArg]Return@4ae7cf]
+// 0x359: ProcessEvent[Probe[main.stringArg]Return@4ae7cf]
 	PrepareEventRoot be 00 00 00 00 00 00 00 
 	Return 
-// 0x308: ProcessExpression[Probe[main.stringArrayArg]@0x4ae98a.expr[0]]
+// 0x363: ProcessExpression[Probe[main.stringArrayArg]@0x4ae98a.expr[0]]
 	ExprPrepare 
-	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
+	ExprDereferenceCfa 00 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferenceCfa 08 00 00 00 08 00 00 00 08 00 00 00 
+	ExprDereferenceCfa 10 00 00 00 08 00 00 00 10 00 00 00 
+	ExprDereferenceCfa 18 00 00 00 08 00 00 00 18 00 00 00 
+	ExprDereferenceCfa 20 00 00 00 08 00 00 00 20 00 00 00 
+	ExprDereferenceCfa 28 00 00 00 08 00 00 00 28 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call aa 04 00 00 // ProcessType[[3]string]
+	Call 46 05 00 00 // ProcessType[[3]string]
 	Return 
-// 0x329: ProcessEvent[Probe[main.stringArrayArg]@4ae98a]
+// 0x3c5: ProcessEvent[Probe[main.stringArrayArg]@4ae98a]
 	PrepareEventRoot c5 00 00 00 31 00 00 00 
-	Call 08 03 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4ae98a.expr[0]]
+	Call 63 03 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4ae98a.expr[0]]
 	Return 
-// 0x338: ProcessEvent[Probe[main.stringArrayArg]Return@4ae9d6]
+// 0x3d4: ProcessEvent[Probe[main.stringArrayArg]Return@4ae9d6]
 	PrepareEventRoot c6 00 00 00 00 00 00 00 
 	Return 
-// 0x342: ProcessExpression[Probe[main.stringSliceArg]@0x4ae90a.expr[0]]
+// 0x3de: ProcessExpression[Probe[main.stringSliceArg]@0x4ae90a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 2e 05 00 00 // ProcessType[[]string]
+	Call ca 05 00 00 // ProcessType[[]string]
 	Return 
-// 0x36b: ProcessEvent[Probe[main.stringSliceArg]@4ae90a]
+// 0x407: ProcessEvent[Probe[main.stringSliceArg]@4ae90a]
 	PrepareEventRoot c3 00 00 00 19 00 00 00 
-	Call 42 03 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4ae90a.expr[0]]
+	Call de 03 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4ae90a.expr[0]]
 	Return 
-// 0x37a: ProcessEvent[Probe[main.stringSliceArg]Return@4ae94f]
+// 0x416: ProcessEvent[Probe[main.stringSliceArg]Return@4ae94f]
 	PrepareEventRoot c4 00 00 00 00 00 00 00 
 	Return 
-// 0x384: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4aec76]
+// 0x420: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4aec76]
 	PrepareEventRoot ce 00 00 00 00 00 00 00 
 	Return 
-// 0x38e: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4aee44.expr[0]]
+// 0x42a: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4aee44.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call cc 05 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 68 06 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x3a9: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4aee44]
+// 0x445: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4aee44]
 	PrepareEventRoot cf 00 00 00 09 00 00 00 
-	Call 8e 03 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4aee44.expr[0]]
+	Call 2a 04 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4aee44.expr[0]]
 	Return 
-// 0x3b8: ProcessType[*****int]
+// 0x454: ProcessType[*****int]
 	ProcessPointer 7e 00 00 00 
 	Return 
-// 0x3be: ProcessType[****int]
+// 0x45a: ProcessType[****int]
 	ProcessPointer b5 00 00 00 
 	Return 
-// 0x3c4: ProcessType[***int]
+// 0x460: ProcessType[***int]
 	ProcessPointer 7f 00 00 00 
 	Return 
-// 0x3ca: ProcessType[**int]
+// 0x466: ProcessType[**int]
 	ProcessPointer 63 00 00 00 
 	Return 
-// 0x3d0: ProcessType[*[]runtime.ancestorInfo]
+// 0x46c: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x3d6: ProcessType[*bool]
+// 0x472: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x3dc: ProcessType[*error]
+// 0x478: ProcessType[*error]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x3e2: ProcessType[*float32]
+// 0x47e: ProcessType[*float32]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x3e8: ProcessType[*float64]
+// 0x484: ProcessType[*float64]
 	ProcessPointer 0f 00 00 00 
 	Return 
-// 0x3ee: ProcessType[*int]
+// 0x48a: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x3f4: ProcessType[*int32]
+// 0x490: ProcessType[*int32]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x3fa: ProcessType[*int64]
+// 0x496: ProcessType[*int64]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x400: ProcessType[*main.bigStruct]
+// 0x49c: ProcessType[*main.bigStruct]
 	ProcessPointer 9c 00 00 00 
 	Return 
-// 0x406: ProcessType[*runtime._defer]
+// 0x4a2: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x40c: ProcessType[*runtime._panic]
+// 0x4a8: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x412: ProcessType[*runtime.cgoCallers]
+// 0x4ae: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 42 00 00 00 
 	Return 
-// 0x418: ProcessType[*runtime.coro]
+// 0x4b4: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x41e: ProcessType[*runtime.g]
+// 0x4ba: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x424: ProcessType[*runtime.m]
+// 0x4c0: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x42a: ProcessType[*runtime.p]
+// 0x4c6: ProcessType[*runtime.p]
 	ProcessPointer 86 00 00 00 
 	Return 
-// 0x430: ProcessType[*runtime.sudog]
+// 0x4cc: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x436: ProcessType[*runtime.synctestBubble]
+// 0x4d2: ProcessType[*runtime.synctestBubble]
 	ProcessPointer 32 00 00 00 
 	Return 
-// 0x43c: ProcessType[*runtime.timer]
+// 0x4d8: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x442: ProcessType[*runtime.traceBuf]
+// 0x4de: ProcessType[*runtime.traceBuf]
 	ProcessPointer 50 00 00 00 
 	Return 
-// 0x448: ProcessType[*string]
+// 0x4e4: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x44e: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+// 0x4ea: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer ac 00 00 00 
 	Return 
-// 0x454: ProcessType[*table<string,int>]
+// 0x4f0: ProcessType[*table<string,int>]
 	ProcessPointer 8d 00 00 00 
 	Return 
-// 0x45a: ProcessType[*table<string,main.bigStruct>]
+// 0x4f6: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer 95 00 00 00 
 	Return 
-// 0x460: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x4fc: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 9f 00 00 00 
 	Return 
-// 0x466: ProcessType[*uint]
+// 0x502: ProcessType[*uint]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x46c: ProcessType[*uint16]
+// 0x508: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x472: ProcessType[*uint32]
+// 0x50e: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x478: ProcessType[*uint64]
+// 0x514: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x47e: ProcessType[*uint8]
+// 0x51a: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x484: ProcessType[*uintptr]
+// 0x520: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x48a: ProcessType[[2]*runtime.traceBuf]
+// 0x526: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call 42 04 00 00 // ProcessType[*runtime.traceBuf]
+	Call de 04 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x49a: ProcessType[[2][2]*runtime.traceBuf]
+// 0x536: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call 8a 04 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call 26 05 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x4aa: ProcessType[[3]string]
+// 0x546: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 2e 07 00 00 // ProcessType[string]
+	Call ca 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x4ba: ProcessType[[]*runtime.p]
+// 0x556: ProcessType[[]*runtime.p]
 	ProcessSlice 87 00 00 00 08 00 00 00 
 	Return 
-// 0x4c4: ProcessType[[]*runtime.p.array]
+// 0x560: ProcessType[[]*runtime.p.array]
 	ProcessSliceDataPrep 
-	Call 2a 04 00 00 // ProcessType[*runtime.p]
+	Call c6 04 00 00 // ProcessType[*runtime.p]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x4d0: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x56c: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 4e 04 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	Call ea 04 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x4dc: ProcessType[[]*table<string,int>.array]
+// 0x578: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 54 04 00 00 // ProcessType[*table<string,int>]
+	Call f0 04 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x4e8: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x584: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 5a 04 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call f6 04 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x4f4: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x590: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 60 04 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call fc 04 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x500: ProcessType[[]int]
+// 0x59c: ProcessType[[]int]
 	ProcessSlice 89 00 00 00 08 00 00 00 
 	Return 
-// 0x50a: ProcessType[[]noalg.map.group[string]int.array]
+// 0x5a6: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call 02 06 00 00 // ProcessType[noalg.map.group[string]int]
+	Call 9e 06 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x516: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x5b2: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call 0d 06 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call a9 06 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x522: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+// 0x5be: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call 18 06 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call b4 06 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x52e: ProcessType[[]string]
+// 0x5ca: ProcessType[[]string]
 	ProcessSlice 8b 00 00 00 10 00 00 00 
 	Return 
-// 0x538: ProcessType[[]string.array]
+// 0x5d4: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call 2e 07 00 00 // ProcessType[string]
+	Call ca 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x544: ProcessType[[]uint8]
+// 0x5e0: ProcessType[[]uint8]
 	ProcessSlice 82 00 00 00 01 00 00 00 
 	Return 
-// 0x54e: ProcessType[[]uintptr]
+// 0x5ea: ProcessType[[]uintptr]
 	ProcessSlice 84 00 00 00 08 00 00 00 
 	Return 
-// 0x558: ProcessType[error]
+// 0x5f4: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x55a: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+// 0x5f6: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups b4 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x566: ProcessType[groupReference<string,int>]
+// 0x602: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups 94 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x572: ProcessType[groupReference<string,main.bigStruct>]
+// 0x60e: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups 9e 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x57e: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x61a: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups ab 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x58a: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+// 0x626: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap b3 00 00 00 af 00 00 00 10 18 
 	Return 
-// 0x596: ProcessType[map<string,int>]
+// 0x632: ProcessType[map<string,int>]
 	ProcessGoSwissMap 93 00 00 00 90 00 00 00 10 18 
 	Return 
-// 0x5a2: ProcessType[map<string,main.bigStruct>]
+// 0x63e: ProcessType[map<string,main.bigStruct>]
 	ProcessGoSwissMap 9d 00 00 00 98 00 00 00 10 18 
 	Return 
-// 0x5ae: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x64a: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap aa 00 00 00 a2 00 00 00 10 18 
 	Return 
-// 0x5ba: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x656: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer a7 00 00 00 
 	Return 
-// 0x5c0: ProcessType[map[string]int]
+// 0x65c: ProcessType[map[string]int]
 	ProcessPointer 70 00 00 00 
 	Return 
-// 0x5c6: ProcessType[map[string]main.bigStruct]
+// 0x662: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 75 00 00 00 
 	Return 
-// 0x5cc: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x668: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 7a 00 00 00 
 	Return 
-// 0x5d2: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x66e: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 23 06 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call bf 06 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x5e2: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x67e: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 33 06 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call cf 06 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x5f2: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x68e: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call 39 06 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call d5 06 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x602: ProcessType[noalg.map.group[string]int]
+// 0x69e: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call e2 05 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call 7e 06 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x60d: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x6a9: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call d2 05 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call 6e 06 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x618: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x6b4: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call f2 05 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 8e 06 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x623: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call 2e 07 00 00 // ProcessType[string]
+// 0x6bf: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call ca 07 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 00 04 00 00 // ProcessType[*main.bigStruct]
+	Call 9c 04 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x633: ProcessType[noalg.struct { key string; elem int }]
-	Call 2e 07 00 00 // ProcessType[string]
+// 0x6cf: ProcessType[noalg.struct { key string; elem int }]
+	Call ca 07 00 00 // ProcessType[string]
 	Return 
-// 0x639: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x6d5: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call ba 05 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 56 06 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x644: ProcessType[runtime.g]
+// 0x6e0: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 0c 04 00 00 // ProcessType[*runtime._panic]
+	Call a8 04 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 06 04 00 00 // ProcessType[*runtime._defer]
+	Call a2 04 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call 24 04 00 00 // ProcessType[*runtime.m]
+	Call c0 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b0 00 00 00 
-	Call 44 05 00 00 // ProcessType[[]uint8]
+	Call e0 05 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call d0 03 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 6c 04 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call 30 04 00 00 // ProcessType[*runtime.sudog]
+	Call cc 04 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 4e 05 00 00 // ProcessType[[]uintptr]
+	Call ea 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call 3c 04 00 00 // ProcessType[*runtime.timer]
+	Call d8 04 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call 18 04 00 00 // ProcessType[*runtime.coro]
+	Call b4 04 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call 36 04 00 00 // ProcessType[*runtime.synctestBubble]
+	Call d2 04 00 00 // ProcessType[*runtime.synctestBubble]
 	Return 
-// 0x6a9: ProcessType[runtime.m]
-	Call 1e 04 00 00 // ProcessType[*runtime.g]
+// 0x745: ProcessType[runtime.m]
+	Call ba 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 48 00 00 00 
-	Call 1e 04 00 00 // ProcessType[*runtime.g]
+	Call ba 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call 1e 04 00 00 // ProcessType[*runtime.g]
+	Call ba 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call 2e 07 00 00 // ProcessType[string]
+	Call ca 07 00 00 // ProcessType[string]
 	IncrementOutputOffset 30 00 00 00 
-	Call ba 04 00 00 // ProcessType[[]*runtime.p]
+	Call 56 05 00 00 // ProcessType[[]*runtime.p]
 	IncrementOutputOffset 28 00 00 00 
-	Call 12 04 00 00 // ProcessType[*runtime.cgoCallers]
+	Call ae 04 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call 24 04 00 00 // ProcessType[*runtime.m]
+	Call c0 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 30 01 00 00 
-	Call 13 07 00 00 // ProcessType[runtime.mLockProfile]
+	Call af 07 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 30 00 00 00 
-	Call 4e 05 00 00 // ProcessType[[]uintptr]
+	Call ea 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call 24 04 00 00 // ProcessType[*runtime.m]
+	Call c0 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call 1e 07 00 00 // ProcessType[runtime.mTraceState]
+	Call ba 07 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x713: ProcessType[runtime.mLockProfile]
+// 0x7af: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 4e 05 00 00 // ProcessType[[]uintptr]
+	Call ea 05 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x71e: ProcessType[runtime.mTraceState]
+// 0x7ba: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call 9a 04 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call 24 04 00 00 // ProcessType[*runtime.m]
+	Call 36 05 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call c0 04 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x72e: ProcessType[string]
+// 0x7ca: ProcessType[string]
 	ProcessString 80 00 00 00 
 	Return 
-// 0x734: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x7d0: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 5a 05 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call f6 05 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x73f: ProcessType[table<string,int>]
+// 0x7db: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 66 05 00 00 // ProcessType[groupReference<string,int>]
+	Call 02 06 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x74a: ProcessType[table<string,main.bigStruct>]
+// 0x7e6: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 72 05 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call 0e 06 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x755: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x7f1: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 7e 05 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 1a 06 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -579,31 +591,31 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 1150
+ID: 5 Len: 8 Enqueue: 1306
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 1838
+ID: 9 Len: 16 Enqueue: 1994
 ID: 10 Len: 4 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 982
+ID: 11 Len: 8 Enqueue: 1138
 ID: 12 Len: 8 Enqueue: 0
-ID: 13 Len: 16 Enqueue: 1368
+ID: 13 Len: 16 Enqueue: 1524
 ID: 14 Len: 8 Enqueue: 0
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 1 Enqueue: 0
 ID: 17 Len: 8 Enqueue: 0
 ID: 18 Len: 4 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 1156
-ID: 20 Len: 8 Enqueue: 1012
-ID: 21 Len: 8 Enqueue: 1138
-ID: 22 Len: 440 Enqueue: 1604
+ID: 19 Len: 8 Enqueue: 1312
+ID: 20 Len: 8 Enqueue: 1168
+ID: 21 Len: 8 Enqueue: 1294
+ID: 22 Len: 440 Enqueue: 1760
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 1036
+ID: 24 Len: 8 Enqueue: 1192
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 1030
+ID: 26 Len: 8 Enqueue: 1186
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 1060
-ID: 29 Len: 1816 Enqueue: 1705
+ID: 28 Len: 8 Enqueue: 1216
+ID: 29 Len: 1816 Enqueue: 1861
 ID: 30 Len: 48 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -612,48 +624,48 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 1348
-ID: 39 Len: 8 Enqueue: 976
+ID: 38 Len: 24 Enqueue: 1504
+ID: 39 Len: 8 Enqueue: 1132
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 1072
+ID: 41 Len: 8 Enqueue: 1228
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 1358
-ID: 44 Len: 8 Enqueue: 1084
+ID: 43 Len: 24 Enqueue: 1514
+ID: 44 Len: 8 Enqueue: 1240
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 1048
+ID: 47 Len: 8 Enqueue: 1204
 ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 8 Enqueue: 1078
+ID: 49 Len: 8 Enqueue: 1234
 ID: 50 Len: 8 Enqueue: 0
 ID: 51 Len: 32 Enqueue: 0
 ID: 52 Len: 32 Enqueue: 0
 ID: 53 Len: 12 Enqueue: 0
 ID: 54 Len: 16 Enqueue: 0
-ID: 55 Len: 8 Enqueue: 1054
+ID: 55 Len: 8 Enqueue: 1210
 ID: 56 Len: 40 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 48 Enqueue: 0
 ID: 59 Len: 8 Enqueue: 0
 ID: 60 Len: 8 Enqueue: 0
 ID: 61 Len: 4 Enqueue: 0
-ID: 62 Len: 24 Enqueue: 1210
+ID: 62 Len: 24 Enqueue: 1366
 ID: 63 Len: 8 Enqueue: 0
-ID: 64 Len: 8 Enqueue: 1066
-ID: 65 Len: 8 Enqueue: 1042
+ID: 64 Len: 8 Enqueue: 1222
+ID: 65 Len: 8 Enqueue: 1198
 ID: 66 Len: 8 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 256 Enqueue: 0
 ID: 69 Len: 16 Enqueue: 0
-ID: 70 Len: 56 Enqueue: 1811
+ID: 70 Len: 56 Enqueue: 1967
 ID: 71 Len: 8 Enqueue: 0
 ID: 72 Len: 0 Enqueue: 0
 ID: 73 Len: 8 Enqueue: 0
 ID: 74 Len: 1 Enqueue: 0
-ID: 75 Len: 56 Enqueue: 1822
+ID: 75 Len: 56 Enqueue: 1978
 ID: 76 Len: 8 Enqueue: 0
-ID: 77 Len: 32 Enqueue: 1178
-ID: 78 Len: 16 Enqueue: 1162
-ID: 79 Len: 8 Enqueue: 1090
+ID: 77 Len: 32 Enqueue: 1334
+ID: 78 Len: 16 Enqueue: 1318
+ID: 79 Len: 8 Enqueue: 1246
 ID: 80 Len: 8 Enqueue: 0
 ID: 81 Len: 48 Enqueue: 0
 ID: 82 Len: 0 Enqueue: 0
@@ -669,39 +681,39 @@ ID: 91 Len: 32 Enqueue: 0
 ID: 92 Len: 160 Enqueue: 0
 ID: 93 Len: 16 Enqueue: 0
 ID: 94 Len: 8 Enqueue: 0
-ID: 95 Len: 8 Enqueue: 1096
+ID: 95 Len: 8 Enqueue: 1252
 ID: 96 Len: 8 Enqueue: 0
 ID: 97 Len: 16 Enqueue: 0
-ID: 98 Len: 8 Enqueue: 1000
-ID: 99 Len: 8 Enqueue: 1006
-ID: 100 Len: 8 Enqueue: 1018
-ID: 101 Len: 8 Enqueue: 1144
-ID: 102 Len: 8 Enqueue: 988
-ID: 103 Len: 8 Enqueue: 994
-ID: 104 Len: 8 Enqueue: 1126
-ID: 105 Len: 8 Enqueue: 1132
-ID: 106 Len: 24 Enqueue: 1280
+ID: 98 Len: 8 Enqueue: 1156
+ID: 99 Len: 8 Enqueue: 1162
+ID: 100 Len: 8 Enqueue: 1174
+ID: 101 Len: 8 Enqueue: 1300
+ID: 102 Len: 8 Enqueue: 1144
+ID: 103 Len: 8 Enqueue: 1150
+ID: 104 Len: 8 Enqueue: 1282
+ID: 105 Len: 8 Enqueue: 1288
+ID: 106 Len: 24 Enqueue: 1436
 ID: 107 Len: 24 Enqueue: 0
-ID: 108 Len: 24 Enqueue: 1326
-ID: 109 Len: 48 Enqueue: 1194
-ID: 110 Len: 8 Enqueue: 1472
+ID: 108 Len: 24 Enqueue: 1482
+ID: 109 Len: 48 Enqueue: 1350
+ID: 110 Len: 8 Enqueue: 1628
 ID: 111 Len: 8 Enqueue: 0
-ID: 112 Len: 48 Enqueue: 1430
+ID: 112 Len: 48 Enqueue: 1586
 ID: 113 Len: 8 Enqueue: 0
-ID: 114 Len: 8 Enqueue: 1108
-ID: 115 Len: 8 Enqueue: 1478
+ID: 114 Len: 8 Enqueue: 1264
+ID: 115 Len: 8 Enqueue: 1634
 ID: 116 Len: 8 Enqueue: 0
-ID: 117 Len: 48 Enqueue: 1442
+ID: 117 Len: 48 Enqueue: 1598
 ID: 118 Len: 8 Enqueue: 0
-ID: 119 Len: 8 Enqueue: 1114
-ID: 120 Len: 8 Enqueue: 1484
+ID: 119 Len: 8 Enqueue: 1270
+ID: 120 Len: 8 Enqueue: 1640
 ID: 121 Len: 8 Enqueue: 0
-ID: 122 Len: 48 Enqueue: 1454
+ID: 122 Len: 48 Enqueue: 1610
 ID: 123 Len: 8 Enqueue: 0
-ID: 124 Len: 8 Enqueue: 1120
-ID: 125 Len: 8 Enqueue: 952
-ID: 126 Len: 8 Enqueue: 958
-ID: 127 Len: 8 Enqueue: 970
+ID: 124 Len: 8 Enqueue: 1276
+ID: 125 Len: 8 Enqueue: 1108
+ID: 126 Len: 8 Enqueue: 1114
+ID: 127 Len: 8 Enqueue: 1126
 ID: 128 Len: 1 Enqueue: 0
 ID: 129 Len: 8 Enqueue: 0
 ID: 130 Len: 1 Enqueue: 0
@@ -709,53 +721,53 @@ ID: 131 Len: 8 Enqueue: 0
 ID: 132 Len: 8 Enqueue: 0
 ID: 133 Len: 8 Enqueue: 0
 ID: 134 Len: 8 Enqueue: 0
-ID: 135 Len: 8 Enqueue: 1220
+ID: 135 Len: 8 Enqueue: 1376
 ID: 136 Len: 8 Enqueue: 0
 ID: 137 Len: 8 Enqueue: 0
 ID: 138 Len: 8 Enqueue: 0
-ID: 139 Len: 16 Enqueue: 1336
+ID: 139 Len: 16 Enqueue: 1492
 ID: 140 Len: 8 Enqueue: 0
-ID: 141 Len: 32 Enqueue: 1855
-ID: 142 Len: 16 Enqueue: 1382
+ID: 141 Len: 32 Enqueue: 2011
+ID: 142 Len: 16 Enqueue: 1538
 ID: 143 Len: 8 Enqueue: 0
-ID: 144 Len: 200 Enqueue: 1538
-ID: 145 Len: 192 Enqueue: 1506
-ID: 146 Len: 24 Enqueue: 1587
-ID: 147 Len: 8 Enqueue: 1244
-ID: 148 Len: 200 Enqueue: 1290
-ID: 149 Len: 32 Enqueue: 1866
-ID: 150 Len: 16 Enqueue: 1394
+ID: 144 Len: 200 Enqueue: 1694
+ID: 145 Len: 192 Enqueue: 1662
+ID: 146 Len: 24 Enqueue: 1743
+ID: 147 Len: 8 Enqueue: 1400
+ID: 148 Len: 200 Enqueue: 1446
+ID: 149 Len: 32 Enqueue: 2022
+ID: 150 Len: 16 Enqueue: 1550
 ID: 151 Len: 8 Enqueue: 0
-ID: 152 Len: 200 Enqueue: 1549
-ID: 153 Len: 192 Enqueue: 1490
-ID: 154 Len: 24 Enqueue: 1571
-ID: 155 Len: 8 Enqueue: 1024
+ID: 152 Len: 200 Enqueue: 1705
+ID: 153 Len: 192 Enqueue: 1646
+ID: 154 Len: 24 Enqueue: 1727
+ID: 155 Len: 8 Enqueue: 1180
 ID: 156 Len: 184 Enqueue: 0
-ID: 157 Len: 8 Enqueue: 1256
-ID: 158 Len: 200 Enqueue: 1302
-ID: 159 Len: 32 Enqueue: 1877
-ID: 160 Len: 16 Enqueue: 1406
+ID: 157 Len: 8 Enqueue: 1412
+ID: 158 Len: 200 Enqueue: 1458
+ID: 159 Len: 32 Enqueue: 2033
+ID: 160 Len: 16 Enqueue: 1562
 ID: 161 Len: 8 Enqueue: 0
-ID: 162 Len: 136 Enqueue: 1560
-ID: 163 Len: 128 Enqueue: 1522
-ID: 164 Len: 16 Enqueue: 1593
-ID: 165 Len: 8 Enqueue: 1466
+ID: 162 Len: 136 Enqueue: 1716
+ID: 163 Len: 128 Enqueue: 1678
+ID: 164 Len: 16 Enqueue: 1749
+ID: 165 Len: 8 Enqueue: 1622
 ID: 166 Len: 8 Enqueue: 0
-ID: 167 Len: 48 Enqueue: 1418
+ID: 167 Len: 48 Enqueue: 1574
 ID: 168 Len: 8 Enqueue: 0
-ID: 169 Len: 8 Enqueue: 1102
-ID: 170 Len: 8 Enqueue: 1268
-ID: 171 Len: 136 Enqueue: 1314
-ID: 172 Len: 32 Enqueue: 1844
-ID: 173 Len: 16 Enqueue: 1370
+ID: 169 Len: 8 Enqueue: 1258
+ID: 170 Len: 8 Enqueue: 1424
+ID: 171 Len: 136 Enqueue: 1470
+ID: 172 Len: 32 Enqueue: 2000
+ID: 173 Len: 16 Enqueue: 1526
 ID: 174 Len: 8 Enqueue: 0
 ID: 175 Len: 136 Enqueue: 0
 ID: 176 Len: 128 Enqueue: 0
 ID: 177 Len: 16 Enqueue: 0
 ID: 178 Len: 8 Enqueue: 0
-ID: 179 Len: 8 Enqueue: 1232
+ID: 179 Len: 8 Enqueue: 1388
 ID: 180 Len: 136 Enqueue: 0
-ID: 181 Len: 8 Enqueue: 964
+ID: 181 Len: 8 Enqueue: 1120
 ID: 182 Len: 128 Enqueue: 0
 ID: 183 Len: 9 Enqueue: 0
 ID: 184 Len: 0 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.26rc1.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.26rc1.sm.txt
@@ -7,13 +7,13 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call b8 03 00 00 // ProcessType[*****int]
+	Call 54 04 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessExpression[Probe[main.PointerChainArg]@0x4c1e54.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call b8 03 00 00 // ProcessType[*****int]
+	Call 54 04 00 00 // ProcessType[*****int]
 	Return 
 // 0x39: ProcessEvent[Probe[main.PointerChainArg]@4c1e54]
 	PrepareEventRoot d7 00 00 00 11 00 00 00 
@@ -24,7 +24,7 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call ca 03 00 00 // ProcessType[**int]
+	Call 66 04 00 00 // ProcessType[**int]
 	Return 
 // 0x68: ProcessEvent[Probe[main.PointerSmallChainArg]@4c1e99]
 	PrepareEventRoot d8 00 00 00 09 00 00 00 
@@ -34,13 +34,13 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call d2 05 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 6e 06 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x92: ProcessExpression[Probe[main.bigMapArg]@0x4c234a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call d2 05 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 6e 06 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0xad: ProcessEvent[Probe[main.bigMapArg]@4c234a]
 	PrepareEventRoot cf 00 00 00 11 00 00 00 
@@ -85,496 +85,508 @@
 	Return 
 // 0x148: ProcessExpression[Probe[main.intArrayArg]@0x4c208a.expr[0]]
 	ExprPrepare 
-	ExprDereferenceCfa 00 00 00 00 18 00 00 00 00 00 00 00 
+	ExprDereferenceCfa 00 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferenceCfa 08 00 00 00 08 00 00 00 08 00 00 00 
+	ExprDereferenceCfa 10 00 00 00 08 00 00 00 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
-// 0x164: ProcessEvent[Probe[main.intArrayArg]@4c208a]
+// 0x17e: ProcessEvent[Probe[main.intArrayArg]@4c208a]
 	PrepareEventRoot c6 00 00 00 19 00 00 00 
 	Call 48 01 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4c208a.expr[0]]
 	Return 
-// 0x173: ProcessEvent[Probe[main.intArrayArg]Return@4c20d6]
+// 0x18d: ProcessEvent[Probe[main.intArrayArg]Return@4c20d6]
 	PrepareEventRoot c7 00 00 00 00 00 00 00 
 	Return 
-// 0x17d: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4c2200.expr[0]]
+// 0x197: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4c2200.expr[0]]
 	ExprPrepare 
-	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
+	ExprDereferenceCfa 00 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferenceCfa 08 00 00 00 08 00 00 00 08 00 00 00 
+	ExprDereferenceCfa 10 00 00 00 08 00 00 00 10 00 00 00 
+	ExprDereferenceCfa 18 00 00 00 08 00 00 00 18 00 00 00 
+	ExprDereferenceCfa 20 00 00 00 08 00 00 00 20 00 00 00 
+	ExprDereferenceCfa 28 00 00 00 08 00 00 00 28 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call b6 04 00 00 // ProcessType[[3]string]
+	Call 52 05 00 00 // ProcessType[[3]string]
 	Return 
-// 0x19e: ProcessEvent[Probe[main.stringArrayArgFrameless]@4c2200]
+// 0x1f9: ProcessEvent[Probe[main.stringArrayArgFrameless]@4c2200]
 	PrepareEventRoot cc 00 00 00 31 00 00 00 
-	Call 7d 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4c2200.expr[0]]
+	Call 97 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4c2200.expr[0]]
 	Return 
-// 0x1ad: ProcessExpression[Probe[main.intSliceArg]@0x4c200a.expr[0]]
+// 0x208: ProcessExpression[Probe[main.intSliceArg]@0x4c200a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 0c 05 00 00 // ProcessType[[]int]
+	Call a8 05 00 00 // ProcessType[[]int]
 	Return 
-// 0x1d6: ProcessEvent[Probe[main.intSliceArg]@4c200a]
+// 0x231: ProcessEvent[Probe[main.intSliceArg]@4c200a]
 	PrepareEventRoot c4 00 00 00 19 00 00 00 
-	Call ad 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4c200a.expr[0]]
+	Call 08 02 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4c200a.expr[0]]
 	Return 
-// 0x1e5: ProcessEvent[Probe[main.intSliceArg]Return@4c204f]
+// 0x240: ProcessEvent[Probe[main.intSliceArg]Return@4c204f]
 	PrepareEventRoot c5 00 00 00 00 00 00 00 
 	Return 
-// 0x1ef: ProcessExpression[Probe[main.stringArg]@0x4c1f8a.expr[0]]
+// 0x24a: ProcessExpression[Probe[main.stringArg]@0x4c1f8a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 5a 07 00 00 // ProcessType[string]
+	Call f6 07 00 00 // ProcessType[string]
 	Return 
-// 0x211: ProcessEvent[Probe[main.stringArg]@4c1f8a]
+// 0x26c: ProcessEvent[Probe[main.stringArg]@4c1f8a]
 	PrepareEventRoot be 00 00 00 11 00 00 00 
-	Call ef 01 00 00 // ProcessExpression[Probe[main.stringArg]@0x4c1f8a.expr[0]]
+	Call 4a 02 00 00 // ProcessExpression[Probe[main.stringArg]@0x4c1f8a.expr[0]]
 	Return 
-// 0x220: ProcessEvent[Probe[main.stringArg]Return@4c1fcf]
+// 0x27b: ProcessEvent[Probe[main.stringArg]Return@4c1fcf]
 	PrepareEventRoot bf 00 00 00 00 00 00 00 
 	Return 
-// 0x22a: ProcessEvent[Probe[main.stringArg]@4c1f8a]
+// 0x285: ProcessEvent[Probe[main.stringArg]@4c1f8a]
 	PrepareEventRoot c0 00 00 00 00 00 00 00 
 	Return 
-// 0x234: ProcessEvent[Probe[main.stringArg]Return@4c1fcf]
+// 0x28f: ProcessEvent[Probe[main.stringArg]Return@4c1fcf]
 	PrepareEventRoot c1 00 00 00 00 00 00 00 
 	Return 
-// 0x23e: ProcessExpression[Probe[main.mapArg]@0x4c22ea.expr[0]]
+// 0x299: ProcessExpression[Probe[main.mapArg]@0x4c22ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call cc 05 00 00 // ProcessType[map[string]int]
+	Call 68 06 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x259: ProcessExpression[Probe[main.mapArg]@0x4c22ea.expr[1]]
+// 0x2b4: ProcessExpression[Probe[main.mapArg]@0x4c22ea.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call cc 05 00 00 // ProcessType[map[string]int]
+	Call 68 06 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x274: ProcessEvent[Probe[main.mapArg]@4c22ea]
+// 0x2cf: ProcessEvent[Probe[main.mapArg]@4c22ea]
 	PrepareEventRoot cd 00 00 00 11 00 00 00 
-	Call 3e 02 00 00 // ProcessExpression[Probe[main.mapArg]@0x4c22ea.expr[0]]
-	Call 59 02 00 00 // ProcessExpression[Probe[main.mapArg]@0x4c22ea.expr[1]]
+	Call 99 02 00 00 // ProcessExpression[Probe[main.mapArg]@0x4c22ea.expr[0]]
+	Call b4 02 00 00 // ProcessExpression[Probe[main.mapArg]@0x4c22ea.expr[1]]
 	Return 
-// 0x288: ProcessEvent[Probe[main.mapArg]Return@4c231f]
+// 0x2e3: ProcessEvent[Probe[main.mapArg]Return@4c231f]
 	PrepareEventRoot ce 00 00 00 00 00 00 00 
 	Return 
-// 0x292: ProcessEvent[Probe[main.noArgs]@4c23ca]
+// 0x2ed: ProcessEvent[Probe[main.noArgs]@4c23ca]
 	PrepareEventRoot d1 00 00 00 00 00 00 00 
 	Return 
-// 0x29c: ProcessEvent[Probe[main.noArgs]Return@4c2406]
+// 0x2f7: ProcessEvent[Probe[main.noArgs]Return@4c2406]
 	PrepareEventRoot d2 00 00 00 00 00 00 00 
 	Return 
-// 0x2a6: ProcessExpression[Probe[main.stringArg]@0x4c1f8a.expr[0]]
+// 0x301: ProcessExpression[Probe[main.stringArg]@0x4c1f8a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 5a 07 00 00 // ProcessType[string]
+	Call f6 07 00 00 // ProcessType[string]
 	Return 
-// 0x2c8: ProcessExpression[Probe[main.stringArg]@0x4c1f8a.expr[1]]
+// 0x323: ProcessExpression[Probe[main.stringArg]@0x4c1f8a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call 5a 07 00 00 // ProcessType[string]
+	Call f6 07 00 00 // ProcessType[string]
 	Return 
-// 0x2ea: ProcessEvent[Probe[main.stringArg]@4c1f8a]
+// 0x345: ProcessEvent[Probe[main.stringArg]@4c1f8a]
 	PrepareEventRoot c2 00 00 00 21 00 00 00 
-	Call a6 02 00 00 // ProcessExpression[Probe[main.stringArg]@0x4c1f8a.expr[0]]
-	Call c8 02 00 00 // ProcessExpression[Probe[main.stringArg]@0x4c1f8a.expr[1]]
+	Call 01 03 00 00 // ProcessExpression[Probe[main.stringArg]@0x4c1f8a.expr[0]]
+	Call 23 03 00 00 // ProcessExpression[Probe[main.stringArg]@0x4c1f8a.expr[1]]
 	Return 
-// 0x2fe: ProcessEvent[Probe[main.stringArg]Return@4c1fcf]
+// 0x359: ProcessEvent[Probe[main.stringArg]Return@4c1fcf]
 	PrepareEventRoot c3 00 00 00 00 00 00 00 
 	Return 
-// 0x308: ProcessExpression[Probe[main.stringArrayArg]@0x4c218a.expr[0]]
+// 0x363: ProcessExpression[Probe[main.stringArrayArg]@0x4c218a.expr[0]]
 	ExprPrepare 
-	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
+	ExprDereferenceCfa 00 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferenceCfa 08 00 00 00 08 00 00 00 08 00 00 00 
+	ExprDereferenceCfa 10 00 00 00 08 00 00 00 10 00 00 00 
+	ExprDereferenceCfa 18 00 00 00 08 00 00 00 18 00 00 00 
+	ExprDereferenceCfa 20 00 00 00 08 00 00 00 20 00 00 00 
+	ExprDereferenceCfa 28 00 00 00 08 00 00 00 28 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call b6 04 00 00 // ProcessType[[3]string]
+	Call 52 05 00 00 // ProcessType[[3]string]
 	Return 
-// 0x329: ProcessEvent[Probe[main.stringArrayArg]@4c218a]
+// 0x3c5: ProcessEvent[Probe[main.stringArrayArg]@4c218a]
 	PrepareEventRoot ca 00 00 00 31 00 00 00 
-	Call 08 03 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4c218a.expr[0]]
+	Call 63 03 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4c218a.expr[0]]
 	Return 
-// 0x338: ProcessEvent[Probe[main.stringArrayArg]Return@4c21d6]
+// 0x3d4: ProcessEvent[Probe[main.stringArrayArg]Return@4c21d6]
 	PrepareEventRoot cb 00 00 00 00 00 00 00 
 	Return 
-// 0x342: ProcessExpression[Probe[main.stringSliceArg]@0x4c210a.expr[0]]
+// 0x3de: ProcessExpression[Probe[main.stringSliceArg]@0x4c210a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 3a 05 00 00 // ProcessType[[]string]
+	Call d6 05 00 00 // ProcessType[[]string]
 	Return 
-// 0x36b: ProcessEvent[Probe[main.stringSliceArg]@4c210a]
+// 0x407: ProcessEvent[Probe[main.stringSliceArg]@4c210a]
 	PrepareEventRoot c8 00 00 00 19 00 00 00 
-	Call 42 03 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4c210a.expr[0]]
+	Call de 03 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4c210a.expr[0]]
 	Return 
-// 0x37a: ProcessEvent[Probe[main.stringSliceArg]Return@4c214f]
+// 0x416: ProcessEvent[Probe[main.stringSliceArg]Return@4c214f]
 	PrepareEventRoot c9 00 00 00 00 00 00 00 
 	Return 
-// 0x384: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4c2436]
+// 0x420: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4c2436]
 	PrepareEventRoot d3 00 00 00 00 00 00 00 
 	Return 
-// 0x38e: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4c2600.expr[0]]
+// 0x42a: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4c2600.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call d8 05 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 74 06 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x3a9: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4c2600]
+// 0x445: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4c2600]
 	PrepareEventRoot d4 00 00 00 09 00 00 00 
-	Call 8e 03 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4c2600.expr[0]]
+	Call 2a 04 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4c2600.expr[0]]
 	Return 
-// 0x3b8: ProcessType[*****int]
+// 0x454: ProcessType[*****int]
 	ProcessPointer 83 00 00 00 
 	Return 
-// 0x3be: ProcessType[****int]
+// 0x45a: ProcessType[****int]
 	ProcessPointer ba 00 00 00 
 	Return 
-// 0x3c4: ProcessType[***int]
+// 0x460: ProcessType[***int]
 	ProcessPointer 84 00 00 00 
 	Return 
-// 0x3ca: ProcessType[**int]
+// 0x466: ProcessType[**int]
 	ProcessPointer 68 00 00 00 
 	Return 
-// 0x3d0: ProcessType[*[]runtime.ancestorInfo]
+// 0x46c: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 29 00 00 00 
 	Return 
-// 0x3d6: ProcessType[*bool]
+// 0x472: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x3dc: ProcessType[*error]
+// 0x478: ProcessType[*error]
 	ProcessPointer 0f 00 00 00 
 	Return 
-// 0x3e2: ProcessType[*float32]
+// 0x47e: ProcessType[*float32]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x3e8: ProcessType[*float64]
+// 0x484: ProcessType[*float64]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x3ee: ProcessType[*int]
+// 0x48a: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x3f4: ProcessType[*int32]
+// 0x490: ProcessType[*int32]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x3fa: ProcessType[*int64]
+// 0x496: ProcessType[*int64]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x400: ProcessType[*internal/runtime/atomic.Pointer[runtime.m]]
+// 0x49c: ProcessType[*internal/runtime/atomic.Pointer[runtime.m]]
 	ProcessPointer 64 00 00 00 
 	Return 
-// 0x406: ProcessType[*main.bigStruct]
+// 0x4a2: ProcessType[*main.bigStruct]
 	ProcessPointer a1 00 00 00 
 	Return 
-// 0x40c: ProcessType[*runtime._defer]
+// 0x4a8: ProcessType[*runtime._defer]
 	ProcessPointer 1c 00 00 00 
 	Return 
-// 0x412: ProcessType[*runtime._panic]
+// 0x4ae: ProcessType[*runtime._panic]
 	ProcessPointer 1a 00 00 00 
 	Return 
-// 0x418: ProcessType[*runtime.cgoCallers]
+// 0x4b4: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 46 00 00 00 
 	Return 
-// 0x41e: ProcessType[*runtime.coro]
+// 0x4ba: ProcessType[*runtime.coro]
 	ProcessPointer 31 00 00 00 
 	Return 
-// 0x424: ProcessType[*runtime.g]
+// 0x4c0: ProcessType[*runtime.g]
 	ProcessPointer 17 00 00 00 
 	Return 
-// 0x42a: ProcessType[*runtime.m]
+// 0x4c6: ProcessType[*runtime.m]
 	ProcessPointer 1e 00 00 00 
 	Return 
-// 0x430: ProcessType[*runtime.p]
+// 0x4cc: ProcessType[*runtime.p]
 	ProcessPointer 8b 00 00 00 
 	Return 
-// 0x436: ProcessType[*runtime.sudog]
+// 0x4d2: ProcessType[*runtime.sudog]
 	ProcessPointer 2b 00 00 00 
 	Return 
-// 0x43c: ProcessType[*runtime.synctestBubble]
+// 0x4d8: ProcessType[*runtime.synctestBubble]
 	ProcessPointer 33 00 00 00 
 	Return 
-// 0x442: ProcessType[*runtime.timer]
+// 0x4de: ProcessType[*runtime.timer]
 	ProcessPointer 2e 00 00 00 
 	Return 
-// 0x448: ProcessType[*runtime.traceBuf]
+// 0x4e4: ProcessType[*runtime.traceBuf]
 	ProcessPointer 54 00 00 00 
 	Return 
-// 0x44e: ProcessType[*runtime.xRegState]
+// 0x4ea: ProcessType[*runtime.xRegState]
 	ProcessPointer 36 00 00 00 
 	Return 
-// 0x454: ProcessType[*string]
+// 0x4f0: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x45a: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+// 0x4f6: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer b1 00 00 00 
 	Return 
-// 0x460: ProcessType[*table<string,int>]
+// 0x4fc: ProcessType[*table<string,int>]
 	ProcessPointer 92 00 00 00 
 	Return 
-// 0x466: ProcessType[*table<string,main.bigStruct>]
+// 0x502: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer 9a 00 00 00 
 	Return 
-// 0x46c: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x508: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer a4 00 00 00 
 	Return 
-// 0x472: ProcessType[*uint]
+// 0x50e: ProcessType[*uint]
 	ProcessPointer 0e 00 00 00 
 	Return 
-// 0x478: ProcessType[*uint16]
+// 0x514: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x47e: ProcessType[*uint32]
+// 0x51a: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x484: ProcessType[*uint64]
+// 0x520: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x48a: ProcessType[*uint8]
+// 0x526: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x490: ProcessType[*uintptr]
+// 0x52c: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x496: ProcessType[[2]*runtime.traceBuf]
+// 0x532: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call 48 04 00 00 // ProcessType[*runtime.traceBuf]
+	Call e4 04 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x4a6: ProcessType[[2][2]*runtime.traceBuf]
+// 0x542: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call 96 04 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call 32 05 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x4b6: ProcessType[[3]string]
+// 0x552: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 5a 07 00 00 // ProcessType[string]
+	Call f6 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x4c6: ProcessType[[]*runtime.p]
+// 0x562: ProcessType[[]*runtime.p]
 	ProcessSlice 8c 00 00 00 08 00 00 00 
 	Return 
-// 0x4d0: ProcessType[[]*runtime.p.array]
+// 0x56c: ProcessType[[]*runtime.p.array]
 	ProcessSliceDataPrep 
-	Call 30 04 00 00 // ProcessType[*runtime.p]
+	Call cc 04 00 00 // ProcessType[*runtime.p]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x4dc: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x578: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 5a 04 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	Call f6 04 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x4e8: ProcessType[[]*table<string,int>.array]
+// 0x584: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 60 04 00 00 // ProcessType[*table<string,int>]
+	Call fc 04 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x4f4: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x590: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 66 04 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call 02 05 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x500: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x59c: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 6c 04 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 08 05 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x50c: ProcessType[[]int]
+// 0x5a8: ProcessType[[]int]
 	ProcessSlice 8e 00 00 00 08 00 00 00 
 	Return 
-// 0x516: ProcessType[[]noalg.map.group[string]int.array]
+// 0x5b2: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call 0e 06 00 00 // ProcessType[noalg.map.group[string]int]
+	Call aa 06 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x522: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x5be: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call 19 06 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call b5 06 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x52e: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+// 0x5ca: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call 24 06 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call c0 06 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x53a: ProcessType[[]string]
+// 0x5d6: ProcessType[[]string]
 	ProcessSlice 90 00 00 00 10 00 00 00 
 	Return 
-// 0x544: ProcessType[[]string.array]
+// 0x5e0: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call 5a 07 00 00 // ProcessType[string]
+	Call f6 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x550: ProcessType[[]uint8]
+// 0x5ec: ProcessType[[]uint8]
 	ProcessSlice 87 00 00 00 01 00 00 00 
 	Return 
-// 0x55a: ProcessType[[]uintptr]
+// 0x5f6: ProcessType[[]uintptr]
 	ProcessSlice 89 00 00 00 08 00 00 00 
 	Return 
-// 0x564: ProcessType[error]
+// 0x600: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x566: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+// 0x602: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups b9 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x572: ProcessType[groupReference<string,int>]
+// 0x60e: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups 99 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x57e: ProcessType[groupReference<string,main.bigStruct>]
+// 0x61a: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups a3 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x58a: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x626: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups b0 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x596: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+// 0x632: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap b8 00 00 00 b4 00 00 00 10 18 
 	Return 
-// 0x5a2: ProcessType[map<string,int>]
+// 0x63e: ProcessType[map<string,int>]
 	ProcessGoSwissMap 98 00 00 00 95 00 00 00 10 18 
 	Return 
-// 0x5ae: ProcessType[map<string,main.bigStruct>]
+// 0x64a: ProcessType[map<string,main.bigStruct>]
 	ProcessGoSwissMap a2 00 00 00 9d 00 00 00 10 18 
 	Return 
-// 0x5ba: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x656: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap af 00 00 00 a7 00 00 00 10 18 
 	Return 
-// 0x5c6: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x662: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer ac 00 00 00 
 	Return 
-// 0x5cc: ProcessType[map[string]int]
+// 0x668: ProcessType[map[string]int]
 	ProcessPointer 75 00 00 00 
 	Return 
-// 0x5d2: ProcessType[map[string]main.bigStruct]
+// 0x66e: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 7a 00 00 00 
 	Return 
-// 0x5d8: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x674: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 7f 00 00 00 
 	Return 
-// 0x5de: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x67a: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 2f 06 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call cb 06 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x5ee: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x68a: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 3f 06 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call db 06 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x5fe: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x69a: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call 45 06 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call e1 06 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x60e: ProcessType[noalg.map.group[string]int]
+// 0x6aa: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call ee 05 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call 8a 06 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x619: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x6b5: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call de 05 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call 7a 06 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x624: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x6c0: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call fe 05 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 9a 06 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x62f: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call 5a 07 00 00 // ProcessType[string]
+// 0x6cb: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call f6 07 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 06 04 00 00 // ProcessType[*main.bigStruct]
+	Call a2 04 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x63f: ProcessType[noalg.struct { key string; elem int }]
-	Call 5a 07 00 00 // ProcessType[string]
+// 0x6db: ProcessType[noalg.struct { key string; elem int }]
+	Call f6 07 00 00 // ProcessType[string]
 	Return 
-// 0x645: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x6e1: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call c6 05 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 62 06 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x650: ProcessType[runtime.g]
+// 0x6ec: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 12 04 00 00 // ProcessType[*runtime._panic]
+	Call ae 04 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 0c 04 00 00 // ProcessType[*runtime._defer]
+	Call a8 04 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call 2a 04 00 00 // ProcessType[*runtime.m]
+	Call c6 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call 50 05 00 00 // ProcessType[[]uint8]
+	Call ec 05 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call d0 03 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 6c 04 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call 36 04 00 00 // ProcessType[*runtime.sudog]
+	Call d2 04 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 5a 05 00 00 // ProcessType[[]uintptr]
+	Call f6 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call 42 04 00 00 // ProcessType[*runtime.timer]
+	Call de 04 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call 1e 04 00 00 // ProcessType[*runtime.coro]
+	Call ba 04 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call 3c 04 00 00 // ProcessType[*runtime.synctestBubble]
+	Call d8 04 00 00 // ProcessType[*runtime.synctestBubble]
 	IncrementOutputOffset 08 00 00 00 
-	Call 54 07 00 00 // ProcessType[runtime.xRegPerG]
+	Call f0 07 00 00 // ProcessType[runtime.xRegPerG]
 	Return 
-// 0x6bf: ProcessType[runtime.m]
-	Call 24 04 00 00 // ProcessType[*runtime.g]
+// 0x75b: ProcessType[runtime.m]
+	Call c0 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 48 00 00 00 
-	Call 24 04 00 00 // ProcessType[*runtime.g]
+	Call c0 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call 24 04 00 00 // ProcessType[*runtime.g]
+	Call c0 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 40 00 00 00 
-	Call 5a 07 00 00 // ProcessType[string]
+	Call f6 07 00 00 // ProcessType[string]
 	IncrementOutputOffset 30 00 00 00 
-	Call c6 04 00 00 // ProcessType[[]*runtime.p]
+	Call 62 05 00 00 // ProcessType[[]*runtime.p]
 	IncrementOutputOffset 28 00 00 00 
-	Call 18 04 00 00 // ProcessType[*runtime.cgoCallers]
+	Call b4 04 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call 2a 04 00 00 // ProcessType[*runtime.m]
+	Call c6 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 48 01 00 00 
-	Call 33 07 00 00 // ProcessType[runtime.mLockProfile]
+	Call cf 07 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 30 00 00 00 
-	Call 5a 05 00 00 // ProcessType[[]uintptr]
+	Call f6 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call 2a 04 00 00 // ProcessType[*runtime.m]
+	Call c6 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call 3e 07 00 00 // ProcessType[runtime.mTraceState]
+	Call da 07 00 00 // ProcessType[runtime.mTraceState]
 	IncrementOutputOffset d0 03 00 00 
-	Call 4e 07 00 00 // ProcessType[runtime.mWeakPointer]
+	Call ea 07 00 00 // ProcessType[runtime.mWeakPointer]
 	Return 
-// 0x733: ProcessType[runtime.mLockProfile]
+// 0x7cf: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 5a 05 00 00 // ProcessType[[]uintptr]
+	Call f6 05 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x73e: ProcessType[runtime.mTraceState]
+// 0x7da: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call a6 04 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call 2a 04 00 00 // ProcessType[*runtime.m]
+	Call 42 05 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call c6 04 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x74e: ProcessType[runtime.mWeakPointer]
-	Call 00 04 00 00 // ProcessType[*internal/runtime/atomic.Pointer[runtime.m]]
+// 0x7ea: ProcessType[runtime.mWeakPointer]
+	Call 9c 04 00 00 // ProcessType[*internal/runtime/atomic.Pointer[runtime.m]]
 	Return 
-// 0x754: ProcessType[runtime.xRegPerG]
-	Call 4e 04 00 00 // ProcessType[*runtime.xRegState]
+// 0x7f0: ProcessType[runtime.xRegPerG]
+	Call ea 04 00 00 // ProcessType[*runtime.xRegState]
 	Return 
-// 0x75a: ProcessType[string]
+// 0x7f6: ProcessType[string]
 	ProcessString 85 00 00 00 
 	Return 
-// 0x760: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x7fc: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 66 05 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call 02 06 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x76b: ProcessType[table<string,int>]
+// 0x807: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 72 05 00 00 // ProcessType[groupReference<string,int>]
+	Call 0e 06 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x776: ProcessType[table<string,main.bigStruct>]
+// 0x812: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 7e 05 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call 1a 06 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x781: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x81d: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 8a 05 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 26 06 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -595,32 +607,32 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 1162
+ID: 5 Len: 8 Enqueue: 1318
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 1882
+ID: 9 Len: 16 Enqueue: 2038
 ID: 10 Len: 4 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 982
+ID: 11 Len: 8 Enqueue: 1138
 ID: 12 Len: 8 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
 ID: 14 Len: 8 Enqueue: 0
-ID: 15 Len: 16 Enqueue: 1380
+ID: 15 Len: 16 Enqueue: 1536
 ID: 16 Len: 8 Enqueue: 0
 ID: 17 Len: 4 Enqueue: 0
 ID: 18 Len: 16 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 1168
+ID: 19 Len: 8 Enqueue: 1324
 ID: 20 Len: 1 Enqueue: 0
-ID: 21 Len: 8 Enqueue: 1012
-ID: 22 Len: 8 Enqueue: 1150
-ID: 23 Len: 456 Enqueue: 1616
+ID: 21 Len: 8 Enqueue: 1168
+ID: 22 Len: 8 Enqueue: 1306
+ID: 23 Len: 456 Enqueue: 1772
 ID: 24 Len: 16 Enqueue: 0
-ID: 25 Len: 8 Enqueue: 1042
+ID: 25 Len: 8 Enqueue: 1198
 ID: 26 Len: 8 Enqueue: 0
-ID: 27 Len: 8 Enqueue: 1036
+ID: 27 Len: 8 Enqueue: 1192
 ID: 28 Len: 8 Enqueue: 0
-ID: 29 Len: 8 Enqueue: 1066
-ID: 30 Len: 1824 Enqueue: 1727
+ID: 29 Len: 8 Enqueue: 1222
+ID: 30 Len: 1824 Enqueue: 1883
 ID: 31 Len: 48 Enqueue: 0
 ID: 32 Len: 8 Enqueue: 0
 ID: 33 Len: 4 Enqueue: 0
@@ -629,51 +641,51 @@ ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 1 Enqueue: 0
 ID: 38 Len: 8 Enqueue: 0
-ID: 39 Len: 24 Enqueue: 1360
-ID: 40 Len: 8 Enqueue: 976
+ID: 39 Len: 24 Enqueue: 1516
+ID: 40 Len: 8 Enqueue: 1132
 ID: 41 Len: 8 Enqueue: 0
-ID: 42 Len: 8 Enqueue: 1078
+ID: 42 Len: 8 Enqueue: 1234
 ID: 43 Len: 8 Enqueue: 0
-ID: 44 Len: 24 Enqueue: 1370
-ID: 45 Len: 8 Enqueue: 1090
+ID: 44 Len: 24 Enqueue: 1526
+ID: 45 Len: 8 Enqueue: 1246
 ID: 46 Len: 8 Enqueue: 0
 ID: 47 Len: 4 Enqueue: 0
-ID: 48 Len: 8 Enqueue: 1054
+ID: 48 Len: 8 Enqueue: 1210
 ID: 49 Len: 8 Enqueue: 0
-ID: 50 Len: 8 Enqueue: 1084
+ID: 50 Len: 8 Enqueue: 1240
 ID: 51 Len: 8 Enqueue: 0
-ID: 52 Len: 8 Enqueue: 1876
-ID: 53 Len: 8 Enqueue: 1102
+ID: 52 Len: 8 Enqueue: 2032
+ID: 53 Len: 8 Enqueue: 1258
 ID: 54 Len: 8 Enqueue: 0
 ID: 55 Len: 32 Enqueue: 0
 ID: 56 Len: 32 Enqueue: 0
 ID: 57 Len: 12 Enqueue: 0
 ID: 58 Len: 16 Enqueue: 0
-ID: 59 Len: 8 Enqueue: 1060
+ID: 59 Len: 8 Enqueue: 1216
 ID: 60 Len: 40 Enqueue: 0
 ID: 61 Len: 8 Enqueue: 0
 ID: 62 Len: 48 Enqueue: 0
 ID: 63 Len: 8 Enqueue: 0
 ID: 64 Len: 8 Enqueue: 0
 ID: 65 Len: 4 Enqueue: 0
-ID: 66 Len: 24 Enqueue: 1222
+ID: 66 Len: 24 Enqueue: 1378
 ID: 67 Len: 8 Enqueue: 0
-ID: 68 Len: 8 Enqueue: 1072
-ID: 69 Len: 8 Enqueue: 1048
+ID: 68 Len: 8 Enqueue: 1228
+ID: 69 Len: 8 Enqueue: 1204
 ID: 70 Len: 8 Enqueue: 0
 ID: 71 Len: 8 Enqueue: 0
 ID: 72 Len: 16 Enqueue: 0
 ID: 73 Len: 256 Enqueue: 0
 ID: 74 Len: 16 Enqueue: 0
-ID: 75 Len: 56 Enqueue: 1843
+ID: 75 Len: 56 Enqueue: 1999
 ID: 76 Len: 8 Enqueue: 0
 ID: 77 Len: 0 Enqueue: 0
 ID: 78 Len: 8 Enqueue: 0
 ID: 79 Len: 1 Enqueue: 0
-ID: 80 Len: 72 Enqueue: 1854
-ID: 81 Len: 32 Enqueue: 1190
-ID: 82 Len: 16 Enqueue: 1174
-ID: 83 Len: 8 Enqueue: 1096
+ID: 80 Len: 72 Enqueue: 2010
+ID: 81 Len: 32 Enqueue: 1346
+ID: 82 Len: 16 Enqueue: 1330
+ID: 83 Len: 8 Enqueue: 1252
 ID: 84 Len: 8 Enqueue: 0
 ID: 85 Len: 0 Enqueue: 0
 ID: 86 Len: 392 Enqueue: 0
@@ -688,41 +700,41 @@ ID: 94 Len: 32 Enqueue: 0
 ID: 95 Len: 160 Enqueue: 0
 ID: 96 Len: 16 Enqueue: 0
 ID: 97 Len: 8 Enqueue: 0
-ID: 98 Len: 8 Enqueue: 1870
-ID: 99 Len: 8 Enqueue: 1024
+ID: 98 Len: 8 Enqueue: 2026
+ID: 99 Len: 8 Enqueue: 1180
 ID: 100 Len: 8 Enqueue: 0
-ID: 101 Len: 8 Enqueue: 1108
+ID: 101 Len: 8 Enqueue: 1264
 ID: 102 Len: 8 Enqueue: 0
-ID: 103 Len: 8 Enqueue: 1000
-ID: 104 Len: 8 Enqueue: 1006
-ID: 105 Len: 8 Enqueue: 1018
-ID: 106 Len: 8 Enqueue: 1156
-ID: 107 Len: 8 Enqueue: 988
-ID: 108 Len: 8 Enqueue: 994
-ID: 109 Len: 8 Enqueue: 1138
-ID: 110 Len: 8 Enqueue: 1144
-ID: 111 Len: 24 Enqueue: 1292
+ID: 103 Len: 8 Enqueue: 1156
+ID: 104 Len: 8 Enqueue: 1162
+ID: 105 Len: 8 Enqueue: 1174
+ID: 106 Len: 8 Enqueue: 1312
+ID: 107 Len: 8 Enqueue: 1144
+ID: 108 Len: 8 Enqueue: 1150
+ID: 109 Len: 8 Enqueue: 1294
+ID: 110 Len: 8 Enqueue: 1300
+ID: 111 Len: 24 Enqueue: 1448
 ID: 112 Len: 24 Enqueue: 0
-ID: 113 Len: 24 Enqueue: 1338
-ID: 114 Len: 48 Enqueue: 1206
-ID: 115 Len: 8 Enqueue: 1484
+ID: 113 Len: 24 Enqueue: 1494
+ID: 114 Len: 48 Enqueue: 1362
+ID: 115 Len: 8 Enqueue: 1640
 ID: 116 Len: 8 Enqueue: 0
-ID: 117 Len: 48 Enqueue: 1442
+ID: 117 Len: 48 Enqueue: 1598
 ID: 118 Len: 8 Enqueue: 0
-ID: 119 Len: 8 Enqueue: 1120
-ID: 120 Len: 8 Enqueue: 1490
+ID: 119 Len: 8 Enqueue: 1276
+ID: 120 Len: 8 Enqueue: 1646
 ID: 121 Len: 8 Enqueue: 0
-ID: 122 Len: 48 Enqueue: 1454
+ID: 122 Len: 48 Enqueue: 1610
 ID: 123 Len: 8 Enqueue: 0
-ID: 124 Len: 8 Enqueue: 1126
-ID: 125 Len: 8 Enqueue: 1496
+ID: 124 Len: 8 Enqueue: 1282
+ID: 125 Len: 8 Enqueue: 1652
 ID: 126 Len: 8 Enqueue: 0
-ID: 127 Len: 48 Enqueue: 1466
+ID: 127 Len: 48 Enqueue: 1622
 ID: 128 Len: 8 Enqueue: 0
-ID: 129 Len: 8 Enqueue: 1132
-ID: 130 Len: 8 Enqueue: 952
-ID: 131 Len: 8 Enqueue: 958
-ID: 132 Len: 8 Enqueue: 970
+ID: 129 Len: 8 Enqueue: 1288
+ID: 130 Len: 8 Enqueue: 1108
+ID: 131 Len: 8 Enqueue: 1114
+ID: 132 Len: 8 Enqueue: 1126
 ID: 133 Len: 1 Enqueue: 0
 ID: 134 Len: 8 Enqueue: 0
 ID: 135 Len: 1 Enqueue: 0
@@ -730,53 +742,53 @@ ID: 136 Len: 8 Enqueue: 0
 ID: 137 Len: 8 Enqueue: 0
 ID: 138 Len: 8 Enqueue: 0
 ID: 139 Len: 8 Enqueue: 0
-ID: 140 Len: 8 Enqueue: 1232
+ID: 140 Len: 8 Enqueue: 1388
 ID: 141 Len: 8 Enqueue: 0
 ID: 142 Len: 8 Enqueue: 0
 ID: 143 Len: 8 Enqueue: 0
-ID: 144 Len: 16 Enqueue: 1348
+ID: 144 Len: 16 Enqueue: 1504
 ID: 145 Len: 8 Enqueue: 0
-ID: 146 Len: 32 Enqueue: 1899
-ID: 147 Len: 16 Enqueue: 1394
+ID: 146 Len: 32 Enqueue: 2055
+ID: 147 Len: 16 Enqueue: 1550
 ID: 148 Len: 8 Enqueue: 0
-ID: 149 Len: 200 Enqueue: 1550
-ID: 150 Len: 192 Enqueue: 1518
-ID: 151 Len: 24 Enqueue: 1599
-ID: 152 Len: 8 Enqueue: 1256
-ID: 153 Len: 200 Enqueue: 1302
-ID: 154 Len: 32 Enqueue: 1910
-ID: 155 Len: 16 Enqueue: 1406
+ID: 149 Len: 200 Enqueue: 1706
+ID: 150 Len: 192 Enqueue: 1674
+ID: 151 Len: 24 Enqueue: 1755
+ID: 152 Len: 8 Enqueue: 1412
+ID: 153 Len: 200 Enqueue: 1458
+ID: 154 Len: 32 Enqueue: 2066
+ID: 155 Len: 16 Enqueue: 1562
 ID: 156 Len: 8 Enqueue: 0
-ID: 157 Len: 200 Enqueue: 1561
-ID: 158 Len: 192 Enqueue: 1502
-ID: 159 Len: 24 Enqueue: 1583
-ID: 160 Len: 8 Enqueue: 1030
+ID: 157 Len: 200 Enqueue: 1717
+ID: 158 Len: 192 Enqueue: 1658
+ID: 159 Len: 24 Enqueue: 1739
+ID: 160 Len: 8 Enqueue: 1186
 ID: 161 Len: 184 Enqueue: 0
-ID: 162 Len: 8 Enqueue: 1268
-ID: 163 Len: 200 Enqueue: 1314
-ID: 164 Len: 32 Enqueue: 1921
-ID: 165 Len: 16 Enqueue: 1418
+ID: 162 Len: 8 Enqueue: 1424
+ID: 163 Len: 200 Enqueue: 1470
+ID: 164 Len: 32 Enqueue: 2077
+ID: 165 Len: 16 Enqueue: 1574
 ID: 166 Len: 8 Enqueue: 0
-ID: 167 Len: 136 Enqueue: 1572
-ID: 168 Len: 128 Enqueue: 1534
-ID: 169 Len: 16 Enqueue: 1605
-ID: 170 Len: 8 Enqueue: 1478
+ID: 167 Len: 136 Enqueue: 1728
+ID: 168 Len: 128 Enqueue: 1690
+ID: 169 Len: 16 Enqueue: 1761
+ID: 170 Len: 8 Enqueue: 1634
 ID: 171 Len: 8 Enqueue: 0
-ID: 172 Len: 48 Enqueue: 1430
+ID: 172 Len: 48 Enqueue: 1586
 ID: 173 Len: 8 Enqueue: 0
-ID: 174 Len: 8 Enqueue: 1114
-ID: 175 Len: 8 Enqueue: 1280
-ID: 176 Len: 136 Enqueue: 1326
-ID: 177 Len: 32 Enqueue: 1888
-ID: 178 Len: 16 Enqueue: 1382
+ID: 174 Len: 8 Enqueue: 1270
+ID: 175 Len: 8 Enqueue: 1436
+ID: 176 Len: 136 Enqueue: 1482
+ID: 177 Len: 32 Enqueue: 2044
+ID: 178 Len: 16 Enqueue: 1538
 ID: 179 Len: 8 Enqueue: 0
 ID: 180 Len: 136 Enqueue: 0
 ID: 181 Len: 128 Enqueue: 0
 ID: 182 Len: 16 Enqueue: 0
 ID: 183 Len: 8 Enqueue: 0
-ID: 184 Len: 8 Enqueue: 1244
+ID: 184 Len: 8 Enqueue: 1400
 ID: 185 Len: 136 Enqueue: 0
-ID: 186 Len: 8 Enqueue: 964
+ID: 186 Len: 8 Enqueue: 1120
 ID: 187 Len: 128 Enqueue: 0
 ID: 188 Len: 9 Enqueue: 0
 ID: 189 Len: 0 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.sm.txt
@@ -7,13 +7,13 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call b8 03 00 00 // ProcessType[*****int]
+	Call 54 04 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessExpression[Probe[main.PointerChainArg]@0xb5388.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call b8 03 00 00 // ProcessType[*****int]
+	Call 54 04 00 00 // ProcessType[*****int]
 	Return 
 // 0x39: ProcessEvent[Probe[main.PointerChainArg]@b5388]
 	PrepareEventRoot bd 00 00 00 11 00 00 00 
@@ -24,7 +24,7 @@
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call ca 03 00 00 // ProcessType[**int]
+	Call 66 04 00 00 // ProcessType[**int]
 	Return 
 // 0x68: ProcessEvent[Probe[main.PointerSmallChainArg]@b53c0]
 	PrepareEventRoot be 00 00 00 09 00 00 00 
@@ -34,13 +34,13 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call f8 05 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 94 06 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x92: ProcessExpression[Probe[main.bigMapArg]@0xb5880.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call f8 05 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 94 06 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0xad: ProcessEvent[Probe[main.bigMapArg]@b5880]
 	PrepareEventRoot b5 00 00 00 11 00 00 00 
@@ -85,433 +85,445 @@
 	Return 
 // 0x148: ProcessExpression[Probe[main.intArrayArg]@0xb55a8.expr[0]]
 	ExprPrepare 
-	ExprDereferenceCfa 08 00 00 00 18 00 00 00 00 00 00 00 
+	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferenceCfa 10 00 00 00 08 00 00 00 08 00 00 00 
+	ExprDereferenceCfa 18 00 00 00 08 00 00 00 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
-// 0x164: ProcessEvent[Probe[main.intArrayArg]@b55a8]
+// 0x17e: ProcessEvent[Probe[main.intArrayArg]@b55a8]
 	PrepareEventRoot ac 00 00 00 19 00 00 00 
 	Call 48 01 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb55a8.expr[0]]
 	Return 
-// 0x173: ProcessEvent[Probe[main.intArrayArg]Return@b55ec]
+// 0x18d: ProcessEvent[Probe[main.intArrayArg]Return@b55ec]
 	PrepareEventRoot ad 00 00 00 00 00 00 00 
 	Return 
-// 0x17d: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb5720.expr[0]]
+// 0x197: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb5720.expr[0]]
 	ExprPrepare 
-	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
+	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferenceCfa 10 00 00 00 08 00 00 00 08 00 00 00 
+	ExprDereferenceCfa 18 00 00 00 08 00 00 00 10 00 00 00 
+	ExprDereferenceCfa 20 00 00 00 08 00 00 00 18 00 00 00 
+	ExprDereferenceCfa 28 00 00 00 08 00 00 00 20 00 00 00 
+	ExprDereferenceCfa 30 00 00 00 08 00 00 00 28 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 9a 04 00 00 // ProcessType[[3]string]
+	Call 36 05 00 00 // ProcessType[[3]string]
 	Return 
-// 0x19e: ProcessEvent[Probe[main.stringArrayArgFrameless]@b5720]
+// 0x1f9: ProcessEvent[Probe[main.stringArrayArgFrameless]@b5720]
 	PrepareEventRoot b2 00 00 00 31 00 00 00 
-	Call 7d 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb5720.expr[0]]
+	Call 97 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb5720.expr[0]]
 	Return 
-// 0x1ad: ProcessExpression[Probe[main.intSliceArg]@0xb5518.expr[0]]
+// 0x208: ProcessExpression[Probe[main.intSliceArg]@0xb5518.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call e6 04 00 00 // ProcessType[[]int]
+	Call 82 05 00 00 // ProcessType[[]int]
 	Return 
-// 0x1d6: ProcessEvent[Probe[main.intSliceArg]@b5518]
+// 0x231: ProcessEvent[Probe[main.intSliceArg]@b5518]
 	PrepareEventRoot aa 00 00 00 19 00 00 00 
-	Call ad 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb5518.expr[0]]
+	Call 08 02 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb5518.expr[0]]
 	Return 
-// 0x1e5: ProcessEvent[Probe[main.intSliceArg]Return@b5554]
+// 0x240: ProcessEvent[Probe[main.intSliceArg]Return@b5554]
 	PrepareEventRoot ab 00 00 00 00 00 00 00 
 	Return 
-// 0x1ef: ProcessExpression[Probe[main.stringArg]@0xb5498.expr[0]]
+// 0x24a: ProcessExpression[Probe[main.stringArg]@0xb5498.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e0 06 00 00 // ProcessType[string]
+	Call 7c 07 00 00 // ProcessType[string]
 	Return 
-// 0x211: ProcessEvent[Probe[main.stringArg]@b5498]
+// 0x26c: ProcessEvent[Probe[main.stringArg]@b5498]
 	PrepareEventRoot a4 00 00 00 11 00 00 00 
-	Call ef 01 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5498.expr[0]]
+	Call 4a 02 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5498.expr[0]]
 	Return 
-// 0x220: ProcessEvent[Probe[main.stringArg]Return@b54d4]
+// 0x27b: ProcessEvent[Probe[main.stringArg]Return@b54d4]
 	PrepareEventRoot a5 00 00 00 00 00 00 00 
 	Return 
-// 0x22a: ProcessEvent[Probe[main.stringArg]@b5498]
+// 0x285: ProcessEvent[Probe[main.stringArg]@b5498]
 	PrepareEventRoot a6 00 00 00 00 00 00 00 
 	Return 
-// 0x234: ProcessEvent[Probe[main.stringArg]Return@b54d4]
+// 0x28f: ProcessEvent[Probe[main.stringArg]Return@b54d4]
 	PrepareEventRoot a7 00 00 00 00 00 00 00 
 	Return 
-// 0x23e: ProcessExpression[Probe[main.mapArg]@0xb5808.expr[0]]
+// 0x299: ProcessExpression[Probe[main.mapArg]@0xb5808.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call f2 05 00 00 // ProcessType[map[string]int]
+	Call 8e 06 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x259: ProcessExpression[Probe[main.mapArg]@0xb5808.expr[1]]
+// 0x2b4: ProcessExpression[Probe[main.mapArg]@0xb5808.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call f2 05 00 00 // ProcessType[map[string]int]
+	Call 8e 06 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x274: ProcessEvent[Probe[main.mapArg]@b5808]
+// 0x2cf: ProcessEvent[Probe[main.mapArg]@b5808]
 	PrepareEventRoot b3 00 00 00 11 00 00 00 
-	Call 3e 02 00 00 // ProcessExpression[Probe[main.mapArg]@0xb5808.expr[0]]
-	Call 59 02 00 00 // ProcessExpression[Probe[main.mapArg]@0xb5808.expr[1]]
+	Call 99 02 00 00 // ProcessExpression[Probe[main.mapArg]@0xb5808.expr[0]]
+	Call b4 02 00 00 // ProcessExpression[Probe[main.mapArg]@0xb5808.expr[1]]
 	Return 
-// 0x288: ProcessEvent[Probe[main.mapArg]Return@b5838]
+// 0x2e3: ProcessEvent[Probe[main.mapArg]Return@b5838]
 	PrepareEventRoot b4 00 00 00 00 00 00 00 
 	Return 
-// 0x292: ProcessEvent[Probe[main.noArgs]@b5938]
+// 0x2ed: ProcessEvent[Probe[main.noArgs]@b5938]
 	PrepareEventRoot b7 00 00 00 00 00 00 00 
 	Return 
-// 0x29c: ProcessEvent[Probe[main.noArgs]Return@b5970]
+// 0x2f7: ProcessEvent[Probe[main.noArgs]Return@b5970]
 	PrepareEventRoot b8 00 00 00 00 00 00 00 
 	Return 
-// 0x2a6: ProcessExpression[Probe[main.stringArg]@0xb5498.expr[0]]
+// 0x301: ProcessExpression[Probe[main.stringArg]@0xb5498.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e0 06 00 00 // ProcessType[string]
+	Call 7c 07 00 00 // ProcessType[string]
 	Return 
-// 0x2c8: ProcessExpression[Probe[main.stringArg]@0xb5498.expr[1]]
+// 0x323: ProcessExpression[Probe[main.stringArg]@0xb5498.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call e0 06 00 00 // ProcessType[string]
+	Call 7c 07 00 00 // ProcessType[string]
 	Return 
-// 0x2ea: ProcessEvent[Probe[main.stringArg]@b5498]
+// 0x345: ProcessEvent[Probe[main.stringArg]@b5498]
 	PrepareEventRoot a8 00 00 00 21 00 00 00 
-	Call a6 02 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5498.expr[0]]
-	Call c8 02 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5498.expr[1]]
+	Call 01 03 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5498.expr[0]]
+	Call 23 03 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5498.expr[1]]
 	Return 
-// 0x2fe: ProcessEvent[Probe[main.stringArg]Return@b54d4]
+// 0x359: ProcessEvent[Probe[main.stringArg]Return@b54d4]
 	PrepareEventRoot a9 00 00 00 00 00 00 00 
 	Return 
-// 0x308: ProcessExpression[Probe[main.stringArrayArg]@0xb56b8.expr[0]]
+// 0x363: ProcessExpression[Probe[main.stringArrayArg]@0xb56b8.expr[0]]
 	ExprPrepare 
-	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
+	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferenceCfa 10 00 00 00 08 00 00 00 08 00 00 00 
+	ExprDereferenceCfa 18 00 00 00 08 00 00 00 10 00 00 00 
+	ExprDereferenceCfa 20 00 00 00 08 00 00 00 18 00 00 00 
+	ExprDereferenceCfa 28 00 00 00 08 00 00 00 20 00 00 00 
+	ExprDereferenceCfa 30 00 00 00 08 00 00 00 28 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 9a 04 00 00 // ProcessType[[3]string]
+	Call 36 05 00 00 // ProcessType[[3]string]
 	Return 
-// 0x329: ProcessEvent[Probe[main.stringArrayArg]@b56b8]
+// 0x3c5: ProcessEvent[Probe[main.stringArrayArg]@b56b8]
 	PrepareEventRoot b0 00 00 00 31 00 00 00 
-	Call 08 03 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb56b8.expr[0]]
+	Call 63 03 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb56b8.expr[0]]
 	Return 
-// 0x338: ProcessEvent[Probe[main.stringArrayArg]Return@b56fc]
+// 0x3d4: ProcessEvent[Probe[main.stringArrayArg]Return@b56fc]
 	PrepareEventRoot b1 00 00 00 00 00 00 00 
 	Return 
-// 0x342: ProcessExpression[Probe[main.stringSliceArg]@0xb5628.expr[0]]
+// 0x3de: ProcessExpression[Probe[main.stringSliceArg]@0xb5628.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 00 05 00 00 // ProcessType[[]string]
+	Call 9c 05 00 00 // ProcessType[[]string]
 	Return 
-// 0x36b: ProcessEvent[Probe[main.stringSliceArg]@b5628]
+// 0x407: ProcessEvent[Probe[main.stringSliceArg]@b5628]
 	PrepareEventRoot ae 00 00 00 19 00 00 00 
-	Call 42 03 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb5628.expr[0]]
+	Call de 03 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb5628.expr[0]]
 	Return 
-// 0x37a: ProcessEvent[Probe[main.stringSliceArg]Return@b5664]
+// 0x416: ProcessEvent[Probe[main.stringSliceArg]Return@b5664]
 	PrepareEventRoot af 00 00 00 00 00 00 00 
 	Return 
-// 0x384: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b59b0]
+// 0x420: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b59b0]
 	PrepareEventRoot b9 00 00 00 00 00 00 00 
 	Return 
-// 0x38e: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb5b24.expr[0]]
+// 0x42a: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb5b24.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 04 06 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call a0 06 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x3a9: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b5b24]
+// 0x445: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b5b24]
 	PrepareEventRoot ba 00 00 00 09 00 00 00 
-	Call 8e 03 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb5b24.expr[0]]
+	Call 2a 04 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb5b24.expr[0]]
 	Return 
-// 0x3b8: ProcessType[*****int]
+// 0x454: ProcessType[*****int]
 	ProcessPointer 7f 00 00 00 
 	Return 
-// 0x3be: ProcessType[****int]
+// 0x45a: ProcessType[****int]
 	ProcessPointer a0 00 00 00 
 	Return 
-// 0x3c4: ProcessType[***int]
+// 0x460: ProcessType[***int]
 	ProcessPointer 80 00 00 00 
 	Return 
-// 0x3ca: ProcessType[**int]
+// 0x466: ProcessType[**int]
 	ProcessPointer 5e 00 00 00 
 	Return 
-// 0x3d0: ProcessType[*[]runtime.ancestorInfo]
+// 0x46c: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x3d6: ProcessType[*bool]
+// 0x472: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x3dc: ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
+// 0x478: ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 99 00 00 00 
 	Return 
-// 0x3e2: ProcessType[*bucket<string,int>]
+// 0x47e: ProcessType[*bucket<string,int>]
 	ProcessPointer 6c 00 00 00 
 	Return 
-// 0x3e8: ProcessType[*bucket<string,main.bigStruct>]
+// 0x484: ProcessType[*bucket<string,main.bigStruct>]
 	ProcessPointer 73 00 00 00 
 	Return 
-// 0x3ee: ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x48a: ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 7d 00 00 00 
 	Return 
-// 0x3f4: ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x490: ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 78 00 00 00 
 	Return 
-// 0x3fa: ProcessType[*error]
+// 0x496: ProcessType[*error]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x400: ProcessType[*float32]
+// 0x49c: ProcessType[*float32]
 	ProcessPointer 10 00 00 00 
 	Return 
-// 0x406: ProcessType[*float64]
+// 0x4a2: ProcessType[*float64]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x40c: ProcessType[*int]
+// 0x4a8: ProcessType[*int]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x412: ProcessType[*int32]
+// 0x4ae: ProcessType[*int32]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x418: ProcessType[*int64]
+// 0x4b4: ProcessType[*int64]
 	ProcessPointer 0e 00 00 00 
 	Return 
-// 0x41e: ProcessType[*main.bigStruct]
+// 0x4ba: ProcessType[*main.bigStruct]
 	ProcessPointer 91 00 00 00 
 	Return 
-// 0x424: ProcessType[*runtime._defer]
+// 0x4c0: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x42a: ProcessType[*runtime._panic]
+// 0x4c6: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x430: ProcessType[*runtime.cgoCallers]
+// 0x4cc: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 3d 00 00 00 
 	Return 
-// 0x436: ProcessType[*runtime.coro]
+// 0x4d2: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x43c: ProcessType[*runtime.g]
+// 0x4d8: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x442: ProcessType[*runtime.m]
+// 0x4de: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x448: ProcessType[*runtime.mapextra]
+// 0x4e4: ProcessType[*runtime.mapextra]
 	ProcessPointer 6e 00 00 00 
 	Return 
-// 0x44e: ProcessType[*runtime.sudog]
+// 0x4ea: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x454: ProcessType[*runtime.timer]
+// 0x4f0: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x45a: ProcessType[*runtime.traceBuf]
+// 0x4f6: ProcessType[*runtime.traceBuf]
 	ProcessPointer 49 00 00 00 
 	Return 
-// 0x460: ProcessType[*string]
+// 0x4fc: ProcessType[*string]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x466: ProcessType[*uint]
+// 0x502: ProcessType[*uint]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x46c: ProcessType[*uint16]
+// 0x508: ProcessType[*uint16]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x472: ProcessType[*uint32]
+// 0x50e: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x478: ProcessType[*uint64]
+// 0x514: ProcessType[*uint64]
 	ProcessPointer 0b 00 00 00 
 	Return 
-// 0x47e: ProcessType[*uint8]
+// 0x51a: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x484: ProcessType[*uintptr]
+// 0x520: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x48a: ProcessType[[2]*runtime.traceBuf]
+// 0x526: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call 5a 04 00 00 // ProcessType[*runtime.traceBuf]
+	Call f6 04 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x49a: ProcessType[[3]string]
+// 0x536: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call e0 06 00 00 // ProcessType[string]
+	Call 7c 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x4aa: ProcessType[[]bucket<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x546: ProcessType[[]bucket<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 4a 05 00 00 // ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
+	Call e6 05 00 00 // ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x4b6: ProcessType[[]bucket<string,int>.array]
+// 0x552: ProcessType[[]bucket<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 55 05 00 00 // ProcessType[bucket<string,int>]
+	Call f1 05 00 00 // ProcessType[bucket<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x4c2: ProcessType[[]bucket<string,main.bigStruct>.array]
+// 0x55e: ProcessType[[]bucket<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 6a 05 00 00 // ProcessType[bucket<string,main.bigStruct>]
+	Call 06 06 00 00 // ProcessType[bucket<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x4ce: ProcessType[[]bucket<string,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x56a: ProcessType[[]bucket<string,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 7f 05 00 00 // ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 1b 06 00 00 // ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x4da: ProcessType[[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x576: ProcessType[[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 94 05 00 00 // ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 30 06 00 00 // ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x4e6: ProcessType[[]int]
+// 0x582: ProcessType[[]int]
 	ProcessSlice 87 00 00 00 08 00 00 00 
 	Return 
-// 0x4f0: ProcessType[[]key<string>]
+// 0x58c: ProcessType[[]key<string>]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call e0 06 00 00 // ProcessType[string]
+	Call 7c 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x500: ProcessType[[]string]
+// 0x59c: ProcessType[[]string]
 	ProcessSlice 89 00 00 00 10 00 00 00 
 	Return 
-// 0x50a: ProcessType[[]string.array]
+// 0x5a6: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call e0 06 00 00 // ProcessType[string]
+	Call 7c 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x516: ProcessType[[]uint8]
+// 0x5b2: ProcessType[[]uint8]
 	ProcessSlice 83 00 00 00 01 00 00 00 
 	Return 
-// 0x520: ProcessType[[]uintptr]
+// 0x5bc: ProcessType[[]uintptr]
 	ProcessSlice 85 00 00 00 08 00 00 00 
 	Return 
-// 0x52a: ProcessType[[]val<main.bigStruct>]
+// 0x5c6: ProcessType[[]val<main.bigStruct>]
 	ProcessArrayDataPrep 40 00 00 00 
-	Call 1e 04 00 00 // ProcessType[*main.bigStruct]
+	Call ba 04 00 00 // ProcessType[*main.bigStruct]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x53a: ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+// 0x5d6: ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessArrayDataPrep 40 00 00 00 
-	Call ec 05 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 88 06 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x54a: ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
+// 0x5e6: ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 88 00 00 00 
-	Call dc 03 00 00 // ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
+	Call 78 04 00 00 // ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x555: ProcessType[bucket<string,int>]
+// 0x5f1: ProcessType[bucket<string,int>]
 	IncrementOutputOffset 08 00 00 00 
-	Call f0 04 00 00 // ProcessType[[]key<string>]
+	Call 8c 05 00 00 // ProcessType[[]key<string>]
 	IncrementOutputOffset 40 00 00 00 
-	Call e2 03 00 00 // ProcessType[*bucket<string,int>]
+	Call 7e 04 00 00 // ProcessType[*bucket<string,int>]
 	Return 
-// 0x56a: ProcessType[bucket<string,main.bigStruct>]
+// 0x606: ProcessType[bucket<string,main.bigStruct>]
 	IncrementOutputOffset 08 00 00 00 
-	Call f0 04 00 00 // ProcessType[[]key<string>]
-	Call 2a 05 00 00 // ProcessType[[]val<main.bigStruct>]
-	Call e8 03 00 00 // ProcessType[*bucket<string,main.bigStruct>]
+	Call 8c 05 00 00 // ProcessType[[]key<string>]
+	Call c6 05 00 00 // ProcessType[[]val<main.bigStruct>]
+	Call 84 04 00 00 // ProcessType[*bucket<string,main.bigStruct>]
 	Return 
-// 0x57f: ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x61b: ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 08 00 00 00 
-	Call f0 04 00 00 // ProcessType[[]key<string>]
-	Call 3a 05 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
-	Call ee 03 00 00 // ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 8c 05 00 00 // ProcessType[[]key<string>]
+	Call d6 05 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+	Call 8a 04 00 00 // ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x594: ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x630: ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 3a 05 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
-	Call f4 03 00 00 // ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call d6 05 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+	Call 90 04 00 00 // ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x5a4: ProcessType[error]
+// 0x640: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x5a6: ProcessType[hash<int,main.aStructNotUsedAsAnArgument>]
+// 0x642: ProcessType[hash<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoHmap 9f 00 00 00 90 00 00 00 08 09 10 18 
 	Return 
-// 0x5b4: ProcessType[hash<string,int>]
+// 0x650: ProcessType[hash<string,int>]
 	ProcessGoHmap 8e 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x5c2: ProcessType[hash<string,main.bigStruct>]
+// 0x65e: ProcessType[hash<string,main.bigStruct>]
 	ProcessGoHmap 92 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x5d0: ProcessType[hash<string,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x66c: ProcessType[hash<string,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoHmap 9b 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x5de: ProcessType[hash<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x67a: ProcessType[hash<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoHmap 9a 00 00 00 58 00 00 00 08 09 10 18 
 	Return 
-// 0x5ec: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x688: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 97 00 00 00 
 	Return 
-// 0x5f2: ProcessType[map[string]int]
+// 0x68e: ProcessType[map[string]int]
 	ProcessPointer 6a 00 00 00 
 	Return 
-// 0x5f8: ProcessType[map[string]main.bigStruct]
+// 0x694: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 71 00 00 00 
 	Return 
-// 0x5fe: ProcessType[map[string]map[int]main.aStructNotUsedAsAnArgument]
+// 0x69a: ProcessType[map[string]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 7b 00 00 00 
 	Return 
-// 0x604: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x6a0: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 76 00 00 00 
 	Return 
-// 0x60a: ProcessType[runtime.g]
+// 0x6a6: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 2a 04 00 00 // ProcessType[*runtime._panic]
+	Call c6 04 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 24 04 00 00 // ProcessType[*runtime._defer]
+	Call c0 04 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call 42 04 00 00 // ProcessType[*runtime.m]
+	Call de 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call 16 05 00 00 // ProcessType[[]uint8]
+	Call b2 05 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call d0 03 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 6c 04 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call 4e 04 00 00 // ProcessType[*runtime.sudog]
+	Call ea 04 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 20 05 00 00 // ProcessType[[]uintptr]
+	Call bc 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call 54 04 00 00 // ProcessType[*runtime.timer]
+	Call f0 04 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call 36 04 00 00 // ProcessType[*runtime.coro]
+	Call d2 04 00 00 // ProcessType[*runtime.coro]
 	Return 
-// 0x665: ProcessType[runtime.m]
-	Call 3c 04 00 00 // ProcessType[*runtime.g]
+// 0x701: ProcessType[runtime.m]
+	Call d8 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 50 00 00 00 
-	Call 3c 04 00 00 // ProcessType[*runtime.g]
+	Call d8 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call 3c 04 00 00 // ProcessType[*runtime.g]
+	Call d8 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call e0 06 00 00 // ProcessType[string]
+	Call 7c 07 00 00 // ProcessType[string]
 	IncrementOutputOffset 40 00 00 00 
-	Call 30 04 00 00 // ProcessType[*runtime.cgoCallers]
+	Call cc 04 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call 42 04 00 00 // ProcessType[*runtime.m]
+	Call de 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 28 01 00 00 
-	Call c5 06 00 00 // ProcessType[runtime.mLockProfile]
+	Call 61 07 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 38 00 00 00 
-	Call 20 05 00 00 // ProcessType[[]uintptr]
+	Call bc 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call 42 04 00 00 // ProcessType[*runtime.m]
+	Call de 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call d0 06 00 00 // ProcessType[runtime.mTraceState]
+	Call 6c 07 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x6c5: ProcessType[runtime.mLockProfile]
+// 0x761: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 20 05 00 00 // ProcessType[[]uintptr]
+	Call bc 05 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x6d0: ProcessType[runtime.mTraceState]
+// 0x76c: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call 8a 04 00 00 // ProcessType[[2]*runtime.traceBuf]
-	Call 42 04 00 00 // ProcessType[*runtime.m]
+	Call 26 05 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call de 04 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x6e0: ProcessType[string]
+// 0x77c: ProcessType[string]
 	ProcessString 81 00 00 00 
 	Return 
 // Extra illegal ops to simplify code bound checks
@@ -533,12 +545,12 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 982
-ID: 6 Len: 8 Enqueue: 1150
+ID: 5 Len: 8 Enqueue: 1138
+ID: 6 Len: 8 Enqueue: 1306
 ID: 7 Len: 2 Enqueue: 0
-ID: 8 Len: 8 Enqueue: 1156
+ID: 8 Len: 8 Enqueue: 1312
 ID: 9 Len: 8 Enqueue: 0
-ID: 10 Len: 16 Enqueue: 1760
+ID: 10 Len: 16 Enqueue: 1916
 ID: 11 Len: 8 Enqueue: 0
 ID: 12 Len: 8 Enqueue: 0
 ID: 13 Len: 4 Enqueue: 0
@@ -546,18 +558,18 @@ ID: 14 Len: 8 Enqueue: 0
 ID: 15 Len: 1 Enqueue: 0
 ID: 16 Len: 4 Enqueue: 0
 ID: 17 Len: 8 Enqueue: 0
-ID: 18 Len: 16 Enqueue: 1444
+ID: 18 Len: 16 Enqueue: 1600
 ID: 19 Len: 8 Enqueue: 0
-ID: 20 Len: 8 Enqueue: 1042
-ID: 21 Len: 8 Enqueue: 1138
-ID: 22 Len: 432 Enqueue: 1546
+ID: 20 Len: 8 Enqueue: 1198
+ID: 21 Len: 8 Enqueue: 1294
+ID: 22 Len: 432 Enqueue: 1702
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 1066
+ID: 24 Len: 8 Enqueue: 1222
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 1060
+ID: 26 Len: 8 Enqueue: 1216
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 1090
-ID: 29 Len: 1760 Enqueue: 1637
+ID: 28 Len: 8 Enqueue: 1246
+ID: 29 Len: 1760 Enqueue: 1793
 ID: 30 Len: 56 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -566,41 +578,41 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 1302
-ID: 39 Len: 8 Enqueue: 976
+ID: 38 Len: 24 Enqueue: 1458
+ID: 39 Len: 8 Enqueue: 1132
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 1102
+ID: 41 Len: 8 Enqueue: 1258
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 1312
-ID: 44 Len: 8 Enqueue: 1108
+ID: 43 Len: 24 Enqueue: 1468
+ID: 44 Len: 8 Enqueue: 1264
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 1078
+ID: 47 Len: 8 Enqueue: 1234
 ID: 48 Len: 8 Enqueue: 0
 ID: 49 Len: 32 Enqueue: 0
 ID: 50 Len: 32 Enqueue: 0
 ID: 51 Len: 12 Enqueue: 0
 ID: 52 Len: 16 Enqueue: 0
-ID: 53 Len: 8 Enqueue: 1084
+ID: 53 Len: 8 Enqueue: 1240
 ID: 54 Len: 40 Enqueue: 0
 ID: 55 Len: 8 Enqueue: 0
 ID: 56 Len: 48 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 8 Enqueue: 0
 ID: 59 Len: 4 Enqueue: 0
-ID: 60 Len: 8 Enqueue: 1072
+ID: 60 Len: 8 Enqueue: 1228
 ID: 61 Len: 8 Enqueue: 0
 ID: 62 Len: 8 Enqueue: 0
 ID: 63 Len: 256 Enqueue: 0
-ID: 64 Len: 64 Enqueue: 1733
+ID: 64 Len: 64 Enqueue: 1889
 ID: 65 Len: 8 Enqueue: 0
 ID: 66 Len: 0 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 1 Enqueue: 0
-ID: 69 Len: 32 Enqueue: 1744
+ID: 69 Len: 32 Enqueue: 1900
 ID: 70 Len: 8 Enqueue: 0
-ID: 71 Len: 16 Enqueue: 1162
-ID: 72 Len: 8 Enqueue: 1114
+ID: 71 Len: 16 Enqueue: 1318
+ID: 72 Len: 8 Enqueue: 1270
 ID: 73 Len: 8 Enqueue: 0
 ID: 74 Len: 48 Enqueue: 0
 ID: 75 Len: 0 Enqueue: 0
@@ -616,47 +628,47 @@ ID: 84 Len: 32 Enqueue: 0
 ID: 85 Len: 160 Enqueue: 0
 ID: 86 Len: 16 Enqueue: 0
 ID: 87 Len: 8 Enqueue: 0
-ID: 88 Len: 8 Enqueue: 1120
+ID: 88 Len: 8 Enqueue: 1276
 ID: 89 Len: 2 Enqueue: 0
 ID: 90 Len: 8 Enqueue: 0
 ID: 91 Len: 16 Enqueue: 0
-ID: 92 Len: 8 Enqueue: 1030
-ID: 93 Len: 8 Enqueue: 1048
-ID: 94 Len: 8 Enqueue: 1036
-ID: 95 Len: 8 Enqueue: 1144
-ID: 96 Len: 8 Enqueue: 1018
-ID: 97 Len: 8 Enqueue: 1024
-ID: 98 Len: 8 Enqueue: 1126
-ID: 99 Len: 8 Enqueue: 1132
-ID: 100 Len: 24 Enqueue: 1254
+ID: 92 Len: 8 Enqueue: 1186
+ID: 93 Len: 8 Enqueue: 1204
+ID: 94 Len: 8 Enqueue: 1192
+ID: 95 Len: 8 Enqueue: 1300
+ID: 96 Len: 8 Enqueue: 1174
+ID: 97 Len: 8 Enqueue: 1180
+ID: 98 Len: 8 Enqueue: 1282
+ID: 99 Len: 8 Enqueue: 1288
+ID: 100 Len: 24 Enqueue: 1410
 ID: 101 Len: 24 Enqueue: 0
-ID: 102 Len: 24 Enqueue: 1280
-ID: 103 Len: 48 Enqueue: 1178
-ID: 104 Len: 8 Enqueue: 1522
+ID: 102 Len: 24 Enqueue: 1436
+ID: 103 Len: 48 Enqueue: 1334
+ID: 104 Len: 8 Enqueue: 1678
 ID: 105 Len: 8 Enqueue: 0
-ID: 106 Len: 48 Enqueue: 1460
-ID: 107 Len: 8 Enqueue: 994
-ID: 108 Len: 208 Enqueue: 1365
-ID: 109 Len: 8 Enqueue: 1096
+ID: 106 Len: 48 Enqueue: 1616
+ID: 107 Len: 8 Enqueue: 1150
+ID: 108 Len: 208 Enqueue: 1521
+ID: 109 Len: 8 Enqueue: 1252
 ID: 110 Len: 8 Enqueue: 0
-ID: 111 Len: 8 Enqueue: 1528
+ID: 111 Len: 8 Enqueue: 1684
 ID: 112 Len: 8 Enqueue: 0
-ID: 113 Len: 48 Enqueue: 1474
-ID: 114 Len: 8 Enqueue: 1000
-ID: 115 Len: 208 Enqueue: 1386
-ID: 116 Len: 8 Enqueue: 1540
+ID: 113 Len: 48 Enqueue: 1630
+ID: 114 Len: 8 Enqueue: 1156
+ID: 115 Len: 208 Enqueue: 1542
+ID: 116 Len: 8 Enqueue: 1696
 ID: 117 Len: 8 Enqueue: 0
-ID: 118 Len: 48 Enqueue: 1502
-ID: 119 Len: 8 Enqueue: 1012
-ID: 120 Len: 88 Enqueue: 1428
-ID: 121 Len: 8 Enqueue: 1534
+ID: 118 Len: 48 Enqueue: 1658
+ID: 119 Len: 8 Enqueue: 1168
+ID: 120 Len: 88 Enqueue: 1584
+ID: 121 Len: 8 Enqueue: 1690
 ID: 122 Len: 8 Enqueue: 0
-ID: 123 Len: 48 Enqueue: 1488
-ID: 124 Len: 8 Enqueue: 1006
-ID: 125 Len: 208 Enqueue: 1407
-ID: 126 Len: 8 Enqueue: 952
-ID: 127 Len: 8 Enqueue: 958
-ID: 128 Len: 8 Enqueue: 970
+ID: 123 Len: 48 Enqueue: 1644
+ID: 124 Len: 8 Enqueue: 1162
+ID: 125 Len: 208 Enqueue: 1563
+ID: 126 Len: 8 Enqueue: 1108
+ID: 127 Len: 8 Enqueue: 1114
+ID: 128 Len: 8 Enqueue: 1126
 ID: 129 Len: 1 Enqueue: 0
 ID: 130 Len: 8 Enqueue: 0
 ID: 131 Len: 1 Enqueue: 0
@@ -665,30 +677,30 @@ ID: 133 Len: 8 Enqueue: 0
 ID: 134 Len: 8 Enqueue: 0
 ID: 135 Len: 8 Enqueue: 0
 ID: 136 Len: 8 Enqueue: 0
-ID: 137 Len: 16 Enqueue: 1290
+ID: 137 Len: 16 Enqueue: 1446
 ID: 138 Len: 8 Enqueue: 0
 ID: 139 Len: 8 Enqueue: 0
-ID: 140 Len: 128 Enqueue: 1264
+ID: 140 Len: 128 Enqueue: 1420
 ID: 141 Len: 64 Enqueue: 0
-ID: 142 Len: 208 Enqueue: 1206
-ID: 143 Len: 64 Enqueue: 1322
-ID: 144 Len: 8 Enqueue: 1054
+ID: 142 Len: 208 Enqueue: 1362
+ID: 143 Len: 64 Enqueue: 1478
+ID: 144 Len: 8 Enqueue: 1210
 ID: 145 Len: 184 Enqueue: 0
-ID: 146 Len: 208 Enqueue: 1218
+ID: 146 Len: 208 Enqueue: 1374
 ID: 147 Len: 8 Enqueue: 0
-ID: 148 Len: 64 Enqueue: 1338
-ID: 149 Len: 8 Enqueue: 1516
+ID: 148 Len: 64 Enqueue: 1494
+ID: 149 Len: 8 Enqueue: 1672
 ID: 150 Len: 8 Enqueue: 0
-ID: 151 Len: 48 Enqueue: 1446
-ID: 152 Len: 8 Enqueue: 988
-ID: 153 Len: 144 Enqueue: 1354
-ID: 154 Len: 88 Enqueue: 1242
-ID: 155 Len: 208 Enqueue: 1230
+ID: 151 Len: 48 Enqueue: 1602
+ID: 152 Len: 8 Enqueue: 1144
+ID: 153 Len: 144 Enqueue: 1510
+ID: 154 Len: 88 Enqueue: 1398
+ID: 155 Len: 208 Enqueue: 1386
 ID: 156 Len: 64 Enqueue: 0
 ID: 157 Len: 64 Enqueue: 0
 ID: 158 Len: 8 Enqueue: 0
-ID: 159 Len: 144 Enqueue: 1194
-ID: 160 Len: 8 Enqueue: 964
+ID: 159 Len: 144 Enqueue: 1350
+ID: 160 Len: 8 Enqueue: 1120
 ID: 161 Len: 128 Enqueue: 0
 ID: 162 Len: 9 Enqueue: 0
 ID: 163 Len: 0 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.sm.txt
@@ -7,13 +7,13 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call b8 03 00 00 // ProcessType[*****int]
+	Call 54 04 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessExpression[Probe[main.PointerChainArg]@0xb520c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call b8 03 00 00 // ProcessType[*****int]
+	Call 54 04 00 00 // ProcessType[*****int]
 	Return 
 // 0x39: ProcessEvent[Probe[main.PointerChainArg]@b520c]
 	PrepareEventRoot ce 00 00 00 11 00 00 00 
@@ -24,7 +24,7 @@
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call ca 03 00 00 // ProcessType[**int]
+	Call 66 04 00 00 // ProcessType[**int]
 	Return 
 // 0x68: ProcessEvent[Probe[main.PointerSmallChainArg]@b5244]
 	PrepareEventRoot cf 00 00 00 09 00 00 00 
@@ -34,13 +34,13 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call aa 05 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 46 06 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x92: ProcessExpression[Probe[main.bigMapArg]@0xb56f0.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call aa 05 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 46 06 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0xad: ProcessEvent[Probe[main.bigMapArg]@b56f0]
 	PrepareEventRoot c6 00 00 00 11 00 00 00 
@@ -85,467 +85,479 @@
 	Return 
 // 0x148: ProcessExpression[Probe[main.intArrayArg]@0xb5428.expr[0]]
 	ExprPrepare 
-	ExprDereferenceCfa 08 00 00 00 18 00 00 00 00 00 00 00 
+	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferenceCfa 10 00 00 00 08 00 00 00 08 00 00 00 
+	ExprDereferenceCfa 18 00 00 00 08 00 00 00 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
-// 0x164: ProcessEvent[Probe[main.intArrayArg]@b5428]
+// 0x17e: ProcessEvent[Probe[main.intArrayArg]@b5428]
 	PrepareEventRoot bd 00 00 00 19 00 00 00 
 	Call 48 01 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb5428.expr[0]]
 	Return 
-// 0x173: ProcessEvent[Probe[main.intArrayArg]Return@b546c]
+// 0x18d: ProcessEvent[Probe[main.intArrayArg]Return@b546c]
 	PrepareEventRoot be 00 00 00 00 00 00 00 
 	Return 
-// 0x17d: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb5590.expr[0]]
+// 0x197: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb5590.expr[0]]
 	ExprPrepare 
-	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
+	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferenceCfa 10 00 00 00 08 00 00 00 08 00 00 00 
+	ExprDereferenceCfa 18 00 00 00 08 00 00 00 10 00 00 00 
+	ExprDereferenceCfa 20 00 00 00 08 00 00 00 18 00 00 00 
+	ExprDereferenceCfa 28 00 00 00 08 00 00 00 20 00 00 00 
+	ExprDereferenceCfa 30 00 00 00 08 00 00 00 28 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call a4 04 00 00 // ProcessType[[3]string]
+	Call 40 05 00 00 // ProcessType[[3]string]
 	Return 
-// 0x19e: ProcessEvent[Probe[main.stringArrayArgFrameless]@b5590]
+// 0x1f9: ProcessEvent[Probe[main.stringArrayArgFrameless]@b5590]
 	PrepareEventRoot c3 00 00 00 31 00 00 00 
-	Call 7d 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb5590.expr[0]]
+	Call 97 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb5590.expr[0]]
 	Return 
-// 0x1ad: ProcessExpression[Probe[main.intSliceArg]@0xb53a8.expr[0]]
+// 0x208: ProcessExpression[Probe[main.intSliceArg]@0xb53a8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call e4 04 00 00 // ProcessType[[]int]
+	Call 80 05 00 00 // ProcessType[[]int]
 	Return 
-// 0x1d6: ProcessEvent[Probe[main.intSliceArg]@b53a8]
+// 0x231: ProcessEvent[Probe[main.intSliceArg]@b53a8]
 	PrepareEventRoot bb 00 00 00 19 00 00 00 
-	Call ad 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb53a8.expr[0]]
+	Call 08 02 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb53a8.expr[0]]
 	Return 
-// 0x1e5: ProcessEvent[Probe[main.intSliceArg]Return@b53e4]
+// 0x240: ProcessEvent[Probe[main.intSliceArg]Return@b53e4]
 	PrepareEventRoot bc 00 00 00 00 00 00 00 
 	Return 
-// 0x1ef: ProcessExpression[Probe[main.stringArg]@0xb5328.expr[0]]
+// 0x24a: ProcessExpression[Probe[main.stringArg]@0xb5328.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 08 07 00 00 // ProcessType[string]
+	Call a4 07 00 00 // ProcessType[string]
 	Return 
-// 0x211: ProcessEvent[Probe[main.stringArg]@b5328]
+// 0x26c: ProcessEvent[Probe[main.stringArg]@b5328]
 	PrepareEventRoot b5 00 00 00 11 00 00 00 
-	Call ef 01 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5328.expr[0]]
+	Call 4a 02 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5328.expr[0]]
 	Return 
-// 0x220: ProcessEvent[Probe[main.stringArg]Return@b5364]
+// 0x27b: ProcessEvent[Probe[main.stringArg]Return@b5364]
 	PrepareEventRoot b6 00 00 00 00 00 00 00 
 	Return 
-// 0x22a: ProcessEvent[Probe[main.stringArg]@b5328]
+// 0x285: ProcessEvent[Probe[main.stringArg]@b5328]
 	PrepareEventRoot b7 00 00 00 00 00 00 00 
 	Return 
-// 0x234: ProcessEvent[Probe[main.stringArg]Return@b5364]
+// 0x28f: ProcessEvent[Probe[main.stringArg]Return@b5364]
 	PrepareEventRoot b8 00 00 00 00 00 00 00 
 	Return 
-// 0x23e: ProcessExpression[Probe[main.mapArg]@0xb5678.expr[0]]
+// 0x299: ProcessExpression[Probe[main.mapArg]@0xb5678.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call a4 05 00 00 // ProcessType[map[string]int]
+	Call 40 06 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x259: ProcessExpression[Probe[main.mapArg]@0xb5678.expr[1]]
+// 0x2b4: ProcessExpression[Probe[main.mapArg]@0xb5678.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call a4 05 00 00 // ProcessType[map[string]int]
+	Call 40 06 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x274: ProcessEvent[Probe[main.mapArg]@b5678]
+// 0x2cf: ProcessEvent[Probe[main.mapArg]@b5678]
 	PrepareEventRoot c4 00 00 00 11 00 00 00 
-	Call 3e 02 00 00 // ProcessExpression[Probe[main.mapArg]@0xb5678.expr[0]]
-	Call 59 02 00 00 // ProcessExpression[Probe[main.mapArg]@0xb5678.expr[1]]
+	Call 99 02 00 00 // ProcessExpression[Probe[main.mapArg]@0xb5678.expr[0]]
+	Call b4 02 00 00 // ProcessExpression[Probe[main.mapArg]@0xb5678.expr[1]]
 	Return 
-// 0x288: ProcessEvent[Probe[main.mapArg]Return@b56a8]
+// 0x2e3: ProcessEvent[Probe[main.mapArg]Return@b56a8]
 	PrepareEventRoot c5 00 00 00 00 00 00 00 
 	Return 
-// 0x292: ProcessEvent[Probe[main.noArgs]@b57a8]
+// 0x2ed: ProcessEvent[Probe[main.noArgs]@b57a8]
 	PrepareEventRoot c8 00 00 00 00 00 00 00 
 	Return 
-// 0x29c: ProcessEvent[Probe[main.noArgs]Return@b57e0]
+// 0x2f7: ProcessEvent[Probe[main.noArgs]Return@b57e0]
 	PrepareEventRoot c9 00 00 00 00 00 00 00 
 	Return 
-// 0x2a6: ProcessExpression[Probe[main.stringArg]@0xb5328.expr[0]]
+// 0x301: ProcessExpression[Probe[main.stringArg]@0xb5328.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 08 07 00 00 // ProcessType[string]
+	Call a4 07 00 00 // ProcessType[string]
 	Return 
-// 0x2c8: ProcessExpression[Probe[main.stringArg]@0xb5328.expr[1]]
+// 0x323: ProcessExpression[Probe[main.stringArg]@0xb5328.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call 08 07 00 00 // ProcessType[string]
+	Call a4 07 00 00 // ProcessType[string]
 	Return 
-// 0x2ea: ProcessEvent[Probe[main.stringArg]@b5328]
+// 0x345: ProcessEvent[Probe[main.stringArg]@b5328]
 	PrepareEventRoot b9 00 00 00 21 00 00 00 
-	Call a6 02 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5328.expr[0]]
-	Call c8 02 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5328.expr[1]]
+	Call 01 03 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5328.expr[0]]
+	Call 23 03 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5328.expr[1]]
 	Return 
-// 0x2fe: ProcessEvent[Probe[main.stringArg]Return@b5364]
+// 0x359: ProcessEvent[Probe[main.stringArg]Return@b5364]
 	PrepareEventRoot ba 00 00 00 00 00 00 00 
 	Return 
-// 0x308: ProcessExpression[Probe[main.stringArrayArg]@0xb5528.expr[0]]
+// 0x363: ProcessExpression[Probe[main.stringArrayArg]@0xb5528.expr[0]]
 	ExprPrepare 
-	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
+	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferenceCfa 10 00 00 00 08 00 00 00 08 00 00 00 
+	ExprDereferenceCfa 18 00 00 00 08 00 00 00 10 00 00 00 
+	ExprDereferenceCfa 20 00 00 00 08 00 00 00 18 00 00 00 
+	ExprDereferenceCfa 28 00 00 00 08 00 00 00 20 00 00 00 
+	ExprDereferenceCfa 30 00 00 00 08 00 00 00 28 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call a4 04 00 00 // ProcessType[[3]string]
+	Call 40 05 00 00 // ProcessType[[3]string]
 	Return 
-// 0x329: ProcessEvent[Probe[main.stringArrayArg]@b5528]
+// 0x3c5: ProcessEvent[Probe[main.stringArrayArg]@b5528]
 	PrepareEventRoot c1 00 00 00 31 00 00 00 
-	Call 08 03 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb5528.expr[0]]
+	Call 63 03 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb5528.expr[0]]
 	Return 
-// 0x338: ProcessEvent[Probe[main.stringArrayArg]Return@b556c]
+// 0x3d4: ProcessEvent[Probe[main.stringArrayArg]Return@b556c]
 	PrepareEventRoot c2 00 00 00 00 00 00 00 
 	Return 
-// 0x342: ProcessExpression[Probe[main.stringSliceArg]@0xb54a8.expr[0]]
+// 0x3de: ProcessExpression[Probe[main.stringSliceArg]@0xb54a8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 12 05 00 00 // ProcessType[[]string]
+	Call ae 05 00 00 // ProcessType[[]string]
 	Return 
-// 0x36b: ProcessEvent[Probe[main.stringSliceArg]@b54a8]
+// 0x407: ProcessEvent[Probe[main.stringSliceArg]@b54a8]
 	PrepareEventRoot bf 00 00 00 19 00 00 00 
-	Call 42 03 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb54a8.expr[0]]
+	Call de 03 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb54a8.expr[0]]
 	Return 
-// 0x37a: ProcessEvent[Probe[main.stringSliceArg]Return@b54e4]
+// 0x416: ProcessEvent[Probe[main.stringSliceArg]Return@b54e4]
 	PrepareEventRoot c0 00 00 00 00 00 00 00 
 	Return 
-// 0x384: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b5820]
+// 0x420: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b5820]
 	PrepareEventRoot ca 00 00 00 00 00 00 00 
 	Return 
-// 0x38e: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb59a0.expr[0]]
+// 0x42a: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb59a0.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call b0 05 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 4c 06 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x3a9: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b59a0]
+// 0x445: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b59a0]
 	PrepareEventRoot cb 00 00 00 09 00 00 00 
-	Call 8e 03 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb59a0.expr[0]]
+	Call 2a 04 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb59a0.expr[0]]
 	Return 
-// 0x3b8: ProcessType[*****int]
+// 0x454: ProcessType[*****int]
 	ProcessPointer 7d 00 00 00 
 	Return 
-// 0x3be: ProcessType[****int]
+// 0x45a: ProcessType[****int]
 	ProcessPointer b1 00 00 00 
 	Return 
-// 0x3c4: ProcessType[***int]
+// 0x460: ProcessType[***int]
 	ProcessPointer 7e 00 00 00 
 	Return 
-// 0x3ca: ProcessType[**int]
+// 0x466: ProcessType[**int]
 	ProcessPointer 63 00 00 00 
 	Return 
-// 0x3d0: ProcessType[*[]runtime.ancestorInfo]
+// 0x46c: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x3d6: ProcessType[*bool]
+// 0x472: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x3dc: ProcessType[*error]
+// 0x478: ProcessType[*error]
 	ProcessPointer 0e 00 00 00 
 	Return 
-// 0x3e2: ProcessType[*float32]
+// 0x47e: ProcessType[*float32]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x3e8: ProcessType[*float64]
+// 0x484: ProcessType[*float64]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x3ee: ProcessType[*int]
+// 0x48a: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x3f4: ProcessType[*int32]
+// 0x490: ProcessType[*int32]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x3fa: ProcessType[*int64]
+// 0x496: ProcessType[*int64]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x400: ProcessType[*main.bigStruct]
+// 0x49c: ProcessType[*main.bigStruct]
 	ProcessPointer 98 00 00 00 
 	Return 
-// 0x406: ProcessType[*runtime._defer]
+// 0x4a2: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x40c: ProcessType[*runtime._panic]
+// 0x4a8: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x412: ProcessType[*runtime.cgoCallers]
+// 0x4ae: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 3f 00 00 00 
 	Return 
-// 0x418: ProcessType[*runtime.coro]
+// 0x4b4: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x41e: ProcessType[*runtime.g]
+// 0x4ba: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x424: ProcessType[*runtime.m]
+// 0x4c0: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x42a: ProcessType[*runtime.sudog]
+// 0x4c6: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x430: ProcessType[*runtime.synctestGroup]
+// 0x4cc: ProcessType[*runtime.synctestGroup]
 	ProcessPointer 32 00 00 00 
 	Return 
-// 0x436: ProcessType[*runtime.timer]
+// 0x4d2: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x43c: ProcessType[*runtime.traceBuf]
+// 0x4d8: ProcessType[*runtime.traceBuf]
 	ProcessPointer 4d 00 00 00 
 	Return 
-// 0x442: ProcessType[*string]
+// 0x4de: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x448: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+// 0x4e4: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer a8 00 00 00 
 	Return 
-// 0x44e: ProcessType[*table<string,int>]
+// 0x4ea: ProcessType[*table<string,int>]
 	ProcessPointer 89 00 00 00 
 	Return 
-// 0x454: ProcessType[*table<string,main.bigStruct>]
+// 0x4f0: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer 91 00 00 00 
 	Return 
-// 0x45a: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x4f6: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 9b 00 00 00 
 	Return 
-// 0x460: ProcessType[*uint]
+// 0x4fc: ProcessType[*uint]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x466: ProcessType[*uint16]
+// 0x502: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x46c: ProcessType[*uint32]
+// 0x508: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x472: ProcessType[*uint64]
+// 0x50e: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x478: ProcessType[*uint8]
+// 0x514: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x47e: ProcessType[*uintptr]
+// 0x51a: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x484: ProcessType[[2]*runtime.traceBuf]
+// 0x520: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call 3c 04 00 00 // ProcessType[*runtime.traceBuf]
+	Call d8 04 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x494: ProcessType[[2][2]*runtime.traceBuf]
+// 0x530: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call 84 04 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call 20 05 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x4a4: ProcessType[[3]string]
+// 0x540: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 08 07 00 00 // ProcessType[string]
+	Call a4 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x4b4: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x550: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 48 04 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	Call e4 04 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x4c0: ProcessType[[]*table<string,int>.array]
+// 0x55c: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 4e 04 00 00 // ProcessType[*table<string,int>]
+	Call ea 04 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x4cc: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x568: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 54 04 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call f0 04 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x4d8: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x574: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 5a 04 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call f6 04 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x4e4: ProcessType[[]int]
+// 0x580: ProcessType[[]int]
 	ProcessSlice 85 00 00 00 08 00 00 00 
 	Return 
-// 0x4ee: ProcessType[[]noalg.map.group[string]int.array]
+// 0x58a: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call e6 05 00 00 // ProcessType[noalg.map.group[string]int]
+	Call 82 06 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x4fa: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x596: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call f1 05 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call 8d 06 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x506: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+// 0x5a2: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call fc 05 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 98 06 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x512: ProcessType[[]string]
+// 0x5ae: ProcessType[[]string]
 	ProcessSlice 87 00 00 00 10 00 00 00 
 	Return 
-// 0x51c: ProcessType[[]string.array]
+// 0x5b8: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call 08 07 00 00 // ProcessType[string]
+	Call a4 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x528: ProcessType[[]uint8]
+// 0x5c4: ProcessType[[]uint8]
 	ProcessSlice 81 00 00 00 01 00 00 00 
 	Return 
-// 0x532: ProcessType[[]uintptr]
+// 0x5ce: ProcessType[[]uintptr]
 	ProcessSlice 83 00 00 00 08 00 00 00 
 	Return 
-// 0x53c: ProcessType[error]
+// 0x5d8: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x53e: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+// 0x5da: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups b0 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x54a: ProcessType[groupReference<string,int>]
+// 0x5e6: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups 90 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x556: ProcessType[groupReference<string,main.bigStruct>]
+// 0x5f2: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups 9a 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x562: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x5fe: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups a7 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x56e: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+// 0x60a: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap af 00 00 00 ab 00 00 00 10 18 
 	Return 
-// 0x57a: ProcessType[map<string,int>]
+// 0x616: ProcessType[map<string,int>]
 	ProcessGoSwissMap 8f 00 00 00 8c 00 00 00 10 18 
 	Return 
-// 0x586: ProcessType[map<string,main.bigStruct>]
+// 0x622: ProcessType[map<string,main.bigStruct>]
 	ProcessGoSwissMap 99 00 00 00 94 00 00 00 10 18 
 	Return 
-// 0x592: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x62e: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap a6 00 00 00 9e 00 00 00 10 18 
 	Return 
-// 0x59e: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x63a: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer a3 00 00 00 
 	Return 
-// 0x5a4: ProcessType[map[string]int]
+// 0x640: ProcessType[map[string]int]
 	ProcessPointer 6f 00 00 00 
 	Return 
-// 0x5aa: ProcessType[map[string]main.bigStruct]
+// 0x646: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 74 00 00 00 
 	Return 
-// 0x5b0: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x64c: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 79 00 00 00 
 	Return 
-// 0x5b6: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x652: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 07 06 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call a3 06 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x5c6: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x662: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 17 06 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call b3 06 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x5d6: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x672: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call 1d 06 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call b9 06 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x5e6: ProcessType[noalg.map.group[string]int]
+// 0x682: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call c6 05 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call 62 06 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x5f1: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x68d: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call b6 05 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call 52 06 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x5fc: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x698: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call d6 05 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 72 06 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x607: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call 08 07 00 00 // ProcessType[string]
+// 0x6a3: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call a4 07 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 00 04 00 00 // ProcessType[*main.bigStruct]
+	Call 9c 04 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x617: ProcessType[noalg.struct { key string; elem int }]
-	Call 08 07 00 00 // ProcessType[string]
+// 0x6b3: ProcessType[noalg.struct { key string; elem int }]
+	Call a4 07 00 00 // ProcessType[string]
 	Return 
-// 0x61d: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x6b9: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call 9e 05 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 3a 06 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x628: ProcessType[runtime.g]
+// 0x6c4: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 0c 04 00 00 // ProcessType[*runtime._panic]
+	Call a8 04 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 06 04 00 00 // ProcessType[*runtime._defer]
+	Call a2 04 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call 24 04 00 00 // ProcessType[*runtime.m]
+	Call c0 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call 28 05 00 00 // ProcessType[[]uint8]
+	Call c4 05 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call d0 03 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 6c 04 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call 2a 04 00 00 // ProcessType[*runtime.sudog]
+	Call c6 04 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 32 05 00 00 // ProcessType[[]uintptr]
+	Call ce 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call 36 04 00 00 // ProcessType[*runtime.timer]
+	Call d2 04 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call 18 04 00 00 // ProcessType[*runtime.coro]
+	Call b4 04 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call 30 04 00 00 // ProcessType[*runtime.synctestGroup]
+	Call cc 04 00 00 // ProcessType[*runtime.synctestGroup]
 	Return 
-// 0x68d: ProcessType[runtime.m]
-	Call 1e 04 00 00 // ProcessType[*runtime.g]
+// 0x729: ProcessType[runtime.m]
+	Call ba 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 50 00 00 00 
-	Call 1e 04 00 00 // ProcessType[*runtime.g]
+	Call ba 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call 1e 04 00 00 // ProcessType[*runtime.g]
+	Call ba 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call 08 07 00 00 // ProcessType[string]
+	Call a4 07 00 00 // ProcessType[string]
 	IncrementOutputOffset 40 00 00 00 
-	Call 12 04 00 00 // ProcessType[*runtime.cgoCallers]
+	Call ae 04 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call 24 04 00 00 // ProcessType[*runtime.m]
+	Call c0 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 28 01 00 00 
-	Call ed 06 00 00 // ProcessType[runtime.mLockProfile]
+	Call 89 07 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 38 00 00 00 
-	Call 32 05 00 00 // ProcessType[[]uintptr]
+	Call ce 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call 24 04 00 00 // ProcessType[*runtime.m]
+	Call c0 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call f8 06 00 00 // ProcessType[runtime.mTraceState]
+	Call 94 07 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x6ed: ProcessType[runtime.mLockProfile]
+// 0x789: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 32 05 00 00 // ProcessType[[]uintptr]
+	Call ce 05 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x6f8: ProcessType[runtime.mTraceState]
+// 0x794: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call 94 04 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call 24 04 00 00 // ProcessType[*runtime.m]
+	Call 30 05 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call c0 04 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x708: ProcessType[string]
+// 0x7a4: ProcessType[string]
 	ProcessString 7f 00 00 00 
 	Return 
-// 0x70e: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x7aa: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 3e 05 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call da 05 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x719: ProcessType[table<string,int>]
+// 0x7b5: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 4a 05 00 00 // ProcessType[groupReference<string,int>]
+	Call e6 05 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x724: ProcessType[table<string,main.bigStruct>]
+// 0x7c0: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 56 05 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call f2 05 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x72f: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x7cb: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 62 05 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call fe 05 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -566,31 +578,31 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 1144
+ID: 5 Len: 8 Enqueue: 1300
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 1800
+ID: 9 Len: 16 Enqueue: 1956
 ID: 10 Len: 8 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 982
+ID: 11 Len: 8 Enqueue: 1138
 ID: 12 Len: 4 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
-ID: 14 Len: 16 Enqueue: 1340
+ID: 14 Len: 16 Enqueue: 1496
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 1 Enqueue: 0
 ID: 17 Len: 4 Enqueue: 0
 ID: 18 Len: 8 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 1150
-ID: 20 Len: 8 Enqueue: 1012
-ID: 21 Len: 8 Enqueue: 1132
-ID: 22 Len: 440 Enqueue: 1576
+ID: 19 Len: 8 Enqueue: 1306
+ID: 20 Len: 8 Enqueue: 1168
+ID: 21 Len: 8 Enqueue: 1288
+ID: 22 Len: 440 Enqueue: 1732
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 1036
+ID: 24 Len: 8 Enqueue: 1192
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 1030
+ID: 26 Len: 8 Enqueue: 1186
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 1060
-ID: 29 Len: 1808 Enqueue: 1677
+ID: 28 Len: 8 Enqueue: 1216
+ID: 29 Len: 1808 Enqueue: 1833
 ID: 30 Len: 56 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -599,45 +611,45 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 1320
-ID: 39 Len: 8 Enqueue: 976
+ID: 38 Len: 24 Enqueue: 1476
+ID: 39 Len: 8 Enqueue: 1132
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 1066
+ID: 41 Len: 8 Enqueue: 1222
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 1330
-ID: 44 Len: 8 Enqueue: 1078
+ID: 43 Len: 24 Enqueue: 1486
+ID: 44 Len: 8 Enqueue: 1234
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 1048
+ID: 47 Len: 8 Enqueue: 1204
 ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 8 Enqueue: 1072
+ID: 49 Len: 8 Enqueue: 1228
 ID: 50 Len: 8 Enqueue: 0
 ID: 51 Len: 32 Enqueue: 0
 ID: 52 Len: 32 Enqueue: 0
 ID: 53 Len: 12 Enqueue: 0
 ID: 54 Len: 16 Enqueue: 0
-ID: 55 Len: 8 Enqueue: 1054
+ID: 55 Len: 8 Enqueue: 1210
 ID: 56 Len: 40 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 48 Enqueue: 0
 ID: 59 Len: 8 Enqueue: 0
 ID: 60 Len: 8 Enqueue: 0
 ID: 61 Len: 4 Enqueue: 0
-ID: 62 Len: 8 Enqueue: 1042
+ID: 62 Len: 8 Enqueue: 1198
 ID: 63 Len: 8 Enqueue: 0
 ID: 64 Len: 8 Enqueue: 0
 ID: 65 Len: 256 Enqueue: 0
 ID: 66 Len: 8 Enqueue: 0
-ID: 67 Len: 64 Enqueue: 1773
+ID: 67 Len: 64 Enqueue: 1929
 ID: 68 Len: 8 Enqueue: 0
 ID: 69 Len: 0 Enqueue: 0
 ID: 70 Len: 8 Enqueue: 0
 ID: 71 Len: 1 Enqueue: 0
-ID: 72 Len: 56 Enqueue: 1784
+ID: 72 Len: 56 Enqueue: 1940
 ID: 73 Len: 8 Enqueue: 0
-ID: 74 Len: 32 Enqueue: 1172
-ID: 75 Len: 16 Enqueue: 1156
-ID: 76 Len: 8 Enqueue: 1084
+ID: 74 Len: 32 Enqueue: 1328
+ID: 75 Len: 16 Enqueue: 1312
+ID: 76 Len: 8 Enqueue: 1240
 ID: 77 Len: 8 Enqueue: 0
 ID: 78 Len: 48 Enqueue: 0
 ID: 79 Len: 0 Enqueue: 0
@@ -654,40 +666,40 @@ ID: 89 Len: 160 Enqueue: 0
 ID: 90 Len: 16 Enqueue: 0
 ID: 91 Len: 8 Enqueue: 0
 ID: 92 Len: 0 Enqueue: 0
-ID: 93 Len: 8 Enqueue: 1090
+ID: 93 Len: 8 Enqueue: 1246
 ID: 94 Len: 2 Enqueue: 0
 ID: 95 Len: 8 Enqueue: 0
 ID: 96 Len: 16 Enqueue: 0
-ID: 97 Len: 8 Enqueue: 1000
-ID: 98 Len: 8 Enqueue: 1018
-ID: 99 Len: 8 Enqueue: 1006
-ID: 100 Len: 8 Enqueue: 1138
-ID: 101 Len: 8 Enqueue: 988
-ID: 102 Len: 8 Enqueue: 994
-ID: 103 Len: 8 Enqueue: 1120
-ID: 104 Len: 8 Enqueue: 1126
-ID: 105 Len: 24 Enqueue: 1252
+ID: 97 Len: 8 Enqueue: 1156
+ID: 98 Len: 8 Enqueue: 1174
+ID: 99 Len: 8 Enqueue: 1162
+ID: 100 Len: 8 Enqueue: 1294
+ID: 101 Len: 8 Enqueue: 1144
+ID: 102 Len: 8 Enqueue: 1150
+ID: 103 Len: 8 Enqueue: 1276
+ID: 104 Len: 8 Enqueue: 1282
+ID: 105 Len: 24 Enqueue: 1408
 ID: 106 Len: 24 Enqueue: 0
-ID: 107 Len: 24 Enqueue: 1298
-ID: 108 Len: 48 Enqueue: 1188
-ID: 109 Len: 8 Enqueue: 1444
+ID: 107 Len: 24 Enqueue: 1454
+ID: 108 Len: 48 Enqueue: 1344
+ID: 109 Len: 8 Enqueue: 1600
 ID: 110 Len: 8 Enqueue: 0
-ID: 111 Len: 48 Enqueue: 1402
+ID: 111 Len: 48 Enqueue: 1558
 ID: 112 Len: 8 Enqueue: 0
-ID: 113 Len: 8 Enqueue: 1102
-ID: 114 Len: 8 Enqueue: 1450
+ID: 113 Len: 8 Enqueue: 1258
+ID: 114 Len: 8 Enqueue: 1606
 ID: 115 Len: 8 Enqueue: 0
-ID: 116 Len: 48 Enqueue: 1414
+ID: 116 Len: 48 Enqueue: 1570
 ID: 117 Len: 8 Enqueue: 0
-ID: 118 Len: 8 Enqueue: 1108
-ID: 119 Len: 8 Enqueue: 1456
+ID: 118 Len: 8 Enqueue: 1264
+ID: 119 Len: 8 Enqueue: 1612
 ID: 120 Len: 8 Enqueue: 0
-ID: 121 Len: 48 Enqueue: 1426
+ID: 121 Len: 48 Enqueue: 1582
 ID: 122 Len: 8 Enqueue: 0
-ID: 123 Len: 8 Enqueue: 1114
-ID: 124 Len: 8 Enqueue: 952
-ID: 125 Len: 8 Enqueue: 958
-ID: 126 Len: 8 Enqueue: 970
+ID: 123 Len: 8 Enqueue: 1270
+ID: 124 Len: 8 Enqueue: 1108
+ID: 125 Len: 8 Enqueue: 1114
+ID: 126 Len: 8 Enqueue: 1126
 ID: 127 Len: 1 Enqueue: 0
 ID: 128 Len: 8 Enqueue: 0
 ID: 129 Len: 1 Enqueue: 0
@@ -696,49 +708,49 @@ ID: 131 Len: 8 Enqueue: 0
 ID: 132 Len: 8 Enqueue: 0
 ID: 133 Len: 8 Enqueue: 0
 ID: 134 Len: 8 Enqueue: 0
-ID: 135 Len: 16 Enqueue: 1308
+ID: 135 Len: 16 Enqueue: 1464
 ID: 136 Len: 8 Enqueue: 0
-ID: 137 Len: 32 Enqueue: 1817
-ID: 138 Len: 16 Enqueue: 1354
+ID: 137 Len: 32 Enqueue: 1973
+ID: 138 Len: 16 Enqueue: 1510
 ID: 139 Len: 8 Enqueue: 0
-ID: 140 Len: 200 Enqueue: 1510
-ID: 141 Len: 192 Enqueue: 1478
-ID: 142 Len: 24 Enqueue: 1559
-ID: 143 Len: 8 Enqueue: 1216
-ID: 144 Len: 200 Enqueue: 1262
-ID: 145 Len: 32 Enqueue: 1828
-ID: 146 Len: 16 Enqueue: 1366
+ID: 140 Len: 200 Enqueue: 1666
+ID: 141 Len: 192 Enqueue: 1634
+ID: 142 Len: 24 Enqueue: 1715
+ID: 143 Len: 8 Enqueue: 1372
+ID: 144 Len: 200 Enqueue: 1418
+ID: 145 Len: 32 Enqueue: 1984
+ID: 146 Len: 16 Enqueue: 1522
 ID: 147 Len: 8 Enqueue: 0
-ID: 148 Len: 200 Enqueue: 1521
-ID: 149 Len: 192 Enqueue: 1462
-ID: 150 Len: 24 Enqueue: 1543
-ID: 151 Len: 8 Enqueue: 1024
+ID: 148 Len: 200 Enqueue: 1677
+ID: 149 Len: 192 Enqueue: 1618
+ID: 150 Len: 24 Enqueue: 1699
+ID: 151 Len: 8 Enqueue: 1180
 ID: 152 Len: 184 Enqueue: 0
-ID: 153 Len: 8 Enqueue: 1228
-ID: 154 Len: 200 Enqueue: 1274
-ID: 155 Len: 32 Enqueue: 1839
-ID: 156 Len: 16 Enqueue: 1378
+ID: 153 Len: 8 Enqueue: 1384
+ID: 154 Len: 200 Enqueue: 1430
+ID: 155 Len: 32 Enqueue: 1995
+ID: 156 Len: 16 Enqueue: 1534
 ID: 157 Len: 8 Enqueue: 0
-ID: 158 Len: 136 Enqueue: 1532
-ID: 159 Len: 128 Enqueue: 1494
-ID: 160 Len: 16 Enqueue: 1565
-ID: 161 Len: 8 Enqueue: 1438
+ID: 158 Len: 136 Enqueue: 1688
+ID: 159 Len: 128 Enqueue: 1650
+ID: 160 Len: 16 Enqueue: 1721
+ID: 161 Len: 8 Enqueue: 1594
 ID: 162 Len: 8 Enqueue: 0
-ID: 163 Len: 48 Enqueue: 1390
+ID: 163 Len: 48 Enqueue: 1546
 ID: 164 Len: 8 Enqueue: 0
-ID: 165 Len: 8 Enqueue: 1096
-ID: 166 Len: 8 Enqueue: 1240
-ID: 167 Len: 136 Enqueue: 1286
-ID: 168 Len: 32 Enqueue: 1806
-ID: 169 Len: 16 Enqueue: 1342
+ID: 165 Len: 8 Enqueue: 1252
+ID: 166 Len: 8 Enqueue: 1396
+ID: 167 Len: 136 Enqueue: 1442
+ID: 168 Len: 32 Enqueue: 1962
+ID: 169 Len: 16 Enqueue: 1498
 ID: 170 Len: 8 Enqueue: 0
 ID: 171 Len: 136 Enqueue: 0
 ID: 172 Len: 128 Enqueue: 0
 ID: 173 Len: 16 Enqueue: 0
 ID: 174 Len: 8 Enqueue: 0
-ID: 175 Len: 8 Enqueue: 1204
+ID: 175 Len: 8 Enqueue: 1360
 ID: 176 Len: 136 Enqueue: 0
-ID: 177 Len: 8 Enqueue: 964
+ID: 177 Len: 8 Enqueue: 1120
 ID: 178 Len: 128 Enqueue: 0
 ID: 179 Len: 9 Enqueue: 0
 ID: 180 Len: 0 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.sm.txt
@@ -7,13 +7,13 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call b8 03 00 00 // ProcessType[*****int]
+	Call 54 04 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessExpression[Probe[main.PointerChainArg]@0xb7da0.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call b8 03 00 00 // ProcessType[*****int]
+	Call 54 04 00 00 // ProcessType[*****int]
 	Return 
 // 0x39: ProcessEvent[Probe[main.PointerChainArg]@b7da0]
 	PrepareEventRoot d3 00 00 00 11 00 00 00 
@@ -24,7 +24,7 @@
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call ca 03 00 00 // ProcessType[**int]
+	Call 66 04 00 00 // ProcessType[**int]
 	Return 
 // 0x68: ProcessEvent[Probe[main.PointerSmallChainArg]@b7dd4]
 	PrepareEventRoot d4 00 00 00 09 00 00 00 
@@ -34,13 +34,13 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call c6 05 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 62 06 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x92: ProcessExpression[Probe[main.bigMapArg]@0xb8240.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call c6 05 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 62 06 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0xad: ProcessEvent[Probe[main.bigMapArg]@b8240]
 	PrepareEventRoot cb 00 00 00 11 00 00 00 
@@ -85,480 +85,492 @@
 	Return 
 // 0x148: ProcessExpression[Probe[main.intArrayArg]@0xb7f98.expr[0]]
 	ExprPrepare 
-	ExprDereferenceCfa 08 00 00 00 18 00 00 00 00 00 00 00 
+	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferenceCfa 10 00 00 00 08 00 00 00 08 00 00 00 
+	ExprDereferenceCfa 18 00 00 00 08 00 00 00 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
-// 0x164: ProcessEvent[Probe[main.intArrayArg]@b7f98]
+// 0x17e: ProcessEvent[Probe[main.intArrayArg]@b7f98]
 	PrepareEventRoot c2 00 00 00 19 00 00 00 
 	Call 48 01 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb7f98.expr[0]]
 	Return 
-// 0x173: ProcessEvent[Probe[main.intArrayArg]Return@b7fd8]
+// 0x18d: ProcessEvent[Probe[main.intArrayArg]Return@b7fd8]
 	PrepareEventRoot c3 00 00 00 00 00 00 00 
 	Return 
-// 0x17d: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb80e0.expr[0]]
+// 0x197: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb80e0.expr[0]]
 	ExprPrepare 
-	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
+	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferenceCfa 10 00 00 00 08 00 00 00 08 00 00 00 
+	ExprDereferenceCfa 18 00 00 00 08 00 00 00 10 00 00 00 
+	ExprDereferenceCfa 20 00 00 00 08 00 00 00 18 00 00 00 
+	ExprDereferenceCfa 28 00 00 00 08 00 00 00 20 00 00 00 
+	ExprDereferenceCfa 30 00 00 00 08 00 00 00 28 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call aa 04 00 00 // ProcessType[[3]string]
+	Call 46 05 00 00 // ProcessType[[3]string]
 	Return 
-// 0x19e: ProcessEvent[Probe[main.stringArrayArgFrameless]@b80e0]
+// 0x1f9: ProcessEvent[Probe[main.stringArrayArgFrameless]@b80e0]
 	PrepareEventRoot c8 00 00 00 31 00 00 00 
-	Call 7d 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb80e0.expr[0]]
+	Call 97 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb80e0.expr[0]]
 	Return 
-// 0x1ad: ProcessExpression[Probe[main.intSliceArg]@0xb7f18.expr[0]]
+// 0x208: ProcessExpression[Probe[main.intSliceArg]@0xb7f18.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 00 05 00 00 // ProcessType[[]int]
+	Call 9c 05 00 00 // ProcessType[[]int]
 	Return 
-// 0x1d6: ProcessEvent[Probe[main.intSliceArg]@b7f18]
+// 0x231: ProcessEvent[Probe[main.intSliceArg]@b7f18]
 	PrepareEventRoot c0 00 00 00 19 00 00 00 
-	Call ad 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb7f18.expr[0]]
+	Call 08 02 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb7f18.expr[0]]
 	Return 
-// 0x1e5: ProcessEvent[Probe[main.intSliceArg]Return@b7f50]
+// 0x240: ProcessEvent[Probe[main.intSliceArg]Return@b7f50]
 	PrepareEventRoot c1 00 00 00 00 00 00 00 
 	Return 
-// 0x1ef: ProcessExpression[Probe[main.stringArg]@0xb7ea8.expr[0]]
+// 0x24a: ProcessExpression[Probe[main.stringArg]@0xb7ea8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 2e 07 00 00 // ProcessType[string]
+	Call ca 07 00 00 // ProcessType[string]
 	Return 
-// 0x211: ProcessEvent[Probe[main.stringArg]@b7ea8]
+// 0x26c: ProcessEvent[Probe[main.stringArg]@b7ea8]
 	PrepareEventRoot ba 00 00 00 11 00 00 00 
-	Call ef 01 00 00 // ProcessExpression[Probe[main.stringArg]@0xb7ea8.expr[0]]
+	Call 4a 02 00 00 // ProcessExpression[Probe[main.stringArg]@0xb7ea8.expr[0]]
 	Return 
-// 0x220: ProcessEvent[Probe[main.stringArg]Return@b7ee0]
+// 0x27b: ProcessEvent[Probe[main.stringArg]Return@b7ee0]
 	PrepareEventRoot bb 00 00 00 00 00 00 00 
 	Return 
-// 0x22a: ProcessEvent[Probe[main.stringArg]@b7ea8]
+// 0x285: ProcessEvent[Probe[main.stringArg]@b7ea8]
 	PrepareEventRoot bc 00 00 00 00 00 00 00 
 	Return 
-// 0x234: ProcessEvent[Probe[main.stringArg]Return@b7ee0]
+// 0x28f: ProcessEvent[Probe[main.stringArg]Return@b7ee0]
 	PrepareEventRoot bd 00 00 00 00 00 00 00 
 	Return 
-// 0x23e: ProcessExpression[Probe[main.mapArg]@0xb81c8.expr[0]]
+// 0x299: ProcessExpression[Probe[main.mapArg]@0xb81c8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call c0 05 00 00 // ProcessType[map[string]int]
+	Call 5c 06 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x259: ProcessExpression[Probe[main.mapArg]@0xb81c8.expr[1]]
+// 0x2b4: ProcessExpression[Probe[main.mapArg]@0xb81c8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call c0 05 00 00 // ProcessType[map[string]int]
+	Call 5c 06 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x274: ProcessEvent[Probe[main.mapArg]@b81c8]
+// 0x2cf: ProcessEvent[Probe[main.mapArg]@b81c8]
 	PrepareEventRoot c9 00 00 00 11 00 00 00 
-	Call 3e 02 00 00 // ProcessExpression[Probe[main.mapArg]@0xb81c8.expr[0]]
-	Call 59 02 00 00 // ProcessExpression[Probe[main.mapArg]@0xb81c8.expr[1]]
+	Call 99 02 00 00 // ProcessExpression[Probe[main.mapArg]@0xb81c8.expr[0]]
+	Call b4 02 00 00 // ProcessExpression[Probe[main.mapArg]@0xb81c8.expr[1]]
 	Return 
-// 0x288: ProcessEvent[Probe[main.mapArg]Return@b81f4]
+// 0x2e3: ProcessEvent[Probe[main.mapArg]Return@b81f4]
 	PrepareEventRoot ca 00 00 00 00 00 00 00 
 	Return 
-// 0x292: ProcessEvent[Probe[main.noArgs]@b82e8]
+// 0x2ed: ProcessEvent[Probe[main.noArgs]@b82e8]
 	PrepareEventRoot cd 00 00 00 00 00 00 00 
 	Return 
-// 0x29c: ProcessEvent[Probe[main.noArgs]Return@b831c]
+// 0x2f7: ProcessEvent[Probe[main.noArgs]Return@b831c]
 	PrepareEventRoot ce 00 00 00 00 00 00 00 
 	Return 
-// 0x2a6: ProcessExpression[Probe[main.stringArg]@0xb7ea8.expr[0]]
+// 0x301: ProcessExpression[Probe[main.stringArg]@0xb7ea8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 2e 07 00 00 // ProcessType[string]
+	Call ca 07 00 00 // ProcessType[string]
 	Return 
-// 0x2c8: ProcessExpression[Probe[main.stringArg]@0xb7ea8.expr[1]]
+// 0x323: ProcessExpression[Probe[main.stringArg]@0xb7ea8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call 2e 07 00 00 // ProcessType[string]
+	Call ca 07 00 00 // ProcessType[string]
 	Return 
-// 0x2ea: ProcessEvent[Probe[main.stringArg]@b7ea8]
+// 0x345: ProcessEvent[Probe[main.stringArg]@b7ea8]
 	PrepareEventRoot be 00 00 00 21 00 00 00 
-	Call a6 02 00 00 // ProcessExpression[Probe[main.stringArg]@0xb7ea8.expr[0]]
-	Call c8 02 00 00 // ProcessExpression[Probe[main.stringArg]@0xb7ea8.expr[1]]
+	Call 01 03 00 00 // ProcessExpression[Probe[main.stringArg]@0xb7ea8.expr[0]]
+	Call 23 03 00 00 // ProcessExpression[Probe[main.stringArg]@0xb7ea8.expr[1]]
 	Return 
-// 0x2fe: ProcessEvent[Probe[main.stringArg]Return@b7ee0]
+// 0x359: ProcessEvent[Probe[main.stringArg]Return@b7ee0]
 	PrepareEventRoot bf 00 00 00 00 00 00 00 
 	Return 
-// 0x308: ProcessExpression[Probe[main.stringArrayArg]@0xb8088.expr[0]]
+// 0x363: ProcessExpression[Probe[main.stringArrayArg]@0xb8088.expr[0]]
 	ExprPrepare 
-	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
+	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferenceCfa 10 00 00 00 08 00 00 00 08 00 00 00 
+	ExprDereferenceCfa 18 00 00 00 08 00 00 00 10 00 00 00 
+	ExprDereferenceCfa 20 00 00 00 08 00 00 00 18 00 00 00 
+	ExprDereferenceCfa 28 00 00 00 08 00 00 00 20 00 00 00 
+	ExprDereferenceCfa 30 00 00 00 08 00 00 00 28 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call aa 04 00 00 // ProcessType[[3]string]
+	Call 46 05 00 00 // ProcessType[[3]string]
 	Return 
-// 0x329: ProcessEvent[Probe[main.stringArrayArg]@b8088]
+// 0x3c5: ProcessEvent[Probe[main.stringArrayArg]@b8088]
 	PrepareEventRoot c6 00 00 00 31 00 00 00 
-	Call 08 03 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb8088.expr[0]]
+	Call 63 03 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb8088.expr[0]]
 	Return 
-// 0x338: ProcessEvent[Probe[main.stringArrayArg]Return@b80c8]
+// 0x3d4: ProcessEvent[Probe[main.stringArrayArg]Return@b80c8]
 	PrepareEventRoot c7 00 00 00 00 00 00 00 
 	Return 
-// 0x342: ProcessExpression[Probe[main.stringSliceArg]@0xb8008.expr[0]]
+// 0x3de: ProcessExpression[Probe[main.stringSliceArg]@0xb8008.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 2e 05 00 00 // ProcessType[[]string]
+	Call ca 05 00 00 // ProcessType[[]string]
 	Return 
-// 0x36b: ProcessEvent[Probe[main.stringSliceArg]@b8008]
+// 0x407: ProcessEvent[Probe[main.stringSliceArg]@b8008]
 	PrepareEventRoot c4 00 00 00 19 00 00 00 
-	Call 42 03 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb8008.expr[0]]
+	Call de 03 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb8008.expr[0]]
 	Return 
-// 0x37a: ProcessEvent[Probe[main.stringSliceArg]Return@b8040]
+// 0x416: ProcessEvent[Probe[main.stringSliceArg]Return@b8040]
 	PrepareEventRoot c5 00 00 00 00 00 00 00 
 	Return 
-// 0x384: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b8360]
+// 0x420: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b8360]
 	PrepareEventRoot cf 00 00 00 00 00 00 00 
 	Return 
-// 0x38e: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb84d8.expr[0]]
+// 0x42a: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb84d8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call cc 05 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 68 06 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x3a9: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b84d8]
+// 0x445: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b84d8]
 	PrepareEventRoot d0 00 00 00 09 00 00 00 
-	Call 8e 03 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb84d8.expr[0]]
+	Call 2a 04 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb84d8.expr[0]]
 	Return 
-// 0x3b8: ProcessType[*****int]
+// 0x454: ProcessType[*****int]
 	ProcessPointer 7f 00 00 00 
 	Return 
-// 0x3be: ProcessType[****int]
+// 0x45a: ProcessType[****int]
 	ProcessPointer b6 00 00 00 
 	Return 
-// 0x3c4: ProcessType[***int]
+// 0x460: ProcessType[***int]
 	ProcessPointer 80 00 00 00 
 	Return 
-// 0x3ca: ProcessType[**int]
+// 0x466: ProcessType[**int]
 	ProcessPointer 64 00 00 00 
 	Return 
-// 0x3d0: ProcessType[*[]runtime.ancestorInfo]
+// 0x46c: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x3d6: ProcessType[*bool]
+// 0x472: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x3dc: ProcessType[*error]
+// 0x478: ProcessType[*error]
 	ProcessPointer 0e 00 00 00 
 	Return 
-// 0x3e2: ProcessType[*float32]
+// 0x47e: ProcessType[*float32]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x3e8: ProcessType[*float64]
+// 0x484: ProcessType[*float64]
 	ProcessPointer 10 00 00 00 
 	Return 
-// 0x3ee: ProcessType[*int]
+// 0x48a: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x3f4: ProcessType[*int32]
+// 0x490: ProcessType[*int32]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x3fa: ProcessType[*int64]
+// 0x496: ProcessType[*int64]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x400: ProcessType[*main.bigStruct]
+// 0x49c: ProcessType[*main.bigStruct]
 	ProcessPointer 9d 00 00 00 
 	Return 
-// 0x406: ProcessType[*runtime._defer]
+// 0x4a2: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x40c: ProcessType[*runtime._panic]
+// 0x4a8: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x412: ProcessType[*runtime.cgoCallers]
+// 0x4ae: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 42 00 00 00 
 	Return 
-// 0x418: ProcessType[*runtime.coro]
+// 0x4b4: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x41e: ProcessType[*runtime.g]
+// 0x4ba: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x424: ProcessType[*runtime.m]
+// 0x4c0: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x42a: ProcessType[*runtime.p]
+// 0x4c6: ProcessType[*runtime.p]
 	ProcessPointer 87 00 00 00 
 	Return 
-// 0x430: ProcessType[*runtime.sudog]
+// 0x4cc: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x436: ProcessType[*runtime.synctestBubble]
+// 0x4d2: ProcessType[*runtime.synctestBubble]
 	ProcessPointer 32 00 00 00 
 	Return 
-// 0x43c: ProcessType[*runtime.timer]
+// 0x4d8: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x442: ProcessType[*runtime.traceBuf]
+// 0x4de: ProcessType[*runtime.traceBuf]
 	ProcessPointer 50 00 00 00 
 	Return 
-// 0x448: ProcessType[*string]
+// 0x4e4: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x44e: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+// 0x4ea: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer ad 00 00 00 
 	Return 
-// 0x454: ProcessType[*table<string,int>]
+// 0x4f0: ProcessType[*table<string,int>]
 	ProcessPointer 8e 00 00 00 
 	Return 
-// 0x45a: ProcessType[*table<string,main.bigStruct>]
+// 0x4f6: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer 96 00 00 00 
 	Return 
-// 0x460: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x4fc: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer a0 00 00 00 
 	Return 
-// 0x466: ProcessType[*uint]
+// 0x502: ProcessType[*uint]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x46c: ProcessType[*uint16]
+// 0x508: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x472: ProcessType[*uint32]
+// 0x50e: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x478: ProcessType[*uint64]
+// 0x514: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x47e: ProcessType[*uint8]
+// 0x51a: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x484: ProcessType[*uintptr]
+// 0x520: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x48a: ProcessType[[2]*runtime.traceBuf]
+// 0x526: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call 42 04 00 00 // ProcessType[*runtime.traceBuf]
+	Call de 04 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x49a: ProcessType[[2][2]*runtime.traceBuf]
+// 0x536: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call 8a 04 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call 26 05 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x4aa: ProcessType[[3]string]
+// 0x546: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 2e 07 00 00 // ProcessType[string]
+	Call ca 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x4ba: ProcessType[[]*runtime.p]
+// 0x556: ProcessType[[]*runtime.p]
 	ProcessSlice 88 00 00 00 08 00 00 00 
 	Return 
-// 0x4c4: ProcessType[[]*runtime.p.array]
+// 0x560: ProcessType[[]*runtime.p.array]
 	ProcessSliceDataPrep 
-	Call 2a 04 00 00 // ProcessType[*runtime.p]
+	Call c6 04 00 00 // ProcessType[*runtime.p]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x4d0: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x56c: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 4e 04 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	Call ea 04 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x4dc: ProcessType[[]*table<string,int>.array]
+// 0x578: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 54 04 00 00 // ProcessType[*table<string,int>]
+	Call f0 04 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x4e8: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x584: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 5a 04 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call f6 04 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x4f4: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x590: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 60 04 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call fc 04 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x500: ProcessType[[]int]
+// 0x59c: ProcessType[[]int]
 	ProcessSlice 8a 00 00 00 08 00 00 00 
 	Return 
-// 0x50a: ProcessType[[]noalg.map.group[string]int.array]
+// 0x5a6: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call 02 06 00 00 // ProcessType[noalg.map.group[string]int]
+	Call 9e 06 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x516: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x5b2: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call 0d 06 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call a9 06 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x522: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+// 0x5be: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call 18 06 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call b4 06 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x52e: ProcessType[[]string]
+// 0x5ca: ProcessType[[]string]
 	ProcessSlice 8c 00 00 00 10 00 00 00 
 	Return 
-// 0x538: ProcessType[[]string.array]
+// 0x5d4: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call 2e 07 00 00 // ProcessType[string]
+	Call ca 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x544: ProcessType[[]uint8]
+// 0x5e0: ProcessType[[]uint8]
 	ProcessSlice 83 00 00 00 01 00 00 00 
 	Return 
-// 0x54e: ProcessType[[]uintptr]
+// 0x5ea: ProcessType[[]uintptr]
 	ProcessSlice 85 00 00 00 08 00 00 00 
 	Return 
-// 0x558: ProcessType[error]
+// 0x5f4: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x55a: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+// 0x5f6: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups b5 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x566: ProcessType[groupReference<string,int>]
+// 0x602: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups 95 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x572: ProcessType[groupReference<string,main.bigStruct>]
+// 0x60e: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups 9f 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x57e: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x61a: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups ac 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x58a: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+// 0x626: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap b4 00 00 00 b0 00 00 00 10 18 
 	Return 
-// 0x596: ProcessType[map<string,int>]
+// 0x632: ProcessType[map<string,int>]
 	ProcessGoSwissMap 94 00 00 00 91 00 00 00 10 18 
 	Return 
-// 0x5a2: ProcessType[map<string,main.bigStruct>]
+// 0x63e: ProcessType[map<string,main.bigStruct>]
 	ProcessGoSwissMap 9e 00 00 00 99 00 00 00 10 18 
 	Return 
-// 0x5ae: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x64a: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap ab 00 00 00 a3 00 00 00 10 18 
 	Return 
-// 0x5ba: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x656: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer a8 00 00 00 
 	Return 
-// 0x5c0: ProcessType[map[string]int]
+// 0x65c: ProcessType[map[string]int]
 	ProcessPointer 71 00 00 00 
 	Return 
-// 0x5c6: ProcessType[map[string]main.bigStruct]
+// 0x662: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 76 00 00 00 
 	Return 
-// 0x5cc: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x668: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 7b 00 00 00 
 	Return 
-// 0x5d2: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x66e: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 23 06 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call bf 06 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x5e2: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x67e: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 33 06 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call cf 06 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x5f2: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x68e: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call 39 06 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call d5 06 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x602: ProcessType[noalg.map.group[string]int]
+// 0x69e: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call e2 05 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call 7e 06 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x60d: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x6a9: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call d2 05 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call 6e 06 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x618: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x6b4: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call f2 05 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 8e 06 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x623: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call 2e 07 00 00 // ProcessType[string]
+// 0x6bf: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call ca 07 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 00 04 00 00 // ProcessType[*main.bigStruct]
+	Call 9c 04 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x633: ProcessType[noalg.struct { key string; elem int }]
-	Call 2e 07 00 00 // ProcessType[string]
+// 0x6cf: ProcessType[noalg.struct { key string; elem int }]
+	Call ca 07 00 00 // ProcessType[string]
 	Return 
-// 0x639: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x6d5: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call ba 05 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 56 06 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x644: ProcessType[runtime.g]
+// 0x6e0: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 0c 04 00 00 // ProcessType[*runtime._panic]
+	Call a8 04 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 06 04 00 00 // ProcessType[*runtime._defer]
+	Call a2 04 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call 24 04 00 00 // ProcessType[*runtime.m]
+	Call c0 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b0 00 00 00 
-	Call 44 05 00 00 // ProcessType[[]uint8]
+	Call e0 05 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call d0 03 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 6c 04 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call 30 04 00 00 // ProcessType[*runtime.sudog]
+	Call cc 04 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 4e 05 00 00 // ProcessType[[]uintptr]
+	Call ea 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call 3c 04 00 00 // ProcessType[*runtime.timer]
+	Call d8 04 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call 18 04 00 00 // ProcessType[*runtime.coro]
+	Call b4 04 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call 36 04 00 00 // ProcessType[*runtime.synctestBubble]
+	Call d2 04 00 00 // ProcessType[*runtime.synctestBubble]
 	Return 
-// 0x6a9: ProcessType[runtime.m]
-	Call 1e 04 00 00 // ProcessType[*runtime.g]
+// 0x745: ProcessType[runtime.m]
+	Call ba 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 48 00 00 00 
-	Call 1e 04 00 00 // ProcessType[*runtime.g]
+	Call ba 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call 1e 04 00 00 // ProcessType[*runtime.g]
+	Call ba 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call 2e 07 00 00 // ProcessType[string]
+	Call ca 07 00 00 // ProcessType[string]
 	IncrementOutputOffset 30 00 00 00 
-	Call ba 04 00 00 // ProcessType[[]*runtime.p]
+	Call 56 05 00 00 // ProcessType[[]*runtime.p]
 	IncrementOutputOffset 28 00 00 00 
-	Call 12 04 00 00 // ProcessType[*runtime.cgoCallers]
+	Call ae 04 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call 24 04 00 00 // ProcessType[*runtime.m]
+	Call c0 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 30 01 00 00 
-	Call 13 07 00 00 // ProcessType[runtime.mLockProfile]
+	Call af 07 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 30 00 00 00 
-	Call 4e 05 00 00 // ProcessType[[]uintptr]
+	Call ea 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call 24 04 00 00 // ProcessType[*runtime.m]
+	Call c0 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call 1e 07 00 00 // ProcessType[runtime.mTraceState]
+	Call ba 07 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x713: ProcessType[runtime.mLockProfile]
+// 0x7af: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 4e 05 00 00 // ProcessType[[]uintptr]
+	Call ea 05 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x71e: ProcessType[runtime.mTraceState]
+// 0x7ba: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call 9a 04 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call 24 04 00 00 // ProcessType[*runtime.m]
+	Call 36 05 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call c0 04 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x72e: ProcessType[string]
+// 0x7ca: ProcessType[string]
 	ProcessString 81 00 00 00 
 	Return 
-// 0x734: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x7d0: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 5a 05 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call f6 05 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x73f: ProcessType[table<string,int>]
+// 0x7db: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 66 05 00 00 // ProcessType[groupReference<string,int>]
+	Call 02 06 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x74a: ProcessType[table<string,main.bigStruct>]
+// 0x7e6: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 72 05 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call 0e 06 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x755: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x7f1: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 7e 05 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 1a 06 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -579,31 +591,31 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 1150
+ID: 5 Len: 8 Enqueue: 1306
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 1838
+ID: 9 Len: 16 Enqueue: 1994
 ID: 10 Len: 8 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 982
+ID: 11 Len: 8 Enqueue: 1138
 ID: 12 Len: 4 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
-ID: 14 Len: 16 Enqueue: 1368
+ID: 14 Len: 16 Enqueue: 1524
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 8 Enqueue: 0
 ID: 17 Len: 1 Enqueue: 0
 ID: 18 Len: 4 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 1156
-ID: 20 Len: 8 Enqueue: 1012
-ID: 21 Len: 8 Enqueue: 1138
-ID: 22 Len: 440 Enqueue: 1604
+ID: 19 Len: 8 Enqueue: 1312
+ID: 20 Len: 8 Enqueue: 1168
+ID: 21 Len: 8 Enqueue: 1294
+ID: 22 Len: 440 Enqueue: 1760
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 1036
+ID: 24 Len: 8 Enqueue: 1192
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 1030
+ID: 26 Len: 8 Enqueue: 1186
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 1060
-ID: 29 Len: 1816 Enqueue: 1705
+ID: 28 Len: 8 Enqueue: 1216
+ID: 29 Len: 1816 Enqueue: 1861
 ID: 30 Len: 48 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -612,48 +624,48 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 1348
-ID: 39 Len: 8 Enqueue: 976
+ID: 38 Len: 24 Enqueue: 1504
+ID: 39 Len: 8 Enqueue: 1132
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 1072
+ID: 41 Len: 8 Enqueue: 1228
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 1358
-ID: 44 Len: 8 Enqueue: 1084
+ID: 43 Len: 24 Enqueue: 1514
+ID: 44 Len: 8 Enqueue: 1240
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 1048
+ID: 47 Len: 8 Enqueue: 1204
 ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 8 Enqueue: 1078
+ID: 49 Len: 8 Enqueue: 1234
 ID: 50 Len: 8 Enqueue: 0
 ID: 51 Len: 32 Enqueue: 0
 ID: 52 Len: 32 Enqueue: 0
 ID: 53 Len: 12 Enqueue: 0
 ID: 54 Len: 16 Enqueue: 0
-ID: 55 Len: 8 Enqueue: 1054
+ID: 55 Len: 8 Enqueue: 1210
 ID: 56 Len: 40 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 48 Enqueue: 0
 ID: 59 Len: 8 Enqueue: 0
 ID: 60 Len: 8 Enqueue: 0
 ID: 61 Len: 4 Enqueue: 0
-ID: 62 Len: 24 Enqueue: 1210
+ID: 62 Len: 24 Enqueue: 1366
 ID: 63 Len: 8 Enqueue: 0
-ID: 64 Len: 8 Enqueue: 1066
-ID: 65 Len: 8 Enqueue: 1042
+ID: 64 Len: 8 Enqueue: 1222
+ID: 65 Len: 8 Enqueue: 1198
 ID: 66 Len: 8 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 256 Enqueue: 0
 ID: 69 Len: 16 Enqueue: 0
-ID: 70 Len: 56 Enqueue: 1811
+ID: 70 Len: 56 Enqueue: 1967
 ID: 71 Len: 8 Enqueue: 0
 ID: 72 Len: 0 Enqueue: 0
 ID: 73 Len: 8 Enqueue: 0
 ID: 74 Len: 1 Enqueue: 0
-ID: 75 Len: 56 Enqueue: 1822
+ID: 75 Len: 56 Enqueue: 1978
 ID: 76 Len: 8 Enqueue: 0
-ID: 77 Len: 32 Enqueue: 1178
-ID: 78 Len: 16 Enqueue: 1162
-ID: 79 Len: 8 Enqueue: 1090
+ID: 77 Len: 32 Enqueue: 1334
+ID: 78 Len: 16 Enqueue: 1318
+ID: 79 Len: 8 Enqueue: 1246
 ID: 80 Len: 8 Enqueue: 0
 ID: 81 Len: 48 Enqueue: 0
 ID: 82 Len: 0 Enqueue: 0
@@ -669,40 +681,40 @@ ID: 91 Len: 32 Enqueue: 0
 ID: 92 Len: 160 Enqueue: 0
 ID: 93 Len: 16 Enqueue: 0
 ID: 94 Len: 8 Enqueue: 0
-ID: 95 Len: 8 Enqueue: 1096
+ID: 95 Len: 8 Enqueue: 1252
 ID: 96 Len: 2 Enqueue: 0
 ID: 97 Len: 8 Enqueue: 0
 ID: 98 Len: 16 Enqueue: 0
-ID: 99 Len: 8 Enqueue: 1000
-ID: 100 Len: 8 Enqueue: 1006
-ID: 101 Len: 8 Enqueue: 1144
-ID: 102 Len: 8 Enqueue: 1018
-ID: 103 Len: 8 Enqueue: 988
-ID: 104 Len: 8 Enqueue: 994
-ID: 105 Len: 8 Enqueue: 1126
-ID: 106 Len: 8 Enqueue: 1132
-ID: 107 Len: 24 Enqueue: 1280
+ID: 99 Len: 8 Enqueue: 1156
+ID: 100 Len: 8 Enqueue: 1162
+ID: 101 Len: 8 Enqueue: 1300
+ID: 102 Len: 8 Enqueue: 1174
+ID: 103 Len: 8 Enqueue: 1144
+ID: 104 Len: 8 Enqueue: 1150
+ID: 105 Len: 8 Enqueue: 1282
+ID: 106 Len: 8 Enqueue: 1288
+ID: 107 Len: 24 Enqueue: 1436
 ID: 108 Len: 24 Enqueue: 0
-ID: 109 Len: 24 Enqueue: 1326
-ID: 110 Len: 48 Enqueue: 1194
-ID: 111 Len: 8 Enqueue: 1472
+ID: 109 Len: 24 Enqueue: 1482
+ID: 110 Len: 48 Enqueue: 1350
+ID: 111 Len: 8 Enqueue: 1628
 ID: 112 Len: 8 Enqueue: 0
-ID: 113 Len: 48 Enqueue: 1430
+ID: 113 Len: 48 Enqueue: 1586
 ID: 114 Len: 8 Enqueue: 0
-ID: 115 Len: 8 Enqueue: 1108
-ID: 116 Len: 8 Enqueue: 1478
+ID: 115 Len: 8 Enqueue: 1264
+ID: 116 Len: 8 Enqueue: 1634
 ID: 117 Len: 8 Enqueue: 0
-ID: 118 Len: 48 Enqueue: 1442
+ID: 118 Len: 48 Enqueue: 1598
 ID: 119 Len: 8 Enqueue: 0
-ID: 120 Len: 8 Enqueue: 1114
-ID: 121 Len: 8 Enqueue: 1484
+ID: 120 Len: 8 Enqueue: 1270
+ID: 121 Len: 8 Enqueue: 1640
 ID: 122 Len: 8 Enqueue: 0
-ID: 123 Len: 48 Enqueue: 1454
+ID: 123 Len: 48 Enqueue: 1610
 ID: 124 Len: 8 Enqueue: 0
-ID: 125 Len: 8 Enqueue: 1120
-ID: 126 Len: 8 Enqueue: 952
-ID: 127 Len: 8 Enqueue: 958
-ID: 128 Len: 8 Enqueue: 970
+ID: 125 Len: 8 Enqueue: 1276
+ID: 126 Len: 8 Enqueue: 1108
+ID: 127 Len: 8 Enqueue: 1114
+ID: 128 Len: 8 Enqueue: 1126
 ID: 129 Len: 1 Enqueue: 0
 ID: 130 Len: 8 Enqueue: 0
 ID: 131 Len: 1 Enqueue: 0
@@ -710,53 +722,53 @@ ID: 132 Len: 8 Enqueue: 0
 ID: 133 Len: 8 Enqueue: 0
 ID: 134 Len: 8 Enqueue: 0
 ID: 135 Len: 8 Enqueue: 0
-ID: 136 Len: 8 Enqueue: 1220
+ID: 136 Len: 8 Enqueue: 1376
 ID: 137 Len: 8 Enqueue: 0
 ID: 138 Len: 8 Enqueue: 0
 ID: 139 Len: 8 Enqueue: 0
-ID: 140 Len: 16 Enqueue: 1336
+ID: 140 Len: 16 Enqueue: 1492
 ID: 141 Len: 8 Enqueue: 0
-ID: 142 Len: 32 Enqueue: 1855
-ID: 143 Len: 16 Enqueue: 1382
+ID: 142 Len: 32 Enqueue: 2011
+ID: 143 Len: 16 Enqueue: 1538
 ID: 144 Len: 8 Enqueue: 0
-ID: 145 Len: 200 Enqueue: 1538
-ID: 146 Len: 192 Enqueue: 1506
-ID: 147 Len: 24 Enqueue: 1587
-ID: 148 Len: 8 Enqueue: 1244
-ID: 149 Len: 200 Enqueue: 1290
-ID: 150 Len: 32 Enqueue: 1866
-ID: 151 Len: 16 Enqueue: 1394
+ID: 145 Len: 200 Enqueue: 1694
+ID: 146 Len: 192 Enqueue: 1662
+ID: 147 Len: 24 Enqueue: 1743
+ID: 148 Len: 8 Enqueue: 1400
+ID: 149 Len: 200 Enqueue: 1446
+ID: 150 Len: 32 Enqueue: 2022
+ID: 151 Len: 16 Enqueue: 1550
 ID: 152 Len: 8 Enqueue: 0
-ID: 153 Len: 200 Enqueue: 1549
-ID: 154 Len: 192 Enqueue: 1490
-ID: 155 Len: 24 Enqueue: 1571
-ID: 156 Len: 8 Enqueue: 1024
+ID: 153 Len: 200 Enqueue: 1705
+ID: 154 Len: 192 Enqueue: 1646
+ID: 155 Len: 24 Enqueue: 1727
+ID: 156 Len: 8 Enqueue: 1180
 ID: 157 Len: 184 Enqueue: 0
-ID: 158 Len: 8 Enqueue: 1256
-ID: 159 Len: 200 Enqueue: 1302
-ID: 160 Len: 32 Enqueue: 1877
-ID: 161 Len: 16 Enqueue: 1406
+ID: 158 Len: 8 Enqueue: 1412
+ID: 159 Len: 200 Enqueue: 1458
+ID: 160 Len: 32 Enqueue: 2033
+ID: 161 Len: 16 Enqueue: 1562
 ID: 162 Len: 8 Enqueue: 0
-ID: 163 Len: 136 Enqueue: 1560
-ID: 164 Len: 128 Enqueue: 1522
-ID: 165 Len: 16 Enqueue: 1593
-ID: 166 Len: 8 Enqueue: 1466
+ID: 163 Len: 136 Enqueue: 1716
+ID: 164 Len: 128 Enqueue: 1678
+ID: 165 Len: 16 Enqueue: 1749
+ID: 166 Len: 8 Enqueue: 1622
 ID: 167 Len: 8 Enqueue: 0
-ID: 168 Len: 48 Enqueue: 1418
+ID: 168 Len: 48 Enqueue: 1574
 ID: 169 Len: 8 Enqueue: 0
-ID: 170 Len: 8 Enqueue: 1102
-ID: 171 Len: 8 Enqueue: 1268
-ID: 172 Len: 136 Enqueue: 1314
-ID: 173 Len: 32 Enqueue: 1844
-ID: 174 Len: 16 Enqueue: 1370
+ID: 170 Len: 8 Enqueue: 1258
+ID: 171 Len: 8 Enqueue: 1424
+ID: 172 Len: 136 Enqueue: 1470
+ID: 173 Len: 32 Enqueue: 2000
+ID: 174 Len: 16 Enqueue: 1526
 ID: 175 Len: 8 Enqueue: 0
 ID: 176 Len: 136 Enqueue: 0
 ID: 177 Len: 128 Enqueue: 0
 ID: 178 Len: 16 Enqueue: 0
 ID: 179 Len: 8 Enqueue: 0
-ID: 180 Len: 8 Enqueue: 1232
+ID: 180 Len: 8 Enqueue: 1388
 ID: 181 Len: 136 Enqueue: 0
-ID: 182 Len: 8 Enqueue: 964
+ID: 182 Len: 8 Enqueue: 1120
 ID: 183 Len: 128 Enqueue: 0
 ID: 184 Len: 9 Enqueue: 0
 ID: 185 Len: 0 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.26rc1.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.26rc1.sm.txt
@@ -7,13 +7,13 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call b8 03 00 00 // ProcessType[*****int]
+	Call 54 04 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessExpression[Probe[main.PointerChainArg]@0xc815c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call b8 03 00 00 // ProcessType[*****int]
+	Call 54 04 00 00 // ProcessType[*****int]
 	Return 
 // 0x39: ProcessEvent[Probe[main.PointerChainArg]@c815c]
 	PrepareEventRoot d8 00 00 00 11 00 00 00 
@@ -24,7 +24,7 @@
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call ca 03 00 00 // ProcessType[**int]
+	Call 66 04 00 00 // ProcessType[**int]
 	Return 
 // 0x68: ProcessEvent[Probe[main.PointerSmallChainArg]@c8190]
 	PrepareEventRoot d9 00 00 00 09 00 00 00 
@@ -34,13 +34,13 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call d2 05 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 6e 06 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x92: ProcessExpression[Probe[main.bigMapArg]@0xc85f8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call d2 05 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 6e 06 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0xad: ProcessEvent[Probe[main.bigMapArg]@c85f8]
 	PrepareEventRoot d0 00 00 00 11 00 00 00 
@@ -85,496 +85,508 @@
 	Return 
 // 0x148: ProcessExpression[Probe[main.intArrayArg]@0xc8358.expr[0]]
 	ExprPrepare 
-	ExprDereferenceCfa 08 00 00 00 18 00 00 00 00 00 00 00 
+	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferenceCfa 10 00 00 00 08 00 00 00 08 00 00 00 
+	ExprDereferenceCfa 18 00 00 00 08 00 00 00 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
-// 0x164: ProcessEvent[Probe[main.intArrayArg]@c8358]
+// 0x17e: ProcessEvent[Probe[main.intArrayArg]@c8358]
 	PrepareEventRoot c7 00 00 00 19 00 00 00 
 	Call 48 01 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xc8358.expr[0]]
 	Return 
-// 0x173: ProcessEvent[Probe[main.intArrayArg]Return@c8398]
+// 0x18d: ProcessEvent[Probe[main.intArrayArg]Return@c8398]
 	PrepareEventRoot c8 00 00 00 00 00 00 00 
 	Return 
-// 0x17d: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xc84a0.expr[0]]
+// 0x197: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xc84a0.expr[0]]
 	ExprPrepare 
-	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
+	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferenceCfa 10 00 00 00 08 00 00 00 08 00 00 00 
+	ExprDereferenceCfa 18 00 00 00 08 00 00 00 10 00 00 00 
+	ExprDereferenceCfa 20 00 00 00 08 00 00 00 18 00 00 00 
+	ExprDereferenceCfa 28 00 00 00 08 00 00 00 20 00 00 00 
+	ExprDereferenceCfa 30 00 00 00 08 00 00 00 28 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call b6 04 00 00 // ProcessType[[3]string]
+	Call 52 05 00 00 // ProcessType[[3]string]
 	Return 
-// 0x19e: ProcessEvent[Probe[main.stringArrayArgFrameless]@c84a0]
+// 0x1f9: ProcessEvent[Probe[main.stringArrayArgFrameless]@c84a0]
 	PrepareEventRoot cd 00 00 00 31 00 00 00 
-	Call 7d 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xc84a0.expr[0]]
+	Call 97 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xc84a0.expr[0]]
 	Return 
-// 0x1ad: ProcessExpression[Probe[main.intSliceArg]@0xc82d8.expr[0]]
+// 0x208: ProcessExpression[Probe[main.intSliceArg]@0xc82d8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 0c 05 00 00 // ProcessType[[]int]
+	Call a8 05 00 00 // ProcessType[[]int]
 	Return 
-// 0x1d6: ProcessEvent[Probe[main.intSliceArg]@c82d8]
+// 0x231: ProcessEvent[Probe[main.intSliceArg]@c82d8]
 	PrepareEventRoot c5 00 00 00 19 00 00 00 
-	Call ad 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xc82d8.expr[0]]
+	Call 08 02 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xc82d8.expr[0]]
 	Return 
-// 0x1e5: ProcessEvent[Probe[main.intSliceArg]Return@c8310]
+// 0x240: ProcessEvent[Probe[main.intSliceArg]Return@c8310]
 	PrepareEventRoot c6 00 00 00 00 00 00 00 
 	Return 
-// 0x1ef: ProcessExpression[Probe[main.stringArg]@0xc8268.expr[0]]
+// 0x24a: ProcessExpression[Probe[main.stringArg]@0xc8268.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 5a 07 00 00 // ProcessType[string]
+	Call f6 07 00 00 // ProcessType[string]
 	Return 
-// 0x211: ProcessEvent[Probe[main.stringArg]@c8268]
+// 0x26c: ProcessEvent[Probe[main.stringArg]@c8268]
 	PrepareEventRoot bf 00 00 00 11 00 00 00 
-	Call ef 01 00 00 // ProcessExpression[Probe[main.stringArg]@0xc8268.expr[0]]
+	Call 4a 02 00 00 // ProcessExpression[Probe[main.stringArg]@0xc8268.expr[0]]
 	Return 
-// 0x220: ProcessEvent[Probe[main.stringArg]Return@c82a0]
+// 0x27b: ProcessEvent[Probe[main.stringArg]Return@c82a0]
 	PrepareEventRoot c0 00 00 00 00 00 00 00 
 	Return 
-// 0x22a: ProcessEvent[Probe[main.stringArg]@c8268]
+// 0x285: ProcessEvent[Probe[main.stringArg]@c8268]
 	PrepareEventRoot c1 00 00 00 00 00 00 00 
 	Return 
-// 0x234: ProcessEvent[Probe[main.stringArg]Return@c82a0]
+// 0x28f: ProcessEvent[Probe[main.stringArg]Return@c82a0]
 	PrepareEventRoot c2 00 00 00 00 00 00 00 
 	Return 
-// 0x23e: ProcessExpression[Probe[main.mapArg]@0xc8588.expr[0]]
+// 0x299: ProcessExpression[Probe[main.mapArg]@0xc8588.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call cc 05 00 00 // ProcessType[map[string]int]
+	Call 68 06 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x259: ProcessExpression[Probe[main.mapArg]@0xc8588.expr[1]]
+// 0x2b4: ProcessExpression[Probe[main.mapArg]@0xc8588.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call cc 05 00 00 // ProcessType[map[string]int]
+	Call 68 06 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x274: ProcessEvent[Probe[main.mapArg]@c8588]
+// 0x2cf: ProcessEvent[Probe[main.mapArg]@c8588]
 	PrepareEventRoot ce 00 00 00 11 00 00 00 
-	Call 3e 02 00 00 // ProcessExpression[Probe[main.mapArg]@0xc8588.expr[0]]
-	Call 59 02 00 00 // ProcessExpression[Probe[main.mapArg]@0xc8588.expr[1]]
+	Call 99 02 00 00 // ProcessExpression[Probe[main.mapArg]@0xc8588.expr[0]]
+	Call b4 02 00 00 // ProcessExpression[Probe[main.mapArg]@0xc8588.expr[1]]
 	Return 
-// 0x288: ProcessEvent[Probe[main.mapArg]Return@c85b4]
+// 0x2e3: ProcessEvent[Probe[main.mapArg]Return@c85b4]
 	PrepareEventRoot cf 00 00 00 00 00 00 00 
 	Return 
-// 0x292: ProcessEvent[Probe[main.noArgs]@c8688]
+// 0x2ed: ProcessEvent[Probe[main.noArgs]@c8688]
 	PrepareEventRoot d2 00 00 00 00 00 00 00 
 	Return 
-// 0x29c: ProcessEvent[Probe[main.noArgs]Return@c86bc]
+// 0x2f7: ProcessEvent[Probe[main.noArgs]Return@c86bc]
 	PrepareEventRoot d3 00 00 00 00 00 00 00 
 	Return 
-// 0x2a6: ProcessExpression[Probe[main.stringArg]@0xc8268.expr[0]]
+// 0x301: ProcessExpression[Probe[main.stringArg]@0xc8268.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 5a 07 00 00 // ProcessType[string]
+	Call f6 07 00 00 // ProcessType[string]
 	Return 
-// 0x2c8: ProcessExpression[Probe[main.stringArg]@0xc8268.expr[1]]
+// 0x323: ProcessExpression[Probe[main.stringArg]@0xc8268.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call 5a 07 00 00 // ProcessType[string]
+	Call f6 07 00 00 // ProcessType[string]
 	Return 
-// 0x2ea: ProcessEvent[Probe[main.stringArg]@c8268]
+// 0x345: ProcessEvent[Probe[main.stringArg]@c8268]
 	PrepareEventRoot c3 00 00 00 21 00 00 00 
-	Call a6 02 00 00 // ProcessExpression[Probe[main.stringArg]@0xc8268.expr[0]]
-	Call c8 02 00 00 // ProcessExpression[Probe[main.stringArg]@0xc8268.expr[1]]
+	Call 01 03 00 00 // ProcessExpression[Probe[main.stringArg]@0xc8268.expr[0]]
+	Call 23 03 00 00 // ProcessExpression[Probe[main.stringArg]@0xc8268.expr[1]]
 	Return 
-// 0x2fe: ProcessEvent[Probe[main.stringArg]Return@c82a0]
+// 0x359: ProcessEvent[Probe[main.stringArg]Return@c82a0]
 	PrepareEventRoot c4 00 00 00 00 00 00 00 
 	Return 
-// 0x308: ProcessExpression[Probe[main.stringArrayArg]@0xc8448.expr[0]]
+// 0x363: ProcessExpression[Probe[main.stringArrayArg]@0xc8448.expr[0]]
 	ExprPrepare 
-	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
+	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferenceCfa 10 00 00 00 08 00 00 00 08 00 00 00 
+	ExprDereferenceCfa 18 00 00 00 08 00 00 00 10 00 00 00 
+	ExprDereferenceCfa 20 00 00 00 08 00 00 00 18 00 00 00 
+	ExprDereferenceCfa 28 00 00 00 08 00 00 00 20 00 00 00 
+	ExprDereferenceCfa 30 00 00 00 08 00 00 00 28 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call b6 04 00 00 // ProcessType[[3]string]
+	Call 52 05 00 00 // ProcessType[[3]string]
 	Return 
-// 0x329: ProcessEvent[Probe[main.stringArrayArg]@c8448]
+// 0x3c5: ProcessEvent[Probe[main.stringArrayArg]@c8448]
 	PrepareEventRoot cb 00 00 00 31 00 00 00 
-	Call 08 03 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xc8448.expr[0]]
+	Call 63 03 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xc8448.expr[0]]
 	Return 
-// 0x338: ProcessEvent[Probe[main.stringArrayArg]Return@c8488]
+// 0x3d4: ProcessEvent[Probe[main.stringArrayArg]Return@c8488]
 	PrepareEventRoot cc 00 00 00 00 00 00 00 
 	Return 
-// 0x342: ProcessExpression[Probe[main.stringSliceArg]@0xc83c8.expr[0]]
+// 0x3de: ProcessExpression[Probe[main.stringSliceArg]@0xc83c8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 3a 05 00 00 // ProcessType[[]string]
+	Call d6 05 00 00 // ProcessType[[]string]
 	Return 
-// 0x36b: ProcessEvent[Probe[main.stringSliceArg]@c83c8]
+// 0x407: ProcessEvent[Probe[main.stringSliceArg]@c83c8]
 	PrepareEventRoot c9 00 00 00 19 00 00 00 
-	Call 42 03 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xc83c8.expr[0]]
+	Call de 03 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xc83c8.expr[0]]
 	Return 
-// 0x37a: ProcessEvent[Probe[main.stringSliceArg]Return@c8400]
+// 0x416: ProcessEvent[Probe[main.stringSliceArg]Return@c8400]
 	PrepareEventRoot ca 00 00 00 00 00 00 00 
 	Return 
-// 0x384: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@c8700]
+// 0x420: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@c8700]
 	PrepareEventRoot d4 00 00 00 00 00 00 00 
 	Return 
-// 0x38e: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xc887c.expr[0]]
+// 0x42a: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xc887c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call d8 05 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 74 06 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x3a9: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@c887c]
+// 0x445: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@c887c]
 	PrepareEventRoot d5 00 00 00 09 00 00 00 
-	Call 8e 03 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xc887c.expr[0]]
+	Call 2a 04 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xc887c.expr[0]]
 	Return 
-// 0x3b8: ProcessType[*****int]
+// 0x454: ProcessType[*****int]
 	ProcessPointer 84 00 00 00 
 	Return 
-// 0x3be: ProcessType[****int]
+// 0x45a: ProcessType[****int]
 	ProcessPointer bb 00 00 00 
 	Return 
-// 0x3c4: ProcessType[***int]
+// 0x460: ProcessType[***int]
 	ProcessPointer 85 00 00 00 
 	Return 
-// 0x3ca: ProcessType[**int]
+// 0x466: ProcessType[**int]
 	ProcessPointer 69 00 00 00 
 	Return 
-// 0x3d0: ProcessType[*[]runtime.ancestorInfo]
+// 0x46c: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 29 00 00 00 
 	Return 
-// 0x3d6: ProcessType[*bool]
+// 0x472: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x3dc: ProcessType[*error]
+// 0x478: ProcessType[*error]
 	ProcessPointer 0f 00 00 00 
 	Return 
-// 0x3e2: ProcessType[*float32]
+// 0x47e: ProcessType[*float32]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x3e8: ProcessType[*float64]
+// 0x484: ProcessType[*float64]
 	ProcessPointer 0e 00 00 00 
 	Return 
-// 0x3ee: ProcessType[*int]
+// 0x48a: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x3f4: ProcessType[*int32]
+// 0x490: ProcessType[*int32]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x3fa: ProcessType[*int64]
+// 0x496: ProcessType[*int64]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x400: ProcessType[*internal/runtime/atomic.Pointer[runtime.m]]
+// 0x49c: ProcessType[*internal/runtime/atomic.Pointer[runtime.m]]
 	ProcessPointer 64 00 00 00 
 	Return 
-// 0x406: ProcessType[*main.bigStruct]
+// 0x4a2: ProcessType[*main.bigStruct]
 	ProcessPointer a2 00 00 00 
 	Return 
-// 0x40c: ProcessType[*runtime._defer]
+// 0x4a8: ProcessType[*runtime._defer]
 	ProcessPointer 1c 00 00 00 
 	Return 
-// 0x412: ProcessType[*runtime._panic]
+// 0x4ae: ProcessType[*runtime._panic]
 	ProcessPointer 1a 00 00 00 
 	Return 
-// 0x418: ProcessType[*runtime.cgoCallers]
+// 0x4b4: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 46 00 00 00 
 	Return 
-// 0x41e: ProcessType[*runtime.coro]
+// 0x4ba: ProcessType[*runtime.coro]
 	ProcessPointer 31 00 00 00 
 	Return 
-// 0x424: ProcessType[*runtime.g]
+// 0x4c0: ProcessType[*runtime.g]
 	ProcessPointer 17 00 00 00 
 	Return 
-// 0x42a: ProcessType[*runtime.m]
+// 0x4c6: ProcessType[*runtime.m]
 	ProcessPointer 1e 00 00 00 
 	Return 
-// 0x430: ProcessType[*runtime.p]
+// 0x4cc: ProcessType[*runtime.p]
 	ProcessPointer 8c 00 00 00 
 	Return 
-// 0x436: ProcessType[*runtime.sudog]
+// 0x4d2: ProcessType[*runtime.sudog]
 	ProcessPointer 2b 00 00 00 
 	Return 
-// 0x43c: ProcessType[*runtime.synctestBubble]
+// 0x4d8: ProcessType[*runtime.synctestBubble]
 	ProcessPointer 33 00 00 00 
 	Return 
-// 0x442: ProcessType[*runtime.timer]
+// 0x4de: ProcessType[*runtime.timer]
 	ProcessPointer 2e 00 00 00 
 	Return 
-// 0x448: ProcessType[*runtime.traceBuf]
+// 0x4e4: ProcessType[*runtime.traceBuf]
 	ProcessPointer 54 00 00 00 
 	Return 
-// 0x44e: ProcessType[*runtime.xRegState]
+// 0x4ea: ProcessType[*runtime.xRegState]
 	ProcessPointer 36 00 00 00 
 	Return 
-// 0x454: ProcessType[*string]
+// 0x4f0: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x45a: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+// 0x4f6: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer b2 00 00 00 
 	Return 
-// 0x460: ProcessType[*table<string,int>]
+// 0x4fc: ProcessType[*table<string,int>]
 	ProcessPointer 93 00 00 00 
 	Return 
-// 0x466: ProcessType[*table<string,main.bigStruct>]
+// 0x502: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer 9b 00 00 00 
 	Return 
-// 0x46c: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x508: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer a5 00 00 00 
 	Return 
-// 0x472: ProcessType[*uint]
+// 0x50e: ProcessType[*uint]
 	ProcessPointer 0b 00 00 00 
 	Return 
-// 0x478: ProcessType[*uint16]
+// 0x514: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x47e: ProcessType[*uint32]
+// 0x51a: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x484: ProcessType[*uint64]
+// 0x520: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x48a: ProcessType[*uint8]
+// 0x526: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x490: ProcessType[*uintptr]
+// 0x52c: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x496: ProcessType[[2]*runtime.traceBuf]
+// 0x532: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call 48 04 00 00 // ProcessType[*runtime.traceBuf]
+	Call e4 04 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x4a6: ProcessType[[2][2]*runtime.traceBuf]
+// 0x542: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call 96 04 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call 32 05 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x4b6: ProcessType[[3]string]
+// 0x552: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 5a 07 00 00 // ProcessType[string]
+	Call f6 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x4c6: ProcessType[[]*runtime.p]
+// 0x562: ProcessType[[]*runtime.p]
 	ProcessSlice 8d 00 00 00 08 00 00 00 
 	Return 
-// 0x4d0: ProcessType[[]*runtime.p.array]
+// 0x56c: ProcessType[[]*runtime.p.array]
 	ProcessSliceDataPrep 
-	Call 30 04 00 00 // ProcessType[*runtime.p]
+	Call cc 04 00 00 // ProcessType[*runtime.p]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x4dc: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x578: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 5a 04 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	Call f6 04 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x4e8: ProcessType[[]*table<string,int>.array]
+// 0x584: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 60 04 00 00 // ProcessType[*table<string,int>]
+	Call fc 04 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x4f4: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x590: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 66 04 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call 02 05 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x500: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x59c: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 6c 04 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 08 05 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x50c: ProcessType[[]int]
+// 0x5a8: ProcessType[[]int]
 	ProcessSlice 8f 00 00 00 08 00 00 00 
 	Return 
-// 0x516: ProcessType[[]noalg.map.group[string]int.array]
+// 0x5b2: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call 0e 06 00 00 // ProcessType[noalg.map.group[string]int]
+	Call aa 06 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x522: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x5be: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call 19 06 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call b5 06 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x52e: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+// 0x5ca: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call 24 06 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call c0 06 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x53a: ProcessType[[]string]
+// 0x5d6: ProcessType[[]string]
 	ProcessSlice 91 00 00 00 10 00 00 00 
 	Return 
-// 0x544: ProcessType[[]string.array]
+// 0x5e0: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call 5a 07 00 00 // ProcessType[string]
+	Call f6 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x550: ProcessType[[]uint8]
+// 0x5ec: ProcessType[[]uint8]
 	ProcessSlice 88 00 00 00 01 00 00 00 
 	Return 
-// 0x55a: ProcessType[[]uintptr]
+// 0x5f6: ProcessType[[]uintptr]
 	ProcessSlice 8a 00 00 00 08 00 00 00 
 	Return 
-// 0x564: ProcessType[error]
+// 0x600: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x566: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+// 0x602: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups ba 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x572: ProcessType[groupReference<string,int>]
+// 0x60e: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups 9a 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x57e: ProcessType[groupReference<string,main.bigStruct>]
+// 0x61a: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups a4 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x58a: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x626: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups b1 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x596: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+// 0x632: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap b9 00 00 00 b5 00 00 00 10 18 
 	Return 
-// 0x5a2: ProcessType[map<string,int>]
+// 0x63e: ProcessType[map<string,int>]
 	ProcessGoSwissMap 99 00 00 00 96 00 00 00 10 18 
 	Return 
-// 0x5ae: ProcessType[map<string,main.bigStruct>]
+// 0x64a: ProcessType[map<string,main.bigStruct>]
 	ProcessGoSwissMap a3 00 00 00 9e 00 00 00 10 18 
 	Return 
-// 0x5ba: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x656: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap b0 00 00 00 a8 00 00 00 10 18 
 	Return 
-// 0x5c6: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x662: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer ad 00 00 00 
 	Return 
-// 0x5cc: ProcessType[map[string]int]
+// 0x668: ProcessType[map[string]int]
 	ProcessPointer 76 00 00 00 
 	Return 
-// 0x5d2: ProcessType[map[string]main.bigStruct]
+// 0x66e: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 7b 00 00 00 
 	Return 
-// 0x5d8: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x674: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 80 00 00 00 
 	Return 
-// 0x5de: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x67a: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 2f 06 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call cb 06 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x5ee: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x68a: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 3f 06 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call db 06 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x5fe: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x69a: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call 45 06 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call e1 06 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x60e: ProcessType[noalg.map.group[string]int]
+// 0x6aa: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call ee 05 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call 8a 06 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x619: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x6b5: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call de 05 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call 7a 06 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x624: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x6c0: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call fe 05 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 9a 06 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x62f: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call 5a 07 00 00 // ProcessType[string]
+// 0x6cb: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call f6 07 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 06 04 00 00 // ProcessType[*main.bigStruct]
+	Call a2 04 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x63f: ProcessType[noalg.struct { key string; elem int }]
-	Call 5a 07 00 00 // ProcessType[string]
+// 0x6db: ProcessType[noalg.struct { key string; elem int }]
+	Call f6 07 00 00 // ProcessType[string]
 	Return 
-// 0x645: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x6e1: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call c6 05 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 62 06 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x650: ProcessType[runtime.g]
+// 0x6ec: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 12 04 00 00 // ProcessType[*runtime._panic]
+	Call ae 04 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 0c 04 00 00 // ProcessType[*runtime._defer]
+	Call a8 04 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call 2a 04 00 00 // ProcessType[*runtime.m]
+	Call c6 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call 50 05 00 00 // ProcessType[[]uint8]
+	Call ec 05 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call d0 03 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 6c 04 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call 36 04 00 00 // ProcessType[*runtime.sudog]
+	Call d2 04 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 5a 05 00 00 // ProcessType[[]uintptr]
+	Call f6 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call 42 04 00 00 // ProcessType[*runtime.timer]
+	Call de 04 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call 1e 04 00 00 // ProcessType[*runtime.coro]
+	Call ba 04 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call 3c 04 00 00 // ProcessType[*runtime.synctestBubble]
+	Call d8 04 00 00 // ProcessType[*runtime.synctestBubble]
 	IncrementOutputOffset 08 00 00 00 
-	Call 54 07 00 00 // ProcessType[runtime.xRegPerG]
+	Call f0 07 00 00 // ProcessType[runtime.xRegPerG]
 	Return 
-// 0x6bf: ProcessType[runtime.m]
-	Call 24 04 00 00 // ProcessType[*runtime.g]
+// 0x75b: ProcessType[runtime.m]
+	Call c0 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 48 00 00 00 
-	Call 24 04 00 00 // ProcessType[*runtime.g]
+	Call c0 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call 24 04 00 00 // ProcessType[*runtime.g]
+	Call c0 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 40 00 00 00 
-	Call 5a 07 00 00 // ProcessType[string]
+	Call f6 07 00 00 // ProcessType[string]
 	IncrementOutputOffset 30 00 00 00 
-	Call c6 04 00 00 // ProcessType[[]*runtime.p]
+	Call 62 05 00 00 // ProcessType[[]*runtime.p]
 	IncrementOutputOffset 28 00 00 00 
-	Call 18 04 00 00 // ProcessType[*runtime.cgoCallers]
+	Call b4 04 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call 2a 04 00 00 // ProcessType[*runtime.m]
+	Call c6 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 48 01 00 00 
-	Call 33 07 00 00 // ProcessType[runtime.mLockProfile]
+	Call cf 07 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 30 00 00 00 
-	Call 5a 05 00 00 // ProcessType[[]uintptr]
+	Call f6 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call 2a 04 00 00 // ProcessType[*runtime.m]
+	Call c6 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call 3e 07 00 00 // ProcessType[runtime.mTraceState]
+	Call da 07 00 00 // ProcessType[runtime.mTraceState]
 	IncrementOutputOffset d0 03 00 00 
-	Call 4e 07 00 00 // ProcessType[runtime.mWeakPointer]
+	Call ea 07 00 00 // ProcessType[runtime.mWeakPointer]
 	Return 
-// 0x733: ProcessType[runtime.mLockProfile]
+// 0x7cf: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 5a 05 00 00 // ProcessType[[]uintptr]
+	Call f6 05 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x73e: ProcessType[runtime.mTraceState]
+// 0x7da: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call a6 04 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call 2a 04 00 00 // ProcessType[*runtime.m]
+	Call 42 05 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call c6 04 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x74e: ProcessType[runtime.mWeakPointer]
-	Call 00 04 00 00 // ProcessType[*internal/runtime/atomic.Pointer[runtime.m]]
+// 0x7ea: ProcessType[runtime.mWeakPointer]
+	Call 9c 04 00 00 // ProcessType[*internal/runtime/atomic.Pointer[runtime.m]]
 	Return 
-// 0x754: ProcessType[runtime.xRegPerG]
-	Call 4e 04 00 00 // ProcessType[*runtime.xRegState]
+// 0x7f0: ProcessType[runtime.xRegPerG]
+	Call ea 04 00 00 // ProcessType[*runtime.xRegState]
 	Return 
-// 0x75a: ProcessType[string]
+// 0x7f6: ProcessType[string]
 	ProcessString 86 00 00 00 
 	Return 
-// 0x760: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x7fc: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 66 05 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call 02 06 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x76b: ProcessType[table<string,int>]
+// 0x807: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 72 05 00 00 // ProcessType[groupReference<string,int>]
+	Call 0e 06 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x776: ProcessType[table<string,main.bigStruct>]
+// 0x812: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 7e 05 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call 1a 06 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x781: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x81d: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 8a 05 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 26 06 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -595,32 +607,32 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 1162
+ID: 5 Len: 8 Enqueue: 1318
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 1882
-ID: 10 Len: 8 Enqueue: 982
+ID: 9 Len: 16 Enqueue: 2038
+ID: 10 Len: 8 Enqueue: 1138
 ID: 11 Len: 8 Enqueue: 0
 ID: 12 Len: 4 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
 ID: 14 Len: 8 Enqueue: 0
-ID: 15 Len: 16 Enqueue: 1380
+ID: 15 Len: 16 Enqueue: 1536
 ID: 16 Len: 8 Enqueue: 0
 ID: 17 Len: 4 Enqueue: 0
 ID: 18 Len: 16 Enqueue: 0
 ID: 19 Len: 1 Enqueue: 0
-ID: 20 Len: 8 Enqueue: 1168
-ID: 21 Len: 8 Enqueue: 1012
-ID: 22 Len: 8 Enqueue: 1150
-ID: 23 Len: 456 Enqueue: 1616
+ID: 20 Len: 8 Enqueue: 1324
+ID: 21 Len: 8 Enqueue: 1168
+ID: 22 Len: 8 Enqueue: 1306
+ID: 23 Len: 456 Enqueue: 1772
 ID: 24 Len: 16 Enqueue: 0
-ID: 25 Len: 8 Enqueue: 1042
+ID: 25 Len: 8 Enqueue: 1198
 ID: 26 Len: 8 Enqueue: 0
-ID: 27 Len: 8 Enqueue: 1036
+ID: 27 Len: 8 Enqueue: 1192
 ID: 28 Len: 8 Enqueue: 0
-ID: 29 Len: 8 Enqueue: 1066
-ID: 30 Len: 1824 Enqueue: 1727
+ID: 29 Len: 8 Enqueue: 1222
+ID: 30 Len: 1824 Enqueue: 1883
 ID: 31 Len: 48 Enqueue: 0
 ID: 32 Len: 8 Enqueue: 0
 ID: 33 Len: 4 Enqueue: 0
@@ -629,51 +641,51 @@ ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 1 Enqueue: 0
 ID: 38 Len: 8 Enqueue: 0
-ID: 39 Len: 24 Enqueue: 1360
-ID: 40 Len: 8 Enqueue: 976
+ID: 39 Len: 24 Enqueue: 1516
+ID: 40 Len: 8 Enqueue: 1132
 ID: 41 Len: 8 Enqueue: 0
-ID: 42 Len: 8 Enqueue: 1078
+ID: 42 Len: 8 Enqueue: 1234
 ID: 43 Len: 8 Enqueue: 0
-ID: 44 Len: 24 Enqueue: 1370
-ID: 45 Len: 8 Enqueue: 1090
+ID: 44 Len: 24 Enqueue: 1526
+ID: 45 Len: 8 Enqueue: 1246
 ID: 46 Len: 8 Enqueue: 0
 ID: 47 Len: 4 Enqueue: 0
-ID: 48 Len: 8 Enqueue: 1054
+ID: 48 Len: 8 Enqueue: 1210
 ID: 49 Len: 8 Enqueue: 0
-ID: 50 Len: 8 Enqueue: 1084
+ID: 50 Len: 8 Enqueue: 1240
 ID: 51 Len: 8 Enqueue: 0
-ID: 52 Len: 8 Enqueue: 1876
-ID: 53 Len: 8 Enqueue: 1102
+ID: 52 Len: 8 Enqueue: 2032
+ID: 53 Len: 8 Enqueue: 1258
 ID: 54 Len: 8 Enqueue: 0
 ID: 55 Len: 32 Enqueue: 0
 ID: 56 Len: 32 Enqueue: 0
 ID: 57 Len: 12 Enqueue: 0
 ID: 58 Len: 16 Enqueue: 0
-ID: 59 Len: 8 Enqueue: 1060
+ID: 59 Len: 8 Enqueue: 1216
 ID: 60 Len: 40 Enqueue: 0
 ID: 61 Len: 8 Enqueue: 0
 ID: 62 Len: 48 Enqueue: 0
 ID: 63 Len: 8 Enqueue: 0
 ID: 64 Len: 8 Enqueue: 0
 ID: 65 Len: 4 Enqueue: 0
-ID: 66 Len: 24 Enqueue: 1222
+ID: 66 Len: 24 Enqueue: 1378
 ID: 67 Len: 8 Enqueue: 0
-ID: 68 Len: 8 Enqueue: 1072
-ID: 69 Len: 8 Enqueue: 1048
+ID: 68 Len: 8 Enqueue: 1228
+ID: 69 Len: 8 Enqueue: 1204
 ID: 70 Len: 8 Enqueue: 0
 ID: 71 Len: 8 Enqueue: 0
 ID: 72 Len: 16 Enqueue: 0
 ID: 73 Len: 256 Enqueue: 0
 ID: 74 Len: 16 Enqueue: 0
-ID: 75 Len: 56 Enqueue: 1843
+ID: 75 Len: 56 Enqueue: 1999
 ID: 76 Len: 8 Enqueue: 0
 ID: 77 Len: 0 Enqueue: 0
 ID: 78 Len: 8 Enqueue: 0
 ID: 79 Len: 1 Enqueue: 0
-ID: 80 Len: 72 Enqueue: 1854
-ID: 81 Len: 32 Enqueue: 1190
-ID: 82 Len: 16 Enqueue: 1174
-ID: 83 Len: 8 Enqueue: 1096
+ID: 80 Len: 72 Enqueue: 2010
+ID: 81 Len: 32 Enqueue: 1346
+ID: 82 Len: 16 Enqueue: 1330
+ID: 83 Len: 8 Enqueue: 1252
 ID: 84 Len: 8 Enqueue: 0
 ID: 85 Len: 0 Enqueue: 0
 ID: 86 Len: 392 Enqueue: 0
@@ -688,42 +700,42 @@ ID: 94 Len: 32 Enqueue: 0
 ID: 95 Len: 160 Enqueue: 0
 ID: 96 Len: 16 Enqueue: 0
 ID: 97 Len: 8 Enqueue: 0
-ID: 98 Len: 8 Enqueue: 1870
-ID: 99 Len: 8 Enqueue: 1024
+ID: 98 Len: 8 Enqueue: 2026
+ID: 99 Len: 8 Enqueue: 1180
 ID: 100 Len: 8 Enqueue: 0
-ID: 101 Len: 8 Enqueue: 1108
+ID: 101 Len: 8 Enqueue: 1264
 ID: 102 Len: 2 Enqueue: 0
 ID: 103 Len: 8 Enqueue: 0
-ID: 104 Len: 8 Enqueue: 1000
-ID: 105 Len: 8 Enqueue: 1006
-ID: 106 Len: 8 Enqueue: 1156
-ID: 107 Len: 8 Enqueue: 1018
-ID: 108 Len: 8 Enqueue: 988
-ID: 109 Len: 8 Enqueue: 994
-ID: 110 Len: 8 Enqueue: 1138
-ID: 111 Len: 8 Enqueue: 1144
-ID: 112 Len: 24 Enqueue: 1292
+ID: 104 Len: 8 Enqueue: 1156
+ID: 105 Len: 8 Enqueue: 1162
+ID: 106 Len: 8 Enqueue: 1312
+ID: 107 Len: 8 Enqueue: 1174
+ID: 108 Len: 8 Enqueue: 1144
+ID: 109 Len: 8 Enqueue: 1150
+ID: 110 Len: 8 Enqueue: 1294
+ID: 111 Len: 8 Enqueue: 1300
+ID: 112 Len: 24 Enqueue: 1448
 ID: 113 Len: 24 Enqueue: 0
-ID: 114 Len: 24 Enqueue: 1338
-ID: 115 Len: 48 Enqueue: 1206
-ID: 116 Len: 8 Enqueue: 1484
+ID: 114 Len: 24 Enqueue: 1494
+ID: 115 Len: 48 Enqueue: 1362
+ID: 116 Len: 8 Enqueue: 1640
 ID: 117 Len: 8 Enqueue: 0
-ID: 118 Len: 48 Enqueue: 1442
+ID: 118 Len: 48 Enqueue: 1598
 ID: 119 Len: 8 Enqueue: 0
-ID: 120 Len: 8 Enqueue: 1120
-ID: 121 Len: 8 Enqueue: 1490
+ID: 120 Len: 8 Enqueue: 1276
+ID: 121 Len: 8 Enqueue: 1646
 ID: 122 Len: 8 Enqueue: 0
-ID: 123 Len: 48 Enqueue: 1454
+ID: 123 Len: 48 Enqueue: 1610
 ID: 124 Len: 8 Enqueue: 0
-ID: 125 Len: 8 Enqueue: 1126
-ID: 126 Len: 8 Enqueue: 1496
+ID: 125 Len: 8 Enqueue: 1282
+ID: 126 Len: 8 Enqueue: 1652
 ID: 127 Len: 8 Enqueue: 0
-ID: 128 Len: 48 Enqueue: 1466
+ID: 128 Len: 48 Enqueue: 1622
 ID: 129 Len: 8 Enqueue: 0
-ID: 130 Len: 8 Enqueue: 1132
-ID: 131 Len: 8 Enqueue: 952
-ID: 132 Len: 8 Enqueue: 958
-ID: 133 Len: 8 Enqueue: 970
+ID: 130 Len: 8 Enqueue: 1288
+ID: 131 Len: 8 Enqueue: 1108
+ID: 132 Len: 8 Enqueue: 1114
+ID: 133 Len: 8 Enqueue: 1126
 ID: 134 Len: 1 Enqueue: 0
 ID: 135 Len: 8 Enqueue: 0
 ID: 136 Len: 1 Enqueue: 0
@@ -731,53 +743,53 @@ ID: 137 Len: 8 Enqueue: 0
 ID: 138 Len: 8 Enqueue: 0
 ID: 139 Len: 8 Enqueue: 0
 ID: 140 Len: 8 Enqueue: 0
-ID: 141 Len: 8 Enqueue: 1232
+ID: 141 Len: 8 Enqueue: 1388
 ID: 142 Len: 8 Enqueue: 0
 ID: 143 Len: 8 Enqueue: 0
 ID: 144 Len: 8 Enqueue: 0
-ID: 145 Len: 16 Enqueue: 1348
+ID: 145 Len: 16 Enqueue: 1504
 ID: 146 Len: 8 Enqueue: 0
-ID: 147 Len: 32 Enqueue: 1899
-ID: 148 Len: 16 Enqueue: 1394
+ID: 147 Len: 32 Enqueue: 2055
+ID: 148 Len: 16 Enqueue: 1550
 ID: 149 Len: 8 Enqueue: 0
-ID: 150 Len: 200 Enqueue: 1550
-ID: 151 Len: 192 Enqueue: 1518
-ID: 152 Len: 24 Enqueue: 1599
-ID: 153 Len: 8 Enqueue: 1256
-ID: 154 Len: 200 Enqueue: 1302
-ID: 155 Len: 32 Enqueue: 1910
-ID: 156 Len: 16 Enqueue: 1406
+ID: 150 Len: 200 Enqueue: 1706
+ID: 151 Len: 192 Enqueue: 1674
+ID: 152 Len: 24 Enqueue: 1755
+ID: 153 Len: 8 Enqueue: 1412
+ID: 154 Len: 200 Enqueue: 1458
+ID: 155 Len: 32 Enqueue: 2066
+ID: 156 Len: 16 Enqueue: 1562
 ID: 157 Len: 8 Enqueue: 0
-ID: 158 Len: 200 Enqueue: 1561
-ID: 159 Len: 192 Enqueue: 1502
-ID: 160 Len: 24 Enqueue: 1583
-ID: 161 Len: 8 Enqueue: 1030
+ID: 158 Len: 200 Enqueue: 1717
+ID: 159 Len: 192 Enqueue: 1658
+ID: 160 Len: 24 Enqueue: 1739
+ID: 161 Len: 8 Enqueue: 1186
 ID: 162 Len: 184 Enqueue: 0
-ID: 163 Len: 8 Enqueue: 1268
-ID: 164 Len: 200 Enqueue: 1314
-ID: 165 Len: 32 Enqueue: 1921
-ID: 166 Len: 16 Enqueue: 1418
+ID: 163 Len: 8 Enqueue: 1424
+ID: 164 Len: 200 Enqueue: 1470
+ID: 165 Len: 32 Enqueue: 2077
+ID: 166 Len: 16 Enqueue: 1574
 ID: 167 Len: 8 Enqueue: 0
-ID: 168 Len: 136 Enqueue: 1572
-ID: 169 Len: 128 Enqueue: 1534
-ID: 170 Len: 16 Enqueue: 1605
-ID: 171 Len: 8 Enqueue: 1478
+ID: 168 Len: 136 Enqueue: 1728
+ID: 169 Len: 128 Enqueue: 1690
+ID: 170 Len: 16 Enqueue: 1761
+ID: 171 Len: 8 Enqueue: 1634
 ID: 172 Len: 8 Enqueue: 0
-ID: 173 Len: 48 Enqueue: 1430
+ID: 173 Len: 48 Enqueue: 1586
 ID: 174 Len: 8 Enqueue: 0
-ID: 175 Len: 8 Enqueue: 1114
-ID: 176 Len: 8 Enqueue: 1280
-ID: 177 Len: 136 Enqueue: 1326
-ID: 178 Len: 32 Enqueue: 1888
-ID: 179 Len: 16 Enqueue: 1382
+ID: 175 Len: 8 Enqueue: 1270
+ID: 176 Len: 8 Enqueue: 1436
+ID: 177 Len: 136 Enqueue: 1482
+ID: 178 Len: 32 Enqueue: 2044
+ID: 179 Len: 16 Enqueue: 1538
 ID: 180 Len: 8 Enqueue: 0
 ID: 181 Len: 136 Enqueue: 0
 ID: 182 Len: 128 Enqueue: 0
 ID: 183 Len: 16 Enqueue: 0
 ID: 184 Len: 8 Enqueue: 0
-ID: 185 Len: 8 Enqueue: 1244
+ID: 185 Len: 8 Enqueue: 1400
 ID: 186 Len: 136 Enqueue: 0
-ID: 187 Len: 8 Enqueue: 964
+ID: 187 Len: 8 Enqueue: 1120
 ID: 188 Len: 128 Enqueue: 0
 ID: 189 Len: 9 Enqueue: 0
 ID: 190 Len: 0 Enqueue: 0

--- a/pkg/dyninst/irgen/resolve_expression_test.go
+++ b/pkg/dyninst/irgen/resolve_expression_test.go
@@ -1,0 +1,318 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package irgen
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/dyninst/exprlang"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/ir"
+)
+
+// TestResolveExpressionMultipleFieldsOnSameStruct tests that resolving
+// multiple field accesses on the same struct variable produces distinct
+// LocationOp offsets for each field.
+//
+// This is a regression test for a bug where template segments like
+// {re.kind} and {re.message} would both resolve to the same field offset,
+// causing both to display the same value in the log message.
+func TestResolveExpressionMultipleFieldsOnSameStruct(t *testing.T) {
+	// Create a struct type with two string fields at different offsets.
+	// Simulating a struct like:
+	//   type richError struct {
+	//       kind    string  // at offset 0
+	//       message string  // at offset 16
+	//   }
+	// We use BaseType to represent string fields for simplicity in this test.
+	stringType := &ir.BaseType{
+		TypeCommon: ir.TypeCommon{
+			ID:       1,
+			Name:     "string",
+			ByteSize: 16,
+		},
+	}
+
+	structType := &ir.StructureType{
+		TypeCommon: ir.TypeCommon{
+			ID:       2,
+			Name:     "richError",
+			ByteSize: 32,
+		},
+		RawFields: []ir.Field{
+			{Name: "kind", Offset: 0, Type: stringType},
+			{Name: "message", Offset: 16, Type: stringType},
+		},
+	}
+
+	// Create a variable of type richError.
+	variable := &ir.Variable{
+		Name: "re",
+		Type: structType,
+	}
+
+	// Create a type catalog with our types.
+	tc := &typeCatalog{
+		typesByID: map[ir.TypeID]ir.Type{
+			stringType.ID: stringType,
+			structType.ID: structType,
+		},
+	}
+
+	// Test case 1: re.kind
+	kindExpr := &exprlang.GetMemberExpr{
+		Base:   &exprlang.RefExpr{Ref: "re"},
+		Member: "kind",
+	}
+
+	resolvedKind, err := resolveExpression(kindExpr, variable, tc)
+	require.NoError(t, err, "failed to resolve re.kind")
+	require.Len(t, resolvedKind.Operations, 1, "expected one operation for re.kind")
+
+	kindLocOp, ok := resolvedKind.Operations[0].(*ir.LocationOp)
+	require.True(t, ok, "expected LocationOp for re.kind")
+	require.Equal(t, uint32(0), kindLocOp.Offset, "re.kind should have offset 0")
+	require.Equal(t, uint32(16), kindLocOp.ByteSize, "re.kind should have byte size 16")
+
+	// Test case 2: re.message
+	messageExpr := &exprlang.GetMemberExpr{
+		Base:   &exprlang.RefExpr{Ref: "re"},
+		Member: "message",
+	}
+
+	resolvedMessage, err := resolveExpression(messageExpr, variable, tc)
+	require.NoError(t, err, "failed to resolve re.message")
+	require.Len(t, resolvedMessage.Operations, 1, "expected one operation for re.message")
+
+	messageLocOp, ok := resolvedMessage.Operations[0].(*ir.LocationOp)
+	require.True(t, ok, "expected LocationOp for re.message")
+	require.Equal(t, uint32(16), messageLocOp.Offset, "re.message should have offset 16")
+	require.Equal(t, uint32(16), messageLocOp.ByteSize, "re.message should have byte size 16")
+
+	// CRITICAL: Verify that the two LocationOps are different objects with different offsets.
+	// This is the main assertion - both should NOT have the same offset.
+	require.NotEqual(t, kindLocOp.Offset, messageLocOp.Offset,
+		"BUG: re.kind and re.message have the same offset! "+
+			"kindLocOp.Offset=%d, messageLocOp.Offset=%d",
+		kindLocOp.Offset, messageLocOp.Offset)
+
+	// Verify the types are correct.
+	require.Equal(t, stringType, resolvedKind.Type, "re.kind should have string type")
+	require.Equal(t, stringType, resolvedMessage.Type, "re.message should have string type")
+}
+
+// TestAnalyzeTemplateSegmentsMultipleFieldAccess tests that when a template
+// has multiple segments accessing different fields of the same struct variable,
+// each segment gets a unique EventExpressionIndex.
+func TestAnalyzeTemplateSegmentsMultipleFieldAccess(t *testing.T) {
+	// Create types
+	stringType := &ir.BaseType{
+		TypeCommon: ir.TypeCommon{
+			ID:       1,
+			Name:     "string",
+			ByteSize: 16,
+		},
+	}
+
+	structType := &ir.StructureType{
+		TypeCommon: ir.TypeCommon{
+			ID:       2,
+			Name:     "richError",
+			ByteSize: 32,
+		},
+		RawFields: []ir.Field{
+			{Name: "kind", Offset: 0, Type: stringType},
+			{Name: "message", Offset: 16, Type: stringType},
+		},
+	}
+
+	// Create expressions for re.kind and re.message
+	kindExpr := &exprlang.GetMemberExpr{
+		Base:   &exprlang.RefExpr{Ref: "re"},
+		Member: "kind",
+	}
+	messageExpr := &exprlang.GetMemberExpr{
+		Base:   &exprlang.RefExpr{Ref: "re"},
+		Member: "message",
+	}
+
+	// Create template segments
+	kindSegment := &ir.JSONSegment{
+		JSON: kindExpr,
+		DSL:  "re.kind",
+	}
+	messageSegment := &ir.JSONSegment{
+		JSON: messageExpr,
+		DSL:  "re.message",
+	}
+
+	// Create a template with both segments
+	template := &ir.Template{
+		TemplateString: "kind={re.kind} message={re.message}",
+		Segments: []ir.TemplateSegment{
+			ir.StringSegment("kind="),
+			kindSegment,
+			ir.StringSegment(" message="),
+			messageSegment,
+		},
+	}
+
+	// Create variable
+	variable := &ir.Variable{
+		Name: "re",
+		Type: structType,
+	}
+
+	// Create type catalog
+	tc := &typeCatalog{
+		typesByID: map[ir.TypeID]ir.Type{
+			stringType.ID: stringType,
+			structType.ID: structType,
+		},
+	}
+
+	// Create analyzed expressions (simulating what analyzeAllProbes does)
+	expressions := []analyzedExpression{
+		{
+			expr:         kindExpr,
+			dsl:          "re.kind",
+			rootVariable: variable,
+			eventKind:    ir.EventKindLine,
+			exprKind:     ir.RootExpressionKindTemplateSegment,
+			segment:      kindSegment,
+			segmentIdx:   1,
+		},
+		{
+			expr:         messageExpr,
+			dsl:          "re.message",
+			rootVariable: variable,
+			eventKind:    ir.EventKindLine,
+			exprKind:     ir.RootExpressionKindTemplateSegment,
+			segment:      messageSegment,
+			segmentIdx:   3,
+		},
+	}
+
+	// Simulate what populateEventExpressions does
+	var rootExpressions []*ir.RootExpression
+	for _, expr := range expressions {
+		resolvedExpr, err := resolveExpression(expr.expr, expr.rootVariable, tc)
+		require.NoError(t, err)
+
+		// Update segment with expression index
+		if seg := expr.segment; seg != nil {
+			seg.EventKind = expr.eventKind
+			seg.EventExpressionIndex = len(rootExpressions)
+		}
+
+		rootExpressions = append(rootExpressions, &ir.RootExpression{
+			Name:       expr.dsl,
+			Kind:       expr.exprKind,
+			Expression: resolvedExpr,
+		})
+	}
+
+	// Verify that each segment has a unique EventExpressionIndex
+	require.Equal(t, 0, kindSegment.EventExpressionIndex,
+		"kindSegment should have EventExpressionIndex 0")
+	require.Equal(t, 1, messageSegment.EventExpressionIndex,
+		"messageSegment should have EventExpressionIndex 1")
+
+	// Verify that the EventExpressionIndex values are different
+	require.NotEqual(t, kindSegment.EventExpressionIndex, messageSegment.EventExpressionIndex,
+		"BUG: kindSegment and messageSegment have the same EventExpressionIndex!")
+
+	// Verify that the resolved expressions have different LocationOp offsets
+	kindLocOp := rootExpressions[0].Expression.Operations[0].(*ir.LocationOp)
+	messageLocOp := rootExpressions[1].Expression.Operations[0].(*ir.LocationOp)
+
+	require.Equal(t, uint32(0), kindLocOp.Offset)
+	require.Equal(t, uint32(16), messageLocOp.Offset)
+	require.NotEqual(t, kindLocOp.Offset, messageLocOp.Offset,
+		"BUG: kind and message expressions have the same LocationOp offset!")
+
+	// Verify the segments in the template still point to the correct objects
+	seg1, ok := template.Segments[1].(*ir.JSONSegment)
+	require.True(t, ok)
+	require.Same(t, kindSegment, seg1, "template segment 1 should be kindSegment")
+
+	seg3, ok := template.Segments[3].(*ir.JSONSegment)
+	require.True(t, ok)
+	require.Same(t, messageSegment, seg3, "template segment 3 should be messageSegment")
+}
+
+// TestResolveExpressionIndependentLocations verifies that each call to
+// resolveExpression creates independent LocationOp objects that don't
+// share state.
+func TestResolveExpressionIndependentLocations(t *testing.T) {
+	stringType := &ir.BaseType{
+		TypeCommon: ir.TypeCommon{
+			ID:       1,
+			Name:     "string",
+			ByteSize: 16,
+		},
+	}
+
+	structType := &ir.StructureType{
+		TypeCommon: ir.TypeCommon{
+			ID:       2,
+			Name:     "testStruct",
+			ByteSize: 48,
+		},
+		RawFields: []ir.Field{
+			{Name: "field1", Offset: 0, Type: stringType},
+			{Name: "field2", Offset: 16, Type: stringType},
+			{Name: "field3", Offset: 32, Type: stringType},
+		},
+	}
+
+	variable := &ir.Variable{
+		Name: "s",
+		Type: structType,
+	}
+
+	tc := &typeCatalog{
+		typesByID: map[ir.TypeID]ir.Type{
+			stringType.ID: stringType,
+			structType.ID: structType,
+		},
+	}
+
+	// Resolve all three fields.
+	fields := []string{"field1", "field2", "field3"}
+	expectedOffsets := []uint32{0, 16, 32}
+	var resolvedLocOps []*ir.LocationOp
+
+	for i, fieldName := range fields {
+		expr := &exprlang.GetMemberExpr{
+			Base:   &exprlang.RefExpr{Ref: "s"},
+			Member: fieldName,
+		}
+
+		resolved, err := resolveExpression(expr, variable, tc)
+		require.NoError(t, err, "failed to resolve s.%s", fieldName)
+		require.Len(t, resolved.Operations, 1)
+
+		locOp, ok := resolved.Operations[0].(*ir.LocationOp)
+		require.True(t, ok)
+		require.Equal(t, expectedOffsets[i], locOp.Offset,
+			"s.%s should have offset %d, got %d", fieldName, expectedOffsets[i], locOp.Offset)
+
+		resolvedLocOps = append(resolvedLocOps, locOp)
+	}
+
+	// Verify all LocationOps are distinct objects (not sharing pointers).
+	for i := 0; i < len(resolvedLocOps); i++ {
+		for j := i + 1; j < len(resolvedLocOps); j++ {
+			require.NotSame(t, resolvedLocOps[i], resolvedLocOps[j],
+				"LocationOps for field%d and field%d should not be the same object",
+				i+1, j+1)
+		}
+	}
+}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -11,11 +11,11 @@ Probes:
       subprogram: {subprogram: 142}
       events:
         - Kind: Entry
-          Type: 1332 EventRootType Probe[main.stackC]
+          Type: 1349 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0xd0a52a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1333 EventRootType Probe[main.stackC]Return
+          Type: 1350 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0xd0a565", Frameless: false}]
           Condition: null
       probeTemplate: {TemplateString: stackC, Segments: [stackC]}
@@ -30,11 +30,11 @@ Probes:
       subprogram: {subprogram: 56}
       events:
         - Kind: Entry
-          Type: 1196 EventRootType Probe[main.testAny]
+          Type: 1213 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0xd04dea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1197 EventRootType Probe[main.testAny]Return
+          Type: 1214 EventRootType Probe[main.testAny]Return
           InjectionPoints: [{PC: "0xd04e25", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -55,11 +55,11 @@ Probes:
       subprogram: {subprogram: 58}
       events:
         - Kind: Entry
-          Type: 1199 EventRootType Probe[main.testAnyPtr]
+          Type: 1216 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0xd04e8a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1200 EventRootType Probe[main.testAnyPtr]Return
+          Type: 1217 EventRootType Probe[main.testAnyPtr]Return
           InjectionPoints: [{PC: "0xd04ebd", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -79,11 +79,11 @@ Probes:
       subprogram: {subprogram: 122}
       events:
         - Kind: Entry
-          Type: 1303 EventRootType Probe[main.testArrayArgAndReturn]
+          Type: 1320 EventRootType Probe[main.testArrayArgAndReturn]
           InjectionPoints: [{PC: "0xd08f6e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1304 EventRootType Probe[main.testArrayArgAndReturn]Return
+          Type: 1321 EventRootType Probe[main.testArrayArgAndReturn]Return
           InjectionPoints: [{PC: "0xd09022", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -104,7 +104,7 @@ Probes:
       subprogram: {subprogram: 19}
       events:
         - Kind: Entry
-          Type: 1147 EventRootType Probe[main.testArrayEmptyStructs]
+          Type: 1164 EventRootType Probe[main.testArrayEmptyStructs]
           InjectionPoints: [{PC: "0xd03040", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -125,7 +125,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - Kind: Entry
-          Type: 1143 EventRootType Probe[main.testArrayOfArrays]
+          Type: 1160 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0xd02fc0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -146,7 +146,7 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - Kind: Entry
-          Type: 1145 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          Type: 1162 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0xd03000", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -167,7 +167,7 @@ Probes:
       subprogram: {subprogram: 66}
       events:
         - Kind: Entry
-          Type: 1208 EventRootType Probe[main.testArrayOfMaps]
+          Type: 1225 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0xd05600", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -188,7 +188,7 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - Kind: Entry
-          Type: 1144 EventRootType Probe[main.testArrayOfStrings]
+          Type: 1161 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0xd02fe0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -208,7 +208,7 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - Kind: Entry
-          Type: 1146 EventRootType Probe[main.testArrayOfStructs]
+          Type: 1163 EventRootType Probe[main.testArrayOfStructs]
           InjectionPoints: [{PC: "0xd03020", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -229,11 +229,11 @@ Probes:
       subprogram: {subprogram: 86}
       events:
         - Kind: Entry
-          Type: 1230 EventRootType Probe[main.testAtomicAdd]
+          Type: 1247 EventRootType Probe[main.testAtomicAdd]
           InjectionPoints: [{PC: "0xd07320", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1231 EventRootType Probe[main.testAtomicAdd]Return
+          Type: 1248 EventRootType Probe[main.testAtomicAdd]Return
           InjectionPoints: [{PC: "0xd07332", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -254,11 +254,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 1165 EventRootType Probe[main.testBigStruct]
+          Type: 1182 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0xd03740", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1166 EventRootType Probe[main.testBigStruct]Return
+          Type: 1183 EventRootType Probe[main.testBigStruct]Return
           InjectionPoints: [{PC: "0xd0375e", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -279,7 +279,7 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - Kind: Entry
-          Type: 1132 EventRootType Probe[main.testBoolArray]
+          Type: 1149 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0xd02e60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -300,7 +300,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - Kind: Entry
-          Type: 1129 EventRootType Probe[main.testByteArray]
+          Type: 1146 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0xd02e00", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -326,11 +326,11 @@ Probes:
       subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1351 EventRootType Probe[main.testStruct]
+          Type: 1368 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0xd0a960", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1352 EventRootType Probe[main.testStruct]Return
+          Type: 1369 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0xd0a982", Frameless: true}]
           Condition: null
     - id: testCaptureExprLine
@@ -345,10 +345,10 @@ Probes:
       segments: []
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1361 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1379 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0xd0460e"
               Frameless: false
@@ -373,10 +373,10 @@ Probes:
       segments: [x=, {json: {ref: x}, dsl: x}]
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1362 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1380 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0xd0460e"
               Frameless: false
@@ -412,7 +412,7 @@ Probes:
       subprogram: {subprogram: 84}
       events:
         - Kind: Entry
-          Type: 1227 EventRootType Probe[main.testCombinedString]
+          Type: 1244 EventRootType Probe[main.testCombinedString]
           InjectionPoints: [{PC: "0xd06f80", Frameless: true}]
           Condition: null
     - id: testCaptureExprWithTemplate
@@ -430,7 +430,7 @@ Probes:
       subprogram: {subprogram: 84}
       events:
         - Kind: Entry
-          Type: 1228 EventRootType Probe[main.testCombinedString]
+          Type: 1245 EventRootType Probe[main.testCombinedString]
           InjectionPoints: [{PC: "0xd06f80", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -452,7 +452,7 @@ Probes:
       subprogram: {subprogram: 87}
       events:
         - Kind: Entry
-          Type: 1232 EventRootType Probe[main.testChannel]
+          Type: 1249 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0xd07340", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -481,7 +481,7 @@ Probes:
       subprogram: {subprogram: 83}
       events:
         - Kind: Entry
-          Type: 1226 EventRootType Probe[main.testCombinedByte]
+          Type: 1243 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0xd06f40", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -512,7 +512,7 @@ Probes:
       subprogram: {subprogram: 95}
       events:
         - Kind: Entry
-          Type: 1240 EventRootType Probe[main.testCycle]
+          Type: 1257 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0xd07720", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -533,7 +533,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - Kind: Entry
-          Type: 1171 EventRootType Probe[main.testDeepMap1]
+          Type: 1188 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0xd03b20", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -554,7 +554,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - Kind: Entry
-          Type: 1172 EventRootType Probe[main.testDeepMap7]
+          Type: 1189 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0xd03b40", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -575,7 +575,7 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - Kind: Entry
-          Type: 1167 EventRootType Probe[main.testDeepPtr1]
+          Type: 1184 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0xd03800", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -596,7 +596,7 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - Kind: Entry
-          Type: 1168 EventRootType Probe[main.testDeepPtr7]
+          Type: 1185 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0xd03820", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -617,7 +617,7 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - Kind: Entry
-          Type: 1169 EventRootType Probe[main.testDeepSlice1]
+          Type: 1186 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0xd039a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -638,7 +638,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - Kind: Entry
-          Type: 1170 EventRootType Probe[main.testDeepSlice7]
+          Type: 1187 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0xd039c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -659,7 +659,7 @@ Probes:
       subprogram: {subprogram: 131}
       events:
         - Kind: Entry
-          Type: 1320 EventRootType Probe[main.testEmptySlice]
+          Type: 1337 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0xd0a040", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -685,7 +685,7 @@ Probes:
       subprogram: {subprogram: 134}
       events:
         - Kind: Entry
-          Type: 1323 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 1340 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0xd0a0a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -712,7 +712,7 @@ Probes:
       subprogram: {subprogram: 150}
       events:
         - Kind: Entry
-          Type: 1346 EventRootType Probe[main.testEmptyString]
+          Type: 1363 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0xd0a660", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -733,7 +733,7 @@ Probes:
       subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1359 EventRootType Probe[main.testEmptyStruct]
+          Type: 1376 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0xd0aae0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -753,7 +753,7 @@ Probes:
       subprogram: {subprogram: 157}
       events:
         - Kind: Entry
-          Type: 1360 EventRootType Probe[main.testEmptyStructPointer]
+          Type: 1377 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0xd0ab00", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -774,7 +774,7 @@ Probes:
       subprogram: {subprogram: 57}
       events:
         - Kind: Entry
-          Type: 1198 EventRootType Probe[main.testError]
+          Type: 1215 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0xd04e60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -795,11 +795,11 @@ Probes:
       subprogram: {subprogram: 48}
       events:
         - Kind: Entry
-          Type: 1180 EventRootType Probe[main.testEsotericHeap]
+          Type: 1197 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0xd0436a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1181 EventRootType Probe[main.testEsotericHeap]Return
+          Type: 1198 EventRootType Probe[main.testEsotericHeap]Return
           InjectionPoints: [{PC: "0xd043ac", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -820,11 +820,11 @@ Probes:
       subprogram: {subprogram: 47}
       events:
         - Kind: Entry
-          Type: 1178 EventRootType Probe[main.testEsotericStack]
+          Type: 1195 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0xd0424e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1179 EventRootType Probe[main.testEsotericStack]Return
+          Type: 1196 EventRootType Probe[main.testEsotericStack]Return
           InjectionPoints: [{PC: "0xd042db", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -845,11 +845,11 @@ Probes:
       subprogram: {subprogram: 53}
       events:
         - Kind: Entry
-          Type: 1190 EventRootType Probe[main.testFrameless]
+          Type: 1207 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0xd04ac0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1191 EventRootType Probe[main.testFrameless]Return
+          Type: 1208 EventRootType Probe[main.testFrameless]Return
           InjectionPoints: [{PC: "0xd04ac5", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -870,11 +870,11 @@ Probes:
       subprogram: {subprogram: 54}
       events:
         - Kind: Entry
-          Type: 1192 EventRootType Probe[main.testFramelessArray]
+          Type: 1209 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0xd04ae4", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1193 EventRootType Probe[main.testFramelessArray]Return
+          Type: 1210 EventRootType Probe[main.testFramelessArray]Return
           InjectionPoints: [{PC: "0xd04b1d", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -898,7 +898,7 @@ Probes:
       subprogram: {subprogram: 54}
       events:
         - Kind: Line
-          Type: 1194 EventRootType Probe[main.testFramelessArray]Line
+          Type: 1211 EventRootType Probe[main.testFramelessArray]Line
           InjectionPoints: [{PC: "0xd04ae8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -919,11 +919,11 @@ Probes:
       subprogram: {subprogram: 49}
       events:
         - Kind: Entry
-          Type: 1182 EventRootType Probe[main.testInlinedBA]
+          Type: 1199 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0xd047aa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1183 EventRootType Probe[main.testInlinedBA]Return
+          Type: 1200 EventRootType Probe[main.testInlinedBA]Return
           InjectionPoints: [{PC: "0xd0480e", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -949,11 +949,11 @@ Probes:
       subprogram: {subprogram: 50}
       events:
         - Kind: Entry
-          Type: 1184 EventRootType Probe[main.testInlinedBB]
+          Type: 1201 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0xd0484e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1185 EventRootType Probe[main.testInlinedBB]Return
+          Type: 1202 EventRootType Probe[main.testInlinedBB]Return
           InjectionPoints: [{PC: "0xd048de", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -979,11 +979,11 @@ Probes:
       subprogram: {subprogram: 51}
       events:
         - Kind: Entry
-          Type: 1186 EventRootType Probe[main.testInlinedBBA]
+          Type: 1203 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0xd0492a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1187 EventRootType Probe[main.testInlinedBBA]Return
+          Type: 1204 EventRootType Probe[main.testInlinedBBA]Return
           InjectionPoints: [{PC: "0xd0496b", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1001,10 +1001,10 @@ Probes:
       template: testInlinedBBB
       segments: [testInlinedBBB]
       captureSnapshot: true
-      subprogram: {subprogram: 159}
+      subprogram: {subprogram: 160}
       events:
         - Kind: Entry
-          Type: 1366 EventRootType Probe[main.testInlinedBBB]
+          Type: 1384 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xd048a6", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1021,11 +1021,11 @@ Probes:
       subprogram: {subprogram: 52}
       events:
         - Kind: Entry
-          Type: 1188 EventRootType Probe[main.testInlinedBC]
+          Type: 1205 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0xd049ae", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1189 EventRootType Probe[main.testInlinedBC]Return
+          Type: 1206 EventRootType Probe[main.testInlinedBC]Return
           InjectionPoints: [{PC: "0xd04a9e", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1039,10 +1039,10 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Entry
-          Type: 1367 EventRootType Probe[main.testInlinedBCA]
+          Type: 1385 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xd049b3", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1059,10 +1059,10 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Line
-          Type: 1368 EventRootType Probe[main.testInlinedBCA]Line
+          Type: 1386 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0xd049b3", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1076,10 +1076,10 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Entry
-          Type: 1369 EventRootType Probe[main.testInlinedBCB]
+          Type: 1387 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xd04a66", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1096,10 +1096,10 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Line
-          Type: 1370 EventRootType Probe[main.testInlinedBCB]Line
+          Type: 1388 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0xd04a66", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1113,10 +1113,10 @@ Probes:
       template: testInlinedFuncFromOtherPackage
       segments: [testInlinedFuncFromOtherPackage]
       captureSnapshot: true
-      subprogram: {subprogram: 165}
+      subprogram: {subprogram: 166}
       events:
         - Kind: Entry
-          Type: 1376 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
+          Type: 1394 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
           InjectionPoints:
             - PC: "0xd02932"
               Frameless: true
@@ -1135,10 +1135,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Entry
-          Type: 1363 EventRootType Probe[main.testInlinedPrint]
+          Type: 1381 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0xd0460a"
               Frameless: false
@@ -1152,7 +1152,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1364 EventRootType Probe[main.testInlinedPrint]Return
+          Type: 1382 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0xd0464a", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1173,10 +1173,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1365 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1383 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0xd0460e"
               Frameless: false
@@ -1204,10 +1204,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 162}
+      subprogram: {subprogram: 163}
       events:
         - Kind: Entry
-          Type: 1371 EventRootType Probe[main.testInlinedSq]
+          Type: 1389 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xd04ac1", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1228,10 +1228,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 162}
+      subprogram: {subprogram: 163}
       events:
         - Kind: Line
-          Type: 1372 EventRootType Probe[main.testInlinedSq]Line
+          Type: 1390 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0xd04ac1", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1250,10 +1250,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 163}
+      subprogram: {subprogram: 164}
       events:
         - Kind: Entry
-          Type: 1373 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1391 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0xd04b05"
               Frameless: false
@@ -1278,7 +1278,7 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - Kind: Entry
-          Type: 1135 EventRootType Probe[main.testInt16Array]
+          Type: 1152 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0xd02ec0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1299,7 +1299,7 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - Kind: Entry
-          Type: 1136 EventRootType Probe[main.testInt32Array]
+          Type: 1153 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0xd02ee0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1320,7 +1320,7 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - Kind: Entry
-          Type: 1137 EventRootType Probe[main.testInt64Array]
+          Type: 1154 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0xd02f00", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1341,7 +1341,7 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - Kind: Entry
-          Type: 1134 EventRootType Probe[main.testInt8Array]
+          Type: 1151 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0xd02ea0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1362,7 +1362,7 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - Kind: Entry
-          Type: 1133 EventRootType Probe[main.testIntArray]
+          Type: 1150 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0xd02e80", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1383,7 +1383,7 @@ Probes:
       subprogram: {subprogram: 55}
       events:
         - Kind: Entry
-          Type: 1195 EventRootType Probe[main.testInterface]
+          Type: 1212 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0xd04dc0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1403,11 +1403,11 @@ Probes:
       subprogram: {subprogram: 121}
       events:
         - Kind: Entry
-          Type: 1301 EventRootType Probe[main.testLargeArgAndReturn]
+          Type: 1318 EventRootType Probe[main.testLargeArgAndReturn]
           InjectionPoints: [{PC: "0xd08dee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1302 EventRootType Probe[main.testLargeArgAndReturn]Return
+          Type: 1319 EventRootType Probe[main.testLargeArgAndReturn]Return
           InjectionPoints: [{PC: "0xd08f33", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1417,6 +1417,49 @@ Probes:
               DSL: arg
               EventKind: Entry
               EventExpressionIndex: 1
+    - id: testLineProbeTemplateWithStructFields
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.executeStructFuncs
+        sourceFile: structs.go
+        lines: ["208"]
+      template: 'sta.a: {sta.a} sta.b: {sta.b} sta.c: {sta.c}'
+      segments:
+        - 'sta.a: '
+        - json: {getmember: [{ref: sta}, a]}
+          dsl: sta.a
+        - ' sta.b: '
+        - json: {getmember: [{ref: sta}, b]}
+          dsl: sta.b
+        - ' sta.c: '
+        - json: {getmember: [{ref: sta}, c]}
+          dsl: sta.c
+      captureSnapshot: false
+      subprogram: {subprogram: 158}
+      events:
+        - Kind: Line
+          Type: 1378 EventRootType Probe[main.executeStructFuncs]Line
+          InjectionPoints: [{PC: "0xd0b1ef", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: 'sta.a: {sta.a} sta.b: {sta.b} sta.c: {sta.c}'
+        Segments:
+            - 'sta.a: '
+            - JSON: {Base: {Ref: sta}, Member: a}
+              DSL: sta.a
+              EventKind: Line
+              EventExpressionIndex: 0
+            - ' sta.b: '
+            - JSON: {Base: {Ref: sta}, Member: b}
+              DSL: sta.b
+              EventKind: Line
+              EventExpressionIndex: 1
+            - ' sta.c: '
+            - JSON: {Base: {Ref: sta}, Member: c}
+              DSL: sta.c
+              EventKind: Line
+              EventExpressionIndex: 2
     - id: testLinkedList
       version: 0
       type: LOG_PROBE
@@ -1428,7 +1471,7 @@ Probes:
       subprogram: {subprogram: 89}
       events:
         - Kind: Entry
-          Type: 1234 EventRootType Probe[main.testLinkedList]
+          Type: 1251 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0xd07540", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1452,7 +1495,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - Kind: Line
-          Type: 1175 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          Type: 1192 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xd03bba", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1473,7 +1516,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - Kind: Line
-          Type: 1176 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          Type: 1193 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xd03c6d", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1494,7 +1537,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - Kind: Line
-          Type: 1177 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          Type: 1194 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xd03d34", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1536,11 +1579,11 @@ Probes:
       subprogram: {subprogram: 124}
       events:
         - Kind: Entry
-          Type: 1307 EventRootType Probe[main.testManyArgsArrayReturn]
+          Type: 1324 EventRootType Probe[main.testManyArgsArrayReturn]
           InjectionPoints: [{PC: "0xd09293", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1308 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          Type: 1325 EventRootType Probe[main.testManyArgsArrayReturn]Return
           InjectionPoints: [{PC: "0xd094a2", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1601,7 +1644,7 @@ Probes:
       subprogram: {subprogram: 64}
       events:
         - Kind: Entry
-          Type: 1206 EventRootType Probe[main.testMapArrayToArray]
+          Type: 1223 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0xd055c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1622,7 +1665,7 @@ Probes:
       subprogram: {subprogram: 70}
       events:
         - Kind: Entry
-          Type: 1213 EventRootType Probe[main.testMapEmbeddedMaps]
+          Type: 1230 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0xd05680", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1643,7 +1686,7 @@ Probes:
       subprogram: {subprogram: 80}
       events:
         - Kind: Entry
-          Type: 1223 EventRootType Probe[main.testMapEmptyKey]
+          Type: 1240 EventRootType Probe[main.testMapEmptyKey]
           InjectionPoints: [{PC: "0xd057c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1664,7 +1707,7 @@ Probes:
       subprogram: {subprogram: 82}
       events:
         - Kind: Entry
-          Type: 1225 EventRootType Probe[main.testMapEmptyKeyAndValue]
+          Type: 1242 EventRootType Probe[main.testMapEmptyKeyAndValue]
           InjectionPoints: [{PC: "0xd05800", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1685,7 +1728,7 @@ Probes:
       subprogram: {subprogram: 81}
       events:
         - Kind: Entry
-          Type: 1224 EventRootType Probe[main.testMapEmptyValue]
+          Type: 1241 EventRootType Probe[main.testMapEmptyValue]
           InjectionPoints: [{PC: "0xd057e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1706,7 +1749,7 @@ Probes:
       subprogram: {subprogram: 68}
       events:
         - Kind: Entry
-          Type: 1210 EventRootType Probe[main.testMapIntToInt]
+          Type: 1227 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0xd05640", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1727,7 +1770,7 @@ Probes:
       subprogram: {subprogram: 79}
       events:
         - Kind: Entry
-          Type: 1222 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          Type: 1239 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0xd057a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1748,7 +1791,7 @@ Probes:
       subprogram: {subprogram: 78}
       events:
         - Kind: Entry
-          Type: 1221 EventRootType Probe[main.testMapLargeKeySmallValue]
+          Type: 1238 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0xd05780", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1771,7 +1814,7 @@ Probes:
       subprogram: {subprogram: 69}
       events:
         - Kind: Entry
-          Type: 1211 EventRootType Probe[main.testMapMassive]
+          Type: 1228 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0xd05660", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1794,7 +1837,7 @@ Probes:
       subprogram: {subprogram: 69}
       events:
         - Kind: Entry
-          Type: 1212 EventRootType Probe[main.testMapMassive]
+          Type: 1229 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0xd05660", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1815,7 +1858,7 @@ Probes:
       subprogram: {subprogram: 77}
       events:
         - Kind: Entry
-          Type: 1220 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          Type: 1237 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0xd05760", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1836,7 +1879,7 @@ Probes:
       subprogram: {subprogram: 76}
       events:
         - Kind: Entry
-          Type: 1219 EventRootType Probe[main.testMapSmallKeySmallValue]
+          Type: 1236 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0xd05740", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1857,7 +1900,7 @@ Probes:
       subprogram: {subprogram: 62}
       events:
         - Kind: Entry
-          Type: 1204 EventRootType Probe[main.testMapStringToInt]
+          Type: 1221 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0xd05580", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1878,7 +1921,7 @@ Probes:
       subprogram: {subprogram: 63}
       events:
         - Kind: Entry
-          Type: 1205 EventRootType Probe[main.testMapStringToSlice]
+          Type: 1222 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0xd055a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1899,7 +1942,7 @@ Probes:
       subprogram: {subprogram: 61}
       events:
         - Kind: Entry
-          Type: 1203 EventRootType Probe[main.testMapStringToStruct]
+          Type: 1220 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0xd05560", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1920,7 +1963,7 @@ Probes:
       subprogram: {subprogram: 71}
       events:
         - Kind: Entry
-          Type: 1214 EventRootType Probe[main.testMapWithLinkedList]
+          Type: 1231 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0xd056a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1941,7 +1984,7 @@ Probes:
       subprogram: {subprogram: 74}
       events:
         - Kind: Entry
-          Type: 1217 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          Type: 1234 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0xd05700", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1962,7 +2005,7 @@ Probes:
       subprogram: {subprogram: 75}
       events:
         - Kind: Entry
-          Type: 1218 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          Type: 1235 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0xd05720", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1983,7 +2026,7 @@ Probes:
       subprogram: {subprogram: 72}
       events:
         - Kind: Entry
-          Type: 1215 EventRootType Probe[main.testMapWithSmallValue]
+          Type: 1232 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0xd056c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2006,7 +2049,7 @@ Probes:
       subprogram: {subprogram: 73}
       events:
         - Kind: Entry
-          Type: 1216 EventRootType Probe[main.testMapWithSmallValueMassive]
+          Type: 1233 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0xd056e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2027,7 +2070,7 @@ Probes:
       subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1343 EventRootType Probe[main.testMassiveString]
+          Type: 1360 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xd0a620", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2049,7 +2092,7 @@ Probes:
       subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1344 EventRootType Probe[main.testMassiveString]
+          Type: 1361 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xd0a620", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2095,11 +2138,11 @@ Probes:
       subprogram: {subprogram: 125}
       events:
         - Kind: Entry
-          Type: 1309 EventRootType Probe[main.testMixedArgsStackReturn]
+          Type: 1326 EventRootType Probe[main.testMixedArgsStackReturn]
           InjectionPoints: [{PC: "0xd09533", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1310 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          Type: 1327 EventRootType Probe[main.testMixedArgsStackReturn]Return
           InjectionPoints: [{PC: "0xd0976b", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2164,11 +2207,11 @@ Probes:
       subprogram: {subprogram: 127}
       events:
         - Kind: Entry
-          Type: 1313 EventRootType Probe[main.testMultipleArrayArgs]
+          Type: 1330 EventRootType Probe[main.testMultipleArrayArgs]
           InjectionPoints: [{PC: "0xd098ae", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1314 EventRootType Probe[main.testMultipleArrayArgs]Return
+          Type: 1331 EventRootType Probe[main.testMultipleArrayArgs]Return
           InjectionPoints: [{PC: "0xd09976", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2198,11 +2241,11 @@ Probes:
       subprogram: {subprogram: 123}
       events:
         - Kind: Entry
-          Type: 1305 EventRootType Probe[main.testMultipleLargeArgs]
+          Type: 1322 EventRootType Probe[main.testMultipleLargeArgs]
           InjectionPoints: [{PC: "0xd0904e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1306 EventRootType Probe[main.testMultipleLargeArgs]Return
+          Type: 1323 EventRootType Probe[main.testMultipleLargeArgs]Return
           InjectionPoints: [{PC: "0xd0926a", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2227,11 +2270,11 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1259 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1276 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xd0840e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1260 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1277 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xd084af", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2266,7 +2309,7 @@ Probes:
       subprogram: {subprogram: 85}
       events:
         - Kind: Entry
-          Type: 1229 EventRootType Probe[main.testMultipleSimpleParams]
+          Type: 1246 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0xd07100", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2306,11 +2349,11 @@ Probes:
       subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1255 EventRootType Probe[main.testNamedReturn]
+          Type: 1272 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0xd0836a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1256 EventRootType Probe[main.testNamedReturn]Return
+          Type: 1273 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0xd083d5", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2336,11 +2379,11 @@ Probes:
       subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1257 EventRootType Probe[main.testNamedReturn]
+          Type: 1274 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0xd0836a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1258 EventRootType Probe[main.testNamedReturn]Return
+          Type: 1275 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0xd083d5", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2367,7 +2410,7 @@ Probes:
       subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1355 EventRootType Probe[main.testNestedPointer]
+          Type: 1372 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0xd0aa60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2391,7 +2434,7 @@ Probes:
       subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1356 EventRootType Probe[main.testNestedPointer]
+          Type: 1373 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0xd0aa60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2421,7 +2464,7 @@ Probes:
       subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1357 EventRootType Probe[main.testNestedPointer]
+          Type: 1374 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0xd0aa60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2445,7 +2488,7 @@ Probes:
       subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1358 EventRootType Probe[main.testNestedPointer]
+          Type: 1375 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0xd0aa60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2471,7 +2514,7 @@ Probes:
       subprogram: {subprogram: 94}
       events:
         - Kind: Entry
-          Type: 1239 EventRootType Probe[main.testNilPointer]
+          Type: 1256 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0xd076e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2497,7 +2540,7 @@ Probes:
       subprogram: {subprogram: 138}
       events:
         - Kind: Entry
-          Type: 1327 EventRootType Probe[main.testNilSlice]
+          Type: 1344 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0xd0a120", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2523,7 +2566,7 @@ Probes:
       subprogram: {subprogram: 135}
       events:
         - Kind: Entry
-          Type: 1324 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 1341 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0xd0a0c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2557,7 +2600,7 @@ Probes:
       subprogram: {subprogram: 137}
       events:
         - Kind: Entry
-          Type: 1326 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 1343 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0xd0a100", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2588,7 +2631,7 @@ Probes:
       subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1342 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 1359 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0xd0a600", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2609,7 +2652,7 @@ Probes:
       subprogram: {subprogram: 90}
       events:
         - Kind: Entry
-          Type: 1235 EventRootType Probe[main.testPointerLoop]
+          Type: 1252 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0xd07560", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2630,7 +2673,7 @@ Probes:
       subprogram: {subprogram: 67}
       events:
         - Kind: Entry
-          Type: 1209 EventRootType Probe[main.testPointerToMap]
+          Type: 1226 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0xd05620", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2651,7 +2694,7 @@ Probes:
       subprogram: {subprogram: 88}
       events:
         - Kind: Entry
-          Type: 1233 EventRootType Probe[main.testPointerToSimpleStruct]
+          Type: 1250 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0xd07520", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2672,11 +2715,11 @@ Probes:
       subprogram: {subprogram: 101}
       events:
         - Kind: Entry
-          Type: 1251 EventRootType Probe[main.testReturnsAny]
+          Type: 1268 EventRootType Probe[main.testReturnsAny]
           InjectionPoints: [{PC: "0xd07fee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1252 EventRootType Probe[main.testReturnsAny]Return
+          Type: 1269 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints:
             - PC: "0xd080a4"
               Frameless: false
@@ -2710,11 +2753,11 @@ Probes:
       subprogram: {subprogram: 100}
       events:
         - Kind: Entry
-          Type: 1249 EventRootType Probe[main.testReturnsAnyAndError]
+          Type: 1266 EventRootType Probe[main.testReturnsAnyAndError]
           InjectionPoints: [{PC: "0xd07e8e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1250 EventRootType Probe[main.testReturnsAnyAndError]Return
+          Type: 1267 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
             - PC: "0xd07ef8"
               Frameless: false
@@ -2747,11 +2790,11 @@ Probes:
       subprogram: {subprogram: 110}
       events:
         - Kind: Entry
-          Type: 1279 EventRootType Probe[main.testReturnsArray]
+          Type: 1296 EventRootType Probe[main.testReturnsArray]
           InjectionPoints: [{PC: "0xd0888a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1280 EventRootType Probe[main.testReturnsArray]Return
+          Type: 1297 EventRootType Probe[main.testReturnsArray]Return
           InjectionPoints: [{PC: "0xd088ed", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2767,11 +2810,11 @@ Probes:
       subprogram: {subprogram: 111}
       events:
         - Kind: Entry
-          Type: 1281 EventRootType Probe[main.testReturnsArrayOne]
+          Type: 1298 EventRootType Probe[main.testReturnsArrayOne]
           InjectionPoints: [{PC: "0xd0890a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1282 EventRootType Probe[main.testReturnsArrayOne]Return
+          Type: 1299 EventRootType Probe[main.testReturnsArrayOne]Return
           InjectionPoints: [{PC: "0xd0894b", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2787,11 +2830,11 @@ Probes:
       subprogram: {subprogram: 112}
       events:
         - Kind: Entry
-          Type: 1283 EventRootType Probe[main.testReturnsArrayZero]
+          Type: 1300 EventRootType Probe[main.testReturnsArrayZero]
           InjectionPoints: [{PC: "0xd0896a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1284 EventRootType Probe[main.testReturnsArrayZero]Return
+          Type: 1301 EventRootType Probe[main.testReturnsArrayZero]Return
           InjectionPoints: [{PC: "0xd089a6", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2807,11 +2850,11 @@ Probes:
       subprogram: {subprogram: 114}
       events:
         - Kind: Entry
-          Type: 1287 EventRootType Probe[main.testReturnsBacktrackInt]
+          Type: 1304 EventRootType Probe[main.testReturnsBacktrackInt]
           InjectionPoints: [{PC: "0xd08a4e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1288 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          Type: 1305 EventRootType Probe[main.testReturnsBacktrackInt]Return
           InjectionPoints: [{PC: "0xd08aca", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2827,11 +2870,11 @@ Probes:
       subprogram: {subprogram: 120}
       events:
         - Kind: Entry
-          Type: 1299 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          Type: 1316 EventRootType Probe[main.testReturnsBoolAndUintptr]
           InjectionPoints: [{PC: "0xd08d8a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1300 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          Type: 1317 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
           InjectionPoints: [{PC: "0xd08dd0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2847,11 +2890,11 @@ Probes:
       subprogram: {subprogram: 108}
       events:
         - Kind: Entry
-          Type: 1275 EventRootType Probe[main.testReturnsComplex]
+          Type: 1292 EventRootType Probe[main.testReturnsComplex]
           InjectionPoints: [{PC: "0xd0874a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1276 EventRootType Probe[main.testReturnsComplex]Return
+          Type: 1293 EventRootType Probe[main.testReturnsComplex]Return
           InjectionPoints: [{PC: "0xd087a6", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2868,11 +2911,11 @@ Probes:
       subprogram: {subprogram: 99}
       events:
         - Kind: Entry
-          Type: 1247 EventRootType Probe[main.testReturnsError]
+          Type: 1264 EventRootType Probe[main.testReturnsError]
           InjectionPoints: [{PC: "0xd07e2a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1248 EventRootType Probe[main.testReturnsError]Return
+          Type: 1265 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
             - PC: "0xd07e5a"
               Frameless: false
@@ -2896,11 +2939,11 @@ Probes:
       subprogram: {subprogram: 96}
       events:
         - Kind: Entry
-          Type: 1241 EventRootType Probe[main.testReturnsInt]
+          Type: 1258 EventRootType Probe[main.testReturnsInt]
           InjectionPoints: [{PC: "0xd07c2a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1242 EventRootType Probe[main.testReturnsInt]Return
+          Type: 1259 EventRootType Probe[main.testReturnsInt]Return
           InjectionPoints: [{PC: "0xd07c7b", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2920,11 +2963,11 @@ Probes:
       subprogram: {subprogram: 98}
       events:
         - Kind: Entry
-          Type: 1245 EventRootType Probe[main.testReturnsIntAndFloat]
+          Type: 1262 EventRootType Probe[main.testReturnsIntAndFloat]
           InjectionPoints: [{PC: "0xd07d4e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1246 EventRootType Probe[main.testReturnsIntAndFloat]Return
+          Type: 1263 EventRootType Probe[main.testReturnsIntAndFloat]Return
           InjectionPoints: [{PC: "0xd07e04", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2944,11 +2987,11 @@ Probes:
       subprogram: {subprogram: 97}
       events:
         - Kind: Entry
-          Type: 1243 EventRootType Probe[main.testReturnsIntPointer]
+          Type: 1260 EventRootType Probe[main.testReturnsIntPointer]
           InjectionPoints: [{PC: "0xd07caa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1244 EventRootType Probe[main.testReturnsIntPointer]Return
+          Type: 1261 EventRootType Probe[main.testReturnsIntPointer]Return
           InjectionPoints: [{PC: "0xd07d1b", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2969,11 +3012,11 @@ Probes:
       subprogram: {subprogram: 102}
       events:
         - Kind: Entry
-          Type: 1253 EventRootType Probe[main.testReturnsInterface]
+          Type: 1270 EventRootType Probe[main.testReturnsInterface]
           InjectionPoints: [{PC: "0xd081ee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1254 EventRootType Probe[main.testReturnsInterface]Return
+          Type: 1271 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
             - PC: "0xd082d1"
               Frameless: false
@@ -2997,11 +3040,11 @@ Probes:
       subprogram: {subprogram: 109}
       events:
         - Kind: Entry
-          Type: 1277 EventRootType Probe[main.testReturnsLargeStruct]
+          Type: 1294 EventRootType Probe[main.testReturnsLargeStruct]
           InjectionPoints: [{PC: "0xd087ce", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1278 EventRootType Probe[main.testReturnsLargeStruct]Return
+          Type: 1295 EventRootType Probe[main.testReturnsLargeStruct]Return
           InjectionPoints: [{PC: "0xd08853", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3017,11 +3060,11 @@ Probes:
       subprogram: {subprogram: 107}
       events:
         - Kind: Entry
-          Type: 1273 EventRootType Probe[main.testReturnsManyFloats]
+          Type: 1290 EventRootType Probe[main.testReturnsManyFloats]
           InjectionPoints: [{PC: "0xd0864e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1274 EventRootType Probe[main.testReturnsManyFloats]Return
+          Type: 1291 EventRootType Probe[main.testReturnsManyFloats]Return
           InjectionPoints: [{PC: "0xd08725", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3037,11 +3080,11 @@ Probes:
       subprogram: {subprogram: 116}
       events:
         - Kind: Entry
-          Type: 1291 EventRootType Probe[main.testReturnsMixed]
+          Type: 1308 EventRootType Probe[main.testReturnsMixed]
           InjectionPoints: [{PC: "0xd08baa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1292 EventRootType Probe[main.testReturnsMixed]Return
+          Type: 1309 EventRootType Probe[main.testReturnsMixed]Return
           InjectionPoints: [{PC: "0xd08c0c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3057,11 +3100,11 @@ Probes:
       subprogram: {subprogram: 113}
       events:
         - Kind: Entry
-          Type: 1285 EventRootType Probe[main.testReturnsMixedStruct]
+          Type: 1302 EventRootType Probe[main.testReturnsMixedStruct]
           InjectionPoints: [{PC: "0xd089ca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1286 EventRootType Probe[main.testReturnsMixedStruct]Return
+          Type: 1303 EventRootType Probe[main.testReturnsMixedStruct]Return
           InjectionPoints: [{PC: "0xd08a18", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3077,11 +3120,11 @@ Probes:
       subprogram: {subprogram: 119}
       events:
         - Kind: Entry
-          Type: 1297 EventRootType Probe[main.testReturnsMultipleFloats]
+          Type: 1314 EventRootType Probe[main.testReturnsMultipleFloats]
           InjectionPoints: [{PC: "0xd08d0a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1298 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          Type: 1315 EventRootType Probe[main.testReturnsMultipleFloats]Return
           InjectionPoints: [{PC: "0xd08d56", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3097,11 +3140,11 @@ Probes:
       subprogram: {subprogram: 118}
       events:
         - Kind: Entry
-          Type: 1295 EventRootType Probe[main.testReturnsOnlyFloat]
+          Type: 1312 EventRootType Probe[main.testReturnsOnlyFloat]
           InjectionPoints: [{PC: "0xd08caa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1296 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          Type: 1313 EventRootType Probe[main.testReturnsOnlyFloat]Return
           InjectionPoints: [{PC: "0xd08cee", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3117,11 +3160,11 @@ Probes:
       subprogram: {subprogram: 106}
       events:
         - Kind: Entry
-          Type: 1271 EventRootType Probe[main.testReturnsPrimitives]
+          Type: 1288 EventRootType Probe[main.testReturnsPrimitives]
           InjectionPoints: [{PC: "0xd085ca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1272 EventRootType Probe[main.testReturnsPrimitives]Return
+          Type: 1289 EventRootType Probe[main.testReturnsPrimitives]Return
           InjectionPoints: [{PC: "0xd08631", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3137,11 +3180,11 @@ Probes:
       subprogram: {subprogram: 117}
       events:
         - Kind: Entry
-          Type: 1293 EventRootType Probe[main.testReturnsStructWithArray]
+          Type: 1310 EventRootType Probe[main.testReturnsStructWithArray]
           InjectionPoints: [{PC: "0xd08c2a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1294 EventRootType Probe[main.testReturnsStructWithArray]Return
+          Type: 1311 EventRootType Probe[main.testReturnsStructWithArray]Return
           InjectionPoints: [{PC: "0xd08c8d", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3157,11 +3200,11 @@ Probes:
       subprogram: {subprogram: 115}
       events:
         - Kind: Entry
-          Type: 1289 EventRootType Probe[main.testReturnsWideStruct]
+          Type: 1306 EventRootType Probe[main.testReturnsWideStruct]
           InjectionPoints: [{PC: "0xd08aee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1290 EventRootType Probe[main.testReturnsWideStruct]Return
+          Type: 1307 EventRootType Probe[main.testReturnsWideStruct]Return
           InjectionPoints: [{PC: "0xd08b74", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3178,7 +3221,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - Kind: Entry
-          Type: 1130 EventRootType Probe[main.testRuneArray]
+          Type: 1147 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0xd02e20", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3212,11 +3255,11 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1261 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1278 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xd0840e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1262 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1279 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xd084af", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3261,7 +3304,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 1151 EventRootType Probe[main.testSingleBool]
+          Type: 1168 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0xd03440", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3282,7 +3325,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - Kind: Entry
-          Type: 1149 EventRootType Probe[main.testSingleByte]
+          Type: 1166 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0xd03400", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3303,7 +3346,7 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 1162 EventRootType Probe[main.testSingleFloat32]
+          Type: 1179 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0xd035a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3324,7 +3367,7 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - Kind: Entry
-          Type: 1163 EventRootType Probe[main.testSingleFloat64]
+          Type: 1180 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0xd035c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3345,7 +3388,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 1152 EventRootType Probe[main.testSingleInt]
+          Type: 1169 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0xd03460", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3366,7 +3409,7 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - Kind: Entry
-          Type: 1154 EventRootType Probe[main.testSingleInt16]
+          Type: 1171 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0xd034a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3388,7 +3431,7 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - Kind: Entry
-          Type: 1155 EventRootType Probe[main.testSingleInt32]
+          Type: 1172 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0xd034c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3409,7 +3452,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - Kind: Entry
-          Type: 1156 EventRootType Probe[main.testSingleInt64]
+          Type: 1173 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0xd034e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3437,7 +3480,7 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - Kind: Entry
-          Type: 1153 EventRootType Probe[main.testSingleInt8]
+          Type: 1170 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0xd03480", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3467,7 +3510,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 1150 EventRootType Probe[main.testSingleRune]
+          Type: 1167 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0xd03420", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3488,7 +3531,7 @@ Probes:
       subprogram: {subprogram: 143}
       events:
         - Kind: Entry
-          Type: 1334 EventRootType Probe[main.testSingleString]
+          Type: 1351 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0xd0a580", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3509,7 +3552,7 @@ Probes:
       subprogram: {subprogram: 29}
       events:
         - Kind: Entry
-          Type: 1157 EventRootType Probe[main.testSingleUint]
+          Type: 1174 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0xd03500", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3530,7 +3573,7 @@ Probes:
       subprogram: {subprogram: 31}
       events:
         - Kind: Entry
-          Type: 1159 EventRootType Probe[main.testSingleUint16]
+          Type: 1176 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0xd03540", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3551,7 +3594,7 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - Kind: Entry
-          Type: 1160 EventRootType Probe[main.testSingleUint32]
+          Type: 1177 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0xd03560", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3572,7 +3615,7 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 1161 EventRootType Probe[main.testSingleUint64]
+          Type: 1178 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0xd03580", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3593,7 +3636,7 @@ Probes:
       subprogram: {subprogram: 30}
       events:
         - Kind: Entry
-          Type: 1158 EventRootType Probe[main.testSingleUint8]
+          Type: 1175 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0xd03520", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3614,7 +3657,7 @@ Probes:
       subprogram: {subprogram: 140}
       events:
         - Kind: Entry
-          Type: 1330 EventRootType Probe[main.testSliceEmptyStructs]
+          Type: 1347 EventRootType Probe[main.testSliceEmptyStructs]
           InjectionPoints: [{PC: "0xd0a160", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3635,7 +3678,7 @@ Probes:
       subprogram: {subprogram: 132}
       events:
         - Kind: Entry
-          Type: 1321 EventRootType Probe[main.testSliceOfSlices]
+          Type: 1338 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0xd0a060", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3656,7 +3699,7 @@ Probes:
       subprogram: {subprogram: 65}
       events:
         - Kind: Entry
-          Type: 1207 EventRootType Probe[main.testSmallMap]
+          Type: 1224 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0xd055e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3676,11 +3719,11 @@ Probes:
       subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1269 EventRootType Probe[main.testSomeNamedReturn]
+          Type: 1286 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0xd084ee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1270 EventRootType Probe[main.testSomeNamedReturn]Return
+          Type: 1287 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0xd0858e", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3700,11 +3743,11 @@ Probes:
       subprogram: {subprogram: 126}
       events:
         - Kind: Entry
-          Type: 1311 EventRootType Probe[main.testStackArgRegReturns]
+          Type: 1328 EventRootType Probe[main.testStackArgRegReturns]
           InjectionPoints: [{PC: "0xd0980a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1312 EventRootType Probe[main.testStackArgRegReturns]Return
+          Type: 1329 EventRootType Probe[main.testStackArgRegReturns]Return
           InjectionPoints: [{PC: "0xd0987c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3725,7 +3768,7 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - Kind: Entry
-          Type: 1131 EventRootType Probe[main.testStringArray]
+          Type: 1148 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0xd02e40", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3746,7 +3789,7 @@ Probes:
       subprogram: {subprogram: 93}
       events:
         - Kind: Entry
-          Type: 1238 EventRootType Probe[main.testStringPointer]
+          Type: 1255 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0xd076a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3767,7 +3810,7 @@ Probes:
       subprogram: {subprogram: 136}
       events:
         - Kind: Entry
-          Type: 1325 EventRootType Probe[main.testStringSlice]
+          Type: 1342 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0xd0a0e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3788,7 +3831,7 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - Kind: Entry
-          Type: 1173 EventRootType Probe[main.testStringType1]
+          Type: 1190 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0xd03b60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3809,7 +3852,7 @@ Probes:
       subprogram: {subprogram: 45}
       events:
         - Kind: Entry
-          Type: 1174 EventRootType Probe[main.testStringType2]
+          Type: 1191 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0xd03b80", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3830,11 +3873,11 @@ Probes:
       subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1353 EventRootType Probe[main.testStruct]
+          Type: 1370 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0xd0a960", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1354 EventRootType Probe[main.testStruct]Return
+          Type: 1371 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0xd0a982", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3860,7 +3903,7 @@ Probes:
       subprogram: {subprogram: 133}
       events:
         - Kind: Entry
-          Type: 1322 EventRootType Probe[main.testStructSlice]
+          Type: 1339 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0xd0a080", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3886,7 +3929,7 @@ Probes:
       subprogram: {subprogram: 59}
       events:
         - Kind: Entry
-          Type: 1201 EventRootType Probe[main.testStructWithAny]
+          Type: 1218 EventRootType Probe[main.testStructWithAny]
           InjectionPoints: [{PC: "0xd04ee0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3906,11 +3949,11 @@ Probes:
       subprogram: {subprogram: 128}
       events:
         - Kind: Entry
-          Type: 1315 EventRootType Probe[main.testStructWithArrayArg]
+          Type: 1332 EventRootType Probe[main.testStructWithArrayArg]
           InjectionPoints: [{PC: "0xd099ae", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1316 EventRootType Probe[main.testStructWithArrayArg]Return
+          Type: 1333 EventRootType Probe[main.testStructWithArrayArg]Return
           InjectionPoints: [{PC: "0xd09a5a", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3931,11 +3974,11 @@ Probes:
       subprogram: {subprogram: 153}
       events:
         - Kind: Entry
-          Type: 1349 EventRootType Probe[main.testStructWithCyclicMaps]
+          Type: 1366 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0xd0a820", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1350 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          Type: 1367 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0xd0a83e", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3955,7 +3998,7 @@ Probes:
       subprogram: {subprogram: 152}
       events:
         - Kind: Entry
-          Type: 1348 EventRootType Probe[main.testStructWithCyclicSlices]
+          Type: 1365 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0xd0a800", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3981,7 +4024,7 @@ Probes:
       subprogram: {subprogram: 60}
       events:
         - Kind: Entry
-          Type: 1202 EventRootType Probe[main.testStructWithMap]
+          Type: 1219 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0xd05540", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4012,7 +4055,7 @@ Probes:
       subprogram: {subprogram: 141}
       events:
         - Kind: Entry
-          Type: 1331 EventRootType Probe[main.testSubslices]
+          Type: 1348 EventRootType Probe[main.testSubslices]
           InjectionPoints: [{PC: "0xd0a180", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4051,7 +4094,7 @@ Probes:
       subprogram: {subprogram: 151}
       events:
         - Kind: Entry
-          Type: 1347 EventRootType Probe[main.testSubstrings]
+          Type: 1364 EventRootType Probe[main.testSubstrings]
           InjectionPoints: [{PC: "0xd0a680", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4083,11 +4126,11 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1263 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1280 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xd0840e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1264 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1281 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xd084af", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -4107,11 +4150,11 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1265 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1282 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xd0840e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1266 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1283 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xd084af", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -4133,11 +4176,11 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1267 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1284 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xd0840e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1268 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1285 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xd084af", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -4165,7 +4208,7 @@ Probes:
       subprogram: {subprogram: 144}
       events:
         - Kind: Entry
-          Type: 1335 EventRootType Probe[main.testThreeStrings]
+          Type: 1352 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0xd0a5a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4196,11 +4239,11 @@ Probes:
       subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1336 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1353 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0xd0a5c0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1337 EventRootType Probe[main.testThreeStringsInStruct]Return
+          Type: 1354 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0xd0a5de", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4229,11 +4272,11 @@ Probes:
       subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1338 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1355 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0xd0a5c0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1339 EventRootType Probe[main.testThreeStringsInStruct]Return
+          Type: 1356 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0xd0a5de", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4264,7 +4307,7 @@ Probes:
       subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1340 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1357 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0xd0a5e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4293,7 +4336,7 @@ Probes:
       subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1341 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1358 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0xd0a5e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4324,7 +4367,7 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 1164 EventRootType Probe[main.testTypeAlias]
+          Type: 1181 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0xd035e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4345,7 +4388,7 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - Kind: Entry
-          Type: 1140 EventRootType Probe[main.testUint16Array]
+          Type: 1157 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0xd02f60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4366,7 +4409,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - Kind: Entry
-          Type: 1141 EventRootType Probe[main.testUint32Array]
+          Type: 1158 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0xd02f80", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4387,7 +4430,7 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - Kind: Entry
-          Type: 1142 EventRootType Probe[main.testUint64Array]
+          Type: 1159 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0xd02fa0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4408,7 +4451,7 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - Kind: Entry
-          Type: 1139 EventRootType Probe[main.testUint8Array]
+          Type: 1156 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0xd02f40", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4429,7 +4472,7 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - Kind: Entry
-          Type: 1138 EventRootType Probe[main.testUintArray]
+          Type: 1155 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0xd02f20", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4450,7 +4493,7 @@ Probes:
       subprogram: {subprogram: 92}
       events:
         - Kind: Entry
-          Type: 1237 EventRootType Probe[main.testUintPointer]
+          Type: 1254 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0xd075c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4471,7 +4514,7 @@ Probes:
       subprogram: {subprogram: 130}
       events:
         - Kind: Entry
-          Type: 1319 EventRootType Probe[main.testUintSlice]
+          Type: 1336 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0xd0a020", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4492,7 +4535,7 @@ Probes:
       subprogram: {subprogram: 149}
       events:
         - Kind: Entry
-          Type: 1345 EventRootType Probe[main.testUnitializedString]
+          Type: 1362 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0xd0a640", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4513,7 +4556,7 @@ Probes:
       subprogram: {subprogram: 91}
       events:
         - Kind: Entry
-          Type: 1236 EventRootType Probe[main.testUnsafePointer]
+          Type: 1253 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0xd07580", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4534,7 +4577,7 @@ Probes:
       subprogram: {subprogram: 20}
       events:
         - Kind: Entry
-          Type: 1148 EventRootType Probe[main.testVeryLargeArray]
+          Type: 1165 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0xd03080", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4555,7 +4598,7 @@ Probes:
       subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1328 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1345 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xd0a140", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4576,7 +4619,7 @@ Probes:
       subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1329 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1346 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xd0a140", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4593,10 +4636,10 @@ Probes:
       template: testWhollyInlinedSubroutine
       segments: [testWhollyInlinedSubroutine]
       captureSnapshot: true
-      subprogram: {subprogram: 164}
+      subprogram: {subprogram: 165}
       events:
         - Kind: Entry
-          Type: 1374 EventRootType Probe[main.firstBehavior.DoSomething]
+          Type: 1392 EventRootType Probe[main.firstBehavior.DoSomething]
           InjectionPoints:
             - PC: "0xd04cea"
               Frameless: false
@@ -4604,7 +4647,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1375 EventRootType Probe[main.firstBehavior.DoSomething]Return
+          Type: 1393 EventRootType Probe[main.firstBehavior.DoSomething]Return
           InjectionPoints: [{PC: "0xd04d30", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -4625,11 +4668,11 @@ Probes:
       subprogram: {subprogram: 129}
       events:
         - Kind: Entry
-          Type: 1317 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          Type: 1334 EventRootType Probe[main.testZeroSizeArgAndReturn]
           InjectionPoints: [{PC: "0xd09a8e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1318 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          Type: 1335 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
           InjectionPoints: [{PC: "0xd09b0c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -7913,6 +7956,73 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 158
+      Name: main.executeStructFuncs
+      OutOfLinePCRanges: [0xd0ab40..0xd0be5d]
+      InlinePCRanges: []
+      Variables:
+        - Name: ptrRcvr
+          Type: 316 PointerType *main.receiver
+          Locations: [{Range: 0xd0ab40..0xd0be5d, Pieces: []}]
+          Role: Local
+        - Name: n
+          Type: 318 StructureType main.nStruct
+          Locations: [{Range: 0xd0ab40..0xd0be5d, Pieces: []}]
+          Role: Local
+        - Name: ns
+          Type: 257 StructureType main.structWithNoStrings
+          Locations: [{Range: 0xd0ab40..0xd0be5d, Pieces: []}]
+          Role: Local
+        - Name: cs
+          Type: 319 StructureType main.cStruct
+          Locations: [{Range: 0xd0ab40..0xd0be5d, Pieces: []}]
+          Role: Local
+        - Name: rcvr
+          Type: 317 StructureType main.receiver
+          Locations: [{Range: 0xd0ab40..0xd0be5d, Pieces: []}]
+          Role: Local
+        - Name: ts
+          Type: 320 StructureType main.threestrings
+          Locations:
+            - Range: 0xd0ab64..0xd0be5d
+              Pieces: [{Size: 48, Op: {CfaOffset: -2080}}]
+          Role: Local
+        - Name: s
+          Type: 311 StructureType main.aStruct
+          Locations:
+            - Range: 0xd0abee..0xd0be5d
+              Pieces: [{Size: 56, Op: {CfaOffset: -1920}}]
+          Role: Local
+        - Name: b
+          Type: 321 StructureType main.bStruct
+          Locations:
+            - Range: 0xd0ac95..0xd0be5d
+              Pieces: [{Size: 72, Op: {CfaOffset: -2080}}]
+          Role: Local
+        - Name: tenStr
+          Type: 322 StructureType main.tenStrings
+          Locations:
+            - Range: 0xd0aff2..0xd0be5d
+              Pieces: [{Size: 160, Op: {CfaOffset: -2080}}]
+          Role: Local
+        - Name: deep
+          Type: 323 StructureType main.deepStruct1
+          Locations:
+            - Range: 0xd0b044..0xd0be5d
+              Pieces: [{Size: 48, Op: {CfaOffset: -2168}}]
+          Role: Local
+        - Name: fields
+          Type: 329 StructureType main.lotsOfFields
+          Locations:
+            - Range: 0xd0b0d1..0xd0be5d
+              Pieces: [{Size: 26, Op: {CfaOffset: -2168}}]
+          Role: Local
+        - Name: sta
+          Type: 330 StructureType main.structWithTwoArrays
+          Locations:
+            - Range: 0xd0b163..0xd0be5d
+              Pieces: [{Size: 72, Op: {CfaOffset: -2168}}]
+          Role: Local
+    - ID: 159
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0xd04600..0xd04662]
       InlinePCRanges:
@@ -7941,28 +8051,28 @@ Subprograms:
             - Range: 0xd04920..0xd0493a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 159
+    - ID: 160
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xd048a6..0xd048de]
           RootRanges: [0xd04840..0xd04905]
       Variables: []
-    - ID: 160
+    - ID: 161
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xd049b3..0xd049f1]
           RootRanges: [0xd049a0..0xd04aae]
       Variables: []
-    - ID: 161
+    - ID: 162
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xd04a66..0xd04a9e]
           RootRanges: [0xd049a0..0xd04aae]
       Variables: []
-    - ID: 162
+    - ID: 163
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -7975,7 +8085,7 @@ Subprograms:
             - Range: 0xd04ac0..0xd04ac5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 163
+    - ID: 164
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -7992,7 +8102,7 @@ Subprograms:
             - Range: 0xd04b8c..0xd04cc5
               Pieces: [{Size: 40, Op: {CfaOffset: -128}}]
           Role: Parameter
-    - ID: 164
+    - ID: 165
       Name: main.firstBehavior.DoSomething
       OutOfLinePCRanges: [0xd04ce0..0xd04d51]
       InlinePCRanges:
@@ -8000,7 +8110,7 @@ Subprograms:
           RootRanges: [0xd0c020..0xd0c0b6]
       Variables:
         - Name: b
-          Type: 316 StructureType main.firstBehavior
+          Type: 333 StructureType main.firstBehavior
           Locations:
             - Range: 0xd04ce0..0xd04d08
               Pieces:
@@ -8029,7 +8139,7 @@ Subprograms:
             - Range: 0xd04d31..0xd04d51
               Pieces: []
           Role: Return
-    - ID: 165
+    - ID: 166
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -8045,20 +8155,20 @@ Types:
       ByteSize: 8
       Pointee: 133 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 1068
+      ID: 1085
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 1069 PointerType *main.deepSlice3
+      Pointee: 1086 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 1087
+      ID: 1104
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 1088 PointerType *main.deepSlice8
+      Pointee: 1105 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 1093
+      ID: 1110
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 1094 PointerType *main.deepSlice9
+      Pointee: 1111 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 148
       Name: '**main.stringType2'
@@ -8066,7 +8176,7 @@ Types:
       GoKind: 22
       Pointee: 149 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 1064
+      ID: 1081
       Name: '**main.t'
       ByteSize: 8
       Pointee: 243 PointerType *main.t
@@ -8078,115 +8188,115 @@ Types:
       GoKind: 22
       Pointee: 88 PointerType *string
     - __kind: PointerType
-      ID: 327
+      ID: 344
       Name: '*[]*main.deepSlice2.array'
       ByteSize: 8
-      Pointee: 326 GoSliceDataType []*main.deepSlice2.array
+      Pointee: 343 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 1072
+      ID: 1089
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 1071 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 1088 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 1091
+      ID: 1108
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 1090 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 1107 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 1097
+      ID: 1114
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 1096 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 1113 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
-      ID: 324
+      ID: 341
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 323 GoSliceDataType []*string.array
+      Pointee: 340 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 393
+      ID: 410
       Name: '*[][][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 392 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Pointee: 409 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 279
       Name: '*[][][][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 276 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 391
+      ID: 408
       Name: '*[][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 390 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Pointee: 407 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 277
       Name: '*[][][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 274 GoSliceHeaderType [][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 389
+      ID: 406
       Name: '*[][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 388 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Pointee: 405 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 275
       Name: '*[][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 272 GoSliceHeaderType [][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 387
+      ID: 404
       Name: '*[][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 386 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Pointee: 403 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 273
       Name: '*[][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 270 GoSliceHeaderType [][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 385
+      ID: 402
       Name: '*[][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 384 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Pointee: 401 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 371
+      ID: 388
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 370 GoSliceDataType [][]uint.array
+      Pointee: 387 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 377
+      ID: 394
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 376 GoSliceDataType []bool.array
+      Pointee: 393 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 856
+      ID: 873
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 855 GoSliceDataType []float64.array
+      Pointee: 872 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 1100
+      ID: 1117
       Name: '*[]interface {}.array'
       ByteSize: 8
-      Pointee: 1099 GoSliceDataType []interface {}.array
+      Pointee: 1116 GoSliceDataType []interface {}.array
     - __kind: PointerType
       ID: 271
       Name: '*[]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 268 GoSliceHeaderType []main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 383
+      ID: 400
       Name: '*[]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 382 GoSliceDataType []main.structWithCyclicSlices.array
+      Pointee: 399 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 407
+      ID: 424
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 406 GoSliceDataType []main.structWithMap.array
+      Pointee: 423 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 373
+      ID: 390
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 372 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 389 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
       ID: 39
       Name: '*[]runtime.ancestorInfo'
@@ -8195,101 +8305,101 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 375
+      ID: 392
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 374 GoSliceDataType []string.array
+      Pointee: 391 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 381
+      ID: 398
       Name: '*[]struct {}.array'
       ByteSize: 8
-      Pointee: 380 GoSliceDataType []struct {}.array
+      Pointee: 397 GoSliceDataType []struct {}.array
     - __kind: PointerType
       ID: 254
       Name: '*[]uint'
       ByteSize: 8
       Pointee: 252 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 369
+      ID: 386
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 368 GoSliceDataType []uint.array
+      Pointee: 385 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 379
+      ID: 396
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 378 GoSliceDataType []uint16.array
+      Pointee: 395 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 320
+      ID: 337
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 319 GoSliceDataType []uint8.array
+      Pointee: 336 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 322
+      ID: 339
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 321 GoSliceDataType []uintptr.array
+      Pointee: 338 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 981
+      ID: 998
       Name: '*archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1.849408e+06
       GoKind: 22
-      Pointee: 982 UnresolvedPointeeType archive/tar.Writer
+      Pointee: 999 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
-      ID: 633
+      ID: 650
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 858496
       GoKind: 22
-      Pointee: 634 GoSliceHeaderType archive/tar.headerError
+      Pointee: 651 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 636
+      ID: 653
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 635 GoSliceDataType archive/tar.headerError.array
+      Pointee: 652 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 921
+      ID: 938
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.253376e+06
       GoKind: 22
-      Pointee: 922 UnresolvedPointeeType archive/tar.regFileWriter
+      Pointee: 939 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
-      ID: 869
+      ID: 886
       Name: '*archive/zip.countWriter'
       ByteSize: 8
       GoRuntimeType: 858688
       GoKind: 22
-      Pointee: 870 UnresolvedPointeeType archive/zip.countWriter
+      Pointee: 887 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
-      ID: 871
+      ID: 888
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
       GoRuntimeType: 858784
       GoKind: 22
-      Pointee: 872 StructureType archive/zip.dirWriter
+      Pointee: 889 StructureType archive/zip.dirWriter
     - __kind: PointerType
-      ID: 968
+      ID: 985
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.773696e+06
       GoKind: 22
-      Pointee: 969 UnresolvedPointeeType archive/zip.fileWriter
+      Pointee: 986 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
-      ID: 897
+      ID: 914
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1.016896e+06
       GoKind: 22
-      Pointee: 898 StructureType archive/zip.nopCloser
+      Pointee: 915 StructureType archive/zip.nopCloser
     - __kind: PointerType
-      ID: 899
+      ID: 916
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
       GoRuntimeType: 1.017152e+06
       GoKind: 22
-      Pointee: 900 UnresolvedPointeeType archive/zip.pooledFlateWriter
+      Pointee: 917 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -8323,30 +8433,30 @@ Types:
       ByteSize: 8
       Pointee: 141 GoHMapBucketType bucket<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1076
+      ID: 1093
       Name: '*bucket<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1077 GoHMapBucketType bucket<int,*main.deepMap3>
+      Pointee: 1094 GoHMapBucketType bucket<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1104
+      ID: 1121
       Name: '*bucket<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1105 GoHMapBucketType bucket<int,*main.deepMap8>
+      Pointee: 1122 GoHMapBucketType bucket<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1113
+      ID: 1130
       Name: '*bucket<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1114 GoHMapBucketType bucket<int,*main.deepMap9>
+      Pointee: 1131 GoHMapBucketType bucket<int,*main.deepMap9>
     - __kind: PointerType
       ID: 164
       Name: '*bucket<int,int>'
       ByteSize: 8
       Pointee: 165 GoHMapBucketType bucket<int,int>
     - __kind: PointerType
-      ID: 1122
+      ID: 1139
       Name: '*bucket<int,interface {}>'
       ByteSize: 8
-      Pointee: 1123 GoHMapBucketType bucket<int,interface {}>
+      Pointee: 1140 GoHMapBucketType bucket<int,interface {}>
     - __kind: PointerType
       ID: 231
       Name: '*bucket<int,struct {}>'
@@ -8368,10 +8478,10 @@ Types:
       ByteSize: 8
       Pointee: 180 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 825
+      ID: 842
       Name: '*bucket<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 826 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 843 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 174
       Name: '*bucket<string,int>'
@@ -8433,393 +8543,393 @@ Types:
       ByteSize: 8
       Pointee: 207 GoHMapBucketType bucket<uint8,uint8>
     - __kind: PointerType
-      ID: 945
+      ID: 962
       Name: '*bufio.Reader'
       ByteSize: 8
       GoRuntimeType: 2.029888e+06
       GoKind: 22
-      Pointee: 946 UnresolvedPointeeType bufio.Reader
+      Pointee: 963 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
-      ID: 970
+      ID: 987
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1.815136e+06
       GoKind: 22
-      Pointee: 971 UnresolvedPointeeType bufio.Writer
+      Pointee: 988 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
-      ID: 1017
+      ID: 1034
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.122848e+06
       GoKind: 22
-      Pointee: 1018 UnresolvedPointeeType bytes.Buffer
+      Pointee: 1035 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 546
+      ID: 563
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 841120
       GoKind: 22
-      Pointee: 441 BaseType compress/flate.CorruptInputError
+      Pointee: 458 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 547
+      ID: 564
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 841216
       GoKind: 22
-      Pointee: 442 GoStringHeaderType compress/flate.InternalError
+      Pointee: 459 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 444
+      ID: 461
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 443 GoStringDataType compress/flate.InternalError.str
+      Pointee: 460 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 919
+      ID: 936
       Name: '*compress/flate.Writer'
       ByteSize: 8
       GoRuntimeType: 1.243616e+06
       GoKind: 22
-      Pointee: 920 UnresolvedPointeeType compress/flate.Writer
+      Pointee: 937 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
-      ID: 865
+      ID: 882
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
       GoRuntimeType: 841312
       GoKind: 22
-      Pointee: 866 UnresolvedPointeeType compress/flate.dictWriter
+      Pointee: 883 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
-      ID: 941
+      ID: 958
       Name: '*compress/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.60032e+06
       GoKind: 22
-      Pointee: 942 UnresolvedPointeeType compress/gzip.Writer
+      Pointee: 959 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
-      ID: 777
+      ID: 794
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.118048e+06
       GoKind: 22
-      Pointee: 778 StructureType context.deadlineExceededError
+      Pointee: 795 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 626
+      ID: 643
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 853408
       GoKind: 22
-      Pointee: 455 BaseType crypto/aes.KeySizeError
+      Pointee: 472 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 627
+      ID: 644
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 853600
       GoKind: 22
-      Pointee: 456 BaseType crypto/des.KeySizeError
+      Pointee: 473 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 931
+      ID: 948
       Name: '*crypto/hmac.hmac'
       ByteSize: 8
       GoRuntimeType: 1.373888e+06
       GoKind: 22
-      Pointee: 932 UnresolvedPointeeType crypto/hmac.hmac
+      Pointee: 949 UnresolvedPointeeType crypto/hmac.hmac
     - __kind: PointerType
-      ID: 956
+      ID: 973
       Name: '*crypto/md5.digest'
       ByteSize: 8
       GoRuntimeType: 1.679328e+06
       GoKind: 22
-      Pointee: 957 UnresolvedPointeeType crypto/md5.digest
+      Pointee: 974 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
-      ID: 628
+      ID: 645
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 853888
       GoKind: 22
-      Pointee: 457 BaseType crypto/rc4.KeySizeError
+      Pointee: 474 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 964
+      ID: 981
       Name: '*crypto/sha1.digest'
       ByteSize: 8
       GoRuntimeType: 1.77088e+06
       GoKind: 22
-      Pointee: 965 UnresolvedPointeeType crypto/sha1.digest
+      Pointee: 982 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
-      ID: 958
+      ID: 975
       Name: '*crypto/sha256.digest'
       ByteSize: 8
       GoRuntimeType: 1.679776e+06
       GoKind: 22
-      Pointee: 959 UnresolvedPointeeType crypto/sha256.digest
+      Pointee: 976 UnresolvedPointeeType crypto/sha256.digest
     - __kind: PointerType
-      ID: 960
+      ID: 977
       Name: '*crypto/sha512.digest'
       ByteSize: 8
       GoRuntimeType: 1.680224e+06
       GoKind: 22
-      Pointee: 961 UnresolvedPointeeType crypto/sha512.digest
+      Pointee: 978 UnresolvedPointeeType crypto/sha512.digest
     - __kind: PointerType
-      ID: 552
+      ID: 569
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 842752
       GoKind: 22
-      Pointee: 445 BaseType crypto/tls.AlertError
+      Pointee: 462 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 717
+      ID: 734
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1.004736e+06
       GoKind: 22
-      Pointee: 718 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 735 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 1043
+      ID: 1060
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2.231968e+06
       GoKind: 22
-      Pointee: 1044 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 1061 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 550
+      ID: 567
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 842560
       GoKind: 22
-      Pointee: 551 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 568 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 548
+      ID: 565
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 842464
       GoKind: 22
-      Pointee: 549 StructureType crypto/tls.RecordHeaderError
+      Pointee: 566 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 716
+      ID: 733
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1.003072e+06
       GoKind: 22
-      Pointee: 673 BaseType crypto/tls.alert
+      Pointee: 690 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 929
+      ID: 946
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
       GoRuntimeType: 1.371008e+06
       GoKind: 22
-      Pointee: 930 UnresolvedPointeeType crypto/tls.cthWrapper
+      Pointee: 947 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
-      ID: 936
+      ID: 953
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
       GoRuntimeType: 1.45008e+06
       GoKind: 22
-      Pointee: 937 UnresolvedPointeeType crypto/tls.finishedHash
+      Pointee: 954 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
-      ID: 812
+      ID: 829
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1.243936e+06
       GoKind: 22
-      Pointee: 813 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 830 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 827
+      ID: 844
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 1.90656e+06
       GoKind: 22
-      Pointee: 828 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 845 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 622
+      ID: 639
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 852352
       GoKind: 22
-      Pointee: 623 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 640 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 616
+      ID: 633
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 851872
       GoKind: 22
-      Pointee: 617 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 634 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 618
+      ID: 635
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 851968
       GoKind: 22
-      Pointee: 619 StructureType crypto/x509.HostnameError
+      Pointee: 636 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 615
+      ID: 632
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 851776
       GoKind: 22
-      Pointee: 454 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 471 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 722
+      ID: 739
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1.010624e+06
       GoKind: 22
-      Pointee: 723 StructureType crypto/x509.SystemRootsError
+      Pointee: 740 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 624
+      ID: 641
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 852448
       GoKind: 22
-      Pointee: 625 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 642 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 620
+      ID: 637
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 852256
       GoKind: 22
-      Pointee: 621 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 638 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 637
+      ID: 654
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 858976
       GoKind: 22
-      Pointee: 638 StructureType encoding/asn1.StructuralError
+      Pointee: 655 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 641
+      ID: 658
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 859168
       GoKind: 22
-      Pointee: 642 StructureType encoding/asn1.SyntaxError
+      Pointee: 659 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 639
+      ID: 656
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 859072
       GoKind: 22
-      Pointee: 640 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 657 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 538
+      ID: 555
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 839392
       GoKind: 22
-      Pointee: 439 BaseType encoding/base64.CorruptInputError
+      Pointee: 456 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 887
+      ID: 904
       Name: '*encoding/base64.encoder'
       ByteSize: 8
       GoRuntimeType: 999872
       GoKind: 22
-      Pointee: 888 UnresolvedPointeeType encoding/base64.encoder
+      Pointee: 905 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
-      ID: 541
+      ID: 558
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 840256
       GoKind: 22
-      Pointee: 440 BaseType encoding/hex.InvalidByteError
+      Pointee: 457 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 509
+      ID: 526
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 834112
       GoKind: 22
-      Pointee: 510 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 527 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 708
+      ID: 725
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 995520
       GoKind: 22
-      Pointee: 709 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 726 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 501
+      ID: 518
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 833728
       GoKind: 22
-      Pointee: 502 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 519 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 507
+      ID: 524
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 834016
       GoKind: 22
-      Pointee: 508 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 525 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 505
+      ID: 522
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 833920
       GoKind: 22
-      Pointee: 506 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 523 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 503
+      ID: 520
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 833824
       GoKind: 22
-      Pointee: 504 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 521 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 1023
+      ID: 1040
       Name: '*encoding/json.encodeState'
       ByteSize: 8
       GoRuntimeType: 2.148416e+06
       GoKind: 22
-      Pointee: 1024 UnresolvedPointeeType encoding/json.encodeState
+      Pointee: 1041 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 511
+      ID: 528
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 834496
       GoKind: 22
-      Pointee: 512 StructureType encoding/json.jsonError
+      Pointee: 529 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 895
+      ID: 912
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
       GoRuntimeType: 1.01344e+06
       GoKind: 22
-      Pointee: 896 UnresolvedPointeeType encoding/pem.lineBreaker
+      Pointee: 913 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
-      ID: 610
+      ID: 627
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 850816
       GoKind: 22
-      Pointee: 611 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 628 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 608
+      ID: 625
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 850720
       GoKind: 22
-      Pointee: 609 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 626 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 612
+      ID: 629
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 850912
       GoKind: 22
-      Pointee: 451 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 468 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 453
+      ID: 470
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 452 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 469 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 613
+      ID: 630
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 851008
       GoKind: 22
-      Pointee: 614 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 631 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
-      ID: 1001
+      ID: 1018
       Name: '*encoding/xml.printer'
       ByteSize: 8
       GoRuntimeType: 2.018368e+06
       GoKind: 22
-      Pointee: 1002 UnresolvedPointeeType encoding/xml.printer
+      Pointee: 1019 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
       ID: 99
       Name: '*error'
@@ -8828,19 +8938,19 @@ Types:
       GoKind: 22
       Pointee: 18 GoInterfaceType error
     - __kind: PointerType
-      ID: 479
+      ID: 496
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 824416
       GoKind: 22
-      Pointee: 480 UnresolvedPointeeType errors.errorString
+      Pointee: 497 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 675
+      ID: 692
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 980160
       GoKind: 22
-      Pointee: 676 UnresolvedPointeeType errors.joinError
+      Pointee: 693 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 101
       Name: '*float32'
@@ -8856,806 +8966,806 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 1011
+      ID: 1028
       Name: '*fmt.pp'
       ByteSize: 8
       GoRuntimeType: 2.114144e+06
       GoKind: 22
-      Pointee: 1012 UnresolvedPointeeType fmt.pp
+      Pointee: 1029 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
-      ID: 677
+      ID: 694
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 980288
       GoKind: 22
-      Pointee: 678 UnresolvedPointeeType fmt.wrapError
+      Pointee: 695 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 679
+      ID: 696
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 980416
       GoKind: 22
-      Pointee: 680 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 697 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 539
+      ID: 556
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 839776
       GoKind: 22
-      Pointee: 540 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 557 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 520
+      ID: 537
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 836896
       GoKind: 22
-      Pointee: 521 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 538 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 522
+      ID: 539
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 836992
       GoKind: 22
-      Pointee: 523 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 540 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 839
+      ID: 856
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 836704
       GoKind: 22
-      Pointee: 840 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 857 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 526
+      ID: 543
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 837280
       GoKind: 22
-      Pointee: 527 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 544 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 841
+      ID: 858
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 836800
       GoKind: 22
-      Pointee: 842 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 859 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 524
+      ID: 541
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 837088
       GoKind: 22
-      Pointee: 433 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 450 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 435
+      ID: 452
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 434 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 451 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 519
+      ID: 536
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 836608
       GoKind: 22
-      Pointee: 430 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 447 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 432
+      ID: 449
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 431 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 448 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 525
+      ID: 542
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 837184
       GoKind: 22
-      Pointee: 436 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 453 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 438
+      ID: 455
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 437 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 454 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 909
+      ID: 926
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
       GoRuntimeType: 1.123808e+06
       GoKind: 22
-      Pointee: 910 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      Pointee: 927 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
-      ID: 989
+      ID: 1006
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
       GoRuntimeType: 1.921568e+06
       GoKind: 22
-      Pointee: 990 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      Pointee: 1007 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
-      ID: 631
+      ID: 648
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 857440
       GoKind: 22
-      Pointee: 632 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 649 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 786
+      ID: 803
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1.127136e+06
       GoKind: 22
-      Pointee: 787 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 804 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 1019
+      ID: 1036
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
       GoRuntimeType: 2.124384e+06
       GoKind: 22
-      Pointee: 1020 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      Pointee: 1037 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
-      ID: 559
+      ID: 576
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 846304
       GoKind: 22
-      Pointee: 560 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 577 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 566
+      ID: 583
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 847360
       GoKind: 22
-      Pointee: 567 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 584 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 561
+      ID: 578
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 847072
       GoKind: 22
-      Pointee: 450 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 467 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 564
+      ID: 581
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 847264
       GoKind: 22
-      Pointee: 565 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 582 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 562
+      ID: 579
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 847168
       GoKind: 22
-      Pointee: 563 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 580 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 582
+      ID: 599
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 849280
       GoKind: 22
-      Pointee: 583 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 600 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 586
+      ID: 603
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 849472
       GoKind: 22
-      Pointee: 587 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 604 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 584
+      ID: 601
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 849376
       GoKind: 22
-      Pointee: 585 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 602 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 580
+      ID: 597
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 849184
       GoKind: 22
-      Pointee: 581 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 598 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 858
+      ID: 875
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 857 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 874 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 594
+      ID: 611
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 849856
       GoKind: 22
-      Pointee: 595 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 612 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 588
+      ID: 605
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 849568
       GoKind: 22
-      Pointee: 589 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 606 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 592
+      ID: 609
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 849760
       GoKind: 22
-      Pointee: 593 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 610 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 590
+      ID: 607
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 849664
       GoKind: 22
-      Pointee: 591 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 608 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 596
+      ID: 613
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 849952
       GoKind: 22
-      Pointee: 597 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 614 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 602
+      ID: 619
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 850240
       GoKind: 22
-      Pointee: 603 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 620 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 604
+      ID: 621
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 850336
       GoKind: 22
-      Pointee: 605 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 622 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 600
+      ID: 617
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 850144
       GoKind: 22
-      Pointee: 601 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 618 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 598
+      ID: 615
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 850048
       GoKind: 22
-      Pointee: 599 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 616 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 606
+      ID: 623
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 850528
       GoKind: 22
-      Pointee: 607 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 624 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 528
+      ID: 545
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 838432
       GoKind: 22
-      Pointee: 529 StructureType github.com/cihub/seelog.baseError
+      Pointee: 546 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 948
+      ID: 965
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1.676416e+06
       GoKind: 22
-      Pointee: 949 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 966 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 530
+      ID: 547
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 838528
       GoKind: 22
-      Pointee: 531 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 548 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 927
+      ID: 944
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
       GoRuntimeType: 1.369888e+06
       GoKind: 22
-      Pointee: 928 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+      Pointee: 945 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
-      ID: 883
+      ID: 900
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
       GoRuntimeType: 998848
       GoKind: 22
-      Pointee: 884 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+      Pointee: 901 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
-      ID: 917
+      ID: 934
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.241696e+06
       GoKind: 22
-      Pointee: 918 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+      Pointee: 935 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
-      ID: 534
+      ID: 551
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 838720
       GoKind: 22
-      Pointee: 535 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 552 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 979
+      ID: 996
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.839616e+06
       GoKind: 22
-      Pointee: 980 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+      Pointee: 997 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
-      ID: 994
+      ID: 1011
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
       GoRuntimeType: 1.993024e+06
       GoKind: 22
-      Pointee: 991 StructureType github.com/cihub/seelog.rollingFileWriterSize
+      Pointee: 1008 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
-      ID: 993
+      ID: 1010
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
       GoRuntimeType: 1.99264e+06
       GoKind: 22
-      Pointee: 992 StructureType github.com/cihub/seelog.rollingFileWriterTime
+      Pointee: 1009 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
-      ID: 885
+      ID: 902
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
       GoRuntimeType: 998976
       GoKind: 22
-      Pointee: 886 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+      Pointee: 903 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
-      ID: 532
+      ID: 549
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 838624
       GoKind: 22
-      Pointee: 533 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 550 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 536
+      ID: 553
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 838816
       GoKind: 22
-      Pointee: 537 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 554 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 952
+      ID: 969
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.677984e+06
       GoKind: 22
-      Pointee: 953 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+      Pointee: 970 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
-      ID: 985
+      ID: 1002
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1.875488e+06
       GoKind: 22
-      Pointee: 986 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+      Pointee: 1003 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
-      ID: 987
+      ID: 1004
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.90624e+06
       GoKind: 22
-      Pointee: 988 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+      Pointee: 1005 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
-      ID: 817
+      ID: 834
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1.255776e+06
       GoKind: 22
-      Pointee: 818 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 835 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 730
+      ID: 747
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.024832e+06
       GoKind: 22
-      Pointee: 731 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 748 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 728
+      ID: 745
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1.024704e+06
       GoKind: 22
-      Pointee: 729 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 746 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 732
+      ID: 749
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.0288e+06
       GoKind: 22
-      Pointee: 733 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 750 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 734
+      ID: 751
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1.028928e+06
       GoKind: 22
-      Pointee: 735 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 752 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 938
+      ID: 955
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
       GoRuntimeType: 1.477728e+06
       GoKind: 22
-      Pointee: 939 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+      Pointee: 956 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
-      ID: 724
+      ID: 741
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.011392e+06
       GoKind: 22
-      Pointee: 725 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 742 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 542
+      ID: 559
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 840448
       GoKind: 22
-      Pointee: 543 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 560 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 1035
+      ID: 1052
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
       GoRuntimeType: 2.211072e+06
       GoKind: 22
-      Pointee: 1036 UnresolvedPointeeType github.com/json-iterator/go.Stream
+      Pointee: 1053 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
-      ID: 788
+      ID: 805
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1.135328e+06
       GoKind: 22
-      Pointee: 789 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 806 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 761
+      ID: 778
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1.114208e+06
       GoKind: 22
-      Pointee: 762 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 779 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 755
+      ID: 772
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1.113824e+06
       GoKind: 22
-      Pointee: 756 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 773 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 694
+      ID: 711
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 989376
       GoKind: 22
-      Pointee: 695 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 712 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 767
+      ID: 784
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1.114592e+06
       GoKind: 22
-      Pointee: 768 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 785 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 693
+      ID: 710
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 989248
       GoKind: 22
-      Pointee: 672 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 689 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 759
+      ID: 776
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1.11408e+06
       GoKind: 22
-      Pointee: 760 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 777 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 757
+      ID: 774
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1.113952e+06
       GoKind: 22
-      Pointee: 758 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 775 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 765
+      ID: 782
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1.114464e+06
       GoKind: 22
-      Pointee: 766 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 783 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 763
+      ID: 780
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1.114336e+06
       GoKind: 22
-      Pointee: 764 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 781 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 1039
+      ID: 1056
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
       GoRuntimeType: 2.222112e+06
       GoKind: 22
-      Pointee: 1040 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+      Pointee: 1057 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
-      ID: 771
+      ID: 788
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1.114976e+06
       GoKind: 22
-      Pointee: 772 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 789 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 698
+      ID: 715
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 989632
       GoKind: 22
-      Pointee: 699 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 716 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 696
+      ID: 713
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 989504
       GoKind: 22
-      Pointee: 697 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 714 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 769
+      ID: 786
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1.114848e+06
       GoKind: 22
-      Pointee: 770 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 787 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 653
+      ID: 670
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 871072
       GoKind: 22
-      Pointee: 462 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 479 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 464
+      ID: 481
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 463 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 480 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 830
+      ID: 847
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1.476192e+06
       GoKind: 22
-      Pointee: 831 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 848 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 738
+      ID: 755
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1.043776e+06
       GoKind: 22
-      Pointee: 739 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 756 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 915
+      ID: 932
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
       GoRuntimeType: 1.17424e+06
       GoKind: 22
-      Pointee: 916 StructureType go.uber.org/zap.nopCloserSink
+      Pointee: 933 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
-      ID: 999
+      ID: 1016
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.008e+06
       GoKind: 22
-      Pointee: 1000 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+      Pointee: 1017 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
-      ID: 901
+      ID: 918
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
       GoRuntimeType: 1.04608e+06
       GoKind: 22
-      Pointee: 902 StructureType go.uber.org/zap/zapcore.writerWrapper
+      Pointee: 919 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
-      ID: 654
+      ID: 671
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 872320
       GoKind: 22
-      Pointee: 465 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 482 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 796
+      ID: 813
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1.175904e+06
       GoKind: 22
-      Pointee: 797 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 814 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 657
+      ID: 674
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 872608
       GoKind: 22
-      Pointee: 658 StructureType golang.org/x/net/http2.connError
+      Pointee: 675 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 656
+      ID: 673
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 872512
       GoKind: 22
-      Pointee: 469 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 486 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 471
+      ID: 488
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 470 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 487 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 660
+      ID: 677
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 872800
       GoKind: 22
-      Pointee: 475 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 492 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 477
+      ID: 494
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 476 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 493 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 659
+      ID: 676
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 872704
       GoKind: 22
-      Pointee: 472 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 489 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 474
+      ID: 491
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 473 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 490 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 655
+      ID: 672
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 872416
       GoKind: 22
-      Pointee: 466 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 483 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 468
+      ID: 485
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 467 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 484 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 997
+      ID: 1014
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.00608e+06
       GoKind: 22
-      Pointee: 998 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1015 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 661
+      ID: 678
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 872896
       GoKind: 22
-      Pointee: 662 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 679 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 663
+      ID: 680
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 872992
       GoKind: 22
-      Pointee: 478 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 495 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 649
+      ID: 666
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 866464
       GoKind: 22
-      Pointee: 650 StructureType google.golang.org/grpc.dropError
+      Pointee: 667 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 794
+      ID: 811
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1.172832e+06
       GoKind: 22
-      Pointee: 795 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 812 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 819
+      ID: 836
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1.263136e+06
       GoKind: 22
-      Pointee: 820 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 837 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 651
+      ID: 668
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 869344
       GoKind: 22
-      Pointee: 652 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 669 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 962
+      ID: 979
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1.684704e+06
       GoKind: 22
-      Pointee: 963 StructureType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 980 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 913
+      ID: 930
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
       GoRuntimeType: 1.169376e+06
       GoKind: 22
-      Pointee: 914 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+      Pointee: 931 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
-      ID: 736
+      ID: 753
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1.038016e+06
       GoKind: 22
-      Pointee: 737 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 754 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 873
+      ID: 890
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
       GoRuntimeType: 869440
       GoKind: 22
-      Pointee: 874 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+      Pointee: 891 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
-      ID: 629
+      ID: 646
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 855328
       GoKind: 22
-      Pointee: 630 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 647 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 726
+      ID: 743
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1.014848e+06
       GoKind: 22
-      Pointee: 727 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 744 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 792
+      ID: 809
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.141088e+06
       GoKind: 22
-      Pointee: 793 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 810 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 790
+      ID: 807
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1.140832e+06
       GoKind: 22
-      Pointee: 791 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 808 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 643
+      ID: 660
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 860032
       GoKind: 22
-      Pointee: 644 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 661 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 645
+      ID: 662
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 860128
       GoKind: 22
-      Pointee: 646 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 663 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 574
+      ID: 591
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 847744
       GoKind: 22
-      Pointee: 575 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 592 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 950
+      ID: 967
       Name: '*hash/crc32.digest'
       ByteSize: 8
       GoRuntimeType: 1.677088e+06
       GoKind: 22
-      Pointee: 951 UnresolvedPointeeType hash/crc32.digest
+      Pointee: 968 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
       ID: 219
       Name: '*hash<[4]int,[4]int>'
@@ -9682,30 +9792,30 @@ Types:
       ByteSize: 8
       Pointee: 139 GoHMapHeaderType hash<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1074
+      ID: 1091
       Name: '*hash<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1075 GoHMapHeaderType hash<int,*main.deepMap3>
+      Pointee: 1092 GoHMapHeaderType hash<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1102
+      ID: 1119
       Name: '*hash<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1103 GoHMapHeaderType hash<int,*main.deepMap8>
+      Pointee: 1120 GoHMapHeaderType hash<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1111
+      ID: 1128
       Name: '*hash<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1112 GoHMapHeaderType hash<int,*main.deepMap9>
+      Pointee: 1129 GoHMapHeaderType hash<int,*main.deepMap9>
     - __kind: PointerType
       ID: 162
       Name: '*hash<int,int>'
       ByteSize: 8
       Pointee: 163 GoHMapHeaderType hash<int,int>
     - __kind: PointerType
-      ID: 1120
+      ID: 1137
       Name: '*hash<int,interface {}>'
       ByteSize: 8
-      Pointee: 1121 GoHMapHeaderType hash<int,interface {}>
+      Pointee: 1138 GoHMapHeaderType hash<int,interface {}>
     - __kind: PointerType
       ID: 229
       Name: '*hash<int,struct {}>'
@@ -9727,10 +9837,10 @@ Types:
       ByteSize: 8
       Pointee: 178 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 823
+      ID: 840
       Name: '*hash<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 824 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 841 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 172
       Name: '*hash<string,int>'
@@ -9792,12 +9902,12 @@ Types:
       ByteSize: 8
       Pointee: 205 GoHMapHeaderType hash<uint8,uint8>
     - __kind: PointerType
-      ID: 664
+      ID: 681
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 873760
       GoKind: 22
-      Pointee: 665 UnresolvedPointeeType html/template.Error
+      Pointee: 682 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 93
       Name: '*int'
@@ -9841,82 +9951,82 @@ Types:
       GoKind: 22
       Pointee: 152 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 544
+      ID: 561
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 840832
       GoKind: 22
-      Pointee: 545 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 562 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 859
+      ID: 876
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
       GoRuntimeType: 829024
       GoKind: 22
-      Pointee: 860 UnresolvedPointeeType internal/godebug.runtimeStderr
+      Pointee: 877 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
-      ID: 753
+      ID: 770
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.113056e+06
       GoKind: 22
-      Pointee: 754 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 771 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 1041
+      ID: 1058
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2.226784e+06
       GoKind: 22
-      Pointee: 1042 UnresolvedPointeeType internal/poll.FD
+      Pointee: 1059 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 751
+      ID: 768
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1.112928e+06
       GoKind: 22
-      Pointee: 752 StructureType internal/poll.errNetClosing
+      Pointee: 769 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 481
+      ID: 498
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 828160
       GoKind: 22
-      Pointee: 482 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 499 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 905
+      ID: 922
       Name: '*io.PipeWriter'
       ByteSize: 8
       GoRuntimeType: 1.104352e+06
       GoKind: 22
-      Pointee: 906 UnresolvedPointeeType io.PipeWriter
+      Pointee: 923 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
-      ID: 903
+      ID: 920
       Name: '*io.discard'
       ByteSize: 8
       GoRuntimeType: 1.103968e+06
       GoKind: 22
-      Pointee: 904 StructureType io.discard
+      Pointee: 921 StructureType io.discard
     - __kind: PointerType
-      ID: 877
+      ID: 894
       Name: '*io.multiWriter'
       ByteSize: 8
       GoRuntimeType: 981184
       GoKind: 22
-      Pointee: 878 UnresolvedPointeeType io.multiWriter
+      Pointee: 895 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
-      ID: 749
+      ID: 766
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1.112672e+06
       GoKind: 22
-      Pointee: 750 UnresolvedPointeeType io/fs.PathError
+      Pointee: 767 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 954
+      ID: 971
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 1.678208e+06
       GoKind: 22
-      Pointee: 955 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+      Pointee: 972 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
       ID: 312
       Name: '*main.anotherStruct'
@@ -9924,19 +10034,19 @@ Types:
       GoKind: 22
       Pointee: 313 StructureType main.anotherStruct
     - __kind: PointerType
-      ID: 331
+      ID: 348
       Name: '*main.deepMap2'
       ByteSize: 8
       GoRuntimeType: 356448
       GoKind: 22
-      Pointee: 332 StructureType main.deepMap2
+      Pointee: 349 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 1079
+      ID: 1096
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 356384
       GoKind: 22
-      Pointee: 1080 UnresolvedPointeeType main.deepMap3
+      Pointee: 1097 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 144
       Name: '*main.deepMap7'
@@ -9945,19 +10055,19 @@ Types:
       GoKind: 22
       Pointee: 145 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 1107
+      ID: 1124
       Name: '*main.deepMap8'
       ByteSize: 8
       GoRuntimeType: 356064
       GoKind: 22
-      Pointee: 1108 StructureType main.deepMap8
+      Pointee: 1125 StructureType main.deepMap8
     - __kind: PointerType
-      ID: 1116
+      ID: 1133
       Name: '*main.deepMap9'
       ByteSize: 8
       GoRuntimeType: 356000
       GoKind: 22
-      Pointee: 1117 StructureType main.deepMap9
+      Pointee: 1134 StructureType main.deepMap9
     - __kind: PointerType
       ID: 126
       Name: '*main.deepPtr2'
@@ -9966,12 +10076,12 @@ Types:
       GoKind: 22
       Pointee: 127 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 1045
+      ID: 1062
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 356960
       GoKind: 22
-      Pointee: 1046 UnresolvedPointeeType main.deepPtr3
+      Pointee: 1063 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 128
       Name: '*main.deepPtr7'
@@ -9980,33 +10090,33 @@ Types:
       GoKind: 22
       Pointee: 129 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 1082
+      ID: 1099
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 356640
       GoKind: 22
-      Pointee: 1083 StructureType main.deepPtr8
+      Pointee: 1100 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 1084
+      ID: 1101
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 356576
       GoKind: 22
-      Pointee: 1085 StructureType main.deepPtr9
+      Pointee: 1102 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 133
       Name: '*main.deepSlice2'
       ByteSize: 8
       GoRuntimeType: 357600
       GoKind: 22
-      Pointee: 325 StructureType main.deepSlice2
+      Pointee: 342 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 1069
+      ID: 1086
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 357536
       GoKind: 22
-      Pointee: 1070 UnresolvedPointeeType main.deepSlice3
+      Pointee: 1087 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 134
       Name: '*main.deepSlice7'
@@ -10015,19 +10125,19 @@ Types:
       GoKind: 22
       Pointee: 135 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 1088
+      ID: 1105
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 357216
       GoKind: 22
-      Pointee: 1089 StructureType main.deepSlice8
+      Pointee: 1106 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 1094
+      ID: 1111
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 357152
       GoKind: 22
-      Pointee: 1095 StructureType main.deepSlice9
+      Pointee: 1112 StructureType main.deepSlice9
     - __kind: PointerType
       ID: 315
       Name: '*main.emptyStruct'
@@ -10042,14 +10152,14 @@ Types:
       GoKind: 22
       Pointee: 155 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 1061
+      ID: 1078
       Name: '*main.firstBehavior'
       ByteSize: 8
       GoRuntimeType: 824128
       GoKind: 22
-      Pointee: 316 StructureType main.firstBehavior
+      Pointee: 333 StructureType main.firstBehavior
     - __kind: PointerType
-      ID: 1126
+      ID: 1143
       Name: '*main.nestedStruct'
       ByteSize: 8
       GoRuntimeType: 357856
@@ -10069,19 +10179,25 @@ Types:
       GoKind: 22
       Pointee: 266 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 1062
+      ID: 316
+      Name: '*main.receiver'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 317 StructureType main.receiver
+    - __kind: PointerType
+      ID: 1079
       Name: '*main.secondBehavior'
       ByteSize: 8
       GoRuntimeType: 824224
       GoKind: 22
-      Pointee: 1063 StructureType main.secondBehavior
+      Pointee: 1080 StructureType main.secondBehavior
     - __kind: PointerType
-      ID: 1050
+      ID: 1067
       Name: '*main.somethingImpl'
       ByteSize: 8
       GoRuntimeType: 824320
       GoKind: 22
-      Pointee: 1051 UnresolvedPointeeType main.somethingImpl
+      Pointee: 1068 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
       ID: 146
       Name: '*main.stringType1'
@@ -10089,28 +10205,28 @@ Types:
       GoKind: 22
       Pointee: 147 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 1048
+      ID: 1065
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 1047 GoStringDataType main.stringType1.str
+      Pointee: 1064 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 149
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 1049 GoStringHeaderType main.stringType2
+      Pointee: 1066 GoStringHeaderType main.stringType2
     - __kind: PointerType
-      ID: 1128
+      ID: 1145
       Name: '*main.stringType2.str'
       ByteSize: 8
-      Pointee: 1127 GoStringDataType main.stringType2.str
+      Pointee: 1144 GoStringDataType main.stringType2.str
     - __kind: PointerType
       ID: 269
       Name: '*main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 267 StructureType main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 348
+      ID: 365
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 355936
@@ -10134,10 +10250,10 @@ Types:
       GoKind: 22
       Pointee: 244 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 1066
+      ID: 1083
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 1065 GoSliceDataType main.t.array
+      Pointee: 1082 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 264
       Name: '*main.threeStringStruct'
@@ -10151,554 +10267,554 @@ Types:
       GoKind: 22
       Pointee: 171 GoMapType map[string]int
     - __kind: PointerType
-      ID: 578
+      ID: 595
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 848608
       GoKind: 22
-      Pointee: 579 StructureType math/big.ErrNaN
+      Pointee: 596 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 867
+      ID: 884
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
       GoRuntimeType: 843232
       GoKind: 22
-      Pointee: 868 StructureType mime/multipart.writerOnly·1
+      Pointee: 885 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
-      ID: 780
+      ID: 797
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1.121376e+06
       GoKind: 22
-      Pointee: 781 UnresolvedPointeeType net.AddrError
+      Pointee: 798 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 806
+      ID: 823
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1.239936e+06
       GoKind: 22
-      Pointee: 807 UnresolvedPointeeType net.DNSError
+      Pointee: 824 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 1005
+      ID: 1022
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2.086816e+06
       GoKind: 22
-      Pointee: 1006 UnresolvedPointeeType net.IPConn
+      Pointee: 1023 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 804
+      ID: 821
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1.239616e+06
       GoKind: 22
-      Pointee: 805 UnresolvedPointeeType net.OpError
+      Pointee: 822 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 782
+      ID: 799
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.121504e+06
       GoKind: 22
-      Pointee: 783 UnresolvedPointeeType net.ParseError
+      Pointee: 800 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 1015
+      ID: 1032
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2.116192e+06
       GoKind: 22
-      Pointee: 1016 UnresolvedPointeeType net.TCPConn
+      Pointee: 1033 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 1025
+      ID: 1042
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2.161152e+06
       GoKind: 22
-      Pointee: 1026 UnresolvedPointeeType net.UDPConn
+      Pointee: 1043 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 1013
+      ID: 1030
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2.11568e+06
       GoKind: 22
-      Pointee: 1014 UnresolvedPointeeType net.UnixConn
+      Pointee: 1031 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 779
+      ID: 796
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1.120608e+06
       GoKind: 22
-      Pointee: 742 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 759 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 744
+      ID: 761
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 743 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 760 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 710
+      ID: 727
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 996288
       GoKind: 22
-      Pointee: 711 StructureType net.canceledError
+      Pointee: 728 StructureType net.canceledError
     - __kind: PointerType
-      ID: 983
+      ID: 1000
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 1.873184e+06
       GoKind: 22
-      Pointee: 984 UnresolvedPointeeType net.conn
+      Pointee: 1001 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 848
+      ID: 865
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1.717408e+06
       GoKind: 22
-      Pointee: 849 StructureType net.dialResult·1
+      Pointee: 866 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 1027
+      ID: 1044
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2.165408e+06
       GoKind: 22
-      Pointee: 1028 UnresolvedPointeeType net.netFD
+      Pointee: 1045 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 513
+      ID: 530
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 835456
       GoKind: 22
-      Pointee: 514 UnresolvedPointeeType net.notFoundError
+      Pointee: 531 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 515
+      ID: 532
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 836128
       GoKind: 22
-      Pointee: 516 StructureType net.result·2
+      Pointee: 533 StructureType net.result·2
     - __kind: PointerType
-      ID: 1009
+      ID: 1026
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.100704e+06
       GoKind: 22
-      Pointee: 1010 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 1027 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 1007
+      ID: 1024
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.100224e+06
       GoKind: 22
-      Pointee: 1008 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 1025 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 784
+      ID: 801
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1.122144e+06
       GoKind: 22
-      Pointee: 785 UnresolvedPointeeType net.temporaryError
+      Pointee: 802 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 808
+      ID: 825
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.240096e+06
       GoKind: 22
-      Pointee: 809 UnresolvedPointeeType net.timeoutError
+      Pointee: 826 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 700
+      ID: 717
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 992064
       GoKind: 22
-      Pointee: 701 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 718 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
-      ID: 861
+      ID: 878
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
       GoRuntimeType: 831328
       GoKind: 22
-      Pointee: 862 StructureType net/http.bufioFlushWriter
+      Pointee: 879 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
-      ID: 490
+      ID: 507
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 832000
       GoKind: 22
-      Pointee: 411 BaseType net/http.http2ConnectionError
+      Pointee: 428 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 491
+      ID: 508
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 832096
       GoKind: 22
-      Pointee: 492 StructureType net/http.http2GoAwayError
+      Pointee: 509 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 800
+      ID: 817
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1.235776e+06
       GoKind: 22
-      Pointee: 801 StructureType net/http.http2StreamError
+      Pointee: 818 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 495
+      ID: 512
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 832576
       GoKind: 22
-      Pointee: 496 StructureType net/http.http2connError
+      Pointee: 513 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 923
+      ID: 940
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
       GoRuntimeType: 1.366528e+06
       GoKind: 22
-      Pointee: 924 UnresolvedPointeeType net/http.http2dataBuffer
+      Pointee: 941 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 494
+      ID: 511
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 832480
       GoKind: 22
-      Pointee: 415 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 432 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 417
+      ID: 434
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 416 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 433 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 498
+      ID: 515
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 832768
       GoKind: 22
-      Pointee: 421 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 438 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 423
+      ID: 440
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 422 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 439 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 497
+      ID: 514
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 832672
       GoKind: 22
-      Pointee: 418 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 435 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 420
+      ID: 437
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 419 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 436 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 775
+      ID: 792
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1.117152e+06
       GoKind: 22
-      Pointee: 776 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 793 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 706
+      ID: 723
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 992704
       GoKind: 22
-      Pointee: 707 StructureType net/http.http2noCachedConnError
+      Pointee: 724 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 974
+      ID: 991
       Name: '*net/http.http2pipe'
       ByteSize: 8
       GoRuntimeType: 1.817184e+06
       GoKind: 22
-      Pointee: 975 UnresolvedPointeeType net/http.http2pipe
+      Pointee: 992 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 493
+      ID: 510
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 832384
       GoKind: 22
-      Pointee: 412 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 429 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 414
+      ID: 431
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 413 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 430 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 863
+      ID: 880
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
       GoRuntimeType: 832864
       GoKind: 22
-      Pointee: 864 StructureType net/http.http2stickyErrWriter
+      Pointee: 881 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
-      ID: 702
+      ID: 719
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 992320
       GoKind: 22
-      Pointee: 703 StructureType net/http.nothingWrittenError
+      Pointee: 720 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 925
+      ID: 942
       Name: '*net/http.persistConn'
       ByteSize: 8
       GoRuntimeType: 2.031136e+06
       GoKind: 22
-      Pointee: 926 UnresolvedPointeeType net/http.persistConn
+      Pointee: 943 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
-      ID: 881
+      ID: 898
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
       GoRuntimeType: 992192
       GoKind: 22
-      Pointee: 882 StructureType net/http.persistConnWriter
+      Pointee: 899 StructureType net/http.persistConnWriter
     - __kind: PointerType
-      ID: 907
+      ID: 924
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1.116128e+06
       GoKind: 22
-      Pointee: 908 StructureType net/http.readWriteCloserBody
+      Pointee: 925 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 499
+      ID: 516
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 832960
       GoKind: 22
-      Pointee: 500 StructureType net/http.requestBodyReadError
+      Pointee: 517 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 802
+      ID: 819
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.236896e+06
       GoKind: 22
-      Pointee: 803 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 820 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 773
+      ID: 790
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1.117024e+06
       GoKind: 22
-      Pointee: 774 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 791 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 704
+      ID: 721
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 992448
       GoKind: 22
-      Pointee: 705 StructureType net/http.transportReadFromServerError
+      Pointee: 722 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 488
+      ID: 505
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 831232
       GoKind: 22
-      Pointee: 489 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 506 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 976
+      ID: 993
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
       GoRuntimeType: 1.81872e+06
       GoKind: 22
-      Pointee: 977 StructureType net/http/internal.FlushAfterChunkWriter
+      Pointee: 994 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
-      ID: 891
+      ID: 908
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
       GoRuntimeType: 1.00576e+06
       GoKind: 22
-      Pointee: 892 UnresolvedPointeeType net/http/internal.chunkedWriter
+      Pointee: 909 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
-      ID: 570
+      ID: 587
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 847552
       GoKind: 22
-      Pointee: 571 StructureType net/netip.parseAddrError
+      Pointee: 588 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 568
+      ID: 585
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 847456
       GoKind: 22
-      Pointee: 569 StructureType net/netip.parsePrefixError
+      Pointee: 586 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 933
+      ID: 950
       Name: '*net/smtp.Client'
       ByteSize: 8
       GoRuntimeType: 1.9808e+06
       GoKind: 22
-      Pointee: 934 UnresolvedPointeeType net/smtp.Client
+      Pointee: 951 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
-      ID: 893
+      ID: 910
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
       GoRuntimeType: 1.01088e+06
       GoKind: 22
-      Pointee: 894 StructureType net/smtp.dataCloser
+      Pointee: 911 StructureType net/smtp.dataCloser
     - __kind: PointerType
-      ID: 554
+      ID: 571
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 843424
       GoKind: 22
-      Pointee: 555 UnresolvedPointeeType net/textproto.Error
+      Pointee: 572 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 553
+      ID: 570
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 843328
       GoKind: 22
-      Pointee: 446 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 463 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 448
+      ID: 465
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 447 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 464 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 889
+      ID: 906
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
       GoRuntimeType: 1.00512e+06
       GoKind: 22
-      Pointee: 890 UnresolvedPointeeType net/textproto.dotWriter
+      Pointee: 907 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
-      ID: 810
+      ID: 827
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1.240416e+06
       GoKind: 22
-      Pointee: 811 UnresolvedPointeeType net/url.Error
+      Pointee: 828 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 517
+      ID: 534
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 836224
       GoKind: 22
-      Pointee: 424 GoStringHeaderType net/url.EscapeError
+      Pointee: 441 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 426
+      ID: 443
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 425 GoStringDataType net/url.EscapeError.str
+      Pointee: 442 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 518
+      ID: 535
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 836320
       GoKind: 22
-      Pointee: 427 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 444 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 429
+      ID: 446
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 428 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 445 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
-      ID: 1033
+      ID: 1050
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2.202656e+06
       GoKind: 22
-      Pointee: 1034 UnresolvedPointeeType os.File
+      Pointee: 1051 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 681
+      ID: 698
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 983232
       GoKind: 22
-      Pointee: 682 UnresolvedPointeeType os.LinkError
+      Pointee: 699 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 745
+      ID: 762
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1.105632e+06
       GoKind: 22
-      Pointee: 746 UnresolvedPointeeType os.SyscallError
+      Pointee: 763 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 1031
+      ID: 1048
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.199712e+06
       GoKind: 22
-      Pointee: 1032 StructureType os.fileWithoutReadFrom
+      Pointee: 1049 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 1029
+      ID: 1046
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.198976e+06
       GoKind: 22
-      Pointee: 1030 StructureType os.fileWithoutWriteTo
+      Pointee: 1047 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 712
+      ID: 729
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1.001792e+06
       GoKind: 22
-      Pointee: 713 UnresolvedPointeeType os/exec.Error
+      Pointee: 730 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 851
+      ID: 868
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 1.952768e+06
       GoKind: 22
-      Pointee: 852 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 869 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 911
+      ID: 928
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
       GoRuntimeType: 1.12816e+06
       GoKind: 22
-      Pointee: 912 UnresolvedPointeeType os/exec.prefixSuffixSaver
+      Pointee: 929 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
-      ID: 714
+      ID: 731
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1.00192e+06
       GoKind: 22
-      Pointee: 715 StructureType os/exec.wrappedError
+      Pointee: 732 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 648
+      ID: 665
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 864544
       GoKind: 22
-      Pointee: 459 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 476 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 461
+      ID: 478
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 460 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 477 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 647
+      ID: 664
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 864448
       GoKind: 22
-      Pointee: 458 BaseType os/user.UnknownUserIdError
+      Pointee: 475 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 483
+      ID: 500
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 828928
       GoKind: 22
-      Pointee: 484 UnresolvedPointeeType reflect.ValueError
+      Pointee: 501 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 576
+      ID: 593
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 848224
       GoKind: 22
-      Pointee: 577 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 594 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 684
+      ID: 701
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 984768
       GoKind: 22
-      Pointee: 685 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 702 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 689
+      ID: 706
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 986688
       GoKind: 22
-      Pointee: 690 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 707 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
@@ -10714,12 +10830,12 @@ Types:
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 686
+      ID: 703
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 984896
       GoKind: 22
-      Pointee: 687 StructureType runtime.boundsError
+      Pointee: 704 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 60
       Name: '*runtime.cgoCallers'
@@ -10735,24 +10851,24 @@ Types:
       GoKind: 22
       Pointee: 48 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 747
+      ID: 764
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1.111008e+06
       GoKind: 22
-      Pointee: 748 StructureType runtime.errorAddressString
+      Pointee: 765 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 683
+      ID: 700
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 984512
       GoKind: 22
-      Pointee: 666 GoStringHeaderType runtime.errorString
+      Pointee: 683 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 668
+      ID: 685
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 667 GoStringDataType runtime.errorString.str
+      Pointee: 684 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 53
       Name: '*runtime.g'
@@ -10775,17 +10891,17 @@ Types:
       GoKind: 22
       Pointee: 143 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
-      ID: 688
+      ID: 705
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 986432
       GoKind: 22
-      Pointee: 669 GoStringHeaderType runtime.plainError
+      Pointee: 686 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 671
+      ID: 688
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 670 GoStringDataType runtime.plainError.str
+      Pointee: 687 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
@@ -10808,12 +10924,12 @@ Types:
       GoKind: 22
       Pointee: 73 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 691
+      ID: 708
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 986944
       GoKind: 22
-      Pointee: 692 UnresolvedPointeeType strconv.NumError
+      Pointee: 709 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 88
       Name: '*string'
@@ -10822,83 +10938,83 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 318
+      ID: 335
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 317 GoStringDataType string.str
+      Pointee: 334 GoStringDataType string.str
     - __kind: PointerType
-      ID: 972
+      ID: 989
       Name: '*strings.Builder'
       ByteSize: 8
       GoRuntimeType: 1.815904e+06
       GoKind: 22
-      Pointee: 973 UnresolvedPointeeType strings.Builder
+      Pointee: 990 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
-      ID: 879
+      ID: 896
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
       GoRuntimeType: 987072
       GoKind: 22
-      Pointee: 880 UnresolvedPointeeType strings.appendSliceWriter
+      Pointee: 897 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
-      ID: 875
+      ID: 892
       Name: '*struct { io.Writer }'
       ByteSize: 8
       GoRuntimeType: 920352
       GoKind: 22
-      Pointee: 876 StructureType struct { io.Writer }
+      Pointee: 893 StructureType struct { io.Writer }
     - __kind: PointerType
       ID: 262
       Name: '*struct {}'
       ByteSize: 8
       Pointee: 118 StructureType struct {}
     - __kind: PointerType
-      ID: 799
+      ID: 816
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1.235136e+06
       GoKind: 22
-      Pointee: 798 BaseType syscall.Errno
+      Pointee: 815 BaseType syscall.Errno
     - __kind: PointerType
-      ID: 1003
+      ID: 1020
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
       GoRuntimeType: 2.018752e+06
       GoKind: 22
-      Pointee: 1004 UnresolvedPointeeType text/tabwriter.Writer
+      Pointee: 1021 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
-      ID: 740
+      ID: 757
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1.047616e+06
       GoKind: 22
-      Pointee: 741 StructureType text/template.ExecError
+      Pointee: 758 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 815
+      ID: 832
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.431648e+06
       GoKind: 22
-      Pointee: 816 UnresolvedPointeeType time.Location
+      Pointee: 833 UnresolvedPointeeType time.Location
     - __kind: PointerType
-      ID: 486
+      ID: 503
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 829792
       GoKind: 22
-      Pointee: 487 UnresolvedPointeeType time.ParseError
+      Pointee: 504 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 485
+      ID: 502
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 829696
       GoKind: 22
-      Pointee: 408 GoStringHeaderType time.fileSizeError
+      Pointee: 425 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 410
+      ID: 427
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 409 GoStringDataType time.fileSizeError.str
+      Pointee: 426 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
       ID: 100
       Name: '*uint'
@@ -10942,59 +11058,95 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: PointerType
-      ID: 966
+      ID: 983
       Name: '*vendor/golang.org/x/crypto/sha3.state'
       ByteSize: 8
       GoRuntimeType: 1.77216e+06
       GoKind: 22
-      Pointee: 967 UnresolvedPointeeType vendor/golang.org/x/crypto/sha3.state
+      Pointee: 984 UnresolvedPointeeType vendor/golang.org/x/crypto/sha3.state
     - __kind: PointerType
-      ID: 572
+      ID: 589
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 847648
       GoKind: 22
-      Pointee: 573 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 590 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 995
+      ID: 1012
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 1.995328e+06
       GoKind: 22
-      Pointee: 996 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1013 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 556
+      ID: 573
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 843808
       GoKind: 22
-      Pointee: 557 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 574 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 558
+      ID: 575
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 843904
       GoKind: 22
-      Pointee: 449 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 466 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 719
+      ID: 736
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1.005504e+06
       GoKind: 22
-      Pointee: 720 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 737 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 721
+      ID: 738
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1.005632e+06
       GoKind: 22
-      Pointee: 674 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 691 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1376
+      ID: 1394
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
     - __kind: EventRootType
-      ID: 1374
+      ID: 1378
+      Name: Probe[main.executeStructFuncs]Line
+      ByteSize: 66
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: sta.a
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 331 ArrayType [3]uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 11, name: sta}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: sta.b
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 11, name: sta}
+                  Offset: 24
+                  ByteSize: 1
+        - Name: sta.c
+          Offset: 26
+          Kind: template_segment
+          Expression:
+            Type: 332 ArrayType [5]int64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 11, name: sta}
+                  Offset: 32
+                  ByteSize: 40
+    - __kind: EventRootType
+      ID: 1392
       Name: Probe[main.firstBehavior.DoSomething]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11003,14 +11155,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 316 StructureType main.firstBehavior
+            Type: 333 StructureType main.firstBehavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 0, name: b}
+                  Variable: {subprogram: 165, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1375
+      ID: 1393
       Name: Probe[main.firstBehavior.DoSomething]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11022,14 +11174,14 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 1, name: ~r0}
+                  Variable: {subprogram: 165, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1332
+      ID: 1349
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1333
+      ID: 1350
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11045,7 +11197,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1199
+      ID: 1216
       Name: Probe[main.testAnyPtr]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11071,7 +11223,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1200
+      ID: 1217
       Name: Probe[main.testAnyPtr]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11087,7 +11239,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1196
+      ID: 1213
       Name: Probe[main.testAny]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11113,7 +11265,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1197
+      ID: 1214
       Name: Probe[main.testAny]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11129,7 +11281,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1303
+      ID: 1320
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11155,7 +11307,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1304
+      ID: 1321
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11171,7 +11323,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1147
+      ID: 1164
       Name: Probe[main.testArrayEmptyStructs]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11197,7 +11349,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1145
+      ID: 1162
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 129
       PresenceBitsetSize: 1
@@ -11223,7 +11375,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1143
+      ID: 1160
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -11249,7 +11401,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1208
+      ID: 1225
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11275,7 +11427,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1144
+      ID: 1161
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -11301,7 +11453,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1146
+      ID: 1163
       Name: Probe[main.testArrayOfStructs]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -11327,7 +11479,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1230
+      ID: 1247
       Name: Probe[main.testAtomicAdd]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11353,7 +11505,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1231
+      ID: 1248
       Name: Probe[main.testAtomicAdd]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11369,7 +11521,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1165
+      ID: 1182
       Name: Probe[main.testBigStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -11395,10 +11547,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1166
+      ID: 1183
       Name: Probe[main.testBigStruct]Return
     - __kind: EventRootType
-      ID: 1132
+      ID: 1149
       Name: Probe[main.testBoolArray]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -11424,7 +11576,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1129
+      ID: 1146
       Name: Probe[main.testByteArray]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -11450,7 +11602,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1232
+      ID: 1249
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11476,7 +11628,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1226
+      ID: 1243
       Name: Probe[main.testCombinedByte]
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -11542,7 +11694,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1227
+      ID: 1244
       Name: Probe[main.testCombinedString]
       ByteSize: 18
       PresenceBitsetSize: 1
@@ -11568,7 +11720,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1228
+      ID: 1245
       Name: Probe[main.testCombinedString]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -11604,7 +11756,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1240
+      ID: 1257
       Name: Probe[main.testCycle]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11630,7 +11782,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1171
+      ID: 1188
       Name: Probe[main.testDeepMap1]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11656,7 +11808,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1172
+      ID: 1189
       Name: Probe[main.testDeepMap7]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11682,7 +11834,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1167
+      ID: 1184
       Name: Probe[main.testDeepPtr1]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11708,7 +11860,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1168
+      ID: 1185
       Name: Probe[main.testDeepPtr7]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11734,7 +11886,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1169
+      ID: 1186
       Name: Probe[main.testDeepSlice1]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11760,7 +11912,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1170
+      ID: 1187
       Name: Probe[main.testDeepSlice7]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11786,7 +11938,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1323
+      ID: 1340
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -11832,7 +11984,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1320
+      ID: 1337
       Name: Probe[main.testEmptySlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11858,7 +12010,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1346
+      ID: 1363
       Name: Probe[main.testEmptyString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11884,7 +12036,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1360
+      ID: 1377
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11910,7 +12062,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1359
+      ID: 1376
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11936,7 +12088,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1198
+      ID: 1215
       Name: Probe[main.testError]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11962,7 +12114,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1180
+      ID: 1197
       Name: Probe[main.testEsotericHeap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11988,10 +12140,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1181
+      ID: 1198
       Name: Probe[main.testEsotericHeap]Return
     - __kind: EventRootType
-      ID: 1178
+      ID: 1195
       Name: Probe[main.testEsotericStack]
       ByteSize: 129
       PresenceBitsetSize: 1
@@ -12017,10 +12169,10 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1179
+      ID: 1196
       Name: Probe[main.testEsotericStack]Return
     - __kind: EventRootType
-      ID: 1192
+      ID: 1209
       Name: Probe[main.testFramelessArray]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12046,7 +12198,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1194
+      ID: 1211
       Name: Probe[main.testFramelessArray]Line
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -12082,7 +12234,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1193
+      ID: 1210
       Name: Probe[main.testFramelessArray]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12098,7 +12250,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1190
+      ID: 1207
       Name: Probe[main.testFrameless]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12124,7 +12276,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1191
+      ID: 1208
       Name: Probe[main.testFrameless]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12140,7 +12292,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1182
+      ID: 1199
       Name: Probe[main.testInlinedBA]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12166,10 +12318,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1183
+      ID: 1200
       Name: Probe[main.testInlinedBA]Return
     - __kind: EventRootType
-      ID: 1186
+      ID: 1203
       Name: Probe[main.testInlinedBBA]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12195,13 +12347,13 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1187
+      ID: 1204
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1366
+      ID: 1384
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 1184
+      ID: 1201
       Name: Probe[main.testInlinedBB]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12247,28 +12399,28 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1185
+      ID: 1202
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1367
+      ID: 1385
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1368
+      ID: 1386
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1369
+      ID: 1387
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1370
+      ID: 1388
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
-      ID: 1188
+      ID: 1205
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 1189
+      ID: 1206
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1363
+      ID: 1381
       Name: Probe[main.testInlinedPrint]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12280,7 +12432,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12290,11 +12442,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1361
+      ID: 1379
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12306,11 +12458,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1362
+      ID: 1380
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12322,7 +12474,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x_val
@@ -12332,11 +12484,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1365
+      ID: 1383
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12348,7 +12500,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12358,14 +12510,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1364
+      ID: 1382
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1371
+      ID: 1389
       Name: Probe[main.testInlinedSq]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12377,7 +12529,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12387,11 +12539,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1372
+      ID: 1390
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12403,7 +12555,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12413,11 +12565,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1373
+      ID: 1391
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12429,7 +12581,7 @@ Types:
             Type: 156 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: a}
+                  Variable: {subprogram: 164, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: a
@@ -12439,11 +12591,11 @@ Types:
             Type: 156 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: a}
+                  Variable: {subprogram: 164, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1135
+      ID: 1152
       Name: Probe[main.testInt16Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12469,7 +12621,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1136
+      ID: 1153
       Name: Probe[main.testInt32Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12495,7 +12647,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1137
+      ID: 1154
       Name: Probe[main.testInt64Array]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12521,7 +12673,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1134
+      ID: 1151
       Name: Probe[main.testInt8Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -12547,7 +12699,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1133
+      ID: 1150
       Name: Probe[main.testIntArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12573,7 +12725,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1195
+      ID: 1212
       Name: Probe[main.testInterface]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12599,7 +12751,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1301
+      ID: 1318
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 161
       PresenceBitsetSize: 1
@@ -12625,7 +12777,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1302
+      ID: 1319
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12641,7 +12793,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1234
+      ID: 1251
       Name: Probe[main.testLinkedList]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12667,36 +12819,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1175
+      ID: 1192
       Name: Probe[main.testLongFunctionWithChangingState]Line
     - __kind: EventRootType
-      ID: 1176
-      Name: Probe[main.testLongFunctionWithChangingState]Line
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: aPerArch
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 1, name: aPerArch}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: b
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 2, name: b}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1177
+      ID: 1193
       Name: Probe[main.testLongFunctionWithChangingState]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12722,7 +12848,33 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1307
+      ID: 1194
+      Name: Probe[main.testLongFunctionWithChangingState]Line
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: aPerArch
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 1, name: aPerArch}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1324
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 147
       PresenceBitsetSize: 3
@@ -12908,7 +13060,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1308
+      ID: 1325
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12924,7 +13076,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1206
+      ID: 1223
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12950,7 +13102,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1213
+      ID: 1230
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12976,7 +13128,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1225
+      ID: 1242
       Name: Probe[main.testMapEmptyKeyAndValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13002,7 +13154,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1223
+      ID: 1240
       Name: Probe[main.testMapEmptyKey]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13028,7 +13180,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1224
+      ID: 1241
       Name: Probe[main.testMapEmptyValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13054,7 +13206,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1210
+      ID: 1227
       Name: Probe[main.testMapIntToInt]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13080,7 +13232,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1222
+      ID: 1239
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13106,7 +13258,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1221
+      ID: 1238
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13132,7 +13284,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1211
+      ID: 1228
       Name: Probe[main.testMapMassive]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13158,7 +13310,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1212
+      ID: 1229
       Name: Probe[main.testMapMassive]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13184,7 +13336,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1220
+      ID: 1237
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13210,7 +13362,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1219
+      ID: 1236
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13236,7 +13388,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1204
+      ID: 1221
       Name: Probe[main.testMapStringToInt]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13262,7 +13414,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1205
+      ID: 1222
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13288,7 +13440,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1203
+      ID: 1220
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13314,7 +13466,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1214
+      ID: 1231
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13340,7 +13492,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1218
+      ID: 1235
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13366,7 +13518,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1217
+      ID: 1234
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13392,7 +13544,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1216
+      ID: 1233
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13418,7 +13570,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1215
+      ID: 1232
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13444,7 +13596,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1343
+      ID: 1360
       Name: Probe[main.testMassiveString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13470,7 +13622,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1344
+      ID: 1361
       Name: Probe[main.testMassiveString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13496,7 +13648,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1309
+      ID: 1326
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 163
       PresenceBitsetSize: 3
@@ -13682,7 +13834,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1310
+      ID: 1327
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13698,7 +13850,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1313
+      ID: 1330
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13744,7 +13896,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1314
+      ID: 1331
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13770,7 +13922,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1305
+      ID: 1322
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 321
       PresenceBitsetSize: 1
@@ -13816,7 +13968,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1306
+      ID: 1323
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13832,7 +13984,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1259
+      ID: 1276
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13858,7 +14010,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1261
+      ID: 1278
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13904,7 +14056,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1263
+      ID: 1280
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -13920,7 +14072,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1265
+      ID: 1282
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -13936,7 +14088,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1267
+      ID: 1284
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -13952,7 +14104,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1260
+      ID: 1277
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13978,7 +14130,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1262
+      ID: 1279
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -14044,7 +14196,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1264
+      ID: 1281
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14070,7 +14222,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1266
+      ID: 1283
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14096,7 +14248,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1268
+      ID: 1285
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14122,7 +14274,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1229
+      ID: 1246
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 62
       PresenceBitsetSize: 2
@@ -14228,7 +14380,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1255
+      ID: 1272
       Name: Probe[main.testNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14254,7 +14406,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1257
+      ID: 1274
       Name: Probe[main.testNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14280,7 +14432,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1256
+      ID: 1273
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14296,7 +14448,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1258
+      ID: 1275
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14322,7 +14474,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1355
+      ID: 1372
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14348,7 +14500,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1356
+      ID: 1373
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14370,10 +14522,10 @@ Types:
                   Bias: 8
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1357
+      ID: 1374
       Name: Probe[main.testNestedPointer]
     - __kind: EventRootType
-      ID: 1358
+      ID: 1375
       Name: Probe[main.testNestedPointer]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -14395,7 +14547,7 @@ Types:
                   Bias: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1239
+      ID: 1256
       Name: Probe[main.testNilPointer]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14441,7 +14593,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1324
+      ID: 1341
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -14487,7 +14639,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1326
+      ID: 1343
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 67
       PresenceBitsetSize: 1
@@ -14553,7 +14705,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1327
+      ID: 1344
       Name: Probe[main.testNilSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -14579,7 +14731,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1342
+      ID: 1359
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14605,7 +14757,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1235
+      ID: 1252
       Name: Probe[main.testPointerLoop]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14631,7 +14783,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1209
+      ID: 1226
       Name: Probe[main.testPointerToMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14657,7 +14809,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1233
+      ID: 1250
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14683,7 +14835,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1249
+      ID: 1266
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 35
       PresenceBitsetSize: 1
@@ -14729,7 +14881,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1250
+      ID: 1267
       Name: Probe[main.testReturnsAnyAndError]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14755,7 +14907,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1251
+      ID: 1268
       Name: Probe[main.testReturnsAny]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14781,7 +14933,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1252
+      ID: 1269
       Name: Probe[main.testReturnsAny]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14797,10 +14949,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1281
+      ID: 1298
       Name: Probe[main.testReturnsArrayOne]
     - __kind: EventRootType
-      ID: 1282
+      ID: 1299
       Name: Probe[main.testReturnsArrayOne]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14816,10 +14968,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1283
+      ID: 1300
       Name: Probe[main.testReturnsArrayZero]
     - __kind: EventRootType
-      ID: 1284
+      ID: 1301
       Name: Probe[main.testReturnsArrayZero]Return
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -14835,10 +14987,10 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1279
+      ID: 1296
       Name: Probe[main.testReturnsArray]
     - __kind: EventRootType
-      ID: 1280
+      ID: 1297
       Name: Probe[main.testReturnsArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -14854,10 +15006,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1287
+      ID: 1304
       Name: Probe[main.testReturnsBacktrackInt]
     - __kind: EventRootType
-      ID: 1288
+      ID: 1305
       Name: Probe[main.testReturnsBacktrackInt]Return
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -14953,10 +15105,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1299
+      ID: 1316
       Name: Probe[main.testReturnsBoolAndUintptr]
     - __kind: EventRootType
-      ID: 1300
+      ID: 1317
       Name: Probe[main.testReturnsBoolAndUintptr]Return
       ByteSize: 10
       PresenceBitsetSize: 1
@@ -14982,10 +15134,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1275
+      ID: 1292
       Name: Probe[main.testReturnsComplex]
     - __kind: EventRootType
-      ID: 1276
+      ID: 1293
       Name: Probe[main.testReturnsComplex]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15011,7 +15163,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1247
+      ID: 1264
       Name: Probe[main.testReturnsError]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -15037,7 +15189,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1248
+      ID: 1265
       Name: Probe[main.testReturnsError]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15053,7 +15205,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1245
+      ID: 1262
       Name: Probe[main.testReturnsIntAndFloat]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15079,7 +15231,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1246
+      ID: 1263
       Name: Probe[main.testReturnsIntAndFloat]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15105,7 +15257,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1243
+      ID: 1260
       Name: Probe[main.testReturnsIntPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15131,7 +15283,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1244
+      ID: 1261
       Name: Probe[main.testReturnsIntPointer]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15147,7 +15299,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1241
+      ID: 1258
       Name: Probe[main.testReturnsInt]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15173,7 +15325,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1242
+      ID: 1259
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15189,7 +15341,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1253
+      ID: 1270
       Name: Probe[main.testReturnsInterface]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15215,7 +15367,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1254
+      ID: 1271
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15231,10 +15383,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1277
+      ID: 1294
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1278
+      ID: 1295
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -15250,10 +15402,10 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1273
+      ID: 1290
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1274
+      ID: 1291
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 139
       PresenceBitsetSize: 3
@@ -15429,10 +15581,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1285
+      ID: 1302
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1286
+      ID: 1303
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15448,10 +15600,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1291
+      ID: 1308
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1292
+      ID: 1309
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -15507,10 +15659,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1297
+      ID: 1314
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1298
+      ID: 1315
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -15536,10 +15688,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1295
+      ID: 1312
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1296
+      ID: 1313
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15555,10 +15707,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1271
+      ID: 1288
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1272
+      ID: 1289
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -15644,10 +15796,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1293
+      ID: 1310
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1294
+      ID: 1311
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15663,10 +15815,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1289
+      ID: 1306
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1290
+      ID: 1307
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -15682,7 +15834,7 @@ Types:
                   Offset: 0
                   ByteSize: 88
     - __kind: EventRootType
-      ID: 1130
+      ID: 1147
       Name: Probe[main.testRuneArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15708,7 +15860,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1151
+      ID: 1168
       Name: Probe[main.testSingleBool]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -15734,7 +15886,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1149
+      ID: 1166
       Name: Probe[main.testSingleByte]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -15760,7 +15912,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1162
+      ID: 1179
       Name: Probe[main.testSingleFloat32]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15786,7 +15938,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1163
+      ID: 1180
       Name: Probe[main.testSingleFloat64]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15812,7 +15964,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1154
+      ID: 1171
       Name: Probe[main.testSingleInt16]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -15838,7 +15990,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1155
+      ID: 1172
       Name: Probe[main.testSingleInt32]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15864,7 +16016,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1156
+      ID: 1173
       Name: Probe[main.testSingleInt64]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15890,7 +16042,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1153
+      ID: 1170
       Name: Probe[main.testSingleInt8]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -15936,7 +16088,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1152
+      ID: 1169
       Name: Probe[main.testSingleInt]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15962,7 +16114,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1150
+      ID: 1167
       Name: Probe[main.testSingleRune]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15988,7 +16140,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1334
+      ID: 1351
       Name: Probe[main.testSingleString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16014,7 +16166,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1159
+      ID: 1176
       Name: Probe[main.testSingleUint16]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -16040,7 +16192,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1160
+      ID: 1177
       Name: Probe[main.testSingleUint32]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -16066,7 +16218,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1161
+      ID: 1178
       Name: Probe[main.testSingleUint64]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16092,7 +16244,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1158
+      ID: 1175
       Name: Probe[main.testSingleUint8]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -16118,7 +16270,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1157
+      ID: 1174
       Name: Probe[main.testSingleUint]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16144,7 +16296,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1330
+      ID: 1347
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16170,7 +16322,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1321
+      ID: 1338
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16196,7 +16348,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1207
+      ID: 1224
       Name: Probe[main.testSmallMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16222,7 +16374,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1269
+      ID: 1286
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16248,7 +16400,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1270
+      ID: 1287
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16284,7 +16436,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1311
+      ID: 1328
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -16310,7 +16462,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1312
+      ID: 1329
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16346,7 +16498,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1131
+      ID: 1148
       Name: Probe[main.testStringArray]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -16372,7 +16524,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1238
+      ID: 1255
       Name: Probe[main.testStringPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16398,7 +16550,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1325
+      ID: 1342
       Name: Probe[main.testStringSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16424,7 +16576,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1173
+      ID: 1190
       Name: Probe[main.testStringType1]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16450,7 +16602,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1174
+      ID: 1191
       Name: Probe[main.testStringType2]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16476,7 +16628,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1322
+      ID: 1339
       Name: Probe[main.testStructSlice]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -16522,7 +16674,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1201
+      ID: 1218
       Name: Probe[main.testStructWithAny]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16548,7 +16700,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1315
+      ID: 1332
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16574,7 +16726,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1316
+      ID: 1333
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16600,7 +16752,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1349
+      ID: 1366
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16626,10 +16778,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1350
+      ID: 1367
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1348
+      ID: 1365
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 289
       PresenceBitsetSize: 1
@@ -16655,7 +16807,7 @@ Types:
                   Offset: 0
                   ByteSize: 144
     - __kind: EventRootType
-      ID: 1202
+      ID: 1219
       Name: Probe[main.testStructWithMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16681,7 +16833,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1351
+      ID: 1368
       Name: Probe[main.testStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16697,7 +16849,7 @@ Types:
                   Offset: 8
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1353
+      ID: 1370
       Name: Probe[main.testStruct]
       ByteSize: 113
       PresenceBitsetSize: 1
@@ -16723,13 +16875,13 @@ Types:
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1352
+      ID: 1369
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1354
+      ID: 1371
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1331
+      ID: 1348
       Name: Probe[main.testSubslices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -16795,7 +16947,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1347
+      ID: 1364
       Name: Probe[main.testSubstrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16861,7 +17013,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1340
+      ID: 1357
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16887,7 +17039,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1341
+      ID: 1358
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16932,7 +17084,7 @@ Types:
                   Bias: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1336
+      ID: 1353
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16958,7 +17110,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1338
+      ID: 1355
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16994,13 +17146,13 @@ Types:
                   Offset: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1337
+      ID: 1354
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1339
+      ID: 1356
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1335
+      ID: 1352
       Name: Probe[main.testThreeStrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17066,7 +17218,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1164
+      ID: 1181
       Name: Probe[main.testTypeAlias]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -17092,7 +17244,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1140
+      ID: 1157
       Name: Probe[main.testUint16Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -17118,7 +17270,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1141
+      ID: 1158
       Name: Probe[main.testUint32Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17144,7 +17296,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1142
+      ID: 1159
       Name: Probe[main.testUint64Array]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17170,7 +17322,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1139
+      ID: 1156
       Name: Probe[main.testUint8Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -17196,7 +17348,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1138
+      ID: 1155
       Name: Probe[main.testUintArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17222,7 +17374,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1237
+      ID: 1254
       Name: Probe[main.testUintPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17248,7 +17400,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1319
+      ID: 1336
       Name: Probe[main.testUintSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17274,7 +17426,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1345
+      ID: 1362
       Name: Probe[main.testUnitializedString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17300,7 +17452,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1236
+      ID: 1253
       Name: Probe[main.testUnsafePointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17326,7 +17478,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1148
+      ID: 1165
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 1601
       PresenceBitsetSize: 1
@@ -17352,7 +17504,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1328
+      ID: 1345
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17378,7 +17530,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1329
+      ID: 1346
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17404,7 +17556,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1317
+      ID: 1334
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17450,7 +17602,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1318
+      ID: 1335
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -17702,7 +17854,15 @@ Types:
       HasCount: true
       Element: 32 StructureType internal/runtime/atomic.Uint32
     - __kind: ArrayType
-      ID: 358
+      ID: 331
+      Name: '[3]uint64'
+      ByteSize: 24
+      GoKind: 17
+      Count: 3
+      HasCount: true
+      Element: 10 BaseType uint64
+    - __kind: ArrayType
+      ID: 375
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 622720
@@ -17711,7 +17871,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 343
+      ID: 360
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 623008
@@ -17737,7 +17897,15 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 843
+      ID: 332
+      Name: '[5]int64'
+      ByteSize: 40
+      GoKind: 17
+      Count: 5
+      HasCount: true
+      Element: 13 BaseType int64
+    - __kind: ArrayType
+      ID: 860
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 624160
@@ -17764,7 +17932,7 @@ Types:
       HasCount: true
       Element: 79 StructureType runtime.pcvalueCacheEnt
     - __kind: ArrayType
-      ID: 328
+      ID: 345
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 620128
@@ -17788,15 +17956,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 326 GoSliceDataType []*main.deepSlice2.array
+      Data: 343 GoSliceDataType []*main.deepSlice2.array
     - __kind: GoSliceDataType
-      ID: 326
+      ID: 343
       Name: '[]*main.deepSlice2.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 133 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 1067
+      ID: 1084
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 447008
@@ -17804,22 +17972,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1068 PointerType **main.deepSlice3
+          Type: 1085 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1071 GoSliceDataType []*main.deepSlice3.array
+      Data: 1088 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 1071
+      ID: 1088
       Name: '[]*main.deepSlice3.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1069 PointerType *main.deepSlice3
+      Element: 1086 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 1086
+      ID: 1103
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 446688
@@ -17827,22 +17995,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1087 PointerType **main.deepSlice8
+          Type: 1104 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1090 GoSliceDataType []*main.deepSlice8.array
+      Data: 1107 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 1090
+      ID: 1107
       Name: '[]*main.deepSlice8.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1088 PointerType *main.deepSlice8
+      Element: 1105 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 1092
+      ID: 1109
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 446624
@@ -17850,20 +18018,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1093 PointerType **main.deepSlice9
+          Type: 1110 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1096 GoSliceDataType []*main.deepSlice9.array
+      Data: 1113 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 1096
+      ID: 1113
       Name: '[]*main.deepSlice9.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1094 PointerType *main.deepSlice9
+      Element: 1111 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 122
       Name: '[]*string'
@@ -17880,9 +18048,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 323 GoSliceDataType []*string.array
+      Data: 340 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 323
+      ID: 340
       Name: '[]*string.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -17902,9 +18070,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 392 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Data: 409 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 392
+      ID: 409
       Name: '[][][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -17924,9 +18092,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 390 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Data: 407 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 390
+      ID: 407
       Name: '[][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -17946,9 +18114,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 388 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Data: 405 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 388
+      ID: 405
       Name: '[][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -17968,9 +18136,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 386 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Data: 403 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 386
+      ID: 403
       Name: '[][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -17990,9 +18158,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 384 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Data: 401 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 384
+      ID: 401
       Name: '[][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -18012,9 +18180,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 370 GoSliceDataType [][]uint.array
+      Data: 387 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 370
+      ID: 387
       Name: '[][]uint.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -18035,177 +18203,177 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 376 GoSliceDataType []bool.array
+      Data: 393 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 376
+      ID: 393
       Name: '[]bool.array'
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 4 BaseType bool
     - __kind: GoSliceDataType
-      ID: 362
+      ID: 379
       Name: '[]bucket<[4]int,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 528
       Element: 222 GoHMapBucketType bucket<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 361
+      ID: 378
       Name: '[]bucket<[4]int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 280
       Element: 217 GoHMapBucketType bucket<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 345
+      ID: 362
       Name: '[]bucket<[4]string,[2]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 656
       Element: 185 GoHMapBucketType bucket<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 352
+      ID: 369
       Name: '[]bucket<bool,main.node>.array'
       DynamicSizeClass: hashmap
       ByteSize: 152
       Element: 197 GoHMapBucketType bucket<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 333
+      ID: 350
       Name: '[]bucket<int,*main.deepMap2>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
       Element: 141 GoHMapBucketType bucket<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 1081
+      ID: 1098
       Name: '[]bucket<int,*main.deepMap3>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
-      Element: 1077 GoHMapBucketType bucket<int,*main.deepMap3>
+      Element: 1094 GoHMapBucketType bucket<int,*main.deepMap3>
     - __kind: GoSliceDataType
-      ID: 1109
+      ID: 1126
       Name: '[]bucket<int,*main.deepMap8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
-      Element: 1105 GoHMapBucketType bucket<int,*main.deepMap8>
+      Element: 1122 GoHMapBucketType bucket<int,*main.deepMap8>
     - __kind: GoSliceDataType
-      ID: 1118
+      ID: 1135
       Name: '[]bucket<int,*main.deepMap9>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
-      Element: 1114 GoHMapBucketType bucket<int,*main.deepMap9>
+      Element: 1131 GoHMapBucketType bucket<int,*main.deepMap9>
     - __kind: GoSliceDataType
-      ID: 335
+      ID: 352
       Name: '[]bucket<int,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
       Element: 165 GoHMapBucketType bucket<int,int>
     - __kind: GoSliceDataType
-      ID: 1125
+      ID: 1142
       Name: '[]bucket<int,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
-      Element: 1123 GoHMapBucketType bucket<int,interface {}>
+      Element: 1140 GoHMapBucketType bucket<int,interface {}>
     - __kind: GoSliceDataType
-      ID: 366
+      ID: 383
       Name: '[]bucket<int,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
       Element: 232 GoHMapBucketType bucket<int,struct {}>
     - __kind: GoSliceDataType
-      ID: 354
+      ID: 371
       Name: '[]bucket<int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 88
       Element: 202 GoHMapBucketType bucket<int,uint8>
     - __kind: GoSliceDataType
-      ID: 349
+      ID: 366
       Name: '[]bucket<string,[]main.structWithMap>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
       Element: 192 GoHMapBucketType bucket<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 341
+      ID: 358
       Name: '[]bucket<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
       Element: 180 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 854
+      ID: 871
       Name: '[]bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
-      Element: 826 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 843 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 339
+      ID: 356
       Name: '[]bucket<string,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
       Element: 175 GoHMapBucketType bucket<string,int>
     - __kind: GoSliceDataType
-      ID: 338
+      ID: 355
       Name: '[]bucket<string,main.nestedStruct>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
       Element: 170 GoHMapBucketType bucket<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 364
+      ID: 381
       Name: '[]bucket<struct {},int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
       Element: 227 GoHMapBucketType bucket<struct {},int>
     - __kind: GoSliceDataType
-      ID: 395
+      ID: 412
       Name: '[]bucket<struct {},main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 400
       Element: 285 GoHMapBucketType bucket<struct {},main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 397
+      ID: 414
       Name: '[]bucket<struct {},map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
       Element: 290 GoHMapBucketType bucket<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 399
+      ID: 416
       Name: '[]bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
       Element: 295 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 401
+      ID: 418
       Name: '[]bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
       Element: 300 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 403
+      ID: 420
       Name: '[]bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
       Element: 305 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 405
+      ID: 422
       Name: '[]bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
       Element: 310 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 367
+      ID: 384
       Name: '[]bucket<struct {},struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 16
       Element: 237 GoHMapBucketType bucket<struct {},struct {}>
     - __kind: GoSliceDataType
-      ID: 359
+      ID: 376
       Name: '[]bucket<uint8,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 280
       Element: 212 GoHMapBucketType bucket<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 356
+      ID: 373
       Name: '[]bucket<uint8,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 32
       Element: 207 GoHMapBucketType bucket<uint8,uint8>
     - __kind: GoSliceHeaderType
-      ID: 838
+      ID: 855
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 454240
@@ -18220,15 +18388,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 855 GoSliceDataType []float64.array
+      Data: 872 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 855
+      ID: 872
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 17 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 1098
+      ID: 1115
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 454688
@@ -18243,56 +18411,56 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1099 GoSliceDataType []interface {}.array
+      Data: 1116 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 1099
+      ID: 1116
       Name: '[]interface {}.array'
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 152 GoEmptyInterfaceType interface {}
     - __kind: ArrayType
-      ID: 360
+      ID: 377
       Name: '[]key<[4]int>'
       ByteSize: 256
       Count: 8
       HasCount: true
-      Element: 358 ArrayType [4]int
+      Element: 375 ArrayType [4]int
     - __kind: ArrayType
-      ID: 342
+      ID: 359
       Name: '[]key<[4]string>'
       ByteSize: 512
       Count: 8
       HasCount: true
-      Element: 343 ArrayType [4]string
+      Element: 360 ArrayType [4]string
     - __kind: ArrayType
-      ID: 350
+      ID: 367
       Name: '[]key<bool>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 4 BaseType bool
     - __kind: ArrayType
-      ID: 329
+      ID: 346
       Name: '[]key<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 336
+      ID: 353
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 11 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 363
+      ID: 380
       Name: '[]key<struct {}>'
       Count: 8
       HasCount: true
       Element: 118 StructureType struct {}
     - __kind: ArrayType
-      ID: 355
+      ID: 372
       Name: '[]key<uint8>'
       ByteSize: 8
       Count: 8
@@ -18313,15 +18481,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 382 GoSliceDataType []main.structWithCyclicSlices.array
+      Data: 399 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 382
+      ID: 399
       Name: '[]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 144
       Element: 267 StructureType main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 347
+      ID: 364
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 447328
@@ -18329,16 +18497,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 348 PointerType *main.structWithMap
+          Type: 365 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 406 GoSliceDataType []main.structWithMap.array
+      Data: 423 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 406
+      ID: 423
       Name: '[]main.structWithMap.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -18358,9 +18526,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 372 GoSliceDataType []main.structWithNoStrings.array
+      Data: 389 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 372
+      ID: 389
       Name: '[]main.structWithNoStrings.array'
       DynamicSizeClass: slice
       ByteSize: 2
@@ -18385,9 +18553,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 374 GoSliceDataType []string.array
+      Data: 391 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 374
+      ID: 391
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -18408,9 +18576,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 380 GoSliceDataType []struct {}.array
+      Data: 397 GoSliceDataType []struct {}.array
     - __kind: GoSliceDataType
-      ID: 380
+      ID: 397
       Name: '[]struct {}.array'
       DynamicSizeClass: slice
       Element: 118 StructureType struct {}
@@ -18430,9 +18598,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 368 GoSliceDataType []uint.array
+      Data: 385 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 368
+      ID: 385
       Name: '[]uint.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -18453,9 +18621,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 378 GoSliceDataType []uint16.array
+      Data: 395 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 378
+      ID: 395
       Name: '[]uint16.array'
       DynamicSizeClass: slice
       ByteSize: 2
@@ -18476,9 +18644,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 319 GoSliceDataType []uint8.array
+      Data: 336 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 319
+      ID: 336
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -18499,165 +18667,165 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 321 GoSliceDataType []uintptr.array
+      Data: 338 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 321
+      ID: 338
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 1 BaseType uintptr
     - __kind: ArrayType
-      ID: 330
+      ID: 347
       Name: '[]val<*main.deepMap2>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 331 PointerType *main.deepMap2
+      Element: 348 PointerType *main.deepMap2
     - __kind: ArrayType
-      ID: 1078
+      ID: 1095
       Name: '[]val<*main.deepMap3>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 1079 PointerType *main.deepMap3
+      Element: 1096 PointerType *main.deepMap3
     - __kind: ArrayType
-      ID: 1106
+      ID: 1123
       Name: '[]val<*main.deepMap8>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 1107 PointerType *main.deepMap8
+      Element: 1124 PointerType *main.deepMap8
     - __kind: ArrayType
-      ID: 1115
+      ID: 1132
       Name: '[]val<*main.deepMap9>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 1116 PointerType *main.deepMap9
+      Element: 1133 PointerType *main.deepMap9
     - __kind: ArrayType
-      ID: 344
+      ID: 361
       Name: '[]val<[2]int>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 106 ArrayType [2]int
     - __kind: ArrayType
-      ID: 357
+      ID: 374
       Name: '[]val<[4]int>'
       ByteSize: 256
       Count: 8
       HasCount: true
-      Element: 358 ArrayType [4]int
+      Element: 375 ArrayType [4]int
     - __kind: ArrayType
-      ID: 346
+      ID: 363
       Name: '[]val<[]main.structWithMap>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 347 GoSliceHeaderType []main.structWithMap
+      Element: 364 GoSliceHeaderType []main.structWithMap
     - __kind: ArrayType
-      ID: 340
+      ID: 357
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
       Element: 258 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 853
+      ID: 870
       Name: '[]val<github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 845 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+      Element: 862 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: ArrayType
-      ID: 334
+      ID: 351
       Name: '[]val<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 1124
+      ID: 1141
       Name: '[]val<interface {}>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 152 GoEmptyInterfaceType interface {}
     - __kind: ArrayType
-      ID: 337
+      ID: 354
       Name: '[]val<main.nestedStruct>'
       ByteSize: 192
       Count: 8
       HasCount: true
       Element: 116 StructureType main.nestedStruct
     - __kind: ArrayType
-      ID: 351
+      ID: 368
       Name: '[]val<main.node>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 241 StructureType main.node
     - __kind: ArrayType
-      ID: 394
+      ID: 411
       Name: '[]val<main.structWithCyclicMaps>'
       ByteSize: 384
       Count: 8
       HasCount: true
       Element: 280 StructureType main.structWithCyclicMaps
     - __kind: ArrayType
-      ID: 396
+      ID: 413
       Name: '[]val<map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 281 GoMapType map[struct {}]main.structWithCyclicMaps
     - __kind: ArrayType
-      ID: 398
+      ID: 415
       Name: '[]val<map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 286 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: ArrayType
-      ID: 400
+      ID: 417
       Name: '[]val<map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 291 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: ArrayType
-      ID: 402
+      ID: 419
       Name: '[]val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 296 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: ArrayType
-      ID: 404
+      ID: 421
       Name: '[]val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 301 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: ArrayType
-      ID: 365
+      ID: 382
       Name: '[]val<struct {}>'
       Count: 8
       HasCount: true
       Element: 118 StructureType struct {}
     - __kind: ArrayType
-      ID: 353
+      ID: 370
       Name: '[]val<uint8>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 982
+      ID: 999
       Name: archive/tar.Writer
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 634
+      ID: 651
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 858592
@@ -18672,33 +18840,33 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 635 GoSliceDataType archive/tar.headerError.array
+      Data: 652 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 635
+      ID: 652
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 922
+      ID: 939
       Name: archive/tar.regFileWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 870
+      ID: 887
       Name: archive/zip.countWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 872
+      ID: 889
       Name: archive/zip.dirWriter
       GoRuntimeType: 1.07872e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 969
+      ID: 986
       Name: archive/zip.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 898
+      ID: 915
       Name: archive/zip.nopCloser
       ByteSize: 16
       GoRuntimeType: 1.376608e+06
@@ -18708,7 +18876,7 @@ Types:
           Offset: 0
           Type: 124 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 900
+      ID: 917
       Name: archive/zip.pooledFlateWriter
       ByteSize: 8
     - __kind: BaseType
@@ -18724,18 +18892,18 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 360 ArrayType []key<[4]int>
+          Type: 377 ArrayType []key<[4]int>
         - Name: values
           Offset: 264
-          Type: 357 ArrayType []val<[4]int>
+          Type: 374 ArrayType []val<[4]int>
         - Name: overflow
           Offset: 520
           Type: 221 PointerType *bucket<[4]int,[4]int>
-      KeyType: 358 ArrayType [4]int
-      ValueType: 358 ArrayType [4]int
+      KeyType: 375 ArrayType [4]int
+      ValueType: 375 ArrayType [4]int
     - __kind: GoHMapBucketType
       ID: 217
       Name: bucket<[4]int,uint8>
@@ -18743,17 +18911,17 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 360 ArrayType []key<[4]int>
+          Type: 377 ArrayType []key<[4]int>
         - Name: values
           Offset: 264
-          Type: 353 ArrayType []val<uint8>
+          Type: 370 ArrayType []val<uint8>
         - Name: overflow
           Offset: 272
           Type: 216 PointerType *bucket<[4]int,uint8>
-      KeyType: 358 ArrayType [4]int
+      KeyType: 375 ArrayType [4]int
       ValueType: 3 BaseType uint8
     - __kind: GoHMapBucketType
       ID: 185
@@ -18762,17 +18930,17 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 342 ArrayType []key<[4]string>
+          Type: 359 ArrayType []key<[4]string>
         - Name: values
           Offset: 520
-          Type: 344 ArrayType []val<[2]int>
+          Type: 361 ArrayType []val<[2]int>
         - Name: overflow
           Offset: 648
           Type: 184 PointerType *bucket<[4]string,[2]int>
-      KeyType: 343 ArrayType [4]string
+      KeyType: 360 ArrayType [4]string
       ValueType: 106 ArrayType [2]int
     - __kind: GoHMapBucketType
       ID: 197
@@ -18781,13 +18949,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 350 ArrayType []key<bool>
+          Type: 367 ArrayType []key<bool>
         - Name: values
           Offset: 16
-          Type: 351 ArrayType []val<main.node>
+          Type: 368 ArrayType []val<main.node>
         - Name: overflow
           Offset: 144
           Type: 196 PointerType *bucket<bool,main.node>
@@ -18800,75 +18968,75 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 329 ArrayType []key<int>
+          Type: 346 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 330 ArrayType []val<*main.deepMap2>
+          Type: 347 ArrayType []val<*main.deepMap2>
         - Name: overflow
           Offset: 136
           Type: 140 PointerType *bucket<int,*main.deepMap2>
       KeyType: 9 BaseType int
-      ValueType: 331 PointerType *main.deepMap2
+      ValueType: 348 PointerType *main.deepMap2
     - __kind: GoHMapBucketType
-      ID: 1077
+      ID: 1094
       Name: bucket<int,*main.deepMap3>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 329 ArrayType []key<int>
+          Type: 346 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 1078 ArrayType []val<*main.deepMap3>
+          Type: 1095 ArrayType []val<*main.deepMap3>
         - Name: overflow
           Offset: 136
-          Type: 1076 PointerType *bucket<int,*main.deepMap3>
+          Type: 1093 PointerType *bucket<int,*main.deepMap3>
       KeyType: 9 BaseType int
-      ValueType: 1079 PointerType *main.deepMap3
+      ValueType: 1096 PointerType *main.deepMap3
     - __kind: GoHMapBucketType
-      ID: 1105
+      ID: 1122
       Name: bucket<int,*main.deepMap8>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 329 ArrayType []key<int>
+          Type: 346 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 1106 ArrayType []val<*main.deepMap8>
+          Type: 1123 ArrayType []val<*main.deepMap8>
         - Name: overflow
           Offset: 136
-          Type: 1104 PointerType *bucket<int,*main.deepMap8>
+          Type: 1121 PointerType *bucket<int,*main.deepMap8>
       KeyType: 9 BaseType int
-      ValueType: 1107 PointerType *main.deepMap8
+      ValueType: 1124 PointerType *main.deepMap8
     - __kind: GoHMapBucketType
-      ID: 1114
+      ID: 1131
       Name: bucket<int,*main.deepMap9>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 329 ArrayType []key<int>
+          Type: 346 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 1115 ArrayType []val<*main.deepMap9>
+          Type: 1132 ArrayType []val<*main.deepMap9>
         - Name: overflow
           Offset: 136
-          Type: 1113 PointerType *bucket<int,*main.deepMap9>
+          Type: 1130 PointerType *bucket<int,*main.deepMap9>
       KeyType: 9 BaseType int
-      ValueType: 1116 PointerType *main.deepMap9
+      ValueType: 1133 PointerType *main.deepMap9
     - __kind: GoHMapBucketType
       ID: 165
       Name: bucket<int,int>
@@ -18876,35 +19044,35 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 329 ArrayType []key<int>
+          Type: 346 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 334 ArrayType []val<int>
+          Type: 351 ArrayType []val<int>
         - Name: overflow
           Offset: 136
           Type: 164 PointerType *bucket<int,int>
       KeyType: 9 BaseType int
       ValueType: 9 BaseType int
     - __kind: GoHMapBucketType
-      ID: 1123
+      ID: 1140
       Name: bucket<int,interface {}>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 329 ArrayType []key<int>
+          Type: 346 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 1124 ArrayType []val<interface {}>
+          Type: 1141 ArrayType []val<interface {}>
         - Name: overflow
           Offset: 200
-          Type: 1122 PointerType *bucket<int,interface {}>
+          Type: 1139 PointerType *bucket<int,interface {}>
       KeyType: 9 BaseType int
       ValueType: 152 GoEmptyInterfaceType interface {}
     - __kind: GoHMapBucketType
@@ -18914,13 +19082,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 329 ArrayType []key<int>
+          Type: 346 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 365 ArrayType []val<struct {}>
+          Type: 382 ArrayType []val<struct {}>
         - Name: overflow
           Offset: 72
           Type: 231 PointerType *bucket<int,struct {}>
@@ -18933,13 +19101,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 329 ArrayType []key<int>
+          Type: 346 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 353 ArrayType []val<uint8>
+          Type: 370 ArrayType []val<uint8>
         - Name: overflow
           Offset: 80
           Type: 201 PointerType *bucket<int,uint8>
@@ -18952,18 +19120,18 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 336 ArrayType []key<string>
+          Type: 353 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 346 ArrayType []val<[]main.structWithMap>
+          Type: 363 ArrayType []val<[]main.structWithMap>
         - Name: overflow
           Offset: 328
           Type: 191 PointerType *bucket<string,[]main.structWithMap>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 347 GoSliceHeaderType []main.structWithMap
+      ValueType: 364 GoSliceHeaderType []main.structWithMap
     - __kind: GoHMapBucketType
       ID: 180
       Name: bucket<string,[]string>
@@ -18971,37 +19139,37 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 336 ArrayType []key<string>
+          Type: 353 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 340 ArrayType []val<[]string>
+          Type: 357 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
           Type: 179 PointerType *bucket<string,[]string>
       KeyType: 11 GoStringHeaderType string
       ValueType: 258 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 826
+      ID: 843
       Name: bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 336 ArrayType []key<string>
+          Type: 353 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 853 ArrayType []val<github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 870 ArrayType []val<github.com/DataDog/go-tuf/data.HexBytes>
         - Name: overflow
           Offset: 328
-          Type: 825 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 842 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 845 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+      ValueType: 862 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoHMapBucketType
       ID: 175
       Name: bucket<string,int>
@@ -19009,13 +19177,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 336 ArrayType []key<string>
+          Type: 353 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 334 ArrayType []val<int>
+          Type: 351 ArrayType []val<int>
         - Name: overflow
           Offset: 200
           Type: 174 PointerType *bucket<string,int>
@@ -19028,13 +19196,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 336 ArrayType []key<string>
+          Type: 353 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 337 ArrayType []val<main.nestedStruct>
+          Type: 354 ArrayType []val<main.nestedStruct>
         - Name: overflow
           Offset: 328
           Type: 169 PointerType *bucket<string,main.nestedStruct>
@@ -19047,13 +19215,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 363 ArrayType []key<struct {}>
+          Type: 380 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 334 ArrayType []val<int>
+          Type: 351 ArrayType []val<int>
         - Name: overflow
           Offset: 72
           Type: 226 PointerType *bucket<struct {},int>
@@ -19066,13 +19234,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 363 ArrayType []key<struct {}>
+          Type: 380 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 394 ArrayType []val<main.structWithCyclicMaps>
+          Type: 411 ArrayType []val<main.structWithCyclicMaps>
         - Name: overflow
           Offset: 392
           Type: 284 PointerType *bucket<struct {},main.structWithCyclicMaps>
@@ -19085,13 +19253,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 363 ArrayType []key<struct {}>
+          Type: 380 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 396 ArrayType []val<map[struct {}]main.structWithCyclicMaps>
+          Type: 413 ArrayType []val<map[struct {}]main.structWithCyclicMaps>
         - Name: overflow
           Offset: 72
           Type: 289 PointerType *bucket<struct {},map[struct {}]main.structWithCyclicMaps>
@@ -19104,13 +19272,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 363 ArrayType []key<struct {}>
+          Type: 380 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 398 ArrayType []val<map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 415 ArrayType []val<map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: overflow
           Offset: 72
           Type: 294 PointerType *bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -19123,13 +19291,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 363 ArrayType []key<struct {}>
+          Type: 380 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 400 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 417 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: overflow
           Offset: 72
           Type: 299 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -19142,13 +19310,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 363 ArrayType []key<struct {}>
+          Type: 380 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 402 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 419 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: overflow
           Offset: 72
           Type: 304 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -19161,13 +19329,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 363 ArrayType []key<struct {}>
+          Type: 380 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 404 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 421 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: overflow
           Offset: 72
           Type: 309 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -19180,13 +19348,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 363 ArrayType []key<struct {}>
+          Type: 380 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 365 ArrayType []val<struct {}>
+          Type: 382 ArrayType []val<struct {}>
         - Name: overflow
           Offset: 8
           Type: 236 PointerType *bucket<struct {},struct {}>
@@ -19199,18 +19367,18 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 355 ArrayType []key<uint8>
+          Type: 372 ArrayType []key<uint8>
         - Name: values
           Offset: 16
-          Type: 357 ArrayType []val<[4]int>
+          Type: 374 ArrayType []val<[4]int>
         - Name: overflow
           Offset: 272
           Type: 211 PointerType *bucket<uint8,[4]int>
       KeyType: 3 BaseType uint8
-      ValueType: 358 ArrayType [4]int
+      ValueType: 375 ArrayType [4]int
     - __kind: GoHMapBucketType
       ID: 207
       Name: bucket<uint8,uint8>
@@ -19218,28 +19386,28 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 355 ArrayType []key<uint8>
+          Type: 372 ArrayType []key<uint8>
         - Name: values
           Offset: 16
-          Type: 353 ArrayType []val<uint8>
+          Type: 370 ArrayType []val<uint8>
         - Name: overflow
           Offset: 24
           Type: 206 PointerType *bucket<uint8,uint8>
       KeyType: 3 BaseType uint8
       ValueType: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 946
+      ID: 963
       Name: bufio.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 971
+      ID: 988
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1018
+      ID: 1035
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
@@ -19265,13 +19433,13 @@ Types:
       GoRuntimeType: 532224
       GoKind: 15
     - __kind: BaseType
-      ID: 441
+      ID: 458
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 764704
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 442
+      ID: 459
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 764800
@@ -19279,92 +19447,92 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 444 PointerType *compress/flate.InternalError.str
+          Type: 461 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 443 GoStringDataType compress/flate.InternalError.str
+      Data: 460 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 443
+      ID: 460
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 920
+      ID: 937
       Name: compress/flate.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 866
+      ID: 883
       Name: compress/flate.dictWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 942
+      ID: 959
       Name: compress/gzip.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 778
+      ID: 795
       Name: context.deadlineExceededError
       GoRuntimeType: 1.296544e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 455
+      ID: 472
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 767296
       GoKind: 2
     - __kind: BaseType
-      ID: 456
+      ID: 473
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 767392
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 932
+      ID: 949
       Name: crypto/hmac.hmac
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 957
+      ID: 974
       Name: crypto/md5.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 457
+      ID: 474
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 767488
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 965
+      ID: 982
       Name: crypto/sha1.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 959
+      ID: 976
       Name: crypto/sha256.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 961
+      ID: 978
       Name: crypto/sha512.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 445
+      ID: 462
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 765280
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 718
+      ID: 735
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1044
+      ID: 1061
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 551
+      ID: 568
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 549
+      ID: 566
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1.605504e+06
@@ -19375,34 +19543,34 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 843 ArrayType [5]uint8
+          Type: 860 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 844 GoInterfaceType net.Conn
+          Type: 861 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 673
+      ID: 690
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 951744
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 930
+      ID: 947
       Name: crypto/tls.cthWrapper
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 937
+      ID: 954
       Name: crypto/tls.finishedHash
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 813
+      ID: 830
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 828
+      ID: 845
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 623
+      ID: 640
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1.608576e+06
@@ -19410,21 +19578,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 827 PointerType *crypto/x509.Certificate
+          Type: 844 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 846 BaseType crypto/x509.InvalidReason
+          Type: 863 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 617
+      ID: 634
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1.076032e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 619
+      ID: 636
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1.40896e+06
@@ -19432,24 +19600,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 827 PointerType *crypto/x509.Certificate
+          Type: 844 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 454
+      ID: 471
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 766912
       GoKind: 2
     - __kind: BaseType
-      ID: 846
+      ID: 863
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 537728
       GoKind: 2
     - __kind: StructureType
-      ID: 723
+      ID: 740
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1.372928e+06
@@ -19459,13 +19627,13 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 625
+      ID: 642
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1.076288e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 621
+      ID: 638
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1.608384e+06
@@ -19473,15 +19641,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 827 PointerType *crypto/x509.Certificate
+          Type: 844 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 18 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 827 PointerType *crypto/x509.Certificate
+          Type: 844 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 638
+      ID: 655
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1.254016e+06
@@ -19491,7 +19659,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 642
+      ID: 659
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1.254176e+06
@@ -19501,55 +19669,55 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 640
+      ID: 657
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 439
+      ID: 456
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 764320
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 888
+      ID: 905
       Name: encoding/base64.encoder
       ByteSize: 8
     - __kind: BaseType
-      ID: 440
+      ID: 457
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 764512
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 510
+      ID: 527
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 709
+      ID: 726
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 502
+      ID: 519
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 508
+      ID: 525
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 506
+      ID: 523
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 504
+      ID: 521
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1024
+      ID: 1041
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 512
+      ID: 529
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1.238656e+06
@@ -19559,19 +19727,19 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 896
+      ID: 913
       Name: encoding/pem.lineBreaker
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 611
+      ID: 628
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 609
+      ID: 626
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 451
+      ID: 468
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 766816
@@ -19579,22 +19747,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 453 PointerType *encoding/xml.UnmarshalError.str
+          Type: 470 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 452 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 469 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 452
+      ID: 469
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 614
+      ID: 631
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1002
+      ID: 1019
       Name: encoding/xml.printer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -19611,11 +19779,11 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 480
+      ID: 497
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 676
+      ID: 693
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -19631,15 +19799,15 @@ Types:
       GoRuntimeType: 532416
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 1012
+      ID: 1029
       Name: fmt.pp
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 678
+      ID: 695
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 680
+      ID: 697
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -19655,11 +19823,11 @@ Types:
       GoRuntimeType: 778048
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 540
+      ID: 557
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 521
+      ID: 538
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1.603776e+06
@@ -19667,7 +19835,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 836 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 853 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 9 BaseType int
@@ -19675,25 +19843,25 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 523
+      ID: 540
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 840
+      ID: 857
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 527
+      ID: 544
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1.072448e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 842
+      ID: 859
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 433
+      ID: 450
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 763744
@@ -19701,18 +19869,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 435 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 452 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 434 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 451 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 434
+      ID: 451
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 836
+      ID: 853
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2.074592e+06
@@ -19720,7 +19888,7 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 837 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 854 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -19735,7 +19903,7 @@ Types:
           Type: 17 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 838 GoSliceHeaderType []float64
+          Type: 855 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 13 BaseType int64
@@ -19744,10 +19912,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 839 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 856 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 841 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 858 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
           Type: 258 GoSliceHeaderType []string
@@ -19761,13 +19929,13 @@ Types:
           Offset: 184
           Type: 13 BaseType int64
     - __kind: BaseType
-      ID: 837
+      ID: 854
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 534272
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 430
+      ID: 447
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 763648
@@ -19775,18 +19943,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 432 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 449 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 431 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 448 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 431
+      ID: 448
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 436
+      ID: 453
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 763840
@@ -19794,60 +19962,60 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 438 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 455 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 437 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 454 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 437
+      ID: 454
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 910
+      ID: 927
       Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 990
+      ID: 1007
       Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 632
+      ID: 649
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 787
+      ID: 804
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1020
+      ID: 1037
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 560
+      ID: 577
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 567
+      ID: 584
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1.075264e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 450
+      ID: 467
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 765952
       GoKind: 2
     - __kind: StructureType
-      ID: 565
+      ID: 582
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1.075136e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 563
+      ID: 580
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1.40704e+06
@@ -19860,7 +20028,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 583
+      ID: 600
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1.40784e+06
@@ -19873,7 +20041,7 @@ Types:
           Offset: 16
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 587
+      ID: 604
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1.607808e+06
@@ -19889,7 +20057,7 @@ Types:
           Offset: 24
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 585
+      ID: 602
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1.248416e+06
@@ -19899,7 +20067,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 581
+      ID: 598
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1.248096e+06
@@ -19909,14 +20077,14 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 822
+      ID: 839
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1.135584e+06
       GoKind: 21
-      HeaderType: 824 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 841 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 845
+      ID: 862
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1.009216e+06
@@ -19931,15 +20099,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 857 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 874 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 857
+      ID: 874
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 595
+      ID: 612
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1.40816e+06
@@ -19947,12 +20115,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 822 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 839 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 822 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 839 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 589
+      ID: 606
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1.248576e+06
@@ -19962,7 +20130,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 593
+      ID: 610
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1.608e+06
@@ -19973,12 +20141,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 845 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 862 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 845 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 862 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 591
+      ID: 608
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1.408e+06
@@ -19991,7 +20159,7 @@ Types:
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 597
+      ID: 614
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1.248736e+06
@@ -19999,9 +20167,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 814 StructureType time.Time
+          Type: 831 StructureType time.Time
     - __kind: StructureType
-      ID: 603
+      ID: 620
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1.40848e+06
@@ -20014,7 +20182,7 @@ Types:
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 605
+      ID: 622
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1.249056e+06
@@ -20024,7 +20192,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 601
+      ID: 618
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1.40832e+06
@@ -20037,7 +20205,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 599
+      ID: 616
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1.248896e+06
@@ -20047,7 +20215,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 607
+      ID: 624
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1.40864e+06
@@ -20060,7 +20228,7 @@ Types:
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 529
+      ID: 546
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1.240896e+06
@@ -20070,11 +20238,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 949
+      ID: 966
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 531
+      ID: 548
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1.241056e+06
@@ -20082,21 +20250,21 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 529 StructureType github.com/cihub/seelog.baseError
+          Type: 546 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 928
+      ID: 945
       Name: github.com/cihub/seelog.connWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 884
+      ID: 901
       Name: github.com/cihub/seelog.consoleWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 918
+      ID: 935
       Name: github.com/cihub/seelog.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 535
+      ID: 552
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1.241376e+06
@@ -20104,13 +20272,13 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 529 StructureType github.com/cihub/seelog.baseError
+          Type: 546 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 980
+      ID: 997
       Name: github.com/cihub/seelog.rollingFileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 991
+      ID: 1008
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
       GoRuntimeType: 1.968864e+06
@@ -20118,12 +20286,12 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 979 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 996 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: maxFileSize
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 992
+      ID: 1009
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
       GoRuntimeType: 1.992256e+06
@@ -20131,7 +20299,7 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 979 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 996 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: timePattern
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -20139,11 +20307,11 @@ Types:
           Offset: 24
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 886
+      ID: 903
       Name: github.com/cihub/seelog.smtpWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 533
+      ID: 550
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1.241216e+06
@@ -20151,9 +20319,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 529 StructureType github.com/cihub/seelog.baseError
+          Type: 546 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 537
+      ID: 554
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1.241536e+06
@@ -20161,64 +20329,64 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 529 StructureType github.com/cihub/seelog.baseError
+          Type: 546 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 953
+      ID: 970
       Name: github.com/cihub/seelog/archive/gzip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 986
+      ID: 1003
       Name: github.com/cihub/seelog/archive/tar.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 988
+      ID: 1005
       Name: github.com/cihub/seelog/archive/zip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 818
+      ID: 835
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 731
+      ID: 748
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 729
+      ID: 746
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 733
+      ID: 750
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 735
+      ID: 752
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 939
+      ID: 956
       Name: github.com/gogo/protobuf/proto.textWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 725
+      ID: 742
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 543
+      ID: 560
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1.242496e+06
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 1036
+      ID: 1053
       Name: github.com/json-iterator/go.Stream
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 789
+      ID: 806
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 762
+      ID: 779
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1.71248e+06
@@ -20234,11 +20402,11 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 756
+      ID: 773
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 695
+      ID: 712
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1.509696e+06
@@ -20251,7 +20419,7 @@ Types:
           Offset: 1
           Type: 14 BaseType int8
     - __kind: StructureType
-      ID: 768
+      ID: 785
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1.712928e+06
@@ -20267,13 +20435,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 672
+      ID: 689
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 949152
       GoKind: 8
     - __kind: StructureType
-      ID: 760
+      ID: 777
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1.712256e+06
@@ -20289,13 +20457,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 847
+      ID: 864
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 761920
       GoKind: 8
     - __kind: StructureType
-      ID: 758
+      ID: 775
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1.712032e+06
@@ -20303,15 +20471,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 847 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 864 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 847 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 864 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 766
+      ID: 783
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1.630624e+06
@@ -20324,7 +20492,7 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 764
+      ID: 781
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1.712704e+06
@@ -20340,11 +20508,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1040
+      ID: 1057
       Name: github.com/tinylib/msgp/msgp.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 772
+      ID: 789
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1.432608e+06
@@ -20354,19 +20522,19 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 699
+      ID: 716
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1.195424e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 697
+      ID: 714
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1.195296e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 770
+      ID: 787
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1.630816e+06
@@ -20379,7 +20547,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 462
+      ID: 479
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 769312
@@ -20387,22 +20555,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 464 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 481 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 463 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 480 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 463
+      ID: 480
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 831
+      ID: 848
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 739
+      ID: 756
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1.265856e+06
@@ -20412,7 +20580,7 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 916
+      ID: 933
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
       GoRuntimeType: 1.48656e+06
@@ -20420,13 +20588,13 @@ Types:
       RawFields:
         - Name: WriteSyncer
           Offset: 0
-          Type: 940 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+          Type: 957 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
     - __kind: UnresolvedPointeeType
-      ID: 1000
+      ID: 1017
       Name: go.uber.org/zap/buffer.Buffer
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 940
+      ID: 957
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
       GoRuntimeType: 1.086144e+06
@@ -20439,7 +20607,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 902
+      ID: 919
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
       GoRuntimeType: 1.381408e+06
@@ -20449,19 +20617,19 @@ Types:
           Offset: 0
           Type: 124 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 465
+      ID: 482
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 769888
       GoKind: 10
     - __kind: BaseType
-      ID: 829
+      ID: 846
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 962400
       GoKind: 10
     - __kind: StructureType
-      ID: 797
+      ID: 814
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1.751008e+06
@@ -20472,12 +20640,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 829 BaseType golang.org/x/net/http2.ErrCode
+          Type: 846 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 658
+      ID: 675
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1.41584e+06
@@ -20485,12 +20653,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 829 BaseType golang.org/x/net/http2.ErrCode
+          Type: 846 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 469
+      ID: 486
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 770080
@@ -20498,18 +20666,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 471 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 488 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 470 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 487 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 470
+      ID: 487
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 475
+      ID: 492
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 770272
@@ -20517,18 +20685,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 477 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 494 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 476 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 493 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 476
+      ID: 493
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 472
+      ID: 489
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 770176
@@ -20536,18 +20704,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 474 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 491 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 473 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 490 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 473
+      ID: 490
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 466
+      ID: 483
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 769984
@@ -20555,22 +20723,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 468 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 485 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 467 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 484 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 467
+      ID: 484
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 998
+      ID: 1015
       Name: golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 662
+      ID: 679
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.266496e+06
@@ -20580,13 +20748,13 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: BaseType
-      ID: 478
+      ID: 495
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 770368
       GoKind: 2
     - __kind: StructureType
-      ID: 650
+      ID: 667
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1.261536e+06
@@ -20596,11 +20764,11 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 795
+      ID: 812
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 820
+      ID: 837
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1.776768e+06
@@ -20616,7 +20784,7 @@ Types:
           Offset: 24
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 652
+      ID: 669
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1.41536e+06
@@ -20629,7 +20797,7 @@ Types:
           Offset: 16
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 963
+      ID: 980
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
       GoRuntimeType: 1.83024e+06
@@ -20637,16 +20805,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 844 GoInterfaceType net.Conn
+          Type: 861 GoInterfaceType net.Conn
         - Name: r
           Offset: 16
-          Type: 978 GoInterfaceType io.Reader
+          Type: 995 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 914
+      ID: 931
       Name: google.golang.org/grpc/internal/transport.bufWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 737
+      ID: 754
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1.379008e+06
@@ -20656,29 +20824,29 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 874
+      ID: 891
       Name: google.golang.org/grpc/mem.writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 630
+      ID: 647
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 727
+      ID: 744
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 793
+      ID: 810
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 791
+      ID: 808
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1.326144e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 644
+      ID: 661
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1.254816e+06
@@ -20688,7 +20856,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 646
+      ID: 663
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1.254976e+06
@@ -20698,11 +20866,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 575
+      ID: 592
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 951
+      ID: 968
       Name: hash/crc32.digest
       ByteSize: 8
     - __kind: GoHMapHeaderType
@@ -20738,7 +20906,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 222 GoHMapBucketType bucket<[4]int,[4]int>
-      BucketsType: 362 GoSliceDataType []bucket<[4]int,[4]int>.array
+      BucketsType: 379 GoSliceDataType []bucket<[4]int,[4]int>.array
     - __kind: GoHMapHeaderType
       ID: 215
       Name: hash<[4]int,uint8>
@@ -20772,7 +20940,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 217 GoHMapBucketType bucket<[4]int,uint8>
-      BucketsType: 361 GoSliceDataType []bucket<[4]int,uint8>.array
+      BucketsType: 378 GoSliceDataType []bucket<[4]int,uint8>.array
     - __kind: GoHMapHeaderType
       ID: 183
       Name: hash<[4]string,[2]int>
@@ -20806,7 +20974,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 185 GoHMapBucketType bucket<[4]string,[2]int>
-      BucketsType: 345 GoSliceDataType []bucket<[4]string,[2]int>.array
+      BucketsType: 362 GoSliceDataType []bucket<[4]string,[2]int>.array
     - __kind: GoHMapHeaderType
       ID: 195
       Name: hash<bool,main.node>
@@ -20840,7 +21008,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 197 GoHMapBucketType bucket<bool,main.node>
-      BucketsType: 352 GoSliceDataType []bucket<bool,main.node>.array
+      BucketsType: 369 GoSliceDataType []bucket<bool,main.node>.array
     - __kind: GoHMapHeaderType
       ID: 139
       Name: hash<int,*main.deepMap2>
@@ -20874,9 +21042,9 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 141 GoHMapBucketType bucket<int,*main.deepMap2>
-      BucketsType: 333 GoSliceDataType []bucket<int,*main.deepMap2>.array
+      BucketsType: 350 GoSliceDataType []bucket<int,*main.deepMap2>.array
     - __kind: GoHMapHeaderType
-      ID: 1075
+      ID: 1092
       Name: hash<int,*main.deepMap3>
       ByteSize: 48
       RawFields:
@@ -20897,20 +21065,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 1076 PointerType *bucket<int,*main.deepMap3>
+          Type: 1093 PointerType *bucket<int,*main.deepMap3>
         - Name: oldbuckets
           Offset: 24
-          Type: 1076 PointerType *bucket<int,*main.deepMap3>
+          Type: 1093 PointerType *bucket<int,*main.deepMap3>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
-      BucketType: 1077 GoHMapBucketType bucket<int,*main.deepMap3>
-      BucketsType: 1081 GoSliceDataType []bucket<int,*main.deepMap3>.array
+      BucketType: 1094 GoHMapBucketType bucket<int,*main.deepMap3>
+      BucketsType: 1098 GoSliceDataType []bucket<int,*main.deepMap3>.array
     - __kind: GoHMapHeaderType
-      ID: 1103
+      ID: 1120
       Name: hash<int,*main.deepMap8>
       ByteSize: 48
       RawFields:
@@ -20931,20 +21099,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 1104 PointerType *bucket<int,*main.deepMap8>
+          Type: 1121 PointerType *bucket<int,*main.deepMap8>
         - Name: oldbuckets
           Offset: 24
-          Type: 1104 PointerType *bucket<int,*main.deepMap8>
+          Type: 1121 PointerType *bucket<int,*main.deepMap8>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
-      BucketType: 1105 GoHMapBucketType bucket<int,*main.deepMap8>
-      BucketsType: 1109 GoSliceDataType []bucket<int,*main.deepMap8>.array
+      BucketType: 1122 GoHMapBucketType bucket<int,*main.deepMap8>
+      BucketsType: 1126 GoSliceDataType []bucket<int,*main.deepMap8>.array
     - __kind: GoHMapHeaderType
-      ID: 1112
+      ID: 1129
       Name: hash<int,*main.deepMap9>
       ByteSize: 48
       RawFields:
@@ -20965,18 +21133,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 1113 PointerType *bucket<int,*main.deepMap9>
+          Type: 1130 PointerType *bucket<int,*main.deepMap9>
         - Name: oldbuckets
           Offset: 24
-          Type: 1113 PointerType *bucket<int,*main.deepMap9>
+          Type: 1130 PointerType *bucket<int,*main.deepMap9>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
-      BucketType: 1114 GoHMapBucketType bucket<int,*main.deepMap9>
-      BucketsType: 1118 GoSliceDataType []bucket<int,*main.deepMap9>.array
+      BucketType: 1131 GoHMapBucketType bucket<int,*main.deepMap9>
+      BucketsType: 1135 GoSliceDataType []bucket<int,*main.deepMap9>.array
     - __kind: GoHMapHeaderType
       ID: 163
       Name: hash<int,int>
@@ -21010,9 +21178,9 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 165 GoHMapBucketType bucket<int,int>
-      BucketsType: 335 GoSliceDataType []bucket<int,int>.array
+      BucketsType: 352 GoSliceDataType []bucket<int,int>.array
     - __kind: GoHMapHeaderType
-      ID: 1121
+      ID: 1138
       Name: hash<int,interface {}>
       ByteSize: 48
       RawFields:
@@ -21033,18 +21201,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 1122 PointerType *bucket<int,interface {}>
+          Type: 1139 PointerType *bucket<int,interface {}>
         - Name: oldbuckets
           Offset: 24
-          Type: 1122 PointerType *bucket<int,interface {}>
+          Type: 1139 PointerType *bucket<int,interface {}>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
-      BucketType: 1123 GoHMapBucketType bucket<int,interface {}>
-      BucketsType: 1125 GoSliceDataType []bucket<int,interface {}>.array
+      BucketType: 1140 GoHMapBucketType bucket<int,interface {}>
+      BucketsType: 1142 GoSliceDataType []bucket<int,interface {}>.array
     - __kind: GoHMapHeaderType
       ID: 230
       Name: hash<int,struct {}>
@@ -21078,7 +21246,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 232 GoHMapBucketType bucket<int,struct {}>
-      BucketsType: 366 GoSliceDataType []bucket<int,struct {}>.array
+      BucketsType: 383 GoSliceDataType []bucket<int,struct {}>.array
     - __kind: GoHMapHeaderType
       ID: 200
       Name: hash<int,uint8>
@@ -21112,7 +21280,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 202 GoHMapBucketType bucket<int,uint8>
-      BucketsType: 354 GoSliceDataType []bucket<int,uint8>.array
+      BucketsType: 371 GoSliceDataType []bucket<int,uint8>.array
     - __kind: GoHMapHeaderType
       ID: 190
       Name: hash<string,[]main.structWithMap>
@@ -21146,7 +21314,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 192 GoHMapBucketType bucket<string,[]main.structWithMap>
-      BucketsType: 349 GoSliceDataType []bucket<string,[]main.structWithMap>.array
+      BucketsType: 366 GoSliceDataType []bucket<string,[]main.structWithMap>.array
     - __kind: GoHMapHeaderType
       ID: 178
       Name: hash<string,[]string>
@@ -21180,9 +21348,9 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 180 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 341 GoSliceDataType []bucket<string,[]string>.array
+      BucketsType: 358 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 824
+      ID: 841
       Name: hash<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       RawFields:
@@ -21203,18 +21371,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 825 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 842 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: oldbuckets
           Offset: 24
-          Type: 825 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 842 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
-      BucketType: 826 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
-      BucketsType: 854 GoSliceDataType []bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      BucketType: 843 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      BucketsType: 871 GoSliceDataType []bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array
     - __kind: GoHMapHeaderType
       ID: 173
       Name: hash<string,int>
@@ -21248,7 +21416,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 175 GoHMapBucketType bucket<string,int>
-      BucketsType: 339 GoSliceDataType []bucket<string,int>.array
+      BucketsType: 356 GoSliceDataType []bucket<string,int>.array
     - __kind: GoHMapHeaderType
       ID: 168
       Name: hash<string,main.nestedStruct>
@@ -21282,7 +21450,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 170 GoHMapBucketType bucket<string,main.nestedStruct>
-      BucketsType: 338 GoSliceDataType []bucket<string,main.nestedStruct>.array
+      BucketsType: 355 GoSliceDataType []bucket<string,main.nestedStruct>.array
     - __kind: GoHMapHeaderType
       ID: 225
       Name: hash<struct {},int>
@@ -21316,7 +21484,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 227 GoHMapBucketType bucket<struct {},int>
-      BucketsType: 364 GoSliceDataType []bucket<struct {},int>.array
+      BucketsType: 381 GoSliceDataType []bucket<struct {},int>.array
     - __kind: GoHMapHeaderType
       ID: 283
       Name: hash<struct {},main.structWithCyclicMaps>
@@ -21350,7 +21518,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 285 GoHMapBucketType bucket<struct {},main.structWithCyclicMaps>
-      BucketsType: 395 GoSliceDataType []bucket<struct {},main.structWithCyclicMaps>.array
+      BucketsType: 412 GoSliceDataType []bucket<struct {},main.structWithCyclicMaps>.array
     - __kind: GoHMapHeaderType
       ID: 288
       Name: hash<struct {},map[struct {}]main.structWithCyclicMaps>
@@ -21384,7 +21552,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 290 GoHMapBucketType bucket<struct {},map[struct {}]main.structWithCyclicMaps>
-      BucketsType: 397 GoSliceDataType []bucket<struct {},map[struct {}]main.structWithCyclicMaps>.array
+      BucketsType: 414 GoSliceDataType []bucket<struct {},map[struct {}]main.structWithCyclicMaps>.array
     - __kind: GoHMapHeaderType
       ID: 293
       Name: hash<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -21418,7 +21586,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 295 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
-      BucketsType: 399 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      BucketsType: 416 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
     - __kind: GoHMapHeaderType
       ID: 298
       Name: hash<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -21452,7 +21620,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 300 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
-      BucketsType: 401 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      BucketsType: 418 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
     - __kind: GoHMapHeaderType
       ID: 303
       Name: hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -21486,7 +21654,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 305 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
-      BucketsType: 403 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      BucketsType: 420 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
     - __kind: GoHMapHeaderType
       ID: 308
       Name: hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -21520,7 +21688,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 310 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
-      BucketsType: 405 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      BucketsType: 422 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
     - __kind: GoHMapHeaderType
       ID: 235
       Name: hash<struct {},struct {}>
@@ -21554,7 +21722,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 237 GoHMapBucketType bucket<struct {},struct {}>
-      BucketsType: 367 GoSliceDataType []bucket<struct {},struct {}>.array
+      BucketsType: 384 GoSliceDataType []bucket<struct {},struct {}>.array
     - __kind: GoHMapHeaderType
       ID: 210
       Name: hash<uint8,[4]int>
@@ -21588,7 +21756,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 212 GoHMapBucketType bucket<uint8,[4]int>
-      BucketsType: 359 GoSliceDataType []bucket<uint8,[4]int>.array
+      BucketsType: 376 GoSliceDataType []bucket<uint8,[4]int>.array
     - __kind: GoHMapHeaderType
       ID: 205
       Name: hash<uint8,uint8>
@@ -21622,9 +21790,9 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 207 GoHMapBucketType bucket<uint8,uint8>
-      BucketsType: 356 GoSliceDataType []bucket<uint8,uint8>.array
+      BucketsType: 373 GoSliceDataType []bucket<uint8,uint8>.array
     - __kind: UnresolvedPointeeType
-      ID: 665
+      ID: 682
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -21671,7 +21839,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 545
+      ID: 562
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -21697,25 +21865,25 @@ Types:
           Offset: 296
           Type: 2 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 860
+      ID: 877
       Name: internal/godebug.runtimeStderr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 754
+      ID: 771
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1042
+      ID: 1059
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 752
+      ID: 769
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1.293504e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 482
+      ID: 499
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -21796,11 +21964,11 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 906
+      ID: 923
       Name: io.PipeWriter
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 947
+      ID: 964
       Name: io.ReadWriteCloser
       ByteSize: 16
       GoRuntimeType: 1.104096e+06
@@ -21813,7 +21981,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 978
+      ID: 995
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 981312
@@ -21826,7 +21994,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 935
+      ID: 952
       Name: io.WriteCloser
       ByteSize: 16
       GoRuntimeType: 1.068864e+06
@@ -21852,21 +22020,21 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 904
+      ID: 921
       Name: io.discard
       GoRuntimeType: 1.281344e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 878
+      ID: 895
       Name: io.multiWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 750
+      ID: 767
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 955
+      ID: 972
       Name: log/slog/internal/buffer.Buffer
       ByteSize: 8
     - __kind: StructureType
@@ -21895,7 +22063,25 @@ Types:
       RawFields:
         - Name: nested
           Offset: 0
-          Type: 1126 PointerType *main.nestedStruct
+          Type: 1143 PointerType *main.nestedStruct
+    - __kind: StructureType
+      ID: 321
+      Name: main.bStruct
+      ByteSize: 72
+      GoKind: 25
+      RawFields:
+        - Name: aInt16
+          Offset: 0
+          Type: 97 BaseType int16
+        - Name: nested
+          Offset: 8
+          Type: 311 StructureType main.aStruct
+        - Name: aBool
+          Offset: 64
+          Type: 4 BaseType bool
+        - Name: aInt32
+          Offset: 68
+          Type: 12 BaseType int32
     - __kind: GoInterfaceType
       ID: 157
       Name: main.behavior
@@ -21925,6 +22111,21 @@ Types:
           Offset: 32
           Type: 124 GoInterfaceType io.Writer
     - __kind: StructureType
+      ID: 319
+      Name: main.cStruct
+      ByteSize: 24
+      GoKind: 25
+      RawFields:
+        - Name: aInt32
+          Offset: 0
+          Type: 12 BaseType int32
+        - Name: aUint
+          Offset: 8
+          Type: 15 BaseType uint
+        - Name: nested
+          Offset: 16
+          Type: 257 StructureType main.structWithNoStrings
+    - __kind: StructureType
       ID: 136
       Name: main.deepMap1
       ByteSize: 8
@@ -21935,7 +22136,7 @@ Types:
           Offset: 0
           Type: 137 GoMapType map[int]*main.deepMap2
     - __kind: StructureType
-      ID: 332
+      ID: 349
       Name: main.deepMap2
       ByteSize: 8
       GoRuntimeType: 1.100384e+06
@@ -21943,9 +22144,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1073 GoMapType map[int]*main.deepMap3
+          Type: 1090 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 1080
+      ID: 1097
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -21957,9 +22158,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1101 GoMapType map[int]*main.deepMap8
+          Type: 1118 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 1108
+      ID: 1125
       Name: main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.099616e+06
@@ -21967,9 +22168,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1110 GoMapType map[int]*main.deepMap9
+          Type: 1127 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 1117
+      ID: 1134
       Name: main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.099488e+06
@@ -21977,7 +22178,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1119 GoMapType map[int]interface {}
+          Type: 1136 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 125
       Name: main.deepPtr1
@@ -21997,9 +22198,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1045 PointerType *main.deepPtr3
+          Type: 1062 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 1046
+      ID: 1063
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -22011,9 +22212,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1082 PointerType *main.deepPtr8
+          Type: 1099 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 1083
+      ID: 1100
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1.100768e+06
@@ -22021,9 +22222,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1084 PointerType *main.deepPtr9
+          Type: 1101 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 1085
+      ID: 1102
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1.10064e+06
@@ -22043,7 +22244,7 @@ Types:
           Offset: 0
           Type: 131 GoSliceHeaderType []*main.deepSlice2
     - __kind: StructureType
-      ID: 325
+      ID: 342
       Name: main.deepSlice2
       ByteSize: 24
       GoRuntimeType: 1.102688e+06
@@ -22051,9 +22252,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1067 GoSliceHeaderType []*main.deepSlice3
+          Type: 1084 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 1070
+      ID: 1087
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -22065,9 +22266,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1086 GoSliceHeaderType []*main.deepSlice8
+          Type: 1103 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 1089
+      ID: 1106
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1.10192e+06
@@ -22075,9 +22276,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1092 GoSliceHeaderType []*main.deepSlice9
+          Type: 1109 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 1095
+      ID: 1112
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1.101792e+06
@@ -22085,7 +22286,73 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1098 GoSliceHeaderType []interface {}
+          Type: 1115 GoSliceHeaderType []interface {}
+    - __kind: StructureType
+      ID: 323
+      Name: main.deepStruct1
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: b
+          Offset: 8
+          Type: 324 StructureType main.deepStruct2
+    - __kind: StructureType
+      ID: 324
+      Name: main.deepStruct2
+      ByteSize: 40
+      GoKind: 25
+      RawFields:
+        - Name: c
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: d
+          Offset: 8
+          Type: 325 StructureType main.deepStruct3
+    - __kind: StructureType
+      ID: 325
+      Name: main.deepStruct3
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: e
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: f
+          Offset: 8
+          Type: 326 StructureType main.deepStruct4
+    - __kind: StructureType
+      ID: 326
+      Name: main.deepStruct4
+      ByteSize: 24
+      GoKind: 25
+      RawFields:
+        - Name: g
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: h
+          Offset: 8
+          Type: 327 StructureType main.deepStruct5
+    - __kind: StructureType
+      ID: 327
+      Name: main.deepStruct5
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: i
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: j
+          Offset: 8
+          Type: 328 StructureType main.deepStruct6
+    - __kind: StructureType
+      ID: 328
+      Name: main.deepStruct6
+      ByteSize: 8
+      GoKind: 25
+      RawFields: [{Name: k, Offset: 0, Type: 9 BaseType int}]
     - __kind: StructureType
       ID: 314
       Name: main.emptyStruct
@@ -22103,16 +22370,16 @@ Types:
           Type: 150 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 1052 StructureType sync.Mutex
+          Type: 1069 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 1053 StructureType sync.Once
+          Type: 1070 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 1056 StructureType sync.WaitGroup
+          Type: 1073 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 1060 StructureType sync/atomic.Int32
+          Type: 1077 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 150
       Name: main.esotericStack
@@ -22142,7 +22409,7 @@ Types:
           Offset: 56
           Type: 57 GoSubroutineType func()
     - __kind: StructureType
-      ID: 316
+      ID: 333
       Name: main.firstBehavior
       ByteSize: 16
       GoRuntimeType: 1.231936e+06
@@ -22188,6 +22455,90 @@ Types:
           Offset: 72
           Type: 9 BaseType int
     - __kind: StructureType
+      ID: 329
+      Name: main.lotsOfFields
+      ByteSize: 26
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 3 BaseType uint8
+        - Name: b
+          Offset: 1
+          Type: 3 BaseType uint8
+        - Name: c
+          Offset: 2
+          Type: 3 BaseType uint8
+        - Name: d
+          Offset: 3
+          Type: 3 BaseType uint8
+        - Name: e
+          Offset: 4
+          Type: 3 BaseType uint8
+        - Name: f
+          Offset: 5
+          Type: 3 BaseType uint8
+        - Name: g
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: h
+          Offset: 7
+          Type: 3 BaseType uint8
+        - Name: i
+          Offset: 8
+          Type: 3 BaseType uint8
+        - Name: j
+          Offset: 9
+          Type: 3 BaseType uint8
+        - Name: k
+          Offset: 10
+          Type: 3 BaseType uint8
+        - Name: l
+          Offset: 11
+          Type: 3 BaseType uint8
+        - Name: m
+          Offset: 12
+          Type: 3 BaseType uint8
+        - Name: n
+          Offset: 13
+          Type: 3 BaseType uint8
+        - Name: o
+          Offset: 14
+          Type: 3 BaseType uint8
+        - Name: p
+          Offset: 15
+          Type: 3 BaseType uint8
+        - Name: q
+          Offset: 16
+          Type: 3 BaseType uint8
+        - Name: r
+          Offset: 17
+          Type: 3 BaseType uint8
+        - Name: s
+          Offset: 18
+          Type: 3 BaseType uint8
+        - Name: t
+          Offset: 19
+          Type: 3 BaseType uint8
+        - Name: u
+          Offset: 20
+          Type: 3 BaseType uint8
+        - Name: v
+          Offset: 21
+          Type: 3 BaseType uint8
+        - Name: w
+          Offset: 22
+          Type: 3 BaseType uint8
+        - Name: x
+          Offset: 23
+          Type: 3 BaseType uint8
+        - Name: y
+          Offset: 24
+          Type: 3 BaseType uint8
+        - Name: z
+          Offset: 25
+          Type: 3 BaseType uint8
+    - __kind: StructureType
       ID: 249
       Name: main.mixedStruct
       ByteSize: 24
@@ -22202,6 +22553,21 @@ Types:
         - Name: c
           Offset: 16
           Type: 9 BaseType int
+    - __kind: StructureType
+      ID: 318
+      Name: main.nStruct
+      ByteSize: 24
+      GoKind: 25
+      RawFields:
+        - Name: aBool
+          Offset: 0
+          Type: 4 BaseType bool
+        - Name: aInt
+          Offset: 8
+          Type: 9 BaseType int
+        - Name: aInt16
+          Offset: 16
+          Type: 97 BaseType int16
     - __kind: StructureType
       ID: 116
       Name: main.nestedStruct
@@ -22238,7 +22604,13 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1063
+      ID: 317
+      Name: main.receiver
+      ByteSize: 8
+      GoKind: 25
+      RawFields: [{Name: u, Offset: 0, Type: 15 BaseType uint}]
+    - __kind: StructureType
+      ID: 1080
       Name: main.secondBehavior
       ByteSize: 8
       GoRuntimeType: 1.232096e+06
@@ -22258,7 +22630,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1051
+      ID: 1068
       Name: main.somethingImpl
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -22269,31 +22641,31 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1048 PointerType *main.stringType1.str
+          Type: 1065 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 1047 GoStringDataType main.stringType1.str
+      Data: 1064 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 1047
+      ID: 1064
       Name: main.stringType1.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 1049
+      ID: 1066
       Name: main.stringType2
       ByteSize: 16
       GoKind: 24
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1128 PointerType *main.stringType2.str
+          Type: 1145 PointerType *main.stringType2.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 1127 GoStringDataType main.stringType2.str
+      Data: 1144 GoStringDataType main.stringType2.str
     - __kind: GoStringDataType
-      ID: 1127
+      ID: 1144
       Name: main.stringType2.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -22390,6 +22762,21 @@ Types:
           Offset: 1
           Type: 4 BaseType bool
     - __kind: StructureType
+      ID: 330
+      Name: main.structWithTwoArrays
+      ByteSize: 72
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 331 ArrayType [3]uint64
+        - Name: b
+          Offset: 24
+          Type: 3 BaseType uint8
+        - Name: c
+          Offset: 32
+          Type: 332 ArrayType [5]int64
+    - __kind: StructureType
       ID: 240
       Name: main.structWithTwoValues
       ByteSize: 16
@@ -22409,23 +22796,74 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1064 PointerType **main.t
+          Type: 1081 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1065 GoSliceDataType main.t.array
+      Data: 1082 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 1065
+      ID: 1082
       Name: main.t.array
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 243 PointerType *main.t
     - __kind: StructureType
+      ID: 322
+      Name: main.tenStrings
+      ByteSize: 160
+      GoKind: 25
+      RawFields:
+        - Name: first
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+        - Name: second
+          Offset: 16
+          Type: 11 GoStringHeaderType string
+        - Name: third
+          Offset: 32
+          Type: 11 GoStringHeaderType string
+        - Name: fourth
+          Offset: 48
+          Type: 11 GoStringHeaderType string
+        - Name: fifth
+          Offset: 64
+          Type: 11 GoStringHeaderType string
+        - Name: sixth
+          Offset: 80
+          Type: 11 GoStringHeaderType string
+        - Name: seventh
+          Offset: 96
+          Type: 11 GoStringHeaderType string
+        - Name: eighth
+          Offset: 112
+          Type: 11 GoStringHeaderType string
+        - Name: ninth
+          Offset: 128
+          Type: 11 GoStringHeaderType string
+        - Name: tenth
+          Offset: 144
+          Type: 11 GoStringHeaderType string
+    - __kind: StructureType
       ID: 263
       Name: main.threeStringStruct
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+        - Name: b
+          Offset: 16
+          Type: 11 GoStringHeaderType string
+        - Name: c
+          Offset: 32
+          Type: 11 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 320
+      Name: main.threestrings
       ByteSize: 48
       GoKind: 25
       RawFields:
@@ -22518,26 +22956,26 @@ Types:
       GoKind: 21
       HeaderType: 139 GoHMapHeaderType hash<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 1073
+      ID: 1090
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 879904
       GoKind: 21
-      HeaderType: 1075 GoHMapHeaderType hash<int,*main.deepMap3>
+      HeaderType: 1092 GoHMapHeaderType hash<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 1101
+      ID: 1118
       Name: map[int]*main.deepMap8
       ByteSize: 8
       GoRuntimeType: 879424
       GoKind: 21
-      HeaderType: 1103 GoHMapHeaderType hash<int,*main.deepMap8>
+      HeaderType: 1120 GoHMapHeaderType hash<int,*main.deepMap8>
     - __kind: GoMapType
-      ID: 1110
+      ID: 1127
       Name: map[int]*main.deepMap9
       ByteSize: 8
       GoRuntimeType: 879328
       GoKind: 21
-      HeaderType: 1112 GoHMapHeaderType hash<int,*main.deepMap9>
+      HeaderType: 1129 GoHMapHeaderType hash<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 161
       Name: map[int]int
@@ -22546,12 +22984,12 @@ Types:
       GoKind: 21
       HeaderType: 163 GoHMapHeaderType hash<int,int>
     - __kind: GoMapType
-      ID: 1119
+      ID: 1136
       Name: map[int]interface {}
       ByteSize: 8
       GoRuntimeType: 879232
       GoKind: 21
-      HeaderType: 1121 GoHMapHeaderType hash<int,interface {}>
+      HeaderType: 1138 GoHMapHeaderType hash<int,interface {}>
     - __kind: GoMapType
       ID: 228
       Name: map[int]struct {}
@@ -22659,7 +23097,7 @@ Types:
       GoKind: 21
       HeaderType: 205 GoHMapHeaderType hash<uint8,uint8>
     - __kind: StructureType
-      ID: 579
+      ID: 596
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1.247776e+06
@@ -22669,7 +23107,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 868
+      ID: 885
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
       GoRuntimeType: 1.244576e+06
@@ -22679,11 +23117,11 @@ Types:
           Offset: 0
           Type: 124 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 781
+      ID: 798
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 844
+      ID: 861
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1.40576e+06
@@ -22696,35 +23134,35 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 807
+      ID: 824
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1006
+      ID: 1023
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 805
+      ID: 822
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 783
+      ID: 800
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1016
+      ID: 1033
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1026
+      ID: 1043
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1014
+      ID: 1031
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 742
+      ID: 759
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1.072064e+06
@@ -22732,28 +23170,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 744 PointerType *net.UnknownNetworkError.str
+          Type: 761 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 743 GoStringDataType net.UnknownNetworkError.str
+      Data: 760 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 743
+      ID: 760
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 711
+      ID: 728
       Name: net.canceledError
       GoRuntimeType: 1.19632e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 984
+      ID: 1001
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 849
+      ID: 866
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 1.96816e+06
@@ -22761,7 +23199,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 844 GoInterfaceType net.Conn
+          Type: 861 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 18 GoInterfaceType error
@@ -22772,27 +23210,27 @@ Types:
           Offset: 33
           Type: 4 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 1028
+      ID: 1045
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 1022
+      ID: 1039
       Name: net.noReadFrom
       GoRuntimeType: 1.07232e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1021
+      ID: 1038
       Name: net.noWriteTo
       GoRuntimeType: 1.072192e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 514
+      ID: 531
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
-      ID: 516
+      ID: 533
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1.603584e+06
@@ -22800,7 +23238,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 832 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 849 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 11 GoStringHeaderType string
@@ -22808,7 +23246,7 @@ Types:
           Offset: 96
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 1010
+      ID: 1027
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.14448e+06
@@ -22816,12 +23254,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1022 StructureType net.noReadFrom
+          Type: 1039 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 1015 PointerType *net.TCPConn
+          Type: 1032 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 1008
+      ID: 1025
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.143936e+06
@@ -22829,24 +23267,24 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1021 StructureType net.noWriteTo
+          Type: 1038 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 1015 PointerType *net.TCPConn
+          Type: 1032 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 785
+      ID: 802
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 809
+      ID: 826
       Name: net.timeoutError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 701
+      ID: 718
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: StructureType
-      ID: 862
+      ID: 879
       Name: net/http.bufioFlushWriter
       ByteSize: 16
       GoRuntimeType: 1.236096e+06
@@ -22856,19 +23294,19 @@ Types:
           Offset: 0
           Type: 124 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 411
+      ID: 428
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 762400
       GoKind: 10
     - __kind: BaseType
-      ID: 821
+      ID: 838
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 949248
       GoKind: 10
     - __kind: StructureType
-      ID: 492
+      ID: 509
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1.601664e+06
@@ -22879,12 +23317,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 821 BaseType net/http.http2ErrCode
+          Type: 838 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 801
+      ID: 818
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1.76704e+06
@@ -22895,12 +23333,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 821 BaseType net/http.http2ErrCode
+          Type: 838 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 496
+      ID: 513
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1.40528e+06
@@ -22908,16 +23346,16 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 821 BaseType net/http.http2ErrCode
+          Type: 838 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 924
+      ID: 941
       Name: net/http.http2dataBuffer
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 415
+      ID: 432
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 762592
@@ -22925,18 +23363,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 417 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 434 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 416 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 433 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 416
+      ID: 433
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 421
+      ID: 438
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 762784
@@ -22944,18 +23382,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 423 PointerType *net/http.http2headerFieldNameError.str
+          Type: 440 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 422 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 439 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 422
+      ID: 439
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 418
+      ID: 435
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 762688
@@ -22963,32 +23401,32 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 420 PointerType *net/http.http2headerFieldValueError.str
+          Type: 437 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 419 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 436 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 419
+      ID: 436
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 776
+      ID: 793
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 707
+      ID: 724
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1.19568e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 975
+      ID: 992
       Name: net/http.http2pipe
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 412
+      ID: 429
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 762496
@@ -22996,18 +23434,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 414 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 431 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 413 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 430 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 413
+      ID: 430
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 864
+      ID: 881
       Name: net/http.http2stickyErrWriter
       ByteSize: 32
       GoRuntimeType: 1.602432e+06
@@ -23015,22 +23453,22 @@ Types:
       RawFields:
         - Name: conn
           Offset: 0
-          Type: 844 GoInterfaceType net.Conn
+          Type: 861 GoInterfaceType net.Conn
         - Name: timeout
           Offset: 16
-          Type: 943 BaseType time.Duration
+          Type: 960 BaseType time.Duration
         - Name: err
           Offset: 24
           Type: 99 PointerType *error
     - __kind: ArrayType
-      ID: 944
+      ID: 961
       Name: net/http.incomparable
       GoRuntimeType: 831040
       GoKind: 17
       HasCount: true
       Element: 57 GoSubroutineType func()
     - __kind: StructureType
-      ID: 703
+      ID: 720
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1.367168e+06
@@ -23040,11 +23478,11 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 926
+      ID: 943
       Name: net/http.persistConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 882
+      ID: 899
       Name: net/http.persistConnWriter
       ByteSize: 8
       GoRuntimeType: 1.367008e+06
@@ -23052,9 +23490,9 @@ Types:
       RawFields:
         - Name: pc
           Offset: 0
-          Type: 925 PointerType *net/http.persistConn
+          Type: 942 PointerType *net/http.persistConn
     - __kind: StructureType
-      ID: 908
+      ID: 925
       Name: net/http.readWriteCloserBody
       ByteSize: 24
       GoRuntimeType: 1.673728e+06
@@ -23062,15 +23500,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 944 ArrayType net/http.incomparable
+          Type: 961 ArrayType net/http.incomparable
         - Name: br
           Offset: 0
-          Type: 945 PointerType *bufio.Reader
+          Type: 962 PointerType *bufio.Reader
         - Name: ReadWriteCloser
           Offset: 8
-          Type: 947 GoInterfaceType io.ReadWriteCloser
+          Type: 964 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 500
+      ID: 517
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1.237056e+06
@@ -23080,17 +23518,17 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 803
+      ID: 820
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 774
+      ID: 791
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1.296224e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 705
+      ID: 722
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1.367328e+06
@@ -23100,11 +23538,11 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 489
+      ID: 506
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 977
+      ID: 994
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
       GoRuntimeType: 1.90528e+06
@@ -23112,13 +23550,13 @@ Types:
       RawFields:
         - Name: Writer
           Offset: 0
-          Type: 970 PointerType *bufio.Writer
+          Type: 987 PointerType *bufio.Writer
     - __kind: UnresolvedPointeeType
-      ID: 892
+      ID: 909
       Name: net/http/internal.chunkedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 571
+      ID: 588
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1.607424e+06
@@ -23134,7 +23572,7 @@ Types:
           Offset: 32
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 569
+      ID: 586
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1.4072e+06
@@ -23147,11 +23585,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 934
+      ID: 951
       Name: net/smtp.Client
       ByteSize: 8
     - __kind: StructureType
-      ID: 894
+      ID: 911
       Name: net/smtp.dataCloser
       ByteSize: 24
       GoRuntimeType: 1.40912e+06
@@ -23159,16 +23597,16 @@ Types:
       RawFields:
         - Name: c
           Offset: 0
-          Type: 933 PointerType *net/smtp.Client
+          Type: 950 PointerType *net/smtp.Client
         - Name: WriteCloser
           Offset: 8
-          Type: 935 GoInterfaceType io.WriteCloser
+          Type: 952 GoInterfaceType io.WriteCloser
     - __kind: UnresolvedPointeeType
-      ID: 555
+      ID: 572
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 446
+      ID: 463
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 765376
@@ -23176,26 +23614,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 448 PointerType *net/textproto.ProtocolError.str
+          Type: 465 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 447 GoStringDataType net/textproto.ProtocolError.str
+      Data: 464 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 447
+      ID: 464
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 890
+      ID: 907
       Name: net/textproto.dotWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 811
+      ID: 828
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 424
+      ID: 441
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 763360
@@ -23203,18 +23641,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 426 PointerType *net/url.EscapeError.str
+          Type: 443 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 425 GoStringDataType net/url.EscapeError.str
+      Data: 442 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 425
+      ID: 442
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 427
+      ID: 444
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 763456
@@ -23222,30 +23660,30 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 429 PointerType *net/url.InvalidHostError.str
+          Type: 446 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 428 GoStringDataType net/url.InvalidHostError.str
+      Data: 445 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 428
+      ID: 445
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1034
+      ID: 1051
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 682
+      ID: 699
       Name: os.LinkError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 746
+      ID: 763
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1032
+      ID: 1049
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.212672e+06
@@ -23253,12 +23691,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1038 StructureType os.noReadFrom
+          Type: 1055 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 1033 PointerType *os.File
+          Type: 1050 PointerType *os.File
     - __kind: StructureType
-      ID: 1030
+      ID: 1047
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.211872e+06
@@ -23266,36 +23704,36 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1037 StructureType os.noWriteTo
+          Type: 1054 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 1033 PointerType *os.File
+          Type: 1050 PointerType *os.File
     - __kind: StructureType
-      ID: 1038
+      ID: 1055
       Name: os.noReadFrom
       GoRuntimeType: 1.06976e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1037
+      ID: 1054
       Name: os.noWriteTo
       GoRuntimeType: 1.069632e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 713
+      ID: 730
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 852
+      ID: 869
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 912
+      ID: 929
       Name: os/exec.prefixSuffixSaver
       ByteSize: 8
     - __kind: StructureType
-      ID: 715
+      ID: 732
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1.510272e+06
@@ -23308,7 +23746,7 @@ Types:
           Offset: 16
           Type: 18 GoInterfaceType error
     - __kind: GoStringHeaderType
-      ID: 459
+      ID: 476
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 768544
@@ -23316,36 +23754,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 461 PointerType *os/user.UnknownGroupIdError.str
+          Type: 478 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 460 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 477 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 460
+      ID: 477
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 458
+      ID: 475
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 768448
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 484
+      ID: 501
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 577
+      ID: 594
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 685
+      ID: 702
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 690
+      ID: 707
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -23357,7 +23795,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 687
+      ID: 704
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1.756608e+06
@@ -23374,9 +23812,9 @@ Types:
           Type: 4 BaseType bool
         - Name: code
           Offset: 17
-          Type: 850 BaseType runtime.boundsErrorCode
+          Type: 867 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 850
+      ID: 867
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 532608
@@ -23396,7 +23834,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 748
+      ID: 765
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1.627552e+06
@@ -23409,7 +23847,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 666
+      ID: 683
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 948096
@@ -23417,13 +23855,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 668 PointerType *runtime.errorString.str
+          Type: 685 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 667 GoStringDataType runtime.errorString.str
+      Data: 684 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 667
+      ID: 684
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -24049,7 +24487,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 669
+      ID: 686
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 948672
@@ -24057,13 +24495,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 671 PointerType *runtime.plainError.str
+          Type: 688 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 670 GoStringDataType runtime.plainError.str
+      Data: 687 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 670
+      ID: 687
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -24145,7 +24583,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 692
+      ID: 709
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -24157,26 +24595,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 318 PointerType *string.str
+          Type: 335 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 317 GoStringDataType string.str
+      Data: 334 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 317
+      ID: 334
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 973
+      ID: 990
       Name: strings.Builder
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 880
+      ID: 897
       Name: strings.appendSliceWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 876
+      ID: 893
       Name: struct { io.Writer }
       ByteSize: 16
       GoRuntimeType: 1.273024e+06
@@ -24192,7 +24630,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1052
+      ID: 1069
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.281664e+06
@@ -24205,7 +24643,7 @@ Types:
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1053
+      ID: 1070
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.282784e+06
@@ -24213,12 +24651,12 @@ Types:
       RawFields:
         - Name: done
           Offset: 0
-          Type: 1054 StructureType sync/atomic.Uint32
+          Type: 1071 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 1052 StructureType sync.Mutex
+          Type: 1069 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 1056
+      ID: 1073
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.421472e+06
@@ -24226,21 +24664,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 1057 StructureType sync.noCopy
+          Type: 1074 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 1058 StructureType sync/atomic.Uint64
+          Type: 1075 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1057
+      ID: 1074
       Name: sync.noCopy
       GoRuntimeType: 947040
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1060
+      ID: 1077
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.283104e+06
@@ -24248,12 +24686,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1055 StructureType sync/atomic.noCopy
+          Type: 1072 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 1054
+      ID: 1071
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1.283264e+06
@@ -24261,12 +24699,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1055 StructureType sync/atomic.noCopy
+          Type: 1072 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1058
+      ID: 1075
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.421856e+06
@@ -24274,37 +24712,37 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1055 StructureType sync/atomic.noCopy
+          Type: 1072 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 1059 StructureType sync/atomic.align64
+          Type: 1076 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 10 BaseType uint64
     - __kind: StructureType
-      ID: 1059
+      ID: 1076
       Name: sync/atomic.align64
       GoRuntimeType: 947232
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1055
+      ID: 1072
       Name: sync/atomic.noCopy
       GoRuntimeType: 947136
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 798
+      ID: 815
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1.194912e+06
       GoKind: 12
     - __kind: UnresolvedPointeeType
-      ID: 1004
+      ID: 1021
       Name: text/tabwriter.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 741
+      ID: 758
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1.514688e+06
@@ -24317,21 +24755,21 @@ Types:
           Offset: 16
           Type: 18 GoInterfaceType error
     - __kind: BaseType
-      ID: 943
+      ID: 960
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1.78288e+06
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 816
+      ID: 833
       Name: time.Location
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 487
+      ID: 504
       Name: time.ParseError
       ByteSize: 8
     - __kind: StructureType
-      ID: 814
+      ID: 831
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.224896e+06
@@ -24345,9 +24783,9 @@ Types:
           Type: 13 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 815 PointerType *time.Location
+          Type: 832 PointerType *time.Location
     - __kind: GoStringHeaderType
-      ID: 408
+      ID: 425
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 761536
@@ -24355,13 +24793,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 410 PointerType *time.fileSizeError.str
+          Type: 427 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 409 GoStringDataType time.fileSizeError.str
+      Data: 426 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 409
+      ID: 426
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -24408,11 +24846,11 @@ Types:
       GoRuntimeType: 532544
       GoKind: 26
     - __kind: UnresolvedPointeeType
-      ID: 967
+      ID: 984
       Name: vendor/golang.org/x/crypto/sha3.state
       ByteSize: 8
     - __kind: StructureType
-      ID: 832
+      ID: 849
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 1.927008e+06
@@ -24423,10 +24861,10 @@ Types:
           Type: 38 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 833 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 850 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 834 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 851 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: off
           Offset: 40
           Type: 9 BaseType int
@@ -24441,18 +24879,18 @@ Types:
           Type: 9 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 835 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 852 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 7 BaseType uint16
     - __kind: BaseType
-      ID: 835
+      ID: 852
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 953376
       GoKind: 9
     - __kind: StructureType
-      ID: 833
+      ID: 850
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1.793376e+06
@@ -24477,21 +24915,21 @@ Types:
           Offset: 10
           Type: 7 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 573
+      ID: 590
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 834
+      ID: 851
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 536192
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 996
+      ID: 1013
       Name: vendor/golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 557
+      ID: 574
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.244896e+06
@@ -24501,13 +24939,13 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: BaseType
-      ID: 449
+      ID: 466
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 765472
       GoKind: 2
     - __kind: StructureType
-      ID: 720
+      ID: 737
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1.510464e+06
@@ -24520,12 +24958,12 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 674
+      ID: 691
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 952224
       GoKind: 5
-MaxTypeID: 1376
+MaxTypeID: 1394
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x175d760", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -11,11 +11,11 @@ Probes:
       subprogram: {subprogram: 142}
       events:
         - Kind: Entry
-          Type: 1507 EventRootType Probe[main.stackC]
+          Type: 1523 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0xcdb96a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1508 EventRootType Probe[main.stackC]Return
+          Type: 1524 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0xcdb9a5", Frameless: false}]
           Condition: null
       probeTemplate: {TemplateString: stackC, Segments: [stackC]}
@@ -30,11 +30,11 @@ Probes:
       subprogram: {subprogram: 56}
       events:
         - Kind: Entry
-          Type: 1371 EventRootType Probe[main.testAny]
+          Type: 1387 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0xcd610a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1372 EventRootType Probe[main.testAny]Return
+          Type: 1388 EventRootType Probe[main.testAny]Return
           InjectionPoints: [{PC: "0xcd6145", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -55,11 +55,11 @@ Probes:
       subprogram: {subprogram: 58}
       events:
         - Kind: Entry
-          Type: 1374 EventRootType Probe[main.testAnyPtr]
+          Type: 1390 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0xcd61aa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1375 EventRootType Probe[main.testAnyPtr]Return
+          Type: 1391 EventRootType Probe[main.testAnyPtr]Return
           InjectionPoints: [{PC: "0xcd61dd", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -79,11 +79,11 @@ Probes:
       subprogram: {subprogram: 122}
       events:
         - Kind: Entry
-          Type: 1478 EventRootType Probe[main.testArrayArgAndReturn]
+          Type: 1494 EventRootType Probe[main.testArrayArgAndReturn]
           InjectionPoints: [{PC: "0xcda3ae", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1479 EventRootType Probe[main.testArrayArgAndReturn]Return
+          Type: 1495 EventRootType Probe[main.testArrayArgAndReturn]Return
           InjectionPoints: [{PC: "0xcda462", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -104,7 +104,7 @@ Probes:
       subprogram: {subprogram: 19}
       events:
         - Kind: Entry
-          Type: 1322 EventRootType Probe[main.testArrayEmptyStructs]
+          Type: 1338 EventRootType Probe[main.testArrayEmptyStructs]
           InjectionPoints: [{PC: "0xcd4360", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -125,7 +125,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - Kind: Entry
-          Type: 1318 EventRootType Probe[main.testArrayOfArrays]
+          Type: 1334 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0xcd42e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -146,7 +146,7 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - Kind: Entry
-          Type: 1320 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          Type: 1336 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0xcd4320", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -167,7 +167,7 @@ Probes:
       subprogram: {subprogram: 66}
       events:
         - Kind: Entry
-          Type: 1383 EventRootType Probe[main.testArrayOfMaps]
+          Type: 1399 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0xcd6920", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -188,7 +188,7 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - Kind: Entry
-          Type: 1319 EventRootType Probe[main.testArrayOfStrings]
+          Type: 1335 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0xcd4300", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -208,7 +208,7 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - Kind: Entry
-          Type: 1321 EventRootType Probe[main.testArrayOfStructs]
+          Type: 1337 EventRootType Probe[main.testArrayOfStructs]
           InjectionPoints: [{PC: "0xcd4340", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -229,11 +229,11 @@ Probes:
       subprogram: {subprogram: 86}
       events:
         - Kind: Entry
-          Type: 1405 EventRootType Probe[main.testAtomicAdd]
+          Type: 1421 EventRootType Probe[main.testAtomicAdd]
           InjectionPoints: [{PC: "0xcd8800", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1406 EventRootType Probe[main.testAtomicAdd]Return
+          Type: 1422 EventRootType Probe[main.testAtomicAdd]Return
           InjectionPoints: [{PC: "0xcd8812", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -254,11 +254,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 1340 EventRootType Probe[main.testBigStruct]
+          Type: 1356 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0xcd4a60", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1341 EventRootType Probe[main.testBigStruct]Return
+          Type: 1357 EventRootType Probe[main.testBigStruct]Return
           InjectionPoints: [{PC: "0xcd4a7e", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -279,7 +279,7 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - Kind: Entry
-          Type: 1307 EventRootType Probe[main.testBoolArray]
+          Type: 1323 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0xcd4180", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -300,7 +300,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - Kind: Entry
-          Type: 1304 EventRootType Probe[main.testByteArray]
+          Type: 1320 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0xcd4120", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -326,11 +326,11 @@ Probes:
       subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1526 EventRootType Probe[main.testStruct]
+          Type: 1542 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0xcdbda0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1527 EventRootType Probe[main.testStruct]Return
+          Type: 1543 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0xcdbdc2", Frameless: true}]
           Condition: null
     - id: testCaptureExprLine
@@ -345,10 +345,10 @@ Probes:
       segments: []
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1536 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1553 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0xcd592e"
               Frameless: false
@@ -373,10 +373,10 @@ Probes:
       segments: [x=, {json: {ref: x}, dsl: x}]
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1537 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1554 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0xcd592e"
               Frameless: false
@@ -412,7 +412,7 @@ Probes:
       subprogram: {subprogram: 84}
       events:
         - Kind: Entry
-          Type: 1402 EventRootType Probe[main.testCombinedString]
+          Type: 1418 EventRootType Probe[main.testCombinedString]
           InjectionPoints: [{PC: "0xcd8460", Frameless: true}]
           Condition: null
     - id: testCaptureExprWithTemplate
@@ -430,7 +430,7 @@ Probes:
       subprogram: {subprogram: 84}
       events:
         - Kind: Entry
-          Type: 1403 EventRootType Probe[main.testCombinedString]
+          Type: 1419 EventRootType Probe[main.testCombinedString]
           InjectionPoints: [{PC: "0xcd8460", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -452,7 +452,7 @@ Probes:
       subprogram: {subprogram: 87}
       events:
         - Kind: Entry
-          Type: 1407 EventRootType Probe[main.testChannel]
+          Type: 1423 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0xcd8820", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -481,7 +481,7 @@ Probes:
       subprogram: {subprogram: 83}
       events:
         - Kind: Entry
-          Type: 1401 EventRootType Probe[main.testCombinedByte]
+          Type: 1417 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0xcd8420", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -512,7 +512,7 @@ Probes:
       subprogram: {subprogram: 95}
       events:
         - Kind: Entry
-          Type: 1415 EventRootType Probe[main.testCycle]
+          Type: 1431 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0xcd8c00", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -533,7 +533,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - Kind: Entry
-          Type: 1346 EventRootType Probe[main.testDeepMap1]
+          Type: 1362 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0xcd4e40", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -554,7 +554,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - Kind: Entry
-          Type: 1347 EventRootType Probe[main.testDeepMap7]
+          Type: 1363 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0xcd4e60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -575,7 +575,7 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - Kind: Entry
-          Type: 1342 EventRootType Probe[main.testDeepPtr1]
+          Type: 1358 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0xcd4b20", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -596,7 +596,7 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - Kind: Entry
-          Type: 1343 EventRootType Probe[main.testDeepPtr7]
+          Type: 1359 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0xcd4b40", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -617,7 +617,7 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - Kind: Entry
-          Type: 1344 EventRootType Probe[main.testDeepSlice1]
+          Type: 1360 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0xcd4cc0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -638,7 +638,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - Kind: Entry
-          Type: 1345 EventRootType Probe[main.testDeepSlice7]
+          Type: 1361 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0xcd4ce0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -659,7 +659,7 @@ Probes:
       subprogram: {subprogram: 131}
       events:
         - Kind: Entry
-          Type: 1495 EventRootType Probe[main.testEmptySlice]
+          Type: 1511 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0xcdb480", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -685,7 +685,7 @@ Probes:
       subprogram: {subprogram: 134}
       events:
         - Kind: Entry
-          Type: 1498 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 1514 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0xcdb4e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -712,7 +712,7 @@ Probes:
       subprogram: {subprogram: 150}
       events:
         - Kind: Entry
-          Type: 1521 EventRootType Probe[main.testEmptyString]
+          Type: 1537 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0xcdbaa0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -733,7 +733,7 @@ Probes:
       subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1534 EventRootType Probe[main.testEmptyStruct]
+          Type: 1550 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0xcdbf20", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -753,7 +753,7 @@ Probes:
       subprogram: {subprogram: 157}
       events:
         - Kind: Entry
-          Type: 1535 EventRootType Probe[main.testEmptyStructPointer]
+          Type: 1551 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0xcdbf40", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -774,7 +774,7 @@ Probes:
       subprogram: {subprogram: 57}
       events:
         - Kind: Entry
-          Type: 1373 EventRootType Probe[main.testError]
+          Type: 1389 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0xcd6180", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -795,11 +795,11 @@ Probes:
       subprogram: {subprogram: 48}
       events:
         - Kind: Entry
-          Type: 1355 EventRootType Probe[main.testEsotericHeap]
+          Type: 1371 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0xcd568a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1356 EventRootType Probe[main.testEsotericHeap]Return
+          Type: 1372 EventRootType Probe[main.testEsotericHeap]Return
           InjectionPoints: [{PC: "0xcd56cc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -820,11 +820,11 @@ Probes:
       subprogram: {subprogram: 47}
       events:
         - Kind: Entry
-          Type: 1353 EventRootType Probe[main.testEsotericStack]
+          Type: 1369 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0xcd556e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1354 EventRootType Probe[main.testEsotericStack]Return
+          Type: 1370 EventRootType Probe[main.testEsotericStack]Return
           InjectionPoints: [{PC: "0xcd55fb", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -845,11 +845,11 @@ Probes:
       subprogram: {subprogram: 53}
       events:
         - Kind: Entry
-          Type: 1365 EventRootType Probe[main.testFrameless]
+          Type: 1381 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0xcd5de0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1366 EventRootType Probe[main.testFrameless]Return
+          Type: 1382 EventRootType Probe[main.testFrameless]Return
           InjectionPoints: [{PC: "0xcd5de5", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -870,11 +870,11 @@ Probes:
       subprogram: {subprogram: 54}
       events:
         - Kind: Entry
-          Type: 1367 EventRootType Probe[main.testFramelessArray]
+          Type: 1383 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0xcd5e04", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1368 EventRootType Probe[main.testFramelessArray]Return
+          Type: 1384 EventRootType Probe[main.testFramelessArray]Return
           InjectionPoints: [{PC: "0xcd5e3d", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -898,7 +898,7 @@ Probes:
       subprogram: {subprogram: 54}
       events:
         - Kind: Line
-          Type: 1369 EventRootType Probe[main.testFramelessArray]Line
+          Type: 1385 EventRootType Probe[main.testFramelessArray]Line
           InjectionPoints: [{PC: "0xcd5e08", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -919,11 +919,11 @@ Probes:
       subprogram: {subprogram: 49}
       events:
         - Kind: Entry
-          Type: 1357 EventRootType Probe[main.testInlinedBA]
+          Type: 1373 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0xcd5aca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1358 EventRootType Probe[main.testInlinedBA]Return
+          Type: 1374 EventRootType Probe[main.testInlinedBA]Return
           InjectionPoints: [{PC: "0xcd5b2e", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -949,11 +949,11 @@ Probes:
       subprogram: {subprogram: 50}
       events:
         - Kind: Entry
-          Type: 1359 EventRootType Probe[main.testInlinedBB]
+          Type: 1375 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0xcd5b6e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1360 EventRootType Probe[main.testInlinedBB]Return
+          Type: 1376 EventRootType Probe[main.testInlinedBB]Return
           InjectionPoints: [{PC: "0xcd5bfe", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -979,11 +979,11 @@ Probes:
       subprogram: {subprogram: 51}
       events:
         - Kind: Entry
-          Type: 1361 EventRootType Probe[main.testInlinedBBA]
+          Type: 1377 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0xcd5c4a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1362 EventRootType Probe[main.testInlinedBBA]Return
+          Type: 1378 EventRootType Probe[main.testInlinedBBA]Return
           InjectionPoints: [{PC: "0xcd5c8b", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1001,10 +1001,10 @@ Probes:
       template: testInlinedBBB
       segments: [testInlinedBBB]
       captureSnapshot: true
-      subprogram: {subprogram: 159}
+      subprogram: {subprogram: 160}
       events:
         - Kind: Entry
-          Type: 1541 EventRootType Probe[main.testInlinedBBB]
+          Type: 1558 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xcd5bc6", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1021,11 +1021,11 @@ Probes:
       subprogram: {subprogram: 52}
       events:
         - Kind: Entry
-          Type: 1363 EventRootType Probe[main.testInlinedBC]
+          Type: 1379 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0xcd5cce", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1364 EventRootType Probe[main.testInlinedBC]Return
+          Type: 1380 EventRootType Probe[main.testInlinedBC]Return
           InjectionPoints: [{PC: "0xcd5dbe", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1039,10 +1039,10 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Entry
-          Type: 1542 EventRootType Probe[main.testInlinedBCA]
+          Type: 1559 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xcd5cd3", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1059,10 +1059,10 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Line
-          Type: 1543 EventRootType Probe[main.testInlinedBCA]Line
+          Type: 1560 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0xcd5cd3", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1076,10 +1076,10 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Entry
-          Type: 1544 EventRootType Probe[main.testInlinedBCB]
+          Type: 1561 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xcd5d86", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1096,10 +1096,10 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Line
-          Type: 1545 EventRootType Probe[main.testInlinedBCB]Line
+          Type: 1562 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0xcd5d86", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1113,10 +1113,10 @@ Probes:
       template: testInlinedFuncFromOtherPackage
       segments: [testInlinedFuncFromOtherPackage]
       captureSnapshot: true
-      subprogram: {subprogram: 165}
+      subprogram: {subprogram: 166}
       events:
         - Kind: Entry
-          Type: 1551 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
+          Type: 1568 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
           InjectionPoints:
             - PC: "0xcd3c41"
               Frameless: true
@@ -1135,10 +1135,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Entry
-          Type: 1538 EventRootType Probe[main.testInlinedPrint]
+          Type: 1555 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0xcd592a"
               Frameless: false
@@ -1152,7 +1152,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1539 EventRootType Probe[main.testInlinedPrint]Return
+          Type: 1556 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0xcd596a", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1173,10 +1173,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1540 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1557 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0xcd592e"
               Frameless: false
@@ -1204,10 +1204,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 162}
+      subprogram: {subprogram: 163}
       events:
         - Kind: Entry
-          Type: 1546 EventRootType Probe[main.testInlinedSq]
+          Type: 1563 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xcd5de1", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1228,10 +1228,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 162}
+      subprogram: {subprogram: 163}
       events:
         - Kind: Line
-          Type: 1547 EventRootType Probe[main.testInlinedSq]Line
+          Type: 1564 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0xcd5de1", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1250,10 +1250,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 163}
+      subprogram: {subprogram: 164}
       events:
         - Kind: Entry
-          Type: 1548 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1565 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0xcd5e25"
               Frameless: false
@@ -1278,7 +1278,7 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - Kind: Entry
-          Type: 1310 EventRootType Probe[main.testInt16Array]
+          Type: 1326 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0xcd41e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1299,7 +1299,7 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - Kind: Entry
-          Type: 1311 EventRootType Probe[main.testInt32Array]
+          Type: 1327 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0xcd4200", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1320,7 +1320,7 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - Kind: Entry
-          Type: 1312 EventRootType Probe[main.testInt64Array]
+          Type: 1328 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0xcd4220", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1341,7 +1341,7 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - Kind: Entry
-          Type: 1309 EventRootType Probe[main.testInt8Array]
+          Type: 1325 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0xcd41c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1362,7 +1362,7 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - Kind: Entry
-          Type: 1308 EventRootType Probe[main.testIntArray]
+          Type: 1324 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0xcd41a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1383,7 +1383,7 @@ Probes:
       subprogram: {subprogram: 55}
       events:
         - Kind: Entry
-          Type: 1370 EventRootType Probe[main.testInterface]
+          Type: 1386 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0xcd60e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1403,11 +1403,11 @@ Probes:
       subprogram: {subprogram: 121}
       events:
         - Kind: Entry
-          Type: 1476 EventRootType Probe[main.testLargeArgAndReturn]
+          Type: 1492 EventRootType Probe[main.testLargeArgAndReturn]
           InjectionPoints: [{PC: "0xcda20e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1477 EventRootType Probe[main.testLargeArgAndReturn]Return
+          Type: 1493 EventRootType Probe[main.testLargeArgAndReturn]Return
           InjectionPoints: [{PC: "0xcda373", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1417,6 +1417,49 @@ Probes:
               DSL: arg
               EventKind: Entry
               EventExpressionIndex: 1
+    - id: testLineProbeTemplateWithStructFields
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.executeStructFuncs
+        sourceFile: structs.go
+        lines: ["208"]
+      template: 'sta.a: {sta.a} sta.b: {sta.b} sta.c: {sta.c}'
+      segments:
+        - 'sta.a: '
+        - json: {getmember: [{ref: sta}, a]}
+          dsl: sta.a
+        - ' sta.b: '
+        - json: {getmember: [{ref: sta}, b]}
+          dsl: sta.b
+        - ' sta.c: '
+        - json: {getmember: [{ref: sta}, c]}
+          dsl: sta.c
+      captureSnapshot: false
+      subprogram: {subprogram: 158}
+      events:
+        - Kind: Line
+          Type: 1552 EventRootType Probe[main.executeStructFuncs]Line
+          InjectionPoints: [{PC: "0xcdc62f", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: 'sta.a: {sta.a} sta.b: {sta.b} sta.c: {sta.c}'
+        Segments:
+            - 'sta.a: '
+            - JSON: {Base: {Ref: sta}, Member: a}
+              DSL: sta.a
+              EventKind: Line
+              EventExpressionIndex: 0
+            - ' sta.b: '
+            - JSON: {Base: {Ref: sta}, Member: b}
+              DSL: sta.b
+              EventKind: Line
+              EventExpressionIndex: 1
+            - ' sta.c: '
+            - JSON: {Base: {Ref: sta}, Member: c}
+              DSL: sta.c
+              EventKind: Line
+              EventExpressionIndex: 2
     - id: testLinkedList
       version: 0
       type: LOG_PROBE
@@ -1428,7 +1471,7 @@ Probes:
       subprogram: {subprogram: 89}
       events:
         - Kind: Entry
-          Type: 1409 EventRootType Probe[main.testLinkedList]
+          Type: 1425 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0xcd8a20", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1452,7 +1495,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - Kind: Line
-          Type: 1350 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          Type: 1366 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xcd4eda", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1473,7 +1516,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - Kind: Line
-          Type: 1351 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          Type: 1367 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xcd4f8d", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1494,7 +1537,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - Kind: Line
-          Type: 1352 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          Type: 1368 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xcd5054", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1536,11 +1579,11 @@ Probes:
       subprogram: {subprogram: 124}
       events:
         - Kind: Entry
-          Type: 1482 EventRootType Probe[main.testManyArgsArrayReturn]
+          Type: 1498 EventRootType Probe[main.testManyArgsArrayReturn]
           InjectionPoints: [{PC: "0xcda6d3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1483 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          Type: 1499 EventRootType Probe[main.testManyArgsArrayReturn]Return
           InjectionPoints: [{PC: "0xcda8e2", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1601,7 +1644,7 @@ Probes:
       subprogram: {subprogram: 64}
       events:
         - Kind: Entry
-          Type: 1381 EventRootType Probe[main.testMapArrayToArray]
+          Type: 1397 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0xcd68e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1622,7 +1665,7 @@ Probes:
       subprogram: {subprogram: 70}
       events:
         - Kind: Entry
-          Type: 1388 EventRootType Probe[main.testMapEmbeddedMaps]
+          Type: 1404 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0xcd69a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1643,7 +1686,7 @@ Probes:
       subprogram: {subprogram: 80}
       events:
         - Kind: Entry
-          Type: 1398 EventRootType Probe[main.testMapEmptyKey]
+          Type: 1414 EventRootType Probe[main.testMapEmptyKey]
           InjectionPoints: [{PC: "0xcd6ae0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1664,7 +1707,7 @@ Probes:
       subprogram: {subprogram: 82}
       events:
         - Kind: Entry
-          Type: 1400 EventRootType Probe[main.testMapEmptyKeyAndValue]
+          Type: 1416 EventRootType Probe[main.testMapEmptyKeyAndValue]
           InjectionPoints: [{PC: "0xcd6b20", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1685,7 +1728,7 @@ Probes:
       subprogram: {subprogram: 81}
       events:
         - Kind: Entry
-          Type: 1399 EventRootType Probe[main.testMapEmptyValue]
+          Type: 1415 EventRootType Probe[main.testMapEmptyValue]
           InjectionPoints: [{PC: "0xcd6b00", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1706,7 +1749,7 @@ Probes:
       subprogram: {subprogram: 68}
       events:
         - Kind: Entry
-          Type: 1385 EventRootType Probe[main.testMapIntToInt]
+          Type: 1401 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0xcd6960", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1727,7 +1770,7 @@ Probes:
       subprogram: {subprogram: 79}
       events:
         - Kind: Entry
-          Type: 1397 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          Type: 1413 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0xcd6ac0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1748,7 +1791,7 @@ Probes:
       subprogram: {subprogram: 78}
       events:
         - Kind: Entry
-          Type: 1396 EventRootType Probe[main.testMapLargeKeySmallValue]
+          Type: 1412 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0xcd6aa0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1771,7 +1814,7 @@ Probes:
       subprogram: {subprogram: 69}
       events:
         - Kind: Entry
-          Type: 1386 EventRootType Probe[main.testMapMassive]
+          Type: 1402 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0xcd6980", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1794,7 +1837,7 @@ Probes:
       subprogram: {subprogram: 69}
       events:
         - Kind: Entry
-          Type: 1387 EventRootType Probe[main.testMapMassive]
+          Type: 1403 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0xcd6980", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1815,7 +1858,7 @@ Probes:
       subprogram: {subprogram: 77}
       events:
         - Kind: Entry
-          Type: 1395 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          Type: 1411 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0xcd6a80", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1836,7 +1879,7 @@ Probes:
       subprogram: {subprogram: 76}
       events:
         - Kind: Entry
-          Type: 1394 EventRootType Probe[main.testMapSmallKeySmallValue]
+          Type: 1410 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0xcd6a60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1857,7 +1900,7 @@ Probes:
       subprogram: {subprogram: 62}
       events:
         - Kind: Entry
-          Type: 1379 EventRootType Probe[main.testMapStringToInt]
+          Type: 1395 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0xcd68a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1878,7 +1921,7 @@ Probes:
       subprogram: {subprogram: 63}
       events:
         - Kind: Entry
-          Type: 1380 EventRootType Probe[main.testMapStringToSlice]
+          Type: 1396 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0xcd68c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1899,7 +1942,7 @@ Probes:
       subprogram: {subprogram: 61}
       events:
         - Kind: Entry
-          Type: 1378 EventRootType Probe[main.testMapStringToStruct]
+          Type: 1394 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0xcd6880", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1920,7 +1963,7 @@ Probes:
       subprogram: {subprogram: 71}
       events:
         - Kind: Entry
-          Type: 1389 EventRootType Probe[main.testMapWithLinkedList]
+          Type: 1405 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0xcd69c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1941,7 +1984,7 @@ Probes:
       subprogram: {subprogram: 74}
       events:
         - Kind: Entry
-          Type: 1392 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          Type: 1408 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0xcd6a20", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1962,7 +2005,7 @@ Probes:
       subprogram: {subprogram: 75}
       events:
         - Kind: Entry
-          Type: 1393 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          Type: 1409 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0xcd6a40", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1983,7 +2026,7 @@ Probes:
       subprogram: {subprogram: 72}
       events:
         - Kind: Entry
-          Type: 1390 EventRootType Probe[main.testMapWithSmallValue]
+          Type: 1406 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0xcd69e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2006,7 +2049,7 @@ Probes:
       subprogram: {subprogram: 73}
       events:
         - Kind: Entry
-          Type: 1391 EventRootType Probe[main.testMapWithSmallValueMassive]
+          Type: 1407 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0xcd6a00", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2027,7 +2070,7 @@ Probes:
       subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1518 EventRootType Probe[main.testMassiveString]
+          Type: 1534 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xcdba60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2049,7 +2092,7 @@ Probes:
       subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1519 EventRootType Probe[main.testMassiveString]
+          Type: 1535 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xcdba60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2095,11 +2138,11 @@ Probes:
       subprogram: {subprogram: 125}
       events:
         - Kind: Entry
-          Type: 1484 EventRootType Probe[main.testMixedArgsStackReturn]
+          Type: 1500 EventRootType Probe[main.testMixedArgsStackReturn]
           InjectionPoints: [{PC: "0xcda973", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1485 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          Type: 1501 EventRootType Probe[main.testMixedArgsStackReturn]Return
           InjectionPoints: [{PC: "0xcdabab", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2164,11 +2207,11 @@ Probes:
       subprogram: {subprogram: 127}
       events:
         - Kind: Entry
-          Type: 1488 EventRootType Probe[main.testMultipleArrayArgs]
+          Type: 1504 EventRootType Probe[main.testMultipleArrayArgs]
           InjectionPoints: [{PC: "0xcdacee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1489 EventRootType Probe[main.testMultipleArrayArgs]Return
+          Type: 1505 EventRootType Probe[main.testMultipleArrayArgs]Return
           InjectionPoints: [{PC: "0xcdadbe", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2198,11 +2241,11 @@ Probes:
       subprogram: {subprogram: 123}
       events:
         - Kind: Entry
-          Type: 1480 EventRootType Probe[main.testMultipleLargeArgs]
+          Type: 1496 EventRootType Probe[main.testMultipleLargeArgs]
           InjectionPoints: [{PC: "0xcda48e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1481 EventRootType Probe[main.testMultipleLargeArgs]Return
+          Type: 1497 EventRootType Probe[main.testMultipleLargeArgs]Return
           InjectionPoints: [{PC: "0xcda6aa", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2227,11 +2270,11 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1434 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1450 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xcd982e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1435 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1451 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcd98cf", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2266,7 +2309,7 @@ Probes:
       subprogram: {subprogram: 85}
       events:
         - Kind: Entry
-          Type: 1404 EventRootType Probe[main.testMultipleSimpleParams]
+          Type: 1420 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0xcd85e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2306,11 +2349,11 @@ Probes:
       subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1430 EventRootType Probe[main.testNamedReturn]
+          Type: 1446 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0xcd978a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1431 EventRootType Probe[main.testNamedReturn]Return
+          Type: 1447 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0xcd97f5", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2336,11 +2379,11 @@ Probes:
       subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1432 EventRootType Probe[main.testNamedReturn]
+          Type: 1448 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0xcd978a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1433 EventRootType Probe[main.testNamedReturn]Return
+          Type: 1449 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0xcd97f5", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2367,7 +2410,7 @@ Probes:
       subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1530 EventRootType Probe[main.testNestedPointer]
+          Type: 1546 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0xcdbea0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2391,7 +2434,7 @@ Probes:
       subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1531 EventRootType Probe[main.testNestedPointer]
+          Type: 1547 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0xcdbea0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2421,7 +2464,7 @@ Probes:
       subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1532 EventRootType Probe[main.testNestedPointer]
+          Type: 1548 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0xcdbea0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2445,7 +2488,7 @@ Probes:
       subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1533 EventRootType Probe[main.testNestedPointer]
+          Type: 1549 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0xcdbea0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2471,7 +2514,7 @@ Probes:
       subprogram: {subprogram: 94}
       events:
         - Kind: Entry
-          Type: 1414 EventRootType Probe[main.testNilPointer]
+          Type: 1430 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0xcd8bc0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2497,7 +2540,7 @@ Probes:
       subprogram: {subprogram: 138}
       events:
         - Kind: Entry
-          Type: 1502 EventRootType Probe[main.testNilSlice]
+          Type: 1518 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0xcdb560", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2523,7 +2566,7 @@ Probes:
       subprogram: {subprogram: 135}
       events:
         - Kind: Entry
-          Type: 1499 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 1515 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0xcdb500", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2557,7 +2600,7 @@ Probes:
       subprogram: {subprogram: 137}
       events:
         - Kind: Entry
-          Type: 1501 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 1517 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0xcdb540", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2588,7 +2631,7 @@ Probes:
       subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1517 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 1533 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0xcdba40", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2609,7 +2652,7 @@ Probes:
       subprogram: {subprogram: 90}
       events:
         - Kind: Entry
-          Type: 1410 EventRootType Probe[main.testPointerLoop]
+          Type: 1426 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0xcd8a40", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2630,7 +2673,7 @@ Probes:
       subprogram: {subprogram: 67}
       events:
         - Kind: Entry
-          Type: 1384 EventRootType Probe[main.testPointerToMap]
+          Type: 1400 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0xcd6940", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2651,7 +2694,7 @@ Probes:
       subprogram: {subprogram: 88}
       events:
         - Kind: Entry
-          Type: 1408 EventRootType Probe[main.testPointerToSimpleStruct]
+          Type: 1424 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0xcd8a00", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2672,11 +2715,11 @@ Probes:
       subprogram: {subprogram: 101}
       events:
         - Kind: Entry
-          Type: 1426 EventRootType Probe[main.testReturnsAny]
+          Type: 1442 EventRootType Probe[main.testReturnsAny]
           InjectionPoints: [{PC: "0xcd942e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1427 EventRootType Probe[main.testReturnsAny]Return
+          Type: 1443 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints:
             - PC: "0xcd94e4"
               Frameless: false
@@ -2710,11 +2753,11 @@ Probes:
       subprogram: {subprogram: 100}
       events:
         - Kind: Entry
-          Type: 1424 EventRootType Probe[main.testReturnsAnyAndError]
+          Type: 1440 EventRootType Probe[main.testReturnsAnyAndError]
           InjectionPoints: [{PC: "0xcd92ce", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1425 EventRootType Probe[main.testReturnsAnyAndError]Return
+          Type: 1441 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
             - PC: "0xcd9324"
               Frameless: false
@@ -2747,11 +2790,11 @@ Probes:
       subprogram: {subprogram: 110}
       events:
         - Kind: Entry
-          Type: 1454 EventRootType Probe[main.testReturnsArray]
+          Type: 1470 EventRootType Probe[main.testReturnsArray]
           InjectionPoints: [{PC: "0xcd9caa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1455 EventRootType Probe[main.testReturnsArray]Return
+          Type: 1471 EventRootType Probe[main.testReturnsArray]Return
           InjectionPoints: [{PC: "0xcd9d0d", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2767,11 +2810,11 @@ Probes:
       subprogram: {subprogram: 111}
       events:
         - Kind: Entry
-          Type: 1456 EventRootType Probe[main.testReturnsArrayOne]
+          Type: 1472 EventRootType Probe[main.testReturnsArrayOne]
           InjectionPoints: [{PC: "0xcd9d2a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1457 EventRootType Probe[main.testReturnsArrayOne]Return
+          Type: 1473 EventRootType Probe[main.testReturnsArrayOne]Return
           InjectionPoints: [{PC: "0xcd9d6b", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2787,11 +2830,11 @@ Probes:
       subprogram: {subprogram: 112}
       events:
         - Kind: Entry
-          Type: 1458 EventRootType Probe[main.testReturnsArrayZero]
+          Type: 1474 EventRootType Probe[main.testReturnsArrayZero]
           InjectionPoints: [{PC: "0xcd9d8a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1459 EventRootType Probe[main.testReturnsArrayZero]Return
+          Type: 1475 EventRootType Probe[main.testReturnsArrayZero]Return
           InjectionPoints: [{PC: "0xcd9dc6", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2807,11 +2850,11 @@ Probes:
       subprogram: {subprogram: 114}
       events:
         - Kind: Entry
-          Type: 1462 EventRootType Probe[main.testReturnsBacktrackInt]
+          Type: 1478 EventRootType Probe[main.testReturnsBacktrackInt]
           InjectionPoints: [{PC: "0xcd9e6e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1463 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          Type: 1479 EventRootType Probe[main.testReturnsBacktrackInt]Return
           InjectionPoints: [{PC: "0xcd9eea", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2827,11 +2870,11 @@ Probes:
       subprogram: {subprogram: 120}
       events:
         - Kind: Entry
-          Type: 1474 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          Type: 1490 EventRootType Probe[main.testReturnsBoolAndUintptr]
           InjectionPoints: [{PC: "0xcda1aa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1475 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          Type: 1491 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
           InjectionPoints: [{PC: "0xcda1f0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2847,11 +2890,11 @@ Probes:
       subprogram: {subprogram: 108}
       events:
         - Kind: Entry
-          Type: 1450 EventRootType Probe[main.testReturnsComplex]
+          Type: 1466 EventRootType Probe[main.testReturnsComplex]
           InjectionPoints: [{PC: "0xcd9b6a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1451 EventRootType Probe[main.testReturnsComplex]Return
+          Type: 1467 EventRootType Probe[main.testReturnsComplex]Return
           InjectionPoints: [{PC: "0xcd9bc6", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2868,11 +2911,11 @@ Probes:
       subprogram: {subprogram: 99}
       events:
         - Kind: Entry
-          Type: 1422 EventRootType Probe[main.testReturnsError]
+          Type: 1438 EventRootType Probe[main.testReturnsError]
           InjectionPoints: [{PC: "0xcd926a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1423 EventRootType Probe[main.testReturnsError]Return
+          Type: 1439 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
             - PC: "0xcd929a"
               Frameless: false
@@ -2896,11 +2939,11 @@ Probes:
       subprogram: {subprogram: 96}
       events:
         - Kind: Entry
-          Type: 1416 EventRootType Probe[main.testReturnsInt]
+          Type: 1432 EventRootType Probe[main.testReturnsInt]
           InjectionPoints: [{PC: "0xcd906a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1417 EventRootType Probe[main.testReturnsInt]Return
+          Type: 1433 EventRootType Probe[main.testReturnsInt]Return
           InjectionPoints: [{PC: "0xcd90bb", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2920,11 +2963,11 @@ Probes:
       subprogram: {subprogram: 98}
       events:
         - Kind: Entry
-          Type: 1420 EventRootType Probe[main.testReturnsIntAndFloat]
+          Type: 1436 EventRootType Probe[main.testReturnsIntAndFloat]
           InjectionPoints: [{PC: "0xcd918e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1421 EventRootType Probe[main.testReturnsIntAndFloat]Return
+          Type: 1437 EventRootType Probe[main.testReturnsIntAndFloat]Return
           InjectionPoints: [{PC: "0xcd9244", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2944,11 +2987,11 @@ Probes:
       subprogram: {subprogram: 97}
       events:
         - Kind: Entry
-          Type: 1418 EventRootType Probe[main.testReturnsIntPointer]
+          Type: 1434 EventRootType Probe[main.testReturnsIntPointer]
           InjectionPoints: [{PC: "0xcd90ea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1419 EventRootType Probe[main.testReturnsIntPointer]Return
+          Type: 1435 EventRootType Probe[main.testReturnsIntPointer]Return
           InjectionPoints: [{PC: "0xcd9154", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2969,11 +3012,11 @@ Probes:
       subprogram: {subprogram: 102}
       events:
         - Kind: Entry
-          Type: 1428 EventRootType Probe[main.testReturnsInterface]
+          Type: 1444 EventRootType Probe[main.testReturnsInterface]
           InjectionPoints: [{PC: "0xcd962e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1429 EventRootType Probe[main.testReturnsInterface]Return
+          Type: 1445 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
             - PC: "0xcd970f"
               Frameless: false
@@ -2997,11 +3040,11 @@ Probes:
       subprogram: {subprogram: 109}
       events:
         - Kind: Entry
-          Type: 1452 EventRootType Probe[main.testReturnsLargeStruct]
+          Type: 1468 EventRootType Probe[main.testReturnsLargeStruct]
           InjectionPoints: [{PC: "0xcd9bee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1453 EventRootType Probe[main.testReturnsLargeStruct]Return
+          Type: 1469 EventRootType Probe[main.testReturnsLargeStruct]Return
           InjectionPoints: [{PC: "0xcd9c73", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3017,11 +3060,11 @@ Probes:
       subprogram: {subprogram: 107}
       events:
         - Kind: Entry
-          Type: 1448 EventRootType Probe[main.testReturnsManyFloats]
+          Type: 1464 EventRootType Probe[main.testReturnsManyFloats]
           InjectionPoints: [{PC: "0xcd9a6e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1449 EventRootType Probe[main.testReturnsManyFloats]Return
+          Type: 1465 EventRootType Probe[main.testReturnsManyFloats]Return
           InjectionPoints: [{PC: "0xcd9b47", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3037,11 +3080,11 @@ Probes:
       subprogram: {subprogram: 116}
       events:
         - Kind: Entry
-          Type: 1466 EventRootType Probe[main.testReturnsMixed]
+          Type: 1482 EventRootType Probe[main.testReturnsMixed]
           InjectionPoints: [{PC: "0xcd9fca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1467 EventRootType Probe[main.testReturnsMixed]Return
+          Type: 1483 EventRootType Probe[main.testReturnsMixed]Return
           InjectionPoints: [{PC: "0xcda02c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3057,11 +3100,11 @@ Probes:
       subprogram: {subprogram: 113}
       events:
         - Kind: Entry
-          Type: 1460 EventRootType Probe[main.testReturnsMixedStruct]
+          Type: 1476 EventRootType Probe[main.testReturnsMixedStruct]
           InjectionPoints: [{PC: "0xcd9dea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1461 EventRootType Probe[main.testReturnsMixedStruct]Return
+          Type: 1477 EventRootType Probe[main.testReturnsMixedStruct]Return
           InjectionPoints: [{PC: "0xcd9e38", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3077,11 +3120,11 @@ Probes:
       subprogram: {subprogram: 119}
       events:
         - Kind: Entry
-          Type: 1472 EventRootType Probe[main.testReturnsMultipleFloats]
+          Type: 1488 EventRootType Probe[main.testReturnsMultipleFloats]
           InjectionPoints: [{PC: "0xcda12a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1473 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          Type: 1489 EventRootType Probe[main.testReturnsMultipleFloats]Return
           InjectionPoints: [{PC: "0xcda176", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3097,11 +3140,11 @@ Probes:
       subprogram: {subprogram: 118}
       events:
         - Kind: Entry
-          Type: 1470 EventRootType Probe[main.testReturnsOnlyFloat]
+          Type: 1486 EventRootType Probe[main.testReturnsOnlyFloat]
           InjectionPoints: [{PC: "0xcda0ca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1471 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          Type: 1487 EventRootType Probe[main.testReturnsOnlyFloat]Return
           InjectionPoints: [{PC: "0xcda10e", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3117,11 +3160,11 @@ Probes:
       subprogram: {subprogram: 106}
       events:
         - Kind: Entry
-          Type: 1446 EventRootType Probe[main.testReturnsPrimitives]
+          Type: 1462 EventRootType Probe[main.testReturnsPrimitives]
           InjectionPoints: [{PC: "0xcd99ea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1447 EventRootType Probe[main.testReturnsPrimitives]Return
+          Type: 1463 EventRootType Probe[main.testReturnsPrimitives]Return
           InjectionPoints: [{PC: "0xcd9a51", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3137,11 +3180,11 @@ Probes:
       subprogram: {subprogram: 117}
       events:
         - Kind: Entry
-          Type: 1468 EventRootType Probe[main.testReturnsStructWithArray]
+          Type: 1484 EventRootType Probe[main.testReturnsStructWithArray]
           InjectionPoints: [{PC: "0xcda04a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1469 EventRootType Probe[main.testReturnsStructWithArray]Return
+          Type: 1485 EventRootType Probe[main.testReturnsStructWithArray]Return
           InjectionPoints: [{PC: "0xcda0ad", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3157,11 +3200,11 @@ Probes:
       subprogram: {subprogram: 115}
       events:
         - Kind: Entry
-          Type: 1464 EventRootType Probe[main.testReturnsWideStruct]
+          Type: 1480 EventRootType Probe[main.testReturnsWideStruct]
           InjectionPoints: [{PC: "0xcd9f0e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1465 EventRootType Probe[main.testReturnsWideStruct]Return
+          Type: 1481 EventRootType Probe[main.testReturnsWideStruct]Return
           InjectionPoints: [{PC: "0xcd9f94", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3178,7 +3221,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - Kind: Entry
-          Type: 1305 EventRootType Probe[main.testRuneArray]
+          Type: 1321 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0xcd4140", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3212,11 +3255,11 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1436 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1452 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xcd982e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1437 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1453 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcd98cf", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3261,7 +3304,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 1326 EventRootType Probe[main.testSingleBool]
+          Type: 1342 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0xcd4760", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3282,7 +3325,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - Kind: Entry
-          Type: 1324 EventRootType Probe[main.testSingleByte]
+          Type: 1340 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0xcd4720", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3303,7 +3346,7 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 1337 EventRootType Probe[main.testSingleFloat32]
+          Type: 1353 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0xcd48c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3324,7 +3367,7 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - Kind: Entry
-          Type: 1338 EventRootType Probe[main.testSingleFloat64]
+          Type: 1354 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0xcd48e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3345,7 +3388,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 1327 EventRootType Probe[main.testSingleInt]
+          Type: 1343 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0xcd4780", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3366,7 +3409,7 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - Kind: Entry
-          Type: 1329 EventRootType Probe[main.testSingleInt16]
+          Type: 1345 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0xcd47c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3388,7 +3431,7 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - Kind: Entry
-          Type: 1330 EventRootType Probe[main.testSingleInt32]
+          Type: 1346 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0xcd47e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3409,7 +3452,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - Kind: Entry
-          Type: 1331 EventRootType Probe[main.testSingleInt64]
+          Type: 1347 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0xcd4800", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3437,7 +3480,7 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - Kind: Entry
-          Type: 1328 EventRootType Probe[main.testSingleInt8]
+          Type: 1344 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0xcd47a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3467,7 +3510,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 1325 EventRootType Probe[main.testSingleRune]
+          Type: 1341 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0xcd4740", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3488,7 +3531,7 @@ Probes:
       subprogram: {subprogram: 143}
       events:
         - Kind: Entry
-          Type: 1509 EventRootType Probe[main.testSingleString]
+          Type: 1525 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0xcdb9c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3509,7 +3552,7 @@ Probes:
       subprogram: {subprogram: 29}
       events:
         - Kind: Entry
-          Type: 1332 EventRootType Probe[main.testSingleUint]
+          Type: 1348 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0xcd4820", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3530,7 +3573,7 @@ Probes:
       subprogram: {subprogram: 31}
       events:
         - Kind: Entry
-          Type: 1334 EventRootType Probe[main.testSingleUint16]
+          Type: 1350 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0xcd4860", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3551,7 +3594,7 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - Kind: Entry
-          Type: 1335 EventRootType Probe[main.testSingleUint32]
+          Type: 1351 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0xcd4880", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3572,7 +3615,7 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 1336 EventRootType Probe[main.testSingleUint64]
+          Type: 1352 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0xcd48a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3593,7 +3636,7 @@ Probes:
       subprogram: {subprogram: 30}
       events:
         - Kind: Entry
-          Type: 1333 EventRootType Probe[main.testSingleUint8]
+          Type: 1349 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0xcd4840", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3614,7 +3657,7 @@ Probes:
       subprogram: {subprogram: 140}
       events:
         - Kind: Entry
-          Type: 1505 EventRootType Probe[main.testSliceEmptyStructs]
+          Type: 1521 EventRootType Probe[main.testSliceEmptyStructs]
           InjectionPoints: [{PC: "0xcdb5a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3635,7 +3678,7 @@ Probes:
       subprogram: {subprogram: 132}
       events:
         - Kind: Entry
-          Type: 1496 EventRootType Probe[main.testSliceOfSlices]
+          Type: 1512 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0xcdb4a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3656,7 +3699,7 @@ Probes:
       subprogram: {subprogram: 65}
       events:
         - Kind: Entry
-          Type: 1382 EventRootType Probe[main.testSmallMap]
+          Type: 1398 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0xcd6900", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3676,11 +3719,11 @@ Probes:
       subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1444 EventRootType Probe[main.testSomeNamedReturn]
+          Type: 1460 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0xcd990e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1445 EventRootType Probe[main.testSomeNamedReturn]Return
+          Type: 1461 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0xcd99ab", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3700,11 +3743,11 @@ Probes:
       subprogram: {subprogram: 126}
       events:
         - Kind: Entry
-          Type: 1486 EventRootType Probe[main.testStackArgRegReturns]
+          Type: 1502 EventRootType Probe[main.testStackArgRegReturns]
           InjectionPoints: [{PC: "0xcdac4a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1487 EventRootType Probe[main.testStackArgRegReturns]Return
+          Type: 1503 EventRootType Probe[main.testStackArgRegReturns]Return
           InjectionPoints: [{PC: "0xcdacbc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3725,7 +3768,7 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - Kind: Entry
-          Type: 1306 EventRootType Probe[main.testStringArray]
+          Type: 1322 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0xcd4160", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3746,7 +3789,7 @@ Probes:
       subprogram: {subprogram: 93}
       events:
         - Kind: Entry
-          Type: 1413 EventRootType Probe[main.testStringPointer]
+          Type: 1429 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0xcd8b80", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3767,7 +3810,7 @@ Probes:
       subprogram: {subprogram: 136}
       events:
         - Kind: Entry
-          Type: 1500 EventRootType Probe[main.testStringSlice]
+          Type: 1516 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0xcdb520", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3788,7 +3831,7 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - Kind: Entry
-          Type: 1348 EventRootType Probe[main.testStringType1]
+          Type: 1364 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0xcd4e80", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3809,7 +3852,7 @@ Probes:
       subprogram: {subprogram: 45}
       events:
         - Kind: Entry
-          Type: 1349 EventRootType Probe[main.testStringType2]
+          Type: 1365 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0xcd4ea0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3830,11 +3873,11 @@ Probes:
       subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1528 EventRootType Probe[main.testStruct]
+          Type: 1544 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0xcdbda0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1529 EventRootType Probe[main.testStruct]Return
+          Type: 1545 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0xcdbdc2", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3860,7 +3903,7 @@ Probes:
       subprogram: {subprogram: 133}
       events:
         - Kind: Entry
-          Type: 1497 EventRootType Probe[main.testStructSlice]
+          Type: 1513 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0xcdb4c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3886,7 +3929,7 @@ Probes:
       subprogram: {subprogram: 59}
       events:
         - Kind: Entry
-          Type: 1376 EventRootType Probe[main.testStructWithAny]
+          Type: 1392 EventRootType Probe[main.testStructWithAny]
           InjectionPoints: [{PC: "0xcd6200", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3906,11 +3949,11 @@ Probes:
       subprogram: {subprogram: 128}
       events:
         - Kind: Entry
-          Type: 1490 EventRootType Probe[main.testStructWithArrayArg]
+          Type: 1506 EventRootType Probe[main.testStructWithArrayArg]
           InjectionPoints: [{PC: "0xcdadee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1491 EventRootType Probe[main.testStructWithArrayArg]Return
+          Type: 1507 EventRootType Probe[main.testStructWithArrayArg]Return
           InjectionPoints: [{PC: "0xcdae9a", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3931,11 +3974,11 @@ Probes:
       subprogram: {subprogram: 153}
       events:
         - Kind: Entry
-          Type: 1524 EventRootType Probe[main.testStructWithCyclicMaps]
+          Type: 1540 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0xcdbc60", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1525 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          Type: 1541 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0xcdbc7e", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3955,7 +3998,7 @@ Probes:
       subprogram: {subprogram: 152}
       events:
         - Kind: Entry
-          Type: 1523 EventRootType Probe[main.testStructWithCyclicSlices]
+          Type: 1539 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0xcdbc40", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3981,7 +4024,7 @@ Probes:
       subprogram: {subprogram: 60}
       events:
         - Kind: Entry
-          Type: 1377 EventRootType Probe[main.testStructWithMap]
+          Type: 1393 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0xcd6860", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4012,7 +4055,7 @@ Probes:
       subprogram: {subprogram: 141}
       events:
         - Kind: Entry
-          Type: 1506 EventRootType Probe[main.testSubslices]
+          Type: 1522 EventRootType Probe[main.testSubslices]
           InjectionPoints: [{PC: "0xcdb5c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4051,7 +4094,7 @@ Probes:
       subprogram: {subprogram: 151}
       events:
         - Kind: Entry
-          Type: 1522 EventRootType Probe[main.testSubstrings]
+          Type: 1538 EventRootType Probe[main.testSubstrings]
           InjectionPoints: [{PC: "0xcdbac0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4083,11 +4126,11 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1438 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1454 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xcd982e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1439 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1455 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcd98cf", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -4107,11 +4150,11 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1440 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1456 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xcd982e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1441 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1457 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcd98cf", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -4133,11 +4176,11 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1442 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1458 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xcd982e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1443 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1459 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcd98cf", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -4165,7 +4208,7 @@ Probes:
       subprogram: {subprogram: 144}
       events:
         - Kind: Entry
-          Type: 1510 EventRootType Probe[main.testThreeStrings]
+          Type: 1526 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0xcdb9e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4196,11 +4239,11 @@ Probes:
       subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1511 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1527 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0xcdba00", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1512 EventRootType Probe[main.testThreeStringsInStruct]Return
+          Type: 1528 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0xcdba1e", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4229,11 +4272,11 @@ Probes:
       subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1513 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1529 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0xcdba00", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1514 EventRootType Probe[main.testThreeStringsInStruct]Return
+          Type: 1530 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0xcdba1e", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4264,7 +4307,7 @@ Probes:
       subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1515 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1531 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0xcdba20", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4293,7 +4336,7 @@ Probes:
       subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1516 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1532 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0xcdba20", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4324,7 +4367,7 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 1339 EventRootType Probe[main.testTypeAlias]
+          Type: 1355 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0xcd4900", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4345,7 +4388,7 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - Kind: Entry
-          Type: 1315 EventRootType Probe[main.testUint16Array]
+          Type: 1331 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0xcd4280", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4366,7 +4409,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - Kind: Entry
-          Type: 1316 EventRootType Probe[main.testUint32Array]
+          Type: 1332 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0xcd42a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4387,7 +4430,7 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - Kind: Entry
-          Type: 1317 EventRootType Probe[main.testUint64Array]
+          Type: 1333 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0xcd42c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4408,7 +4451,7 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - Kind: Entry
-          Type: 1314 EventRootType Probe[main.testUint8Array]
+          Type: 1330 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0xcd4260", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4429,7 +4472,7 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - Kind: Entry
-          Type: 1313 EventRootType Probe[main.testUintArray]
+          Type: 1329 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0xcd4240", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4450,7 +4493,7 @@ Probes:
       subprogram: {subprogram: 92}
       events:
         - Kind: Entry
-          Type: 1412 EventRootType Probe[main.testUintPointer]
+          Type: 1428 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0xcd8aa0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4471,7 +4514,7 @@ Probes:
       subprogram: {subprogram: 130}
       events:
         - Kind: Entry
-          Type: 1494 EventRootType Probe[main.testUintSlice]
+          Type: 1510 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0xcdb460", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4492,7 +4535,7 @@ Probes:
       subprogram: {subprogram: 149}
       events:
         - Kind: Entry
-          Type: 1520 EventRootType Probe[main.testUnitializedString]
+          Type: 1536 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0xcdba80", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4513,7 +4556,7 @@ Probes:
       subprogram: {subprogram: 91}
       events:
         - Kind: Entry
-          Type: 1411 EventRootType Probe[main.testUnsafePointer]
+          Type: 1427 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0xcd8a60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4534,7 +4577,7 @@ Probes:
       subprogram: {subprogram: 20}
       events:
         - Kind: Entry
-          Type: 1323 EventRootType Probe[main.testVeryLargeArray]
+          Type: 1339 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0xcd43a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4555,7 +4598,7 @@ Probes:
       subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1503 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1519 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xcdb580", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4576,7 +4619,7 @@ Probes:
       subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1504 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1520 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xcdb580", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4593,10 +4636,10 @@ Probes:
       template: testWhollyInlinedSubroutine
       segments: [testWhollyInlinedSubroutine]
       captureSnapshot: true
-      subprogram: {subprogram: 164}
+      subprogram: {subprogram: 165}
       events:
         - Kind: Entry
-          Type: 1549 EventRootType Probe[main.firstBehavior.DoSomething]
+          Type: 1566 EventRootType Probe[main.firstBehavior.DoSomething]
           InjectionPoints:
             - PC: "0xcd600a"
               Frameless: false
@@ -4604,7 +4647,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1550 EventRootType Probe[main.firstBehavior.DoSomething]Return
+          Type: 1567 EventRootType Probe[main.firstBehavior.DoSomething]Return
           InjectionPoints: [{PC: "0xcd6050", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -4625,11 +4668,11 @@ Probes:
       subprogram: {subprogram: 129}
       events:
         - Kind: Entry
-          Type: 1492 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          Type: 1508 EventRootType Probe[main.testZeroSizeArgAndReturn]
           InjectionPoints: [{PC: "0xcdaece", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1493 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          Type: 1509 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
           InjectionPoints: [{PC: "0xcdaf4c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -7913,6 +7956,69 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 158
+      Name: main.executeStructFuncs
+      OutOfLinePCRanges: [0xcdbf80..0xcdd29d]
+      InlinePCRanges: []
+      Variables:
+        - Name: n
+          Type: 319 StructureType main.nStruct
+          Locations: [{Range: 0xcdbf80..0xcdd29d, Pieces: []}]
+          Role: Local
+        - Name: ns
+          Type: 260 StructureType main.structWithNoStrings
+          Locations: [{Range: 0xcdbf80..0xcdd29d, Pieces: []}]
+          Role: Local
+        - Name: cs
+          Type: 320 StructureType main.cStruct
+          Locations: [{Range: 0xcdbf80..0xcdd29d, Pieces: []}]
+          Role: Local
+        - Name: rcvr
+          Type: 321 StructureType main.receiver
+          Locations: [{Range: 0xcdbf80..0xcdd29d, Pieces: []}]
+          Role: Local
+        - Name: ts
+          Type: 322 StructureType main.threestrings
+          Locations:
+            - Range: 0xcdbfa4..0xcdd29d
+              Pieces: [{Size: 48, Op: {CfaOffset: -2080}}]
+          Role: Local
+        - Name: s
+          Type: 314 StructureType main.aStruct
+          Locations:
+            - Range: 0xcdc02e..0xcdd29d
+              Pieces: [{Size: 56, Op: {CfaOffset: -1920}}]
+          Role: Local
+        - Name: b
+          Type: 323 StructureType main.bStruct
+          Locations:
+            - Range: 0xcdc0d5..0xcdd29d
+              Pieces: [{Size: 72, Op: {CfaOffset: -2080}}]
+          Role: Local
+        - Name: tenStr
+          Type: 324 StructureType main.tenStrings
+          Locations:
+            - Range: 0xcdc432..0xcdd29d
+              Pieces: [{Size: 160, Op: {CfaOffset: -2080}}]
+          Role: Local
+        - Name: deep
+          Type: 325 StructureType main.deepStruct1
+          Locations:
+            - Range: 0xcdc484..0xcdd29d
+              Pieces: [{Size: 48, Op: {CfaOffset: -2168}}]
+          Role: Local
+        - Name: fields
+          Type: 331 StructureType main.lotsOfFields
+          Locations:
+            - Range: 0xcdc511..0xcdd29d
+              Pieces: [{Size: 26, Op: {CfaOffset: -2168}}]
+          Role: Local
+        - Name: sta
+          Type: 332 StructureType main.structWithTwoArrays
+          Locations:
+            - Range: 0xcdc5a3..0xcdd29d
+              Pieces: [{Size: 72, Op: {CfaOffset: -2168}}]
+          Role: Local
+    - ID: 159
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0xcd5920..0xcd5982]
       InlinePCRanges:
@@ -7941,28 +8047,28 @@ Subprograms:
             - Range: 0xcd5c40..0xcd5c5a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 159
+    - ID: 160
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xcd5bc6..0xcd5bfe]
           RootRanges: [0xcd5b60..0xcd5c25]
       Variables: []
-    - ID: 160
+    - ID: 161
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xcd5cd3..0xcd5d11]
           RootRanges: [0xcd5cc0..0xcd5dce]
       Variables: []
-    - ID: 161
+    - ID: 162
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xcd5d86..0xcd5dbe]
           RootRanges: [0xcd5cc0..0xcd5dce]
       Variables: []
-    - ID: 162
+    - ID: 163
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -7975,7 +8081,7 @@ Subprograms:
             - Range: 0xcd5de0..0xcd5de5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 163
+    - ID: 164
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -7992,7 +8098,7 @@ Subprograms:
             - Range: 0xcd5eac..0xcd5fe5
               Pieces: [{Size: 40, Op: {CfaOffset: -128}}]
           Role: Parameter
-    - ID: 164
+    - ID: 165
       Name: main.firstBehavior.DoSomething
       OutOfLinePCRanges: [0xcd6000..0xcd6071]
       InlinePCRanges:
@@ -8000,7 +8106,7 @@ Subprograms:
           RootRanges: [0xcdd460..0xcdd4f6]
       Variables:
         - Name: b
-          Type: 319 StructureType main.firstBehavior
+          Type: 335 StructureType main.firstBehavior
           Locations:
             - Range: 0xcd6000..0xcd6028
               Pieces:
@@ -8029,7 +8135,7 @@ Subprograms:
             - Range: 0xcd6051..0xcd6071
               Pieces: []
           Role: Return
-    - ID: 165
+    - ID: 166
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -8045,20 +8151,20 @@ Types:
       ByteSize: 8
       Pointee: 138 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 1219
+      ID: 1235
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 1220 PointerType *main.deepSlice3
+      Pointee: 1236 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 1244
+      ID: 1260
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 1245 PointerType *main.deepSlice8
+      Pointee: 1261 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 1250
+      ID: 1266
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 1251 PointerType *main.deepSlice9
+      Pointee: 1267 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 151
       Name: '**main.stringType2'
@@ -8066,7 +8172,7 @@ Types:
       GoKind: 22
       Pointee: 152 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 1215
+      ID: 1231
       Name: '**main.t'
       ByteSize: 8
       Pointee: 246 PointerType *main.t
@@ -8103,30 +8209,30 @@ Types:
       ByteSize: 8
       Pointee: 146 PointerType *table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1227
+      ID: 1243
       Name: '**table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1228 PointerType *table<int,*main.deepMap3>
+      Pointee: 1244 PointerType *table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1261
+      ID: 1277
       Name: '**table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1262 PointerType *table<int,*main.deepMap8>
+      Pointee: 1278 PointerType *table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1276
+      ID: 1292
       Name: '**table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1277 PointerType *table<int,*main.deepMap9>
+      Pointee: 1293 PointerType *table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 167
       Name: '**table<int,int>'
       ByteSize: 8
       Pointee: 168 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 1291
+      ID: 1307
       Name: '**table<int,interface {}>'
       ByteSize: 8
-      Pointee: 1292 PointerType *table<int,interface {}>
+      Pointee: 1308 PointerType *table<int,interface {}>
     - __kind: PointerType
       ID: 234
       Name: '**table<int,struct {}>'
@@ -8148,10 +8254,10 @@ Types:
       ByteSize: 8
       Pointee: 183 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 962
+      ID: 978
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 963 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 979 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 177
       Name: '**table<string,int>'
@@ -8213,115 +8319,115 @@ Types:
       ByteSize: 8
       Pointee: 210 PointerType *table<uint8,uint8>
     - __kind: PointerType
-      ID: 330
+      ID: 346
       Name: '*[]*main.deepSlice2.array'
       ByteSize: 8
-      Pointee: 329 GoSliceDataType []*main.deepSlice2.array
+      Pointee: 345 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 1223
+      ID: 1239
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 1222 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 1238 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 1248
+      ID: 1264
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 1247 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 1263 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 1254
+      ID: 1270
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 1253 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 1269 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
-      ID: 327
+      ID: 343
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 326 GoSliceDataType []*string.array
+      Pointee: 342 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 490
+      ID: 506
       Name: '*[][][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 489 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Pointee: 505 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 282
       Name: '*[][][][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 279 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 488
+      ID: 504
       Name: '*[][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 487 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Pointee: 503 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 280
       Name: '*[][][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 277 GoSliceHeaderType [][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 486
+      ID: 502
       Name: '*[][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 485 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Pointee: 501 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 278
       Name: '*[][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 275 GoSliceHeaderType [][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 484
+      ID: 500
       Name: '*[][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 483 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Pointee: 499 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 276
       Name: '*[][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 273 GoSliceHeaderType [][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 482
+      ID: 498
       Name: '*[][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 481 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Pointee: 497 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 468
+      ID: 484
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 467 GoSliceDataType [][]uint.array
+      Pointee: 483 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 474
+      ID: 490
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 473 GoSliceDataType []bool.array
+      Pointee: 489 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 999
+      ID: 1015
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 998 GoSliceDataType []float64.array
+      Pointee: 1014 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 1257
+      ID: 1273
       Name: '*[]interface {}.array'
       ByteSize: 8
-      Pointee: 1256 GoSliceDataType []interface {}.array
+      Pointee: 1272 GoSliceDataType []interface {}.array
     - __kind: PointerType
       ID: 274
       Name: '*[]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 271 GoSliceHeaderType []main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 480
+      ID: 496
       Name: '*[]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 479 GoSliceDataType []main.structWithCyclicSlices.array
+      Pointee: 495 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 540
+      ID: 556
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 539 GoSliceDataType []main.structWithMap.array
+      Pointee: 555 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 470
+      ID: 486
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 469 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 485 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
       ID: 39
       Name: '*[]runtime.ancestorInfo'
@@ -8330,101 +8436,101 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 472
+      ID: 488
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 471 GoSliceDataType []string.array
+      Pointee: 487 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 478
+      ID: 494
       Name: '*[]struct {}.array'
       ByteSize: 8
-      Pointee: 477 GoSliceDataType []struct {}.array
+      Pointee: 493 GoSliceDataType []struct {}.array
     - __kind: PointerType
       ID: 257
       Name: '*[]uint'
       ByteSize: 8
       Pointee: 255 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 466
+      ID: 482
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 465 GoSliceDataType []uint.array
+      Pointee: 481 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 476
+      ID: 492
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 475 GoSliceDataType []uint16.array
+      Pointee: 491 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 323
+      ID: 339
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 322 GoSliceDataType []uint8.array
+      Pointee: 338 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 325
+      ID: 341
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 324 GoSliceDataType []uintptr.array
+      Pointee: 340 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 1129
+      ID: 1145
       Name: '*archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1.97904e+06
       GoKind: 22
-      Pointee: 1130 UnresolvedPointeeType archive/tar.Writer
+      Pointee: 1146 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
-      ID: 770
+      ID: 786
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 927616
       GoKind: 22
-      Pointee: 771 GoSliceHeaderType archive/tar.headerError
+      Pointee: 787 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 773
+      ID: 789
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 772 GoSliceDataType archive/tar.headerError.array
+      Pointee: 788 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 1064
+      ID: 1080
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.432864e+06
       GoKind: 22
-      Pointee: 1065 UnresolvedPointeeType archive/tar.regFileWriter
+      Pointee: 1081 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
-      ID: 1012
+      ID: 1028
       Name: '*archive/zip.countWriter'
       ByteSize: 8
       GoRuntimeType: 927808
       GoKind: 22
-      Pointee: 1013 UnresolvedPointeeType archive/zip.countWriter
+      Pointee: 1029 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
-      ID: 1014
+      ID: 1030
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
       GoRuntimeType: 927904
       GoKind: 22
-      Pointee: 1015 StructureType archive/zip.dirWriter
+      Pointee: 1031 StructureType archive/zip.dirWriter
     - __kind: PointerType
-      ID: 1112
+      ID: 1128
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.89872e+06
       GoKind: 22
-      Pointee: 1113 UnresolvedPointeeType archive/zip.fileWriter
+      Pointee: 1129 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
-      ID: 1040
+      ID: 1056
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1.05424e+06
       GoKind: 22
-      Pointee: 1041 StructureType archive/zip.nopCloser
+      Pointee: 1057 StructureType archive/zip.nopCloser
     - __kind: PointerType
-      ID: 1042
+      ID: 1058
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
       GoRuntimeType: 1.054496e+06
       GoKind: 22
-      Pointee: 1043 UnresolvedPointeeType archive/zip.pooledFlateWriter
+      Pointee: 1059 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -8433,421 +8539,421 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 1087
+      ID: 1103
       Name: '*bufio.Reader'
       ByteSize: 8
       GoRuntimeType: 2.167168e+06
       GoKind: 22
-      Pointee: 1088 UnresolvedPointeeType bufio.Reader
+      Pointee: 1104 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
-      ID: 1116
+      ID: 1132
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1.943232e+06
       GoKind: 22
-      Pointee: 1117 UnresolvedPointeeType bufio.Writer
+      Pointee: 1133 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
-      ID: 1167
+      ID: 1183
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.264448e+06
       GoKind: 22
-      Pointee: 1168 UnresolvedPointeeType bytes.Buffer
+      Pointee: 1184 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 682
+      ID: 698
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 910144
       GoKind: 22
-      Pointee: 574 BaseType compress/flate.CorruptInputError
+      Pointee: 590 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 683
+      ID: 699
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 910240
       GoKind: 22
-      Pointee: 575 GoStringHeaderType compress/flate.InternalError
+      Pointee: 591 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 577
+      ID: 593
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 576 GoStringDataType compress/flate.InternalError.str
+      Pointee: 592 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 1062
+      ID: 1078
       Name: '*compress/flate.Writer'
       ByteSize: 8
       GoRuntimeType: 1.422304e+06
       GoKind: 22
-      Pointee: 1063 UnresolvedPointeeType compress/flate.Writer
+      Pointee: 1079 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
-      ID: 1008
+      ID: 1024
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
       GoRuntimeType: 910336
       GoKind: 22
-      Pointee: 1009 UnresolvedPointeeType compress/flate.dictWriter
+      Pointee: 1025 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
-      ID: 1084
+      ID: 1100
       Name: '*compress/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.72048e+06
       GoKind: 22
-      Pointee: 1085 UnresolvedPointeeType compress/gzip.Writer
+      Pointee: 1101 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
-      ID: 914
+      ID: 930
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.200832e+06
       GoKind: 22
-      Pointee: 915 StructureType context.deadlineExceededError
+      Pointee: 931 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 762
+      ID: 778
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 922240
       GoKind: 22
-      Pointee: 588 BaseType crypto/aes.KeySizeError
+      Pointee: 604 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 763
+      ID: 779
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 922432
       GoKind: 22
-      Pointee: 589 BaseType crypto/des.KeySizeError
+      Pointee: 605 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 764
+      ID: 780
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 922720
       GoKind: 22
-      Pointee: 590 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 606 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 1074
+      ID: 1090
       Name: '*crypto/internal/fips140/hmac.HMAC'
       ByteSize: 8
       GoRuntimeType: 1.562784e+06
       GoKind: 22
-      Pointee: 1075 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
+      Pointee: 1091 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
     - __kind: PointerType
-      ID: 1108
+      ID: 1124
       Name: '*crypto/internal/fips140/sha256.Digest'
       ByteSize: 8
       GoRuntimeType: 1.857152e+06
       GoKind: 22
-      Pointee: 1109 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
+      Pointee: 1125 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
     - __kind: PointerType
-      ID: 1140
+      ID: 1156
       Name: '*crypto/internal/fips140/sha3.Digest'
       ByteSize: 8
       GoRuntimeType: 2.114496e+06
       GoKind: 22
-      Pointee: 1141 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
+      Pointee: 1157 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
     - __kind: PointerType
-      ID: 1114
+      ID: 1130
       Name: '*crypto/internal/fips140/sha3.SHAKE'
       ByteSize: 8
       GoRuntimeType: 1.899232e+06
       GoKind: 22
-      Pointee: 1115 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
+      Pointee: 1131 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
     - __kind: PointerType
-      ID: 1110
+      ID: 1126
       Name: '*crypto/internal/fips140/sha512.Digest'
       ByteSize: 8
       GoRuntimeType: 1.857824e+06
       GoKind: 22
-      Pointee: 1111 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
+      Pointee: 1127 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
     - __kind: PointerType
-      ID: 1106
+      ID: 1122
       Name: '*crypto/md5.digest'
       ByteSize: 8
       GoRuntimeType: 1.849984e+06
       GoKind: 22
-      Pointee: 1107 UnresolvedPointeeType crypto/md5.digest
+      Pointee: 1123 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
-      ID: 765
+      ID: 781
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 923008
       GoKind: 22
-      Pointee: 591 BaseType crypto/rc4.KeySizeError
+      Pointee: 607 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 1124
+      ID: 1140
       Name: '*crypto/sha1.digest'
       ByteSize: 8
       GoRuntimeType: 1.948608e+06
       GoKind: 22
-      Pointee: 1125 UnresolvedPointeeType crypto/sha1.digest
+      Pointee: 1141 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
-      ID: 1096
+      ID: 1112
       Name: '*crypto/sha3.SHA3'
       ByteSize: 8
       GoRuntimeType: 1.803968e+06
       GoKind: 22
-      Pointee: 1097 UnresolvedPointeeType crypto/sha3.SHA3
+      Pointee: 1113 UnresolvedPointeeType crypto/sha3.SHA3
     - __kind: PointerType
-      ID: 688
+      ID: 704
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 911872
       GoKind: 22
-      Pointee: 578 BaseType crypto/tls.AlertError
+      Pointee: 594 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 854
+      ID: 870
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1.042848e+06
       GoKind: 22
-      Pointee: 855 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 871 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 1193
+      ID: 1209
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2.37632e+06
       GoKind: 22
-      Pointee: 1194 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 1210 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 686
+      ID: 702
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 911680
       GoKind: 22
-      Pointee: 687 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 703 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 684
+      ID: 700
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 911584
       GoKind: 22
-      Pointee: 685 StructureType crypto/tls.RecordHeaderError
+      Pointee: 701 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 853
+      ID: 869
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1.041184e+06
       GoKind: 22
-      Pointee: 810 BaseType crypto/tls.alert
+      Pointee: 826 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 1072
+      ID: 1088
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
       GoRuntimeType: 1.555744e+06
       GoKind: 22
-      Pointee: 1073 UnresolvedPointeeType crypto/tls.cthWrapper
+      Pointee: 1089 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
-      ID: 1079
+      ID: 1095
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
       GoRuntimeType: 1.638176e+06
       GoKind: 22
-      Pointee: 1080 UnresolvedPointeeType crypto/tls.finishedHash
+      Pointee: 1096 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
-      ID: 949
+      ID: 965
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1.422624e+06
       GoKind: 22
-      Pointee: 950 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 966 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 964
+      ID: 980
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.037088e+06
       GoKind: 22
-      Pointee: 965 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 981 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 758
+      ID: 774
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 921280
       GoKind: 22
-      Pointee: 759 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 775 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 752
+      ID: 768
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 920800
       GoKind: 22
-      Pointee: 753 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 769 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 754
+      ID: 770
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 920896
       GoKind: 22
-      Pointee: 755 StructureType crypto/x509.HostnameError
+      Pointee: 771 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 751
+      ID: 767
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 920704
       GoKind: 22
-      Pointee: 587 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 603 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 859
+      ID: 875
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1.048608e+06
       GoKind: 22
-      Pointee: 860 StructureType crypto/x509.SystemRootsError
+      Pointee: 876 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 760
+      ID: 776
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 921376
       GoKind: 22
-      Pointee: 761 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 777 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 756
+      ID: 772
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 921184
       GoKind: 22
-      Pointee: 757 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 773 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 774
+      ID: 790
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 928096
       GoKind: 22
-      Pointee: 775 StructureType encoding/asn1.StructuralError
+      Pointee: 791 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 778
+      ID: 794
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 928288
       GoKind: 22
-      Pointee: 779 StructureType encoding/asn1.SyntaxError
+      Pointee: 795 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 776
+      ID: 792
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 928192
       GoKind: 22
-      Pointee: 777 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 793 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 672
+      ID: 688
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 908224
       GoKind: 22
-      Pointee: 572 BaseType encoding/base64.CorruptInputError
+      Pointee: 588 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 1030
+      ID: 1046
       Name: '*encoding/base64.encoder'
       ByteSize: 8
       GoRuntimeType: 1.038368e+06
       GoKind: 22
-      Pointee: 1031 UnresolvedPointeeType encoding/base64.encoder
+      Pointee: 1047 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
-      ID: 675
+      ID: 691
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 909088
       GoKind: 22
-      Pointee: 573 BaseType encoding/hex.InvalidByteError
+      Pointee: 589 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 643
+      ID: 659
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 902944
       GoKind: 22
-      Pointee: 644 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 660 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 845
+      ID: 861
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1.034656e+06
       GoKind: 22
-      Pointee: 846 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 862 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 635
+      ID: 651
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 902560
       GoKind: 22
-      Pointee: 636 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 652 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 641
+      ID: 657
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 902848
       GoKind: 22
-      Pointee: 642 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 658 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 639
+      ID: 655
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 902752
       GoKind: 22
-      Pointee: 640 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 656 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 637
+      ID: 653
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 902656
       GoKind: 22
-      Pointee: 638 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 654 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 1173
+      ID: 1189
       Name: '*encoding/json.encodeState'
       ByteSize: 8
       GoRuntimeType: 2.289472e+06
       GoKind: 22
-      Pointee: 1174 UnresolvedPointeeType encoding/json.encodeState
+      Pointee: 1190 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 645
+      ID: 661
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 903328
       GoKind: 22
-      Pointee: 646 StructureType encoding/json.jsonError
+      Pointee: 662 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 1038
+      ID: 1054
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
       GoRuntimeType: 1.051168e+06
       GoKind: 22
-      Pointee: 1039 UnresolvedPointeeType encoding/pem.lineBreaker
+      Pointee: 1055 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
-      ID: 746
+      ID: 762
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 919744
       GoKind: 22
-      Pointee: 747 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 763 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 744
+      ID: 760
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 919648
       GoKind: 22
-      Pointee: 745 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 761 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 748
+      ID: 764
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 919840
       GoKind: 22
-      Pointee: 584 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 600 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 586
+      ID: 602
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 585 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 601 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 749
+      ID: 765
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 919936
       GoKind: 22
-      Pointee: 750 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 766 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
-      ID: 1151
+      ID: 1167
       Name: '*encoding/xml.printer'
       ByteSize: 8
       GoRuntimeType: 2.152928e+06
       GoKind: 22
-      Pointee: 1152 UnresolvedPointeeType encoding/xml.printer
+      Pointee: 1168 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
       ID: 104
       Name: '*error'
@@ -8856,19 +8962,19 @@ Types:
       GoKind: 22
       Pointee: 13 GoInterfaceType error
     - __kind: PointerType
-      ID: 613
+      ID: 629
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 893248
       GoKind: 22
-      Pointee: 614 UnresolvedPointeeType errors.errorString
+      Pointee: 630 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 812
+      ID: 828
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1.019552e+06
       GoKind: 22
-      Pointee: 813 UnresolvedPointeeType errors.joinError
+      Pointee: 829 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 106
       Name: '*float32'
@@ -8884,813 +8990,813 @@ Types:
       GoKind: 22
       Pointee: 18 BaseType float64
     - __kind: PointerType
-      ID: 1161
+      ID: 1177
       Name: '*fmt.pp'
       ByteSize: 8
       GoRuntimeType: 2.256768e+06
       GoKind: 22
-      Pointee: 1162 UnresolvedPointeeType fmt.pp
+      Pointee: 1178 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
-      ID: 814
+      ID: 830
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.01968e+06
       GoKind: 22
-      Pointee: 815 UnresolvedPointeeType fmt.wrapError
+      Pointee: 831 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 816
+      ID: 832
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1.019808e+06
       GoKind: 22
-      Pointee: 817 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 833 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 673
+      ID: 689
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 908608
       GoKind: 22
-      Pointee: 674 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 690 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 654
+      ID: 670
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 905728
       GoKind: 22
-      Pointee: 655 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 671 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 656
+      ID: 672
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 905824
       GoKind: 22
-      Pointee: 657 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 673 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 976
+      ID: 992
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 905536
       GoKind: 22
-      Pointee: 977 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 993 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 660
+      ID: 676
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 906112
       GoKind: 22
-      Pointee: 661 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 677 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 978
+      ID: 994
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 905632
       GoKind: 22
-      Pointee: 979 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 995 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 658
+      ID: 674
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 905920
       GoKind: 22
-      Pointee: 566 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 582 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 568
+      ID: 584
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 567 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 583 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 653
+      ID: 669
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 905440
       GoKind: 22
-      Pointee: 563 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 579 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 565
+      ID: 581
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 564 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 580 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 659
+      ID: 675
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 906016
       GoKind: 22
-      Pointee: 569 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 585 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 571
+      ID: 587
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 570 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 586 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 1052
+      ID: 1068
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
       GoRuntimeType: 1.206336e+06
       GoKind: 22
-      Pointee: 1053 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      Pointee: 1069 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
-      ID: 1137
+      ID: 1153
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
       GoRuntimeType: 2.052096e+06
       GoKind: 22
-      Pointee: 1138 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      Pointee: 1154 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
-      ID: 768
+      ID: 784
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 926560
       GoKind: 22
-      Pointee: 769 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 785 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 923
+      ID: 939
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1.20992e+06
       GoKind: 22
-      Pointee: 924 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 940 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 1169
+      ID: 1185
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
       GoRuntimeType: 2.266496e+06
       GoKind: 22
-      Pointee: 1170 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      Pointee: 1186 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
-      ID: 695
+      ID: 711
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 915232
       GoKind: 22
-      Pointee: 696 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 712 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 702
+      ID: 718
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 916288
       GoKind: 22
-      Pointee: 703 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 719 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 697
+      ID: 713
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 916000
       GoKind: 22
-      Pointee: 583 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 599 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 700
+      ID: 716
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 916192
       GoKind: 22
-      Pointee: 701 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 717 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 698
+      ID: 714
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 916096
       GoKind: 22
-      Pointee: 699 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 715 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 718
+      ID: 734
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 918208
       GoKind: 22
-      Pointee: 719 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 735 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 722
+      ID: 738
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 918400
       GoKind: 22
-      Pointee: 723 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 739 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 720
+      ID: 736
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 918304
       GoKind: 22
-      Pointee: 721 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 737 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 716
+      ID: 732
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 918112
       GoKind: 22
-      Pointee: 717 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 733 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 1001
+      ID: 1017
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 1000 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 1016 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 730
+      ID: 746
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 918784
       GoKind: 22
-      Pointee: 731 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 747 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 724
+      ID: 740
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 918496
       GoKind: 22
-      Pointee: 725 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 741 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 728
+      ID: 744
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 918688
       GoKind: 22
-      Pointee: 729 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 745 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 726
+      ID: 742
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 918592
       GoKind: 22
-      Pointee: 727 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 743 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 732
+      ID: 748
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 918880
       GoKind: 22
-      Pointee: 733 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 749 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 738
+      ID: 754
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 919168
       GoKind: 22
-      Pointee: 739 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 755 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 740
+      ID: 756
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 919264
       GoKind: 22
-      Pointee: 741 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 757 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 736
+      ID: 752
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 919072
       GoKind: 22
-      Pointee: 737 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 753 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 734
+      ID: 750
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 918976
       GoKind: 22
-      Pointee: 735 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 751 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 742
+      ID: 758
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 919456
       GoKind: 22
-      Pointee: 743 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 759 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 662
+      ID: 678
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 907264
       GoKind: 22
-      Pointee: 663 StructureType github.com/cihub/seelog.baseError
+      Pointee: 679 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 1090
+      ID: 1106
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1.796576e+06
       GoKind: 22
-      Pointee: 1091 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 1107 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 664
+      ID: 680
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 907360
       GoKind: 22
-      Pointee: 665 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 681 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 1070
+      ID: 1086
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
       GoRuntimeType: 1.554624e+06
       GoKind: 22
-      Pointee: 1071 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+      Pointee: 1087 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
-      ID: 1026
+      ID: 1042
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
       GoRuntimeType: 1.037344e+06
       GoKind: 22
-      Pointee: 1027 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+      Pointee: 1043 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
-      ID: 1060
+      ID: 1076
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.420384e+06
       GoKind: 22
-      Pointee: 1061 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+      Pointee: 1077 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
-      ID: 668
+      ID: 684
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 907552
       GoKind: 22
-      Pointee: 669 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 685 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 1127
+      ID: 1143
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.96896e+06
       GoKind: 22
-      Pointee: 1128 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+      Pointee: 1144 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
-      ID: 1144
+      ID: 1160
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
       GoRuntimeType: 2.12608e+06
       GoKind: 22
-      Pointee: 1139 StructureType github.com/cihub/seelog.rollingFileWriterSize
+      Pointee: 1155 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
-      ID: 1143
+      ID: 1159
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
       GoRuntimeType: 2.125696e+06
       GoKind: 22
-      Pointee: 1142 StructureType github.com/cihub/seelog.rollingFileWriterTime
+      Pointee: 1158 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
-      ID: 1028
+      ID: 1044
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
       GoRuntimeType: 1.037472e+06
       GoKind: 22
-      Pointee: 1029 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+      Pointee: 1045 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
-      ID: 666
+      ID: 682
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 907456
       GoKind: 22
-      Pointee: 667 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 683 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 670
+      ID: 686
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 907648
       GoKind: 22
-      Pointee: 671 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 687 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 1092
+      ID: 1108
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.798368e+06
       GoKind: 22
-      Pointee: 1093 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+      Pointee: 1109 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
-      ID: 1133
+      ID: 1149
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 2.005696e+06
       GoKind: 22
-      Pointee: 1134 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+      Pointee: 1150 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
-      ID: 1135
+      ID: 1151
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
       GoRuntimeType: 2.036768e+06
       GoKind: 22
-      Pointee: 1136 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+      Pointee: 1152 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
-      ID: 954
+      ID: 970
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1.435264e+06
       GoKind: 22
-      Pointee: 955 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 971 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 867
+      ID: 883
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.062688e+06
       GoKind: 22
-      Pointee: 868 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 884 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 865
+      ID: 881
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1.06256e+06
       GoKind: 22
-      Pointee: 866 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 882 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 869
+      ID: 885
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.066656e+06
       GoKind: 22
-      Pointee: 870 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 886 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 871
+      ID: 887
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1.066784e+06
       GoKind: 22
-      Pointee: 872 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 888 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 1081
+      ID: 1097
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
       GoRuntimeType: 1.665248e+06
       GoKind: 22
-      Pointee: 1082 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+      Pointee: 1098 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
-      ID: 861
+      ID: 877
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.049248e+06
       GoKind: 22
-      Pointee: 862 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 878 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 676
+      ID: 692
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 909280
       GoKind: 22
-      Pointee: 677 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 693 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 1185
+      ID: 1201
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
       GoRuntimeType: 2.352544e+06
       GoKind: 22
-      Pointee: 1186 UnresolvedPointeeType github.com/json-iterator/go.Stream
+      Pointee: 1202 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
-      ID: 925
+      ID: 941
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1.218368e+06
       GoKind: 22
-      Pointee: 926 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 942 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 898
+      ID: 914
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1.19712e+06
       GoKind: 22
-      Pointee: 899 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 915 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 892
+      ID: 908
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1.196736e+06
       GoKind: 22
-      Pointee: 893 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 909 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 831
+      ID: 847
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1.02864e+06
       GoKind: 22
-      Pointee: 832 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 848 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 904
+      ID: 920
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1.197504e+06
       GoKind: 22
-      Pointee: 905 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 921 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 830
+      ID: 846
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1.028512e+06
       GoKind: 22
-      Pointee: 809 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 825 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 896
+      ID: 912
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1.196992e+06
       GoKind: 22
-      Pointee: 897 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 913 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 894
+      ID: 910
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1.196864e+06
       GoKind: 22
-      Pointee: 895 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 911 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 902
+      ID: 918
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1.197376e+06
       GoKind: 22
-      Pointee: 903 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 919 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 900
+      ID: 916
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1.197248e+06
       GoKind: 22
-      Pointee: 901 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 917 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 1189
+      ID: 1205
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
       GoRuntimeType: 2.364352e+06
       GoKind: 22
-      Pointee: 1190 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+      Pointee: 1206 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
-      ID: 908
+      ID: 924
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1.197888e+06
       GoKind: 22
-      Pointee: 909 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 925 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 835
+      ID: 851
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1.028896e+06
       GoKind: 22
-      Pointee: 836 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 852 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 833
+      ID: 849
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1.028768e+06
       GoKind: 22
-      Pointee: 834 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 850 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 906
+      ID: 922
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1.19776e+06
       GoKind: 22
-      Pointee: 907 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 923 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 790
+      ID: 806
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 941056
       GoKind: 22
-      Pointee: 596 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 612 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 598
+      ID: 614
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 597 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 613 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 967
+      ID: 983
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1.663712e+06
       GoKind: 22
-      Pointee: 968 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 984 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 875
+      ID: 891
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1.081504e+06
       GoKind: 22
-      Pointee: 876 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 892 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 1058
+      ID: 1074
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
       GoRuntimeType: 1.25792e+06
       GoKind: 22
-      Pointee: 1059 StructureType go.uber.org/zap.nopCloserSink
+      Pointee: 1075 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
-      ID: 1149
+      ID: 1165
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.141056e+06
       GoKind: 22
-      Pointee: 1150 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+      Pointee: 1166 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
-      ID: 1044
+      ID: 1060
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
       GoRuntimeType: 1.083808e+06
       GoKind: 22
-      Pointee: 1045 StructureType go.uber.org/zap/zapcore.writerWrapper
+      Pointee: 1061 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
-      ID: 791
+      ID: 807
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 942304
       GoKind: 22
-      Pointee: 599 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 615 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 933
+      ID: 949
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1.259584e+06
       GoKind: 22
-      Pointee: 934 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 950 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 794
+      ID: 810
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 942592
       GoKind: 22
-      Pointee: 795 StructureType golang.org/x/net/http2.connError
+      Pointee: 811 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 793
+      ID: 809
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 942496
       GoKind: 22
-      Pointee: 603 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 619 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 605
+      ID: 621
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 604 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 620 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 797
+      ID: 813
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 942784
       GoKind: 22
-      Pointee: 609 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 625 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 611
+      ID: 627
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 610 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 626 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 796
+      ID: 812
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 942688
       GoKind: 22
-      Pointee: 606 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 622 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 608
+      ID: 624
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 607 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 623 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 792
+      ID: 808
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 942400
       GoKind: 22
-      Pointee: 600 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 616 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 602
+      ID: 618
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 601 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 617 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1147
+      ID: 1163
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.139136e+06
       GoKind: 22
-      Pointee: 1148 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1164 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 798
+      ID: 814
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 942880
       GoKind: 22
-      Pointee: 799 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 815 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 800
+      ID: 816
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 942976
       GoKind: 22
-      Pointee: 612 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 628 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 786
+      ID: 802
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 936256
       GoKind: 22
-      Pointee: 787 StructureType google.golang.org/grpc.dropError
+      Pointee: 803 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 931
+      ID: 947
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1.25664e+06
       GoKind: 22
-      Pointee: 932 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 948 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 956
+      ID: 972
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1.442624e+06
       GoKind: 22
-      Pointee: 957 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 973 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 788
+      ID: 804
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 939328
       GoKind: 22
-      Pointee: 789 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 805 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 1098
+      ID: 1114
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1.804416e+06
       GoKind: 22
-      Pointee: 1099 StructureType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 1115 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 1056
+      ID: 1072
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
       GoRuntimeType: 1.253184e+06
       GoKind: 22
-      Pointee: 1057 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+      Pointee: 1073 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
-      ID: 873
+      ID: 889
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1.075744e+06
       GoKind: 22
-      Pointee: 874 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 890 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 1016
+      ID: 1032
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
       GoRuntimeType: 939424
       GoKind: 22
-      Pointee: 1017 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+      Pointee: 1033 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
-      ID: 766
+      ID: 782
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 924448
       GoKind: 22
-      Pointee: 767 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 783 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 863
+      ID: 879
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1.052576e+06
       GoKind: 22
-      Pointee: 864 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 880 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 929
+      ID: 945
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.22464e+06
       GoKind: 22
-      Pointee: 930 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 946 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 927
+      ID: 943
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1.224384e+06
       GoKind: 22
-      Pointee: 928 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 944 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 780
+      ID: 796
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 929152
       GoKind: 22
-      Pointee: 781 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 797 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 782
+      ID: 798
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 929248
       GoKind: 22
-      Pointee: 783 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 799 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 710
+      ID: 726
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 916672
       GoKind: 22
-      Pointee: 711 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 727 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 1104
+      ID: 1120
       Name: '*hash/crc32.digest'
       ByteSize: 8
       GoRuntimeType: 1.845056e+06
       GoKind: 22
-      Pointee: 1105 UnresolvedPointeeType hash/crc32.digest
+      Pointee: 1121 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
-      ID: 801
+      ID: 817
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 943744
       GoKind: 22
-      Pointee: 802 UnresolvedPointeeType html/template.Error
+      Pointee: 818 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 98
       Name: '*int'
@@ -9734,89 +9840,89 @@ Types:
       GoKind: 22
       Pointee: 155 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 680
+      ID: 696
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 909856
       GoKind: 22
-      Pointee: 681 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 697 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 678
+      ID: 694
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 909760
       GoKind: 22
-      Pointee: 679 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 695 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 1002
+      ID: 1018
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
       GoRuntimeType: 897760
       GoKind: 22
-      Pointee: 1003 UnresolvedPointeeType internal/godebug.runtimeStderr
+      Pointee: 1019 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
-      ID: 890
+      ID: 906
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.195968e+06
       GoKind: 22
-      Pointee: 891 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 907 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 1191
+      ID: 1207
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2.369984e+06
       GoKind: 22
-      Pointee: 1192 UnresolvedPointeeType internal/poll.FD
+      Pointee: 1208 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 888
+      ID: 904
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1.19584e+06
       GoKind: 22
-      Pointee: 889 StructureType internal/poll.errNetClosing
+      Pointee: 905 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 615
+      ID: 631
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 896992
       GoKind: 22
-      Pointee: 616 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 632 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 1048
+      ID: 1064
       Name: '*io.PipeWriter'
       ByteSize: 8
       GoRuntimeType: 1.187648e+06
       GoKind: 22
-      Pointee: 1049 UnresolvedPointeeType io.PipeWriter
+      Pointee: 1065 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
-      ID: 1046
+      ID: 1062
       Name: '*io.discard'
       ByteSize: 8
       GoRuntimeType: 1.187264e+06
       GoKind: 22
-      Pointee: 1047 StructureType io.discard
+      Pointee: 1063 StructureType io.discard
     - __kind: PointerType
-      ID: 1020
+      ID: 1036
       Name: '*io.multiWriter'
       ByteSize: 8
       GoRuntimeType: 1.020576e+06
       GoKind: 22
-      Pointee: 1021 UnresolvedPointeeType io.multiWriter
+      Pointee: 1037 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
-      ID: 886
+      ID: 902
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1.195584e+06
       GoKind: 22
-      Pointee: 887 UnresolvedPointeeType io/fs.PathError
+      Pointee: 903 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 1094
+      ID: 1110
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 1.798592e+06
       GoKind: 22
-      Pointee: 1095 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+      Pointee: 1111 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
       ID: 315
       Name: '*main.anotherStruct'
@@ -9824,19 +9930,19 @@ Types:
       GoKind: 22
       Pointee: 316 StructureType main.anotherStruct
     - __kind: PointerType
-      ID: 337
+      ID: 353
       Name: '*main.deepMap2'
       ByteSize: 8
       GoRuntimeType: 383744
       GoKind: 22
-      Pointee: 338 StructureType main.deepMap2
+      Pointee: 354 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 1235
+      ID: 1251
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 383680
       GoKind: 22
-      Pointee: 1236 UnresolvedPointeeType main.deepMap3
+      Pointee: 1252 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 147
       Name: '*main.deepMap7'
@@ -9845,19 +9951,19 @@ Types:
       GoKind: 22
       Pointee: 148 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 1269
+      ID: 1285
       Name: '*main.deepMap8'
       ByteSize: 8
       GoRuntimeType: 383360
       GoKind: 22
-      Pointee: 1270 StructureType main.deepMap8
+      Pointee: 1286 StructureType main.deepMap8
     - __kind: PointerType
-      ID: 1284
+      ID: 1300
       Name: '*main.deepMap9'
       ByteSize: 8
       GoRuntimeType: 383296
       GoKind: 22
-      Pointee: 1285 StructureType main.deepMap9
+      Pointee: 1301 StructureType main.deepMap9
     - __kind: PointerType
       ID: 131
       Name: '*main.deepPtr2'
@@ -9866,12 +9972,12 @@ Types:
       GoKind: 22
       Pointee: 132 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 1195
+      ID: 1211
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 384256
       GoKind: 22
-      Pointee: 1196 UnresolvedPointeeType main.deepPtr3
+      Pointee: 1212 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 133
       Name: '*main.deepPtr7'
@@ -9880,33 +9986,33 @@ Types:
       GoKind: 22
       Pointee: 134 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 1239
+      ID: 1255
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 383936
       GoKind: 22
-      Pointee: 1240 StructureType main.deepPtr8
+      Pointee: 1256 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 1241
+      ID: 1257
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 383872
       GoKind: 22
-      Pointee: 1242 StructureType main.deepPtr9
+      Pointee: 1258 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 138
       Name: '*main.deepSlice2'
       ByteSize: 8
       GoRuntimeType: 384896
       GoKind: 22
-      Pointee: 328 StructureType main.deepSlice2
+      Pointee: 344 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 1220
+      ID: 1236
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 384832
       GoKind: 22
-      Pointee: 1221 UnresolvedPointeeType main.deepSlice3
+      Pointee: 1237 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 139
       Name: '*main.deepSlice7'
@@ -9915,19 +10021,19 @@ Types:
       GoKind: 22
       Pointee: 140 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 1245
+      ID: 1261
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 384512
       GoKind: 22
-      Pointee: 1246 StructureType main.deepSlice8
+      Pointee: 1262 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 1251
+      ID: 1267
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 384448
       GoKind: 22
-      Pointee: 1252 StructureType main.deepSlice9
+      Pointee: 1268 StructureType main.deepSlice9
     - __kind: PointerType
       ID: 318
       Name: '*main.emptyStruct'
@@ -9942,14 +10048,14 @@ Types:
       GoKind: 22
       Pointee: 158 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 1212
+      ID: 1228
       Name: '*main.firstBehavior'
       ByteSize: 8
       GoRuntimeType: 892960
       GoKind: 22
-      Pointee: 319 StructureType main.firstBehavior
+      Pointee: 335 StructureType main.firstBehavior
     - __kind: PointerType
-      ID: 1301
+      ID: 1317
       Name: '*main.nestedStruct'
       ByteSize: 8
       GoRuntimeType: 385152
@@ -9969,19 +10075,19 @@ Types:
       GoKind: 22
       Pointee: 269 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 1213
+      ID: 1229
       Name: '*main.secondBehavior'
       ByteSize: 8
       GoRuntimeType: 893056
       GoKind: 22
-      Pointee: 1214 StructureType main.secondBehavior
+      Pointee: 1230 StructureType main.secondBehavior
     - __kind: PointerType
-      ID: 1200
+      ID: 1216
       Name: '*main.somethingImpl'
       ByteSize: 8
       GoRuntimeType: 893152
       GoKind: 22
-      Pointee: 1201 UnresolvedPointeeType main.somethingImpl
+      Pointee: 1217 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
       ID: 149
       Name: '*main.stringType1'
@@ -9989,28 +10095,28 @@ Types:
       GoKind: 22
       Pointee: 150 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 1198
+      ID: 1214
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 1197 GoStringDataType main.stringType1.str
+      Pointee: 1213 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 152
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 1199 GoStringHeaderType main.stringType2
+      Pointee: 1215 GoStringHeaderType main.stringType2
     - __kind: PointerType
-      ID: 1303
+      ID: 1319
       Name: '*main.stringType2.str'
       ByteSize: 8
-      Pointee: 1302 GoStringDataType main.stringType2.str
+      Pointee: 1318 GoStringDataType main.stringType2.str
     - __kind: PointerType
       ID: 272
       Name: '*main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 270 StructureType main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 389
+      ID: 405
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 383232
@@ -10034,10 +10140,10 @@ Types:
       GoKind: 22
       Pointee: 247 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 1217
+      ID: 1233
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 1216 GoSliceDataType main.t.array
+      Pointee: 1232 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 267
       Name: '*main.threeStringStruct'
@@ -10070,30 +10176,30 @@ Types:
       ByteSize: 8
       Pointee: 144 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1225
+      ID: 1241
       Name: '*map<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1226 GoSwissMapHeaderType map<int,*main.deepMap3>
+      Pointee: 1242 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1259
+      ID: 1275
       Name: '*map<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1260 GoSwissMapHeaderType map<int,*main.deepMap8>
+      Pointee: 1276 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1274
+      ID: 1290
       Name: '*map<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1275 GoSwissMapHeaderType map<int,*main.deepMap9>
+      Pointee: 1291 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: PointerType
       ID: 165
       Name: '*map<int,int>'
       ByteSize: 8
       Pointee: 166 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 1289
+      ID: 1305
       Name: '*map<int,interface {}>'
       ByteSize: 8
-      Pointee: 1290 GoSwissMapHeaderType map<int,interface {}>
+      Pointee: 1306 GoSwissMapHeaderType map<int,interface {}>
     - __kind: PointerType
       ID: 232
       Name: '*map<int,struct {}>'
@@ -10115,10 +10221,10 @@ Types:
       ByteSize: 8
       Pointee: 181 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 960
+      ID: 976
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 961 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 977 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 175
       Name: '*map<string,int>'
@@ -10186,696 +10292,696 @@ Types:
       GoKind: 22
       Pointee: 174 GoMapType map[string]int
     - __kind: PointerType
-      ID: 714
+      ID: 730
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 917536
       GoKind: 22
-      Pointee: 715 StructureType math/big.ErrNaN
+      Pointee: 731 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 1010
+      ID: 1026
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
       GoRuntimeType: 912352
       GoKind: 22
-      Pointee: 1011 StructureType mime/multipart.writerOnly·1
+      Pointee: 1027 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
-      ID: 917
+      ID: 933
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1.20416e+06
       GoKind: 22
-      Pointee: 918 UnresolvedPointeeType net.AddrError
+      Pointee: 934 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 943
+      ID: 959
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1.418624e+06
       GoKind: 22
-      Pointee: 944 UnresolvedPointeeType net.DNSError
+      Pointee: 960 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 1155
+      ID: 1171
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2.227584e+06
       GoKind: 22
-      Pointee: 1156 UnresolvedPointeeType net.IPConn
+      Pointee: 1172 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 941
+      ID: 957
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1.418304e+06
       GoKind: 22
-      Pointee: 942 UnresolvedPointeeType net.OpError
+      Pointee: 958 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 919
+      ID: 935
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.204288e+06
       GoKind: 22
-      Pointee: 920 UnresolvedPointeeType net.ParseError
+      Pointee: 936 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 1165
+      ID: 1181
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2.257792e+06
       GoKind: 22
-      Pointee: 1166 UnresolvedPointeeType net.TCPConn
+      Pointee: 1182 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 1175
+      ID: 1191
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2.302784e+06
       GoKind: 22
-      Pointee: 1176 UnresolvedPointeeType net.UDPConn
+      Pointee: 1192 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 1163
+      ID: 1179
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2.25728e+06
       GoKind: 22
-      Pointee: 1164 UnresolvedPointeeType net.UnixConn
+      Pointee: 1180 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 916
+      ID: 932
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1.203392e+06
       GoKind: 22
-      Pointee: 879 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 895 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 881
+      ID: 897
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 880 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 896 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 847
+      ID: 863
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1.035552e+06
       GoKind: 22
-      Pointee: 848 StructureType net.canceledError
+      Pointee: 864 StructureType net.canceledError
     - __kind: PointerType
-      ID: 1131
+      ID: 1147
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 2.002816e+06
       GoKind: 22
-      Pointee: 1132 UnresolvedPointeeType net.conn
+      Pointee: 1148 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 985
+      ID: 1001
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1.840352e+06
       GoKind: 22
-      Pointee: 986 StructureType net.dialResult·1
+      Pointee: 1002 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 1177
+      ID: 1193
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2.30704e+06
       GoKind: 22
-      Pointee: 1178 UnresolvedPointeeType net.netFD
+      Pointee: 1194 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 647
+      ID: 663
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 904288
       GoKind: 22
-      Pointee: 648 UnresolvedPointeeType net.notFoundError
+      Pointee: 664 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 649
+      ID: 665
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 904960
       GoKind: 22
-      Pointee: 650 StructureType net.result·2
+      Pointee: 666 StructureType net.result·2
     - __kind: PointerType
-      ID: 1159
+      ID: 1175
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.243808e+06
       GoKind: 22
-      Pointee: 1160 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 1176 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 1157
+      ID: 1173
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.243328e+06
       GoKind: 22
-      Pointee: 1158 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 1174 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 921
+      ID: 937
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1.204928e+06
       GoKind: 22
-      Pointee: 922 UnresolvedPointeeType net.temporaryError
+      Pointee: 938 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 945
+      ID: 961
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.418784e+06
       GoKind: 22
-      Pointee: 946 UnresolvedPointeeType net.timeoutError
+      Pointee: 962 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 837
+      ID: 853
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1.031328e+06
       GoKind: 22
-      Pointee: 838 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 854 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
-      ID: 1004
+      ID: 1020
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
       GoRuntimeType: 900064
       GoKind: 22
-      Pointee: 1005 StructureType net/http.bufioFlushWriter
+      Pointee: 1021 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
-      ID: 624
+      ID: 640
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 900736
       GoKind: 22
-      Pointee: 544 BaseType net/http.http2ConnectionError
+      Pointee: 560 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 625
+      ID: 641
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 900832
       GoKind: 22
-      Pointee: 626 StructureType net/http.http2GoAwayError
+      Pointee: 642 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 937
+      ID: 953
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1.414464e+06
       GoKind: 22
-      Pointee: 938 StructureType net/http.http2StreamError
+      Pointee: 954 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 629
+      ID: 645
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 901408
       GoKind: 22
-      Pointee: 630 StructureType net/http.http2connError
+      Pointee: 646 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 1066
+      ID: 1082
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
       GoRuntimeType: 1.551104e+06
       GoKind: 22
-      Pointee: 1067 UnresolvedPointeeType net/http.http2dataBuffer
+      Pointee: 1083 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 628
+      ID: 644
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 901312
       GoKind: 22
-      Pointee: 548 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 564 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 550
+      ID: 566
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 549 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 565 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 632
+      ID: 648
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 901600
       GoKind: 22
-      Pointee: 554 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 570 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 556
+      ID: 572
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 555 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 571 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 631
+      ID: 647
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 901504
       GoKind: 22
-      Pointee: 551 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 567 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 553
+      ID: 569
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 552 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 568 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 912
+      ID: 928
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1.199936e+06
       GoKind: 22
-      Pointee: 913 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 929 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 843
+      ID: 859
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1.031968e+06
       GoKind: 22
-      Pointee: 844 StructureType net/http.http2noCachedConnError
+      Pointee: 860 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 1120
+      ID: 1136
       Name: '*net/http.http2pipe'
       ByteSize: 8
       GoRuntimeType: 1.94528e+06
       GoKind: 22
-      Pointee: 1121 UnresolvedPointeeType net/http.http2pipe
+      Pointee: 1137 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 627
+      ID: 643
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 901216
       GoKind: 22
-      Pointee: 545 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 561 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 547
+      ID: 563
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 546 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 562 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1006
+      ID: 1022
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
       GoRuntimeType: 901696
       GoKind: 22
-      Pointee: 1007 StructureType net/http.http2stickyErrWriter
+      Pointee: 1023 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
-      ID: 839
+      ID: 855
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1.031584e+06
       GoKind: 22
-      Pointee: 840 StructureType net/http.nothingWrittenError
+      Pointee: 856 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 1068
+      ID: 1084
       Name: '*net/http.persistConn'
       ByteSize: 8
       GoRuntimeType: 2.168416e+06
       GoKind: 22
-      Pointee: 1069 UnresolvedPointeeType net/http.persistConn
+      Pointee: 1085 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
-      ID: 1024
+      ID: 1040
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
       GoRuntimeType: 1.031456e+06
       GoKind: 22
-      Pointee: 1025 StructureType net/http.persistConnWriter
+      Pointee: 1041 StructureType net/http.persistConnWriter
     - __kind: PointerType
-      ID: 1050
+      ID: 1066
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1.19904e+06
       GoKind: 22
-      Pointee: 1051 StructureType net/http.readWriteCloserBody
+      Pointee: 1067 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 633
+      ID: 649
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 901792
       GoKind: 22
-      Pointee: 634 StructureType net/http.requestBodyReadError
+      Pointee: 650 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 939
+      ID: 955
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.415584e+06
       GoKind: 22
-      Pointee: 940 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 956 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 910
+      ID: 926
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1.199808e+06
       GoKind: 22
-      Pointee: 911 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 927 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 841
+      ID: 857
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1.031712e+06
       GoKind: 22
-      Pointee: 842 StructureType net/http.transportReadFromServerError
+      Pointee: 858 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 1102
+      ID: 1118
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
       GoRuntimeType: 1.836992e+06
       GoKind: 22
-      Pointee: 1103 StructureType net/http.unencryptedNetConnInTLSConn
+      Pointee: 1119 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 622
+      ID: 638
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 899968
       GoKind: 22
-      Pointee: 623 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 639 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 1122
+      ID: 1138
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
       GoRuntimeType: 1.946816e+06
       GoKind: 22
-      Pointee: 1123 StructureType net/http/internal.FlushAfterChunkWriter
+      Pointee: 1139 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
-      ID: 1034
+      ID: 1050
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
       GoRuntimeType: 1.044e+06
       GoKind: 22
-      Pointee: 1035 UnresolvedPointeeType net/http/internal.chunkedWriter
+      Pointee: 1051 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
-      ID: 706
+      ID: 722
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 916480
       GoKind: 22
-      Pointee: 707 StructureType net/netip.parseAddrError
+      Pointee: 723 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 704
+      ID: 720
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 916384
       GoKind: 22
-      Pointee: 705 StructureType net/netip.parsePrefixError
+      Pointee: 721 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 1076
+      ID: 1092
       Name: '*net/smtp.Client'
       ByteSize: 8
       GoRuntimeType: 2.113088e+06
       GoKind: 22
-      Pointee: 1077 UnresolvedPointeeType net/smtp.Client
+      Pointee: 1093 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
-      ID: 1036
+      ID: 1052
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
       GoRuntimeType: 1.048864e+06
       GoKind: 22
-      Pointee: 1037 StructureType net/smtp.dataCloser
+      Pointee: 1053 StructureType net/smtp.dataCloser
     - __kind: PointerType
-      ID: 690
+      ID: 706
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 912544
       GoKind: 22
-      Pointee: 691 UnresolvedPointeeType net/textproto.Error
+      Pointee: 707 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 689
+      ID: 705
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 912448
       GoKind: 22
-      Pointee: 579 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 595 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 581
+      ID: 597
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 580 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 596 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 1032
+      ID: 1048
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
       GoRuntimeType: 1.043232e+06
       GoKind: 22
-      Pointee: 1033 UnresolvedPointeeType net/textproto.dotWriter
+      Pointee: 1049 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
-      ID: 947
+      ID: 963
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1.419104e+06
       GoKind: 22
-      Pointee: 948 UnresolvedPointeeType net/url.Error
+      Pointee: 964 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 651
+      ID: 667
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 905056
       GoKind: 22
-      Pointee: 557 GoStringHeaderType net/url.EscapeError
+      Pointee: 573 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 559
+      ID: 575
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 558 GoStringDataType net/url.EscapeError.str
+      Pointee: 574 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 652
+      ID: 668
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 905152
       GoKind: 22
-      Pointee: 560 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 576 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 562
+      ID: 578
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 561 GoStringDataType net/url.InvalidHostError.str
-    - __kind: PointerType
-      ID: 435
-      Name: '*noalg.map.group[[4]int][4]int'
-      ByteSize: 8
-      Pointee: 436 StructureType noalg.map.group[[4]int][4]int
-    - __kind: PointerType
-      ID: 427
-      Name: '*noalg.map.group[[4]int]uint8'
-      ByteSize: 8
-      Pointee: 428 StructureType noalg.map.group[[4]int]uint8
-    - __kind: PointerType
-      ID: 375
-      Name: '*noalg.map.group[[4]string][2]int'
-      ByteSize: 8
-      Pointee: 376 StructureType noalg.map.group[[4]string][2]int
-    - __kind: PointerType
-      ID: 394
-      Name: '*noalg.map.group[bool]main.node'
-      ByteSize: 8
-      Pointee: 395 StructureType noalg.map.group[bool]main.node
-    - __kind: PointerType
-      ID: 333
-      Name: '*noalg.map.group[int]*main.deepMap2'
-      ByteSize: 8
-      Pointee: 334 StructureType noalg.map.group[int]*main.deepMap2
-    - __kind: PointerType
-      ID: 1231
-      Name: '*noalg.map.group[int]*main.deepMap3'
-      ByteSize: 8
-      Pointee: 1232 StructureType noalg.map.group[int]*main.deepMap3
-    - __kind: PointerType
-      ID: 1265
-      Name: '*noalg.map.group[int]*main.deepMap8'
-      ByteSize: 8
-      Pointee: 1266 StructureType noalg.map.group[int]*main.deepMap8
-    - __kind: PointerType
-      ID: 1280
-      Name: '*noalg.map.group[int]*main.deepMap9'
-      ByteSize: 8
-      Pointee: 1281 StructureType noalg.map.group[int]*main.deepMap9
-    - __kind: PointerType
-      ID: 343
-      Name: '*noalg.map.group[int]int'
-      ByteSize: 8
-      Pointee: 344 StructureType noalg.map.group[int]int
-    - __kind: PointerType
-      ID: 1295
-      Name: '*noalg.map.group[int]interface {}'
-      ByteSize: 8
-      Pointee: 1296 StructureType noalg.map.group[int]interface {}
+      Pointee: 577 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
       ID: 451
-      Name: '*noalg.map.group[int]struct {}'
+      Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 452 StructureType noalg.map.group[int]struct {}
-    - __kind: PointerType
-      ID: 402
-      Name: '*noalg.map.group[int]uint8'
-      ByteSize: 8
-      Pointee: 403 StructureType noalg.map.group[int]uint8
-    - __kind: PointerType
-      ID: 384
-      Name: '*noalg.map.group[string][]main.structWithMap'
-      ByteSize: 8
-      Pointee: 385 StructureType noalg.map.group[string][]main.structWithMap
-    - __kind: PointerType
-      ID: 367
-      Name: '*noalg.map.group[string][]string'
-      ByteSize: 8
-      Pointee: 368 StructureType noalg.map.group[string][]string
-    - __kind: PointerType
-      ID: 992
-      Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
-      ByteSize: 8
-      Pointee: 993 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-    - __kind: PointerType
-      ID: 359
-      Name: '*noalg.map.group[string]int'
-      ByteSize: 8
-      Pointee: 360 StructureType noalg.map.group[string]int
-    - __kind: PointerType
-      ID: 351
-      Name: '*noalg.map.group[string]main.nestedStruct'
-      ByteSize: 8
-      Pointee: 352 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 452 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
       ID: 443
-      Name: '*noalg.map.group[struct {}]int'
+      Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 444 StructureType noalg.map.group[struct {}]int
+      Pointee: 444 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 493
-      Name: '*noalg.map.group[struct {}]main.structWithCyclicMaps'
+      ID: 391
+      Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 494 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
-    - __kind: PointerType
-      ID: 501
-      Name: '*noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps'
-      ByteSize: 8
-      Pointee: 502 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
-    - __kind: PointerType
-      ID: 509
-      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
-      ByteSize: 8
-      Pointee: 510 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-    - __kind: PointerType
-      ID: 517
-      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
-      ByteSize: 8
-      Pointee: 518 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-    - __kind: PointerType
-      ID: 525
-      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
-      ByteSize: 8
-      Pointee: 526 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-    - __kind: PointerType
-      ID: 533
-      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
-      ByteSize: 8
-      Pointee: 534 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-    - __kind: PointerType
-      ID: 459
-      Name: '*noalg.map.group[struct {}]struct {}'
-      ByteSize: 8
-      Pointee: 460 StructureType noalg.map.group[struct {}]struct {}
-    - __kind: PointerType
-      ID: 418
-      Name: '*noalg.map.group[uint8][4]int'
-      ByteSize: 8
-      Pointee: 419 StructureType noalg.map.group[uint8][4]int
+      Pointee: 392 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
       ID: 410
+      Name: '*noalg.map.group[bool]main.node'
+      ByteSize: 8
+      Pointee: 411 StructureType noalg.map.group[bool]main.node
+    - __kind: PointerType
+      ID: 349
+      Name: '*noalg.map.group[int]*main.deepMap2'
+      ByteSize: 8
+      Pointee: 350 StructureType noalg.map.group[int]*main.deepMap2
+    - __kind: PointerType
+      ID: 1247
+      Name: '*noalg.map.group[int]*main.deepMap3'
+      ByteSize: 8
+      Pointee: 1248 StructureType noalg.map.group[int]*main.deepMap3
+    - __kind: PointerType
+      ID: 1281
+      Name: '*noalg.map.group[int]*main.deepMap8'
+      ByteSize: 8
+      Pointee: 1282 StructureType noalg.map.group[int]*main.deepMap8
+    - __kind: PointerType
+      ID: 1296
+      Name: '*noalg.map.group[int]*main.deepMap9'
+      ByteSize: 8
+      Pointee: 1297 StructureType noalg.map.group[int]*main.deepMap9
+    - __kind: PointerType
+      ID: 359
+      Name: '*noalg.map.group[int]int'
+      ByteSize: 8
+      Pointee: 360 StructureType noalg.map.group[int]int
+    - __kind: PointerType
+      ID: 1311
+      Name: '*noalg.map.group[int]interface {}'
+      ByteSize: 8
+      Pointee: 1312 StructureType noalg.map.group[int]interface {}
+    - __kind: PointerType
+      ID: 467
+      Name: '*noalg.map.group[int]struct {}'
+      ByteSize: 8
+      Pointee: 468 StructureType noalg.map.group[int]struct {}
+    - __kind: PointerType
+      ID: 418
+      Name: '*noalg.map.group[int]uint8'
+      ByteSize: 8
+      Pointee: 419 StructureType noalg.map.group[int]uint8
+    - __kind: PointerType
+      ID: 400
+      Name: '*noalg.map.group[string][]main.structWithMap'
+      ByteSize: 8
+      Pointee: 401 StructureType noalg.map.group[string][]main.structWithMap
+    - __kind: PointerType
+      ID: 383
+      Name: '*noalg.map.group[string][]string'
+      ByteSize: 8
+      Pointee: 384 StructureType noalg.map.group[string][]string
+    - __kind: PointerType
+      ID: 1008
+      Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
+      ByteSize: 8
+      Pointee: 1009 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+    - __kind: PointerType
+      ID: 375
+      Name: '*noalg.map.group[string]int'
+      ByteSize: 8
+      Pointee: 376 StructureType noalg.map.group[string]int
+    - __kind: PointerType
+      ID: 367
+      Name: '*noalg.map.group[string]main.nestedStruct'
+      ByteSize: 8
+      Pointee: 368 StructureType noalg.map.group[string]main.nestedStruct
+    - __kind: PointerType
+      ID: 459
+      Name: '*noalg.map.group[struct {}]int'
+      ByteSize: 8
+      Pointee: 460 StructureType noalg.map.group[struct {}]int
+    - __kind: PointerType
+      ID: 509
+      Name: '*noalg.map.group[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 510 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 517
+      Name: '*noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 518 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 525
+      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 526 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 533
+      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 534 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 541
+      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 542 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 549
+      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 550 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 475
+      Name: '*noalg.map.group[struct {}]struct {}'
+      ByteSize: 8
+      Pointee: 476 StructureType noalg.map.group[struct {}]struct {}
+    - __kind: PointerType
+      ID: 434
+      Name: '*noalg.map.group[uint8][4]int'
+      ByteSize: 8
+      Pointee: 435 StructureType noalg.map.group[uint8][4]int
+    - __kind: PointerType
+      ID: 426
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 411 StructureType noalg.map.group[uint8]uint8
+      Pointee: 427 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
-      ID: 1183
+      ID: 1199
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2.345696e+06
       GoKind: 22
-      Pointee: 1184 UnresolvedPointeeType os.File
+      Pointee: 1200 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 818
+      ID: 834
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1.022624e+06
       GoKind: 22
-      Pointee: 819 UnresolvedPointeeType os.LinkError
+      Pointee: 835 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 882
+      ID: 898
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1.188928e+06
       GoKind: 22
-      Pointee: 883 UnresolvedPointeeType os.SyscallError
+      Pointee: 899 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 1181
+      ID: 1197
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.342016e+06
       GoKind: 22
-      Pointee: 1182 StructureType os.fileWithoutReadFrom
+      Pointee: 1198 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 1179
+      ID: 1195
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.34128e+06
       GoKind: 22
-      Pointee: 1180 StructureType os.fileWithoutWriteTo
+      Pointee: 1196 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 849
+      ID: 865
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1.039904e+06
       GoKind: 22
-      Pointee: 850 UnresolvedPointeeType os/exec.Error
+      Pointee: 866 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 988
+      ID: 1004
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2.082944e+06
       GoKind: 22
-      Pointee: 989 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 1005 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 1054
+      ID: 1070
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
       GoRuntimeType: 1.2112e+06
       GoKind: 22
-      Pointee: 1055 UnresolvedPointeeType os/exec.prefixSuffixSaver
+      Pointee: 1071 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
-      ID: 851
+      ID: 867
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1.040032e+06
       GoKind: 22
-      Pointee: 852 StructureType os/exec.wrappedError
+      Pointee: 868 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 785
+      ID: 801
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 934336
       GoKind: 22
-      Pointee: 593 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 609 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 595
+      ID: 611
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 594 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 610 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 784
+      ID: 800
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 934240
       GoKind: 22
-      Pointee: 592 BaseType os/user.UnknownUserIdError
+      Pointee: 608 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 617
+      ID: 633
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 897664
       GoKind: 22
-      Pointee: 618 UnresolvedPointeeType reflect.ValueError
+      Pointee: 634 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 712
+      ID: 728
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 917152
       GoKind: 22
-      Pointee: 713 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 729 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 822
+      ID: 838
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1.02416e+06
       GoKind: 22
-      Pointee: 823 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 839 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 826
+      ID: 842
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1.025952e+06
       GoKind: 22
-      Pointee: 827 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 843 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
@@ -10891,12 +10997,12 @@ Types:
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 824
+      ID: 840
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1.024288e+06
       GoKind: 22
-      Pointee: 825 StructureType runtime.boundsError
+      Pointee: 841 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 62
       Name: '*runtime.cgoCallers'
@@ -10912,24 +11018,24 @@ Types:
       GoKind: 22
       Pointee: 48 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 884
+      ID: 900
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1.194304e+06
       GoKind: 22
-      Pointee: 885 StructureType runtime.errorAddressString
+      Pointee: 901 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 820
+      ID: 836
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1.023776e+06
       GoKind: 22
-      Pointee: 803 GoStringHeaderType runtime.errorString
+      Pointee: 819 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 805
+      ID: 821
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 804 GoStringDataType runtime.errorString.str
+      Pointee: 820 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 55
       Name: '*runtime.g'
@@ -10945,17 +11051,17 @@ Types:
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
-      ID: 821
+      ID: 837
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1.023904e+06
       GoKind: 22
-      Pointee: 806 GoStringHeaderType runtime.plainError
+      Pointee: 822 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 808
+      ID: 824
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 807 GoStringDataType runtime.plainError.str
+      Pointee: 823 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
@@ -10985,12 +11091,12 @@ Types:
       GoKind: 22
       Pointee: 77 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 828
+      ID: 844
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1.026208e+06
       GoKind: 22
-      Pointee: 829 UnresolvedPointeeType strconv.NumError
+      Pointee: 845 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 93
       Name: '*string'
@@ -10999,218 +11105,218 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 321
+      ID: 337
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 320 GoStringDataType string.str
+      Pointee: 336 GoStringDataType string.str
     - __kind: PointerType
-      ID: 1118
+      ID: 1134
       Name: '*strings.Builder'
       ByteSize: 8
       GoRuntimeType: 1.944e+06
       GoKind: 22
-      Pointee: 1119 UnresolvedPointeeType strings.Builder
+      Pointee: 1135 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
-      ID: 1022
+      ID: 1038
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
       GoRuntimeType: 1.026336e+06
       GoKind: 22
-      Pointee: 1023 UnresolvedPointeeType strings.appendSliceWriter
+      Pointee: 1039 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
-      ID: 1018
+      ID: 1034
       Name: '*struct { io.Writer }'
       ByteSize: 8
       GoRuntimeType: 967136
       GoKind: 22
-      Pointee: 1019 StructureType struct { io.Writer }
+      Pointee: 1035 StructureType struct { io.Writer }
     - __kind: PointerType
       ID: 265
       Name: '*struct {}'
       ByteSize: 8
       Pointee: 123 StructureType struct {}
     - __kind: PointerType
-      ID: 936
+      ID: 952
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1.413824e+06
       GoKind: 22
-      Pointee: 935 BaseType syscall.Errno
+      Pointee: 951 BaseType syscall.Errno
     - __kind: PointerType
       ID: 225
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 433 StructureType table<[4]int,[4]int>
+      Pointee: 449 StructureType table<[4]int,[4]int>
     - __kind: PointerType
       ID: 220
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 425 StructureType table<[4]int,uint8>
+      Pointee: 441 StructureType table<[4]int,uint8>
     - __kind: PointerType
       ID: 188
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 373 StructureType table<[4]string,[2]int>
+      Pointee: 389 StructureType table<[4]string,[2]int>
     - __kind: PointerType
       ID: 200
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 392 StructureType table<bool,main.node>
+      Pointee: 408 StructureType table<bool,main.node>
     - __kind: PointerType
       ID: 146
       Name: '*table<int,*main.deepMap2>'
       ByteSize: 8
-      Pointee: 331 StructureType table<int,*main.deepMap2>
+      Pointee: 347 StructureType table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1228
+      ID: 1244
       Name: '*table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1229 StructureType table<int,*main.deepMap3>
+      Pointee: 1245 StructureType table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1262
+      ID: 1278
       Name: '*table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1263 StructureType table<int,*main.deepMap8>
+      Pointee: 1279 StructureType table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1277
+      ID: 1293
       Name: '*table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1278 StructureType table<int,*main.deepMap9>
+      Pointee: 1294 StructureType table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 168
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 341 StructureType table<int,int>
+      Pointee: 357 StructureType table<int,int>
     - __kind: PointerType
-      ID: 1292
+      ID: 1308
       Name: '*table<int,interface {}>'
       ByteSize: 8
-      Pointee: 1293 StructureType table<int,interface {}>
+      Pointee: 1309 StructureType table<int,interface {}>
     - __kind: PointerType
       ID: 235
       Name: '*table<int,struct {}>'
       ByteSize: 8
-      Pointee: 449 StructureType table<int,struct {}>
+      Pointee: 465 StructureType table<int,struct {}>
     - __kind: PointerType
       ID: 205
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 400 StructureType table<int,uint8>
+      Pointee: 416 StructureType table<int,uint8>
     - __kind: PointerType
       ID: 195
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 382 StructureType table<string,[]main.structWithMap>
+      Pointee: 398 StructureType table<string,[]main.structWithMap>
     - __kind: PointerType
       ID: 183
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 365 StructureType table<string,[]string>
+      Pointee: 381 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 963
+      ID: 979
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 990 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 1006 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 178
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 357 StructureType table<string,int>
+      Pointee: 373 StructureType table<string,int>
     - __kind: PointerType
       ID: 173
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 349 StructureType table<string,main.nestedStruct>
+      Pointee: 365 StructureType table<string,main.nestedStruct>
     - __kind: PointerType
       ID: 230
       Name: '*table<struct {},int>'
       ByteSize: 8
-      Pointee: 441 StructureType table<struct {},int>
+      Pointee: 457 StructureType table<struct {},int>
     - __kind: PointerType
       ID: 288
       Name: '*table<struct {},main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 491 StructureType table<struct {},main.structWithCyclicMaps>
+      Pointee: 507 StructureType table<struct {},main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 293
       Name: '*table<struct {},map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 499 StructureType table<struct {},map[struct {}]main.structWithCyclicMaps>
+      Pointee: 515 StructureType table<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 298
       Name: '*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 507 StructureType table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 523 StructureType table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 303
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 515 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 531 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 308
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 523 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 539 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 313
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 531 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 547 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 240
       Name: '*table<struct {},struct {}>'
       ByteSize: 8
-      Pointee: 457 StructureType table<struct {},struct {}>
+      Pointee: 473 StructureType table<struct {},struct {}>
     - __kind: PointerType
       ID: 215
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 416 StructureType table<uint8,[4]int>
+      Pointee: 432 StructureType table<uint8,[4]int>
     - __kind: PointerType
       ID: 210
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 408 StructureType table<uint8,uint8>
+      Pointee: 424 StructureType table<uint8,uint8>
     - __kind: PointerType
-      ID: 1153
+      ID: 1169
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
       GoRuntimeType: 2.153312e+06
       GoKind: 22
-      Pointee: 1154 UnresolvedPointeeType text/tabwriter.Writer
+      Pointee: 1170 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
-      ID: 877
+      ID: 893
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1.085344e+06
       GoKind: 22
-      Pointee: 878 StructureType text/template.ExecError
+      Pointee: 894 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 952
+      ID: 968
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.619168e+06
       GoKind: 22
-      Pointee: 953 UnresolvedPointeeType time.Location
+      Pointee: 969 UnresolvedPointeeType time.Location
     - __kind: PointerType
-      ID: 620
+      ID: 636
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 898528
       GoKind: 22
-      Pointee: 621 UnresolvedPointeeType time.ParseError
+      Pointee: 637 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 619
+      ID: 635
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 898432
       GoKind: 22
-      Pointee: 541 GoStringHeaderType time.fileSizeError
+      Pointee: 557 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 543
+      ID: 559
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 542 GoStringDataType time.fileSizeError.str
+      Pointee: 558 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
       ID: 105
       Name: '*uint'
@@ -11254,52 +11360,88 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: PointerType
-      ID: 708
+      ID: 724
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 916576
       GoKind: 22
-      Pointee: 709 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 725 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 1145
+      ID: 1161
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.128768e+06
       GoKind: 22
-      Pointee: 1146 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1162 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 692
+      ID: 708
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 912736
       GoKind: 22
-      Pointee: 693 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 709 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 694
+      ID: 710
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 912832
       GoKind: 22
-      Pointee: 582 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 598 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 856
+      ID: 872
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1.043744e+06
       GoKind: 22
-      Pointee: 857 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 873 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 858
+      ID: 874
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1.043872e+06
       GoKind: 22
-      Pointee: 811 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 827 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1551
+      ID: 1568
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
     - __kind: EventRootType
-      ID: 1549
+      ID: 1552
+      Name: Probe[main.executeStructFuncs]Line
+      ByteSize: 66
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: sta.a
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 333 ArrayType [3]uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 10, name: sta}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: sta.b
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 10, name: sta}
+                  Offset: 24
+                  ByteSize: 1
+        - Name: sta.c
+          Offset: 26
+          Kind: template_segment
+          Expression:
+            Type: 334 ArrayType [5]int64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 10, name: sta}
+                  Offset: 32
+                  ByteSize: 40
+    - __kind: EventRootType
+      ID: 1566
       Name: Probe[main.firstBehavior.DoSomething]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11308,14 +11450,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 319 StructureType main.firstBehavior
+            Type: 335 StructureType main.firstBehavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 0, name: b}
+                  Variable: {subprogram: 165, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1550
+      ID: 1567
       Name: Probe[main.firstBehavior.DoSomething]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11327,14 +11469,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 1, name: ~r0}
+                  Variable: {subprogram: 165, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1507
+      ID: 1523
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1508
+      ID: 1524
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11350,7 +11492,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1374
+      ID: 1390
       Name: Probe[main.testAnyPtr]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11376,7 +11518,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1375
+      ID: 1391
       Name: Probe[main.testAnyPtr]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11392,7 +11534,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1371
+      ID: 1387
       Name: Probe[main.testAny]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11418,7 +11560,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1372
+      ID: 1388
       Name: Probe[main.testAny]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11434,7 +11576,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1478
+      ID: 1494
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11460,7 +11602,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1479
+      ID: 1495
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11476,7 +11618,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1322
+      ID: 1338
       Name: Probe[main.testArrayEmptyStructs]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11502,7 +11644,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1320
+      ID: 1336
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 129
       PresenceBitsetSize: 1
@@ -11528,7 +11670,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1318
+      ID: 1334
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -11554,7 +11696,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1383
+      ID: 1399
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11580,7 +11722,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1319
+      ID: 1335
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -11606,7 +11748,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1321
+      ID: 1337
       Name: Probe[main.testArrayOfStructs]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -11632,7 +11774,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1405
+      ID: 1421
       Name: Probe[main.testAtomicAdd]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11658,7 +11800,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1406
+      ID: 1422
       Name: Probe[main.testAtomicAdd]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11674,7 +11816,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1340
+      ID: 1356
       Name: Probe[main.testBigStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -11700,10 +11842,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1341
+      ID: 1357
       Name: Probe[main.testBigStruct]Return
     - __kind: EventRootType
-      ID: 1307
+      ID: 1323
       Name: Probe[main.testBoolArray]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -11729,7 +11871,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1304
+      ID: 1320
       Name: Probe[main.testByteArray]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -11755,7 +11897,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1407
+      ID: 1423
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11781,7 +11923,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1401
+      ID: 1417
       Name: Probe[main.testCombinedByte]
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -11847,7 +11989,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1402
+      ID: 1418
       Name: Probe[main.testCombinedString]
       ByteSize: 18
       PresenceBitsetSize: 1
@@ -11873,7 +12015,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1403
+      ID: 1419
       Name: Probe[main.testCombinedString]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -11909,7 +12051,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1415
+      ID: 1431
       Name: Probe[main.testCycle]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11935,7 +12077,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1346
+      ID: 1362
       Name: Probe[main.testDeepMap1]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11961,7 +12103,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1347
+      ID: 1363
       Name: Probe[main.testDeepMap7]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11987,7 +12129,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1342
+      ID: 1358
       Name: Probe[main.testDeepPtr1]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12013,7 +12155,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1343
+      ID: 1359
       Name: Probe[main.testDeepPtr7]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12039,7 +12181,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1344
+      ID: 1360
       Name: Probe[main.testDeepSlice1]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12065,7 +12207,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1345
+      ID: 1361
       Name: Probe[main.testDeepSlice7]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12091,7 +12233,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1498
+      ID: 1514
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -12137,7 +12279,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1495
+      ID: 1511
       Name: Probe[main.testEmptySlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12163,7 +12305,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1521
+      ID: 1537
       Name: Probe[main.testEmptyString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12189,7 +12331,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1535
+      ID: 1551
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12215,7 +12357,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1534
+      ID: 1550
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -12241,7 +12383,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1373
+      ID: 1389
       Name: Probe[main.testError]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12267,7 +12409,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1355
+      ID: 1371
       Name: Probe[main.testEsotericHeap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12293,10 +12435,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1356
+      ID: 1372
       Name: Probe[main.testEsotericHeap]Return
     - __kind: EventRootType
-      ID: 1353
+      ID: 1369
       Name: Probe[main.testEsotericStack]
       ByteSize: 129
       PresenceBitsetSize: 1
@@ -12322,10 +12464,10 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1354
+      ID: 1370
       Name: Probe[main.testEsotericStack]Return
     - __kind: EventRootType
-      ID: 1367
+      ID: 1383
       Name: Probe[main.testFramelessArray]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12351,7 +12493,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1369
+      ID: 1385
       Name: Probe[main.testFramelessArray]Line
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -12387,7 +12529,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1368
+      ID: 1384
       Name: Probe[main.testFramelessArray]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12403,7 +12545,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1365
+      ID: 1381
       Name: Probe[main.testFrameless]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12429,7 +12571,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1366
+      ID: 1382
       Name: Probe[main.testFrameless]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12445,7 +12587,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1357
+      ID: 1373
       Name: Probe[main.testInlinedBA]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12471,10 +12613,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1358
+      ID: 1374
       Name: Probe[main.testInlinedBA]Return
     - __kind: EventRootType
-      ID: 1361
+      ID: 1377
       Name: Probe[main.testInlinedBBA]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12500,13 +12642,13 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1362
+      ID: 1378
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1541
+      ID: 1558
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 1359
+      ID: 1375
       Name: Probe[main.testInlinedBB]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12552,28 +12694,28 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1360
+      ID: 1376
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1542
+      ID: 1559
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1543
+      ID: 1560
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1544
+      ID: 1561
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1545
+      ID: 1562
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
-      ID: 1363
+      ID: 1379
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 1364
+      ID: 1380
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1538
+      ID: 1555
       Name: Probe[main.testInlinedPrint]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12585,7 +12727,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12595,11 +12737,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1536
+      ID: 1553
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12611,11 +12753,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1537
+      ID: 1554
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12627,7 +12769,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x_val
@@ -12637,11 +12779,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1540
+      ID: 1557
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12653,7 +12795,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12663,14 +12805,14 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1539
+      ID: 1556
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1546
+      ID: 1563
       Name: Probe[main.testInlinedSq]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12682,7 +12824,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12692,11 +12834,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1547
+      ID: 1564
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12708,7 +12850,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12718,11 +12860,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1548
+      ID: 1565
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12734,7 +12876,7 @@ Types:
             Type: 159 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: a}
+                  Variable: {subprogram: 164, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: a
@@ -12744,11 +12886,11 @@ Types:
             Type: 159 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: a}
+                  Variable: {subprogram: 164, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1310
+      ID: 1326
       Name: Probe[main.testInt16Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12774,7 +12916,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1311
+      ID: 1327
       Name: Probe[main.testInt32Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12800,7 +12942,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1312
+      ID: 1328
       Name: Probe[main.testInt64Array]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12826,7 +12968,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1309
+      ID: 1325
       Name: Probe[main.testInt8Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -12852,7 +12994,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1308
+      ID: 1324
       Name: Probe[main.testIntArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12878,7 +13020,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1370
+      ID: 1386
       Name: Probe[main.testInterface]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12904,7 +13046,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1476
+      ID: 1492
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 161
       PresenceBitsetSize: 1
@@ -12930,7 +13072,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1477
+      ID: 1493
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12946,7 +13088,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1409
+      ID: 1425
       Name: Probe[main.testLinkedList]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12972,36 +13114,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1350
+      ID: 1366
       Name: Probe[main.testLongFunctionWithChangingState]Line
     - __kind: EventRootType
-      ID: 1351
-      Name: Probe[main.testLongFunctionWithChangingState]Line
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: aPerArch
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 1, name: aPerArch}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: b
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 2, name: b}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1352
+      ID: 1367
       Name: Probe[main.testLongFunctionWithChangingState]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13027,7 +13143,33 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1482
+      ID: 1368
+      Name: Probe[main.testLongFunctionWithChangingState]Line
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: aPerArch
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 1, name: aPerArch}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1498
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 147
       PresenceBitsetSize: 3
@@ -13213,7 +13355,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1483
+      ID: 1499
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13229,7 +13371,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1381
+      ID: 1397
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13255,7 +13397,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1388
+      ID: 1404
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13281,7 +13423,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1400
+      ID: 1416
       Name: Probe[main.testMapEmptyKeyAndValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13307,7 +13449,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1398
+      ID: 1414
       Name: Probe[main.testMapEmptyKey]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13333,7 +13475,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1399
+      ID: 1415
       Name: Probe[main.testMapEmptyValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13359,7 +13501,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1385
+      ID: 1401
       Name: Probe[main.testMapIntToInt]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13385,7 +13527,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1397
+      ID: 1413
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13411,7 +13553,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1396
+      ID: 1412
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13437,7 +13579,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1386
+      ID: 1402
       Name: Probe[main.testMapMassive]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13463,7 +13605,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1387
+      ID: 1403
       Name: Probe[main.testMapMassive]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13489,7 +13631,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1395
+      ID: 1411
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13515,7 +13657,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1394
+      ID: 1410
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13541,7 +13683,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1379
+      ID: 1395
       Name: Probe[main.testMapStringToInt]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13567,7 +13709,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1380
+      ID: 1396
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13593,7 +13735,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1378
+      ID: 1394
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13619,7 +13761,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1389
+      ID: 1405
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13645,7 +13787,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1393
+      ID: 1409
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13671,7 +13813,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1392
+      ID: 1408
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13697,7 +13839,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1391
+      ID: 1407
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13723,7 +13865,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1390
+      ID: 1406
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13749,7 +13891,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1518
+      ID: 1534
       Name: Probe[main.testMassiveString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13775,7 +13917,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1519
+      ID: 1535
       Name: Probe[main.testMassiveString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13801,7 +13943,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1484
+      ID: 1500
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 163
       PresenceBitsetSize: 3
@@ -13987,7 +14129,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1485
+      ID: 1501
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -14003,7 +14145,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1488
+      ID: 1504
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -14049,7 +14191,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1489
+      ID: 1505
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -14075,7 +14217,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1480
+      ID: 1496
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 321
       PresenceBitsetSize: 1
@@ -14121,7 +14263,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1481
+      ID: 1497
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -14137,7 +14279,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1434
+      ID: 1450
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14163,7 +14305,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1436
+      ID: 1452
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14209,7 +14351,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1438
+      ID: 1454
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14225,7 +14367,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1440
+      ID: 1456
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14241,7 +14383,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1442
+      ID: 1458
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14257,7 +14399,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1435
+      ID: 1451
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14283,7 +14425,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1437
+      ID: 1453
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -14349,7 +14491,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1439
+      ID: 1455
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14375,7 +14517,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1441
+      ID: 1457
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14401,7 +14543,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1443
+      ID: 1459
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14427,7 +14569,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1404
+      ID: 1420
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 62
       PresenceBitsetSize: 2
@@ -14533,7 +14675,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1430
+      ID: 1446
       Name: Probe[main.testNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14559,7 +14701,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1432
+      ID: 1448
       Name: Probe[main.testNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14585,7 +14727,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1431
+      ID: 1447
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14601,7 +14743,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1433
+      ID: 1449
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14627,7 +14769,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1530
+      ID: 1546
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14653,7 +14795,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1531
+      ID: 1547
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14675,10 +14817,10 @@ Types:
                   Bias: 8
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1532
+      ID: 1548
       Name: Probe[main.testNestedPointer]
     - __kind: EventRootType
-      ID: 1533
+      ID: 1549
       Name: Probe[main.testNestedPointer]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -14700,7 +14842,7 @@ Types:
                   Bias: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1414
+      ID: 1430
       Name: Probe[main.testNilPointer]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14746,7 +14888,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1499
+      ID: 1515
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -14792,7 +14934,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1501
+      ID: 1517
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 67
       PresenceBitsetSize: 1
@@ -14858,7 +15000,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1502
+      ID: 1518
       Name: Probe[main.testNilSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -14884,7 +15026,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1517
+      ID: 1533
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14910,7 +15052,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1410
+      ID: 1426
       Name: Probe[main.testPointerLoop]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14936,7 +15078,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1384
+      ID: 1400
       Name: Probe[main.testPointerToMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14962,7 +15104,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1408
+      ID: 1424
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14988,7 +15130,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1424
+      ID: 1440
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 35
       PresenceBitsetSize: 1
@@ -15034,7 +15176,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1425
+      ID: 1441
       Name: Probe[main.testReturnsAnyAndError]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15060,7 +15202,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1426
+      ID: 1442
       Name: Probe[main.testReturnsAny]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15086,7 +15228,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1427
+      ID: 1443
       Name: Probe[main.testReturnsAny]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15102,10 +15244,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1456
+      ID: 1472
       Name: Probe[main.testReturnsArrayOne]
     - __kind: EventRootType
-      ID: 1457
+      ID: 1473
       Name: Probe[main.testReturnsArrayOne]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15121,10 +15263,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1458
+      ID: 1474
       Name: Probe[main.testReturnsArrayZero]
     - __kind: EventRootType
-      ID: 1459
+      ID: 1475
       Name: Probe[main.testReturnsArrayZero]Return
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -15140,10 +15282,10 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1454
+      ID: 1470
       Name: Probe[main.testReturnsArray]
     - __kind: EventRootType
-      ID: 1455
+      ID: 1471
       Name: Probe[main.testReturnsArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15159,10 +15301,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1462
+      ID: 1478
       Name: Probe[main.testReturnsBacktrackInt]
     - __kind: EventRootType
-      ID: 1463
+      ID: 1479
       Name: Probe[main.testReturnsBacktrackInt]Return
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -15258,10 +15400,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1474
+      ID: 1490
       Name: Probe[main.testReturnsBoolAndUintptr]
     - __kind: EventRootType
-      ID: 1475
+      ID: 1491
       Name: Probe[main.testReturnsBoolAndUintptr]Return
       ByteSize: 10
       PresenceBitsetSize: 1
@@ -15287,10 +15429,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1450
+      ID: 1466
       Name: Probe[main.testReturnsComplex]
     - __kind: EventRootType
-      ID: 1451
+      ID: 1467
       Name: Probe[main.testReturnsComplex]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15316,7 +15458,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1422
+      ID: 1438
       Name: Probe[main.testReturnsError]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -15342,7 +15484,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1423
+      ID: 1439
       Name: Probe[main.testReturnsError]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15358,7 +15500,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1420
+      ID: 1436
       Name: Probe[main.testReturnsIntAndFloat]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15384,7 +15526,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1421
+      ID: 1437
       Name: Probe[main.testReturnsIntAndFloat]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15410,7 +15552,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1418
+      ID: 1434
       Name: Probe[main.testReturnsIntPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15436,7 +15578,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1419
+      ID: 1435
       Name: Probe[main.testReturnsIntPointer]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15452,7 +15594,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1416
+      ID: 1432
       Name: Probe[main.testReturnsInt]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15478,7 +15620,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1417
+      ID: 1433
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15494,7 +15636,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1428
+      ID: 1444
       Name: Probe[main.testReturnsInterface]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15520,7 +15662,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1429
+      ID: 1445
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15536,10 +15678,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1452
+      ID: 1468
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1453
+      ID: 1469
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -15555,10 +15697,10 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1448
+      ID: 1464
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1449
+      ID: 1465
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 139
       PresenceBitsetSize: 3
@@ -15734,10 +15876,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1460
+      ID: 1476
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1461
+      ID: 1477
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15753,10 +15895,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1466
+      ID: 1482
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1467
+      ID: 1483
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -15812,10 +15954,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1472
+      ID: 1488
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1473
+      ID: 1489
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -15841,10 +15983,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1470
+      ID: 1486
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1471
+      ID: 1487
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15860,10 +16002,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1446
+      ID: 1462
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1447
+      ID: 1463
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -15949,10 +16091,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1468
+      ID: 1484
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1469
+      ID: 1485
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15968,10 +16110,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1464
+      ID: 1480
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1465
+      ID: 1481
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -15987,7 +16129,7 @@ Types:
                   Offset: 0
                   ByteSize: 88
     - __kind: EventRootType
-      ID: 1305
+      ID: 1321
       Name: Probe[main.testRuneArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16013,7 +16155,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1326
+      ID: 1342
       Name: Probe[main.testSingleBool]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -16039,7 +16181,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1324
+      ID: 1340
       Name: Probe[main.testSingleByte]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -16065,7 +16207,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1337
+      ID: 1353
       Name: Probe[main.testSingleFloat32]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -16091,7 +16233,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1338
+      ID: 1354
       Name: Probe[main.testSingleFloat64]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16117,7 +16259,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1329
+      ID: 1345
       Name: Probe[main.testSingleInt16]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -16143,7 +16285,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1330
+      ID: 1346
       Name: Probe[main.testSingleInt32]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -16169,7 +16311,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1331
+      ID: 1347
       Name: Probe[main.testSingleInt64]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16195,7 +16337,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1328
+      ID: 1344
       Name: Probe[main.testSingleInt8]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -16241,7 +16383,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1327
+      ID: 1343
       Name: Probe[main.testSingleInt]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16267,7 +16409,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1325
+      ID: 1341
       Name: Probe[main.testSingleRune]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -16293,7 +16435,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1509
+      ID: 1525
       Name: Probe[main.testSingleString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16319,7 +16461,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1334
+      ID: 1350
       Name: Probe[main.testSingleUint16]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -16345,7 +16487,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1335
+      ID: 1351
       Name: Probe[main.testSingleUint32]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -16371,7 +16513,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1336
+      ID: 1352
       Name: Probe[main.testSingleUint64]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16397,7 +16539,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1333
+      ID: 1349
       Name: Probe[main.testSingleUint8]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -16423,7 +16565,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1332
+      ID: 1348
       Name: Probe[main.testSingleUint]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16449,7 +16591,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1505
+      ID: 1521
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16475,7 +16617,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1496
+      ID: 1512
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16501,7 +16643,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1382
+      ID: 1398
       Name: Probe[main.testSmallMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16527,7 +16669,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1444
+      ID: 1460
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16553,7 +16695,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1445
+      ID: 1461
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16589,7 +16731,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1486
+      ID: 1502
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -16615,7 +16757,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1487
+      ID: 1503
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16651,7 +16793,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1306
+      ID: 1322
       Name: Probe[main.testStringArray]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -16677,7 +16819,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1413
+      ID: 1429
       Name: Probe[main.testStringPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16703,7 +16845,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1500
+      ID: 1516
       Name: Probe[main.testStringSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16729,7 +16871,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1348
+      ID: 1364
       Name: Probe[main.testStringType1]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16755,7 +16897,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1349
+      ID: 1365
       Name: Probe[main.testStringType2]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16781,7 +16923,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1497
+      ID: 1513
       Name: Probe[main.testStructSlice]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -16827,7 +16969,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1376
+      ID: 1392
       Name: Probe[main.testStructWithAny]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16853,7 +16995,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1490
+      ID: 1506
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16879,7 +17021,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1491
+      ID: 1507
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16905,7 +17047,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1524
+      ID: 1540
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16931,10 +17073,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1525
+      ID: 1541
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1523
+      ID: 1539
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 289
       PresenceBitsetSize: 1
@@ -16960,7 +17102,7 @@ Types:
                   Offset: 0
                   ByteSize: 144
     - __kind: EventRootType
-      ID: 1377
+      ID: 1393
       Name: Probe[main.testStructWithMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16986,7 +17128,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1526
+      ID: 1542
       Name: Probe[main.testStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17002,7 +17144,7 @@ Types:
                   Offset: 8
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1528
+      ID: 1544
       Name: Probe[main.testStruct]
       ByteSize: 113
       PresenceBitsetSize: 1
@@ -17028,13 +17170,13 @@ Types:
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1527
+      ID: 1543
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1529
+      ID: 1545
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1506
+      ID: 1522
       Name: Probe[main.testSubslices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -17100,7 +17242,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1522
+      ID: 1538
       Name: Probe[main.testSubstrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17166,7 +17308,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1515
+      ID: 1531
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17192,7 +17334,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1516
+      ID: 1532
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17237,7 +17379,7 @@ Types:
                   Bias: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1511
+      ID: 1527
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17263,7 +17405,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1513
+      ID: 1529
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17299,13 +17441,13 @@ Types:
                   Offset: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1512
+      ID: 1528
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1514
+      ID: 1530
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1510
+      ID: 1526
       Name: Probe[main.testThreeStrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17371,7 +17513,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1339
+      ID: 1355
       Name: Probe[main.testTypeAlias]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -17397,7 +17539,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1315
+      ID: 1331
       Name: Probe[main.testUint16Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -17423,7 +17565,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1316
+      ID: 1332
       Name: Probe[main.testUint32Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17449,7 +17591,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1317
+      ID: 1333
       Name: Probe[main.testUint64Array]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17475,7 +17617,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1314
+      ID: 1330
       Name: Probe[main.testUint8Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -17501,7 +17643,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1313
+      ID: 1329
       Name: Probe[main.testUintArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17527,7 +17669,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1412
+      ID: 1428
       Name: Probe[main.testUintPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17553,7 +17695,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1494
+      ID: 1510
       Name: Probe[main.testUintSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17579,7 +17721,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1520
+      ID: 1536
       Name: Probe[main.testUnitializedString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17605,7 +17747,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1411
+      ID: 1427
       Name: Probe[main.testUnsafePointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17631,7 +17773,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1323
+      ID: 1339
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 1601
       PresenceBitsetSize: 1
@@ -17657,7 +17799,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1503
+      ID: 1519
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17683,7 +17825,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1504
+      ID: 1520
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17709,7 +17851,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1492
+      ID: 1508
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17755,7 +17897,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1493
+      ID: 1509
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -18023,7 +18165,15 @@ Types:
       HasCount: true
       Element: 32 StructureType internal/runtime/atomic.Uint32
     - __kind: ArrayType
-      ID: 422
+      ID: 333
+      Name: '[3]uint64'
+      ByteSize: 24
+      GoKind: 17
+      Count: 3
+      HasCount: true
+      Element: 8 BaseType uint64
+    - __kind: ArrayType
+      ID: 438
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 679840
@@ -18032,7 +18182,7 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 379
+      ID: 395
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 680128
@@ -18058,7 +18208,15 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 980
+      ID: 334
+      Name: '[5]int64'
+      ByteSize: 40
+      GoKind: 17
+      Count: 5
+      HasCount: true
+      Element: 12 BaseType int64
+    - __kind: ArrayType
+      ID: 996
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 681664
@@ -18100,15 +18258,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 329 GoSliceDataType []*main.deepSlice2.array
+      Data: 345 GoSliceDataType []*main.deepSlice2.array
     - __kind: GoSliceDataType
-      ID: 329
+      ID: 345
       Name: '[]*main.deepSlice2.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 138 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 1218
+      ID: 1234
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 475456
@@ -18116,22 +18274,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1219 PointerType **main.deepSlice3
+          Type: 1235 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1222 GoSliceDataType []*main.deepSlice3.array
+      Data: 1238 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 1222
+      ID: 1238
       Name: '[]*main.deepSlice3.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1220 PointerType *main.deepSlice3
+      Element: 1236 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 1243
+      ID: 1259
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 475136
@@ -18139,22 +18297,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1244 PointerType **main.deepSlice8
+          Type: 1260 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1247 GoSliceDataType []*main.deepSlice8.array
+      Data: 1263 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 1247
+      ID: 1263
       Name: '[]*main.deepSlice8.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1245 PointerType *main.deepSlice8
+      Element: 1261 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 1249
+      ID: 1265
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 475072
@@ -18162,20 +18320,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1250 PointerType **main.deepSlice9
+          Type: 1266 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1253 GoSliceDataType []*main.deepSlice9.array
+      Data: 1269 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 1253
+      ID: 1269
       Name: '[]*main.deepSlice9.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1251 PointerType *main.deepSlice9
+      Element: 1267 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 127
       Name: '[]*string'
@@ -18192,171 +18350,171 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 326 GoSliceDataType []*string.array
+      Data: 342 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 326
+      ID: 342
       Name: '[]*string.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 93 PointerType *string
     - __kind: GoSliceDataType
-      ID: 439
+      ID: 455
       Name: '[]*table<[4]int,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 225 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 431
+      ID: 447
       Name: '[]*table<[4]int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 220 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 380
+      ID: 396
       Name: '[]*table<[4]string,[2]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 188 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 398
+      ID: 414
       Name: '[]*table<bool,main.node>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 200 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 339
+      ID: 355
       Name: '[]*table<int,*main.deepMap2>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 146 PointerType *table<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 1237
+      ID: 1253
       Name: '[]*table<int,*main.deepMap3>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1228 PointerType *table<int,*main.deepMap3>
+      Element: 1244 PointerType *table<int,*main.deepMap3>
     - __kind: GoSliceDataType
-      ID: 1271
+      ID: 1287
       Name: '[]*table<int,*main.deepMap8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1262 PointerType *table<int,*main.deepMap8>
+      Element: 1278 PointerType *table<int,*main.deepMap8>
     - __kind: GoSliceDataType
-      ID: 1286
+      ID: 1302
       Name: '[]*table<int,*main.deepMap9>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1277 PointerType *table<int,*main.deepMap9>
+      Element: 1293 PointerType *table<int,*main.deepMap9>
     - __kind: GoSliceDataType
-      ID: 347
+      ID: 363
       Name: '[]*table<int,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 168 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 1299
+      ID: 1315
       Name: '[]*table<int,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1292 PointerType *table<int,interface {}>
+      Element: 1308 PointerType *table<int,interface {}>
     - __kind: GoSliceDataType
-      ID: 455
+      ID: 471
       Name: '[]*table<int,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 235 PointerType *table<int,struct {}>
     - __kind: GoSliceDataType
-      ID: 406
+      ID: 422
       Name: '[]*table<int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 205 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 390
+      ID: 406
       Name: '[]*table<string,[]main.structWithMap>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 195 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 371
+      ID: 387
       Name: '[]*table<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 183 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 996
+      ID: 1012
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 963 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 979 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 363
+      ID: 379
       Name: '[]*table<string,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 178 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 355
+      ID: 371
       Name: '[]*table<string,main.nestedStruct>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 173 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 447
+      ID: 463
       Name: '[]*table<struct {},int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 230 PointerType *table<struct {},int>
     - __kind: GoSliceDataType
-      ID: 497
+      ID: 513
       Name: '[]*table<struct {},main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 288 PointerType *table<struct {},main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 505
+      ID: 521
       Name: '[]*table<struct {},map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 293 PointerType *table<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 513
+      ID: 529
       Name: '[]*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 298 PointerType *table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 521
+      ID: 537
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 303 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 529
+      ID: 545
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 308 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 537
+      ID: 553
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 313 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 463
+      ID: 479
       Name: '[]*table<struct {},struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 240 PointerType *table<struct {},struct {}>
     - __kind: GoSliceDataType
-      ID: 423
+      ID: 439
       Name: '[]*table<uint8,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 215 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 414
+      ID: 430
       Name: '[]*table<uint8,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
@@ -18376,9 +18534,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 489 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Data: 505 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 489
+      ID: 505
       Name: '[][][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -18398,9 +18556,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 487 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Data: 503 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 487
+      ID: 503
       Name: '[][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -18420,9 +18578,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 485 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Data: 501 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 485
+      ID: 501
       Name: '[][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -18442,9 +18600,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 483 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Data: 499 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 483
+      ID: 499
       Name: '[][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -18464,9 +18622,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 481 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Data: 497 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 481
+      ID: 497
       Name: '[][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -18486,9 +18644,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 467 GoSliceDataType [][]uint.array
+      Data: 483 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 467
+      ID: 483
       Name: '[][]uint.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -18509,15 +18667,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 473 GoSliceDataType []bool.array
+      Data: 489 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 473
+      ID: 489
       Name: '[]bool.array'
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 975
+      ID: 991
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 484480
@@ -18532,15 +18690,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 998 GoSliceDataType []float64.array
+      Data: 1014 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 998
+      ID: 1014
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 18 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 1255
+      ID: 1271
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 484928
@@ -18555,9 +18713,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1256 GoSliceDataType []interface {}.array
+      Data: 1272 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 1256
+      ID: 1272
       Name: '[]interface {}.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -18577,15 +18735,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 479 GoSliceDataType []main.structWithCyclicSlices.array
+      Data: 495 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 479
+      ID: 495
       Name: '[]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 144
       Element: 270 StructureType main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 388
+      ID: 404
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 475776
@@ -18593,16 +18751,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 389 PointerType *main.structWithMap
+          Type: 405 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 539 GoSliceDataType []main.structWithMap.array
+      Data: 555 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 539
+      ID: 555
       Name: '[]main.structWithMap.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -18622,175 +18780,175 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 469 GoSliceDataType []main.structWithNoStrings.array
+      Data: 485 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 469
+      ID: 485
       Name: '[]main.structWithNoStrings.array'
       DynamicSizeClass: slice
       ByteSize: 2
       Element: 260 StructureType main.structWithNoStrings
     - __kind: GoSliceDataType
-      ID: 440
+      ID: 456
       Name: '[]noalg.map.group[[4]int][4]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 520
-      Element: 436 StructureType noalg.map.group[[4]int][4]int
+      Element: 452 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 432
+      ID: 448
       Name: '[]noalg.map.group[[4]int]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 428 StructureType noalg.map.group[[4]int]uint8
+      Element: 444 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 381
+      ID: 397
       Name: '[]noalg.map.group[[4]string][2]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 648
-      Element: 376 StructureType noalg.map.group[[4]string][2]int
+      Element: 392 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 399
+      ID: 415
       Name: '[]noalg.map.group[bool]main.node.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 395 StructureType noalg.map.group[bool]main.node
+      Element: 411 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
-      ID: 340
+      ID: 356
       Name: '[]noalg.map.group[int]*main.deepMap2.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 334 StructureType noalg.map.group[int]*main.deepMap2
+      Element: 350 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSliceDataType
-      ID: 1238
+      ID: 1254
       Name: '[]noalg.map.group[int]*main.deepMap3.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1232 StructureType noalg.map.group[int]*main.deepMap3
+      Element: 1248 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSliceDataType
-      ID: 1272
+      ID: 1288
       Name: '[]noalg.map.group[int]*main.deepMap8.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1266 StructureType noalg.map.group[int]*main.deepMap8
+      Element: 1282 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSliceDataType
-      ID: 1287
+      ID: 1303
       Name: '[]noalg.map.group[int]*main.deepMap9.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1281 StructureType noalg.map.group[int]*main.deepMap9
+      Element: 1297 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSliceDataType
-      ID: 348
+      ID: 364
       Name: '[]noalg.map.group[int]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 344 StructureType noalg.map.group[int]int
+      Element: 360 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 1300
+      ID: 1316
       Name: '[]noalg.map.group[int]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 1296 StructureType noalg.map.group[int]interface {}
+      Element: 1312 StructureType noalg.map.group[int]interface {}
     - __kind: GoSliceDataType
-      ID: 456
+      ID: 472
       Name: '[]noalg.map.group[int]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 452 StructureType noalg.map.group[int]struct {}
+      Element: 468 StructureType noalg.map.group[int]struct {}
     - __kind: GoSliceDataType
-      ID: 407
+      ID: 423
       Name: '[]noalg.map.group[int]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 403 StructureType noalg.map.group[int]uint8
+      Element: 419 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
-      ID: 391
+      ID: 407
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 385 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 401 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
-      ID: 372
+      ID: 388
       Name: '[]noalg.map.group[string][]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 368 StructureType noalg.map.group[string][]string
+      Element: 384 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 997
+      ID: 1013
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 993 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 1009 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
-      ID: 364
+      ID: 380
       Name: '[]noalg.map.group[string]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 360 StructureType noalg.map.group[string]int
+      Element: 376 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 356
+      ID: 372
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 352 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 368 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 448
+      ID: 464
       Name: '[]noalg.map.group[struct {}]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 444 StructureType noalg.map.group[struct {}]int
+      Element: 460 StructureType noalg.map.group[struct {}]int
     - __kind: GoSliceDataType
-      ID: 498
+      ID: 514
       Name: '[]noalg.map.group[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 392
-      Element: 494 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      Element: 510 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 506
+      ID: 522
       Name: '[]noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 502 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 518 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 514
+      ID: 530
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 510 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 526 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 522
+      ID: 538
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 518 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 534 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 530
+      ID: 546
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 526 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 542 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 538
+      ID: 554
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 534 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 550 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 464
+      ID: 480
       Name: '[]noalg.map.group[struct {}]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 16
-      Element: 460 StructureType noalg.map.group[struct {}]struct {}
+      Element: 476 StructureType noalg.map.group[struct {}]struct {}
     - __kind: GoSliceDataType
-      ID: 424
+      ID: 440
       Name: '[]noalg.map.group[uint8][4]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 419 StructureType noalg.map.group[uint8][4]int
+      Element: 435 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 415
+      ID: 431
       Name: '[]noalg.map.group[uint8]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 24
-      Element: 411 StructureType noalg.map.group[uint8]uint8
+      Element: 427 StructureType noalg.map.group[uint8]uint8
     - __kind: UnresolvedPointeeType
       ID: 40
       Name: '[]runtime.ancestorInfo'
@@ -18811,9 +18969,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 471 GoSliceDataType []string.array
+      Data: 487 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 471
+      ID: 487
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -18833,9 +18991,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 477 GoSliceDataType []struct {}.array
+      Data: 493 GoSliceDataType []struct {}.array
     - __kind: GoSliceDataType
-      ID: 477
+      ID: 493
       Name: '[]struct {}.array'
       DynamicSizeClass: slice
       Element: 123 StructureType struct {}
@@ -18855,9 +19013,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 465 GoSliceDataType []uint.array
+      Data: 481 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 465
+      ID: 481
       Name: '[]uint.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -18878,9 +19036,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 475 GoSliceDataType []uint16.array
+      Data: 491 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 475
+      ID: 491
       Name: '[]uint16.array'
       DynamicSizeClass: slice
       ByteSize: 2
@@ -18901,9 +19059,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 322 GoSliceDataType []uint8.array
+      Data: 338 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 322
+      ID: 338
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -18924,19 +19082,19 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 324 GoSliceDataType []uintptr.array
+      Data: 340 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 324
+      ID: 340
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 1 BaseType uintptr
     - __kind: UnresolvedPointeeType
-      ID: 1130
+      ID: 1146
       Name: archive/tar.Writer
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 771
+      ID: 787
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 927712
@@ -18951,33 +19109,33 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 772 GoSliceDataType archive/tar.headerError.array
+      Data: 788 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 772
+      ID: 788
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1065
+      ID: 1081
       Name: archive/tar.regFileWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1013
+      ID: 1029
       Name: archive/zip.countWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1015
+      ID: 1031
       Name: archive/zip.dirWriter
       GoRuntimeType: 1.11648e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1113
+      ID: 1129
       Name: archive/zip.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1041
+      ID: 1057
       Name: archive/zip.nopCloser
       ByteSize: 16
       GoRuntimeType: 1.561664e+06
@@ -18987,7 +19145,7 @@ Types:
           Offset: 0
           Type: 129 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1043
+      ID: 1059
       Name: archive/zip.pooledFlateWriter
       ByteSize: 8
     - __kind: BaseType
@@ -18997,15 +19155,15 @@ Types:
       GoRuntimeType: 582112
       GoKind: 1
     - __kind: UnresolvedPointeeType
-      ID: 1088
+      ID: 1104
       Name: bufio.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1117
+      ID: 1133
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1168
+      ID: 1184
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
@@ -19031,13 +19189,13 @@ Types:
       GoRuntimeType: 581856
       GoKind: 15
     - __kind: BaseType
-      ID: 574
+      ID: 590
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 832128
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 575
+      ID: 591
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 832224
@@ -19045,110 +19203,110 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 577 PointerType *compress/flate.InternalError.str
+          Type: 593 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 576 GoStringDataType compress/flate.InternalError.str
+      Data: 592 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 576
+      ID: 592
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1063
+      ID: 1079
       Name: compress/flate.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1009
+      ID: 1025
       Name: compress/flate.dictWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1085
+      ID: 1101
       Name: compress/gzip.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 915
+      ID: 931
       Name: context.deadlineExceededError
       GoRuntimeType: 1.476064e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 588
+      ID: 604
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 834720
       GoKind: 2
     - __kind: BaseType
-      ID: 589
+      ID: 605
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 834816
       GoKind: 2
     - __kind: BaseType
-      ID: 590
+      ID: 606
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 834912
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1075
+      ID: 1091
       Name: crypto/internal/fips140/hmac.HMAC
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1109
+      ID: 1125
       Name: crypto/internal/fips140/sha256.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1141
+      ID: 1157
       Name: crypto/internal/fips140/sha3.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1115
+      ID: 1131
       Name: crypto/internal/fips140/sha3.SHAKE
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1111
+      ID: 1127
       Name: crypto/internal/fips140/sha512.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1107
+      ID: 1123
       Name: crypto/md5.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 591
+      ID: 607
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 835008
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1125
+      ID: 1141
       Name: crypto/sha1.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1097
+      ID: 1113
       Name: crypto/sha3.SHA3
       ByteSize: 8
     - __kind: BaseType
-      ID: 578
+      ID: 594
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 832704
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 855
+      ID: 871
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1194
+      ID: 1210
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 687
+      ID: 703
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 685
+      ID: 701
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1.725088e+06
@@ -19159,34 +19317,34 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 980 ArrayType [5]uint8
+          Type: 996 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 981 GoInterfaceType net.Conn
+          Type: 997 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 810
+      ID: 826
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 989952
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1073
+      ID: 1089
       Name: crypto/tls.cthWrapper
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1080
+      ID: 1096
       Name: crypto/tls.finishedHash
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 950
+      ID: 966
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 965
+      ID: 981
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 759
+      ID: 775
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1.727968e+06
@@ -19194,21 +19352,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 964 PointerType *crypto/x509.Certificate
+          Type: 980 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 983 BaseType crypto/x509.InvalidReason
+          Type: 999 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 753
+      ID: 769
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1.114048e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 755
+      ID: 771
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1.596384e+06
@@ -19216,24 +19374,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 964 PointerType *crypto/x509.Certificate
+          Type: 980 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 587
+      ID: 603
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 834336
       GoKind: 2
     - __kind: BaseType
-      ID: 983
+      ID: 999
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 587296
       GoKind: 2
     - __kind: StructureType
-      ID: 860
+      ID: 876
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1.557664e+06
@@ -19243,13 +19401,13 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 761
+      ID: 777
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1.114304e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 757
+      ID: 773
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1.727776e+06
@@ -19257,15 +19415,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 964 PointerType *crypto/x509.Certificate
+          Type: 980 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 13 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 964 PointerType *crypto/x509.Certificate
+          Type: 980 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 775
+      ID: 791
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1.433504e+06
@@ -19275,7 +19433,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 779
+      ID: 795
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1.433664e+06
@@ -19285,55 +19443,55 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 777
+      ID: 793
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 572
+      ID: 588
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 831744
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 1031
+      ID: 1047
       Name: encoding/base64.encoder
       ByteSize: 8
     - __kind: BaseType
-      ID: 573
+      ID: 589
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 831936
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 644
+      ID: 660
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 846
+      ID: 862
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 636
+      ID: 652
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 642
+      ID: 658
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 640
+      ID: 656
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 638
+      ID: 654
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1174
+      ID: 1190
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 646
+      ID: 662
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1.417344e+06
@@ -19343,19 +19501,19 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1039
+      ID: 1055
       Name: encoding/pem.lineBreaker
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 747
+      ID: 763
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 745
+      ID: 761
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 584
+      ID: 600
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 834240
@@ -19363,22 +19521,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 586 PointerType *encoding/xml.UnmarshalError.str
+          Type: 602 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 585 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 601 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 585
+      ID: 601
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 750
+      ID: 766
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1152
+      ID: 1168
       Name: encoding/xml.printer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -19395,11 +19553,11 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 614
+      ID: 630
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 813
+      ID: 829
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -19415,15 +19573,15 @@ Types:
       GoRuntimeType: 582048
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 1162
+      ID: 1178
       Name: fmt.pp
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 815
+      ID: 831
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 817
+      ID: 833
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -19439,11 +19597,11 @@ Types:
       GoRuntimeType: 845856
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 674
+      ID: 690
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 655
+      ID: 671
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1.723936e+06
@@ -19451,7 +19609,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 973 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 989 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 7 BaseType int
@@ -19459,25 +19617,25 @@ Types:
           Offset: 200
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 657
+      ID: 673
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 977
+      ID: 993
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 661
+      ID: 677
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1.110336e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 979
+      ID: 995
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 566
+      ID: 582
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 831168
@@ -19485,18 +19643,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 568 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 584 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 567 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 583 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 567
+      ID: 583
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 973
+      ID: 989
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2.21312e+06
@@ -19504,7 +19662,7 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 974 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 990 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -19519,7 +19677,7 @@ Types:
           Type: 18 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 975 GoSliceHeaderType []float64
+          Type: 991 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 12 BaseType int64
@@ -19528,10 +19686,10 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 976 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 992 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 978 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 994 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
           Type: 261 GoSliceHeaderType []string
@@ -19545,13 +19703,13 @@ Types:
           Offset: 184
           Type: 12 BaseType int64
     - __kind: BaseType
-      ID: 974
+      ID: 990
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 583904
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 563
+      ID: 579
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 831072
@@ -19559,18 +19717,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 565 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 581 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 564 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 580 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 564
+      ID: 580
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 569
+      ID: 585
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 831264
@@ -19578,60 +19736,60 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 571 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 587 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 570 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 586 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 570
+      ID: 586
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1053
+      ID: 1069
       Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1138
+      ID: 1154
       Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 769
+      ID: 785
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 924
+      ID: 940
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1170
+      ID: 1186
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 696
+      ID: 712
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 703
+      ID: 719
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1.11328e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 583
+      ID: 599
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 833376
       GoKind: 2
     - __kind: StructureType
-      ID: 701
+      ID: 717
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1.113152e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 699
+      ID: 715
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1.594464e+06
@@ -19644,7 +19802,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 719
+      ID: 735
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1.595264e+06
@@ -19657,7 +19815,7 @@ Types:
           Offset: 16
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 723
+      ID: 739
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1.7272e+06
@@ -19673,7 +19831,7 @@ Types:
           Offset: 24
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 721
+      ID: 737
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1.427104e+06
@@ -19683,7 +19841,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 717
+      ID: 733
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1.426784e+06
@@ -19693,14 +19851,14 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 959
+      ID: 975
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1.497024e+06
       GoKind: 21
-      HeaderType: 961 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 977 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 982
+      ID: 998
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1.047328e+06
@@ -19715,15 +19873,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1000 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 1016 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 1000
+      ID: 1016
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 731
+      ID: 747
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1.595584e+06
@@ -19731,12 +19889,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 959 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 975 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 959 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 975 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 725
+      ID: 741
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1.427264e+06
@@ -19746,7 +19904,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 729
+      ID: 745
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1.727392e+06
@@ -19757,12 +19915,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 982 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 998 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 982 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 998 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 727
+      ID: 743
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1.595424e+06
@@ -19775,7 +19933,7 @@ Types:
           Offset: 8
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 733
+      ID: 749
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1.427424e+06
@@ -19783,9 +19941,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 951 StructureType time.Time
+          Type: 967 StructureType time.Time
     - __kind: StructureType
-      ID: 739
+      ID: 755
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1.595904e+06
@@ -19798,7 +19956,7 @@ Types:
           Offset: 8
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 741
+      ID: 757
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1.427744e+06
@@ -19808,7 +19966,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 737
+      ID: 753
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1.595744e+06
@@ -19821,7 +19979,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 735
+      ID: 751
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1.427584e+06
@@ -19831,7 +19989,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 743
+      ID: 759
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1.596064e+06
@@ -19844,7 +20002,7 @@ Types:
           Offset: 8
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 663
+      ID: 679
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1.419584e+06
@@ -19854,11 +20012,11 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1091
+      ID: 1107
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 665
+      ID: 681
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1.419744e+06
@@ -19866,21 +20024,21 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 663 StructureType github.com/cihub/seelog.baseError
+          Type: 679 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1071
+      ID: 1087
       Name: github.com/cihub/seelog.connWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1027
+      ID: 1043
       Name: github.com/cihub/seelog.consoleWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1061
+      ID: 1077
       Name: github.com/cihub/seelog.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 669
+      ID: 685
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1.420064e+06
@@ -19888,13 +20046,13 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 663 StructureType github.com/cihub/seelog.baseError
+          Type: 679 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1128
+      ID: 1144
       Name: github.com/cihub/seelog.rollingFileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1139
+      ID: 1155
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
       GoRuntimeType: 2.101504e+06
@@ -19902,12 +20060,12 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1127 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1143 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: maxFileSize
           Offset: 8
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 1142
+      ID: 1158
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
       GoRuntimeType: 2.125312e+06
@@ -19915,7 +20073,7 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1127 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1143 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: timePattern
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -19923,11 +20081,11 @@ Types:
           Offset: 24
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1029
+      ID: 1045
       Name: github.com/cihub/seelog.smtpWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 667
+      ID: 683
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1.419904e+06
@@ -19935,9 +20093,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 663 StructureType github.com/cihub/seelog.baseError
+          Type: 679 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 671
+      ID: 687
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1.420224e+06
@@ -19945,64 +20103,64 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 663 StructureType github.com/cihub/seelog.baseError
+          Type: 679 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1093
+      ID: 1109
       Name: github.com/cihub/seelog/archive/gzip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1134
+      ID: 1150
       Name: github.com/cihub/seelog/archive/tar.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1136
+      ID: 1152
       Name: github.com/cihub/seelog/archive/zip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 955
+      ID: 971
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 868
+      ID: 884
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 866
+      ID: 882
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 870
+      ID: 886
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 872
+      ID: 888
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1082
+      ID: 1098
       Name: github.com/gogo/protobuf/proto.textWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 862
+      ID: 878
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 677
+      ID: 693
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1.421184e+06
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 7 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 1186
+      ID: 1202
       Name: github.com/json-iterator/go.Stream
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 926
+      ID: 942
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 899
+      ID: 915
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1.8352e+06
@@ -20018,11 +20176,11 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 893
+      ID: 909
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 832
+      ID: 848
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1.697984e+06
@@ -20035,7 +20193,7 @@ Types:
           Offset: 1
           Type: 15 BaseType int8
     - __kind: StructureType
-      ID: 905
+      ID: 921
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1.835648e+06
@@ -20051,13 +20209,13 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 809
+      ID: 825
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 987264
       GoKind: 8
     - __kind: StructureType
-      ID: 897
+      ID: 913
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1.834976e+06
@@ -20073,13 +20231,13 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 984
+      ID: 1000
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 829344
       GoKind: 8
     - __kind: StructureType
-      ID: 895
+      ID: 911
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1.834752e+06
@@ -20087,15 +20245,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 984 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 1000 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 984 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 1000 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 903
+      ID: 919
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1.74944e+06
@@ -20108,7 +20266,7 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 901
+      ID: 917
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1.835424e+06
@@ -20124,11 +20282,11 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1190
+      ID: 1206
       Name: github.com/tinylib/msgp/msgp.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 909
+      ID: 925
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1.620128e+06
@@ -20138,19 +20296,19 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 836
+      ID: 852
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1.280128e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 834
+      ID: 850
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1.28e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 907
+      ID: 923
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1.749632e+06
@@ -20163,7 +20321,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 596
+      ID: 612
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 836832
@@ -20171,22 +20329,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 598 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 614 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 597 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 613 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 597
+      ID: 613
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 968
+      ID: 984
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 876
+      ID: 892
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1.445344e+06
@@ -20196,7 +20354,7 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 1059
+      ID: 1075
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
       GoRuntimeType: 1.67408e+06
@@ -20204,13 +20362,13 @@ Types:
       RawFields:
         - Name: WriteSyncer
           Offset: 0
-          Type: 1083 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+          Type: 1099 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
     - __kind: UnresolvedPointeeType
-      ID: 1150
+      ID: 1166
       Name: go.uber.org/zap/buffer.Buffer
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1083
+      ID: 1099
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
       GoRuntimeType: 1.124032e+06
@@ -20223,7 +20381,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1045
+      ID: 1061
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
       GoRuntimeType: 1.566624e+06
@@ -20233,19 +20391,19 @@ Types:
           Offset: 0
           Type: 129 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 599
+      ID: 615
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 837408
       GoKind: 10
     - __kind: BaseType
-      ID: 966
+      ID: 982
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 1.000416e+06
       GoKind: 10
     - __kind: StructureType
-      ID: 934
+      ID: 950
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1.8744e+06
@@ -20256,12 +20414,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 966 BaseType golang.org/x/net/http2.ErrCode
+          Type: 982 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 795
+      ID: 811
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1.603104e+06
@@ -20269,12 +20427,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 966 BaseType golang.org/x/net/http2.ErrCode
+          Type: 982 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 603
+      ID: 619
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 837600
@@ -20282,18 +20440,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 605 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 621 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 604 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 620 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 604
+      ID: 620
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 609
+      ID: 625
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 837792
@@ -20301,18 +20459,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 611 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 627 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 610 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 626 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 610
+      ID: 626
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 606
+      ID: 622
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 837696
@@ -20320,18 +20478,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 608 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 624 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 607 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 623 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 607
+      ID: 623
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 600
+      ID: 616
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 837504
@@ -20339,22 +20497,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 602 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 618 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 601 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 617 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 601
+      ID: 617
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1148
+      ID: 1164
       Name: golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 799
+      ID: 815
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.445984e+06
@@ -20364,13 +20522,13 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: BaseType
-      ID: 612
+      ID: 628
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 837888
       GoKind: 2
     - __kind: StructureType
-      ID: 787
+      ID: 803
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1.441024e+06
@@ -20380,11 +20538,11 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 932
+      ID: 948
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 957
+      ID: 973
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1.902304e+06
@@ -20400,7 +20558,7 @@ Types:
           Offset: 24
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 789
+      ID: 805
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1.602624e+06
@@ -20413,7 +20571,7 @@ Types:
           Offset: 16
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 1099
+      ID: 1115
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
       GoRuntimeType: 1.959872e+06
@@ -20421,16 +20579,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 981 GoInterfaceType net.Conn
+          Type: 997 GoInterfaceType net.Conn
         - Name: r
           Offset: 16
-          Type: 1126 GoInterfaceType io.Reader
+          Type: 1142 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 1057
+      ID: 1073
       Name: google.golang.org/grpc/internal/transport.bufWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 874
+      ID: 890
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1.564224e+06
@@ -20440,29 +20598,29 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1017
+      ID: 1033
       Name: google.golang.org/grpc/mem.writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 767
+      ID: 783
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 864
+      ID: 880
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 930
+      ID: 946
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 928
+      ID: 944
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1.507584e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 781
+      ID: 797
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1.434304e+06
@@ -20472,7 +20630,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 783
+      ID: 799
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1.434464e+06
@@ -20482,393 +20640,393 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 711
+      ID: 727
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 434
+      ID: 450
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 435 PointerType *noalg.map.group[[4]int][4]int
+          Type: 451 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 436 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 440 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      GroupType: 452 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 456 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 426
+      ID: 442
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 427 PointerType *noalg.map.group[[4]int]uint8
+          Type: 443 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 428 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 432 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 444 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 448 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 374
+      ID: 390
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 375 PointerType *noalg.map.group[[4]string][2]int
+          Type: 391 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 376 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 381 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 392 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 397 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 393
+      ID: 409
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 394 PointerType *noalg.map.group[bool]main.node
+          Type: 410 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 395 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 399 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 411 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 415 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 332
+      ID: 348
       Name: groupReference<int,*main.deepMap2>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 333 PointerType *noalg.map.group[int]*main.deepMap2
+          Type: 349 PointerType *noalg.map.group[int]*main.deepMap2
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 334 StructureType noalg.map.group[int]*main.deepMap2
-      GroupSliceType: 340 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
+      GroupType: 350 StructureType noalg.map.group[int]*main.deepMap2
+      GroupSliceType: 356 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
     - __kind: GoSwissMapGroupsType
-      ID: 1230
+      ID: 1246
       Name: groupReference<int,*main.deepMap3>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1231 PointerType *noalg.map.group[int]*main.deepMap3
+          Type: 1247 PointerType *noalg.map.group[int]*main.deepMap3
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1232 StructureType noalg.map.group[int]*main.deepMap3
-      GroupSliceType: 1238 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+      GroupType: 1248 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 1254 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
     - __kind: GoSwissMapGroupsType
-      ID: 1264
+      ID: 1280
       Name: groupReference<int,*main.deepMap8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1265 PointerType *noalg.map.group[int]*main.deepMap8
+          Type: 1281 PointerType *noalg.map.group[int]*main.deepMap8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1266 StructureType noalg.map.group[int]*main.deepMap8
-      GroupSliceType: 1272 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
+      GroupType: 1282 StructureType noalg.map.group[int]*main.deepMap8
+      GroupSliceType: 1288 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
     - __kind: GoSwissMapGroupsType
-      ID: 1279
+      ID: 1295
       Name: groupReference<int,*main.deepMap9>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1280 PointerType *noalg.map.group[int]*main.deepMap9
+          Type: 1296 PointerType *noalg.map.group[int]*main.deepMap9
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1281 StructureType noalg.map.group[int]*main.deepMap9
-      GroupSliceType: 1287 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
+      GroupType: 1297 StructureType noalg.map.group[int]*main.deepMap9
+      GroupSliceType: 1303 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
     - __kind: GoSwissMapGroupsType
-      ID: 342
+      ID: 358
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 343 PointerType *noalg.map.group[int]int
+          Type: 359 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 344 StructureType noalg.map.group[int]int
-      GroupSliceType: 348 GoSliceDataType []noalg.map.group[int]int.array
+      GroupType: 360 StructureType noalg.map.group[int]int
+      GroupSliceType: 364 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 1294
+      ID: 1310
       Name: groupReference<int,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1295 PointerType *noalg.map.group[int]interface {}
+          Type: 1311 PointerType *noalg.map.group[int]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1296 StructureType noalg.map.group[int]interface {}
-      GroupSliceType: 1300 GoSliceDataType []noalg.map.group[int]interface {}.array
+      GroupType: 1312 StructureType noalg.map.group[int]interface {}
+      GroupSliceType: 1316 GoSliceDataType []noalg.map.group[int]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 450
+      ID: 466
       Name: groupReference<int,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 451 PointerType *noalg.map.group[int]struct {}
+          Type: 467 PointerType *noalg.map.group[int]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 452 StructureType noalg.map.group[int]struct {}
-      GroupSliceType: 456 GoSliceDataType []noalg.map.group[int]struct {}.array
+      GroupType: 468 StructureType noalg.map.group[int]struct {}
+      GroupSliceType: 472 GoSliceDataType []noalg.map.group[int]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 401
+      ID: 417
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 402 PointerType *noalg.map.group[int]uint8
+          Type: 418 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 403 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 407 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 419 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 423 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 383
+      ID: 399
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 384 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 400 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 385 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 391 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 401 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 407 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 366
+      ID: 382
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 367 PointerType *noalg.map.group[string][]string
+          Type: 383 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 368 StructureType noalg.map.group[string][]string
-      GroupSliceType: 372 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 384 StructureType noalg.map.group[string][]string
+      GroupSliceType: 388 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 991
+      ID: 1007
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 992 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1008 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 993 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 997 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 1009 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 1013 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
-      ID: 358
+      ID: 374
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 359 PointerType *noalg.map.group[string]int
+          Type: 375 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 360 StructureType noalg.map.group[string]int
-      GroupSliceType: 364 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 376 StructureType noalg.map.group[string]int
+      GroupSliceType: 380 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 350
+      ID: 366
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 351 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 367 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 352 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 356 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+      GroupType: 368 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 372 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 442
+      ID: 458
       Name: groupReference<struct {},int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 443 PointerType *noalg.map.group[struct {}]int
+          Type: 459 PointerType *noalg.map.group[struct {}]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 444 StructureType noalg.map.group[struct {}]int
-      GroupSliceType: 448 GoSliceDataType []noalg.map.group[struct {}]int.array
+      GroupType: 460 StructureType noalg.map.group[struct {}]int
+      GroupSliceType: 464 GoSliceDataType []noalg.map.group[struct {}]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 492
+      ID: 508
       Name: groupReference<struct {},main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 493 PointerType *noalg.map.group[struct {}]main.structWithCyclicMaps
+          Type: 509 PointerType *noalg.map.group[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 494 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 498 GoSliceDataType []noalg.map.group[struct {}]main.structWithCyclicMaps.array
+      GroupType: 510 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 514 GoSliceDataType []noalg.map.group[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 500
+      ID: 516
       Name: groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 501 PointerType *noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 517 PointerType *noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 502 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 506 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 518 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 522 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 508
+      ID: 524
       Name: groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 509 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 525 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 510 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 514 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 526 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 530 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 516
+      ID: 532
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 517 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 533 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 518 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 522 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 534 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 538 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 524
+      ID: 540
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 525 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 541 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 526 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 530 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 542 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 546 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 532
+      ID: 548
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 533 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 549 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 534 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 538 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 550 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 554 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 458
+      ID: 474
       Name: groupReference<struct {},struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 459 PointerType *noalg.map.group[struct {}]struct {}
+          Type: 475 PointerType *noalg.map.group[struct {}]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 460 StructureType noalg.map.group[struct {}]struct {}
-      GroupSliceType: 464 GoSliceDataType []noalg.map.group[struct {}]struct {}.array
+      GroupType: 476 StructureType noalg.map.group[struct {}]struct {}
+      GroupSliceType: 480 GoSliceDataType []noalg.map.group[struct {}]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 417
+      ID: 433
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 418 PointerType *noalg.map.group[uint8][4]int
+          Type: 434 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 419 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 424 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 435 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 440 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 409
+      ID: 425
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 410 PointerType *noalg.map.group[uint8]uint8
+          Type: 426 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 411 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 415 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 427 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 431 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: UnresolvedPointeeType
-      ID: 1105
+      ID: 1121
       Name: hash/crc32.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 802
+      ID: 818
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -20915,7 +21073,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 681
+      ID: 697
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -20941,29 +21099,29 @@ Types:
           Offset: 296
           Type: 2 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 679
+      ID: 695
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1003
+      ID: 1019
       Name: internal/godebug.runtimeStderr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 891
+      ID: 907
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1192
+      ID: 1208
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 889
+      ID: 905
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1.472864e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 616
+      ID: 632
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -21044,7 +21202,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1204
+      ID: 1220
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.470304e+06
@@ -21057,11 +21215,11 @@ Types:
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 1049
+      ID: 1065
       Name: io.PipeWriter
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1089
+      ID: 1105
       Name: io.ReadWriteCloser
       ByteSize: 16
       GoRuntimeType: 1.187392e+06
@@ -21074,7 +21232,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1126
+      ID: 1142
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 1.020704e+06
@@ -21087,7 +21245,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1078
+      ID: 1094
       Name: io.WriteCloser
       ByteSize: 16
       GoRuntimeType: 1.106624e+06
@@ -21113,21 +21271,21 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1047
+      ID: 1063
       Name: io.discard
       GoRuntimeType: 1.460704e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1021
+      ID: 1037
       Name: io.multiWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 887
+      ID: 903
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1095
+      ID: 1111
       Name: log/slog/internal/buffer.Buffer
       ByteSize: 8
     - __kind: StructureType
@@ -21156,7 +21314,25 @@ Types:
       RawFields:
         - Name: nested
           Offset: 0
-          Type: 1301 PointerType *main.nestedStruct
+          Type: 1317 PointerType *main.nestedStruct
+    - __kind: StructureType
+      ID: 323
+      Name: main.bStruct
+      ByteSize: 72
+      GoKind: 25
+      RawFields:
+        - Name: aInt16
+          Offset: 0
+          Type: 102 BaseType int16
+        - Name: nested
+          Offset: 8
+          Type: 314 StructureType main.aStruct
+        - Name: aBool
+          Offset: 64
+          Type: 4 BaseType bool
+        - Name: aInt32
+          Offset: 68
+          Type: 10 BaseType int32
     - __kind: GoInterfaceType
       ID: 160
       Name: main.behavior
@@ -21186,6 +21362,21 @@ Types:
           Offset: 32
           Type: 129 GoInterfaceType io.Writer
     - __kind: StructureType
+      ID: 320
+      Name: main.cStruct
+      ByteSize: 24
+      GoKind: 25
+      RawFields:
+        - Name: aInt32
+          Offset: 0
+          Type: 10 BaseType int32
+        - Name: aUint
+          Offset: 8
+          Type: 16 BaseType uint
+        - Name: nested
+          Offset: 16
+          Type: 260 StructureType main.structWithNoStrings
+    - __kind: StructureType
       ID: 141
       Name: main.deepMap1
       ByteSize: 8
@@ -21196,7 +21387,7 @@ Types:
           Offset: 0
           Type: 142 GoMapType map[int]*main.deepMap2
     - __kind: StructureType
-      ID: 338
+      ID: 354
       Name: main.deepMap2
       ByteSize: 8
       GoRuntimeType: 1.18368e+06
@@ -21204,9 +21395,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1224 GoMapType map[int]*main.deepMap3
+          Type: 1240 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 1236
+      ID: 1252
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -21218,9 +21409,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1258 GoMapType map[int]*main.deepMap8
+          Type: 1274 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 1270
+      ID: 1286
       Name: main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.182912e+06
@@ -21228,9 +21419,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1273 GoMapType map[int]*main.deepMap9
+          Type: 1289 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 1285
+      ID: 1301
       Name: main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.182784e+06
@@ -21238,7 +21429,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1288 GoMapType map[int]interface {}
+          Type: 1304 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 130
       Name: main.deepPtr1
@@ -21258,9 +21449,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1195 PointerType *main.deepPtr3
+          Type: 1211 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 1196
+      ID: 1212
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -21272,9 +21463,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1239 PointerType *main.deepPtr8
+          Type: 1255 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 1240
+      ID: 1256
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1.184064e+06
@@ -21282,9 +21473,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1241 PointerType *main.deepPtr9
+          Type: 1257 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 1242
+      ID: 1258
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1.183936e+06
@@ -21304,7 +21495,7 @@ Types:
           Offset: 0
           Type: 136 GoSliceHeaderType []*main.deepSlice2
     - __kind: StructureType
-      ID: 328
+      ID: 344
       Name: main.deepSlice2
       ByteSize: 24
       GoRuntimeType: 1.185984e+06
@@ -21312,9 +21503,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1218 GoSliceHeaderType []*main.deepSlice3
+          Type: 1234 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 1221
+      ID: 1237
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -21326,9 +21517,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1243 GoSliceHeaderType []*main.deepSlice8
+          Type: 1259 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 1246
+      ID: 1262
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1.185216e+06
@@ -21336,9 +21527,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1249 GoSliceHeaderType []*main.deepSlice9
+          Type: 1265 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 1252
+      ID: 1268
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1.185088e+06
@@ -21346,7 +21537,73 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1255 GoSliceHeaderType []interface {}
+          Type: 1271 GoSliceHeaderType []interface {}
+    - __kind: StructureType
+      ID: 325
+      Name: main.deepStruct1
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: b
+          Offset: 8
+          Type: 326 StructureType main.deepStruct2
+    - __kind: StructureType
+      ID: 326
+      Name: main.deepStruct2
+      ByteSize: 40
+      GoKind: 25
+      RawFields:
+        - Name: c
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: d
+          Offset: 8
+          Type: 327 StructureType main.deepStruct3
+    - __kind: StructureType
+      ID: 327
+      Name: main.deepStruct3
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: e
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: f
+          Offset: 8
+          Type: 328 StructureType main.deepStruct4
+    - __kind: StructureType
+      ID: 328
+      Name: main.deepStruct4
+      ByteSize: 24
+      GoKind: 25
+      RawFields:
+        - Name: g
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: h
+          Offset: 8
+          Type: 329 StructureType main.deepStruct5
+    - __kind: StructureType
+      ID: 329
+      Name: main.deepStruct5
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: i
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: j
+          Offset: 8
+          Type: 330 StructureType main.deepStruct6
+    - __kind: StructureType
+      ID: 330
+      Name: main.deepStruct6
+      ByteSize: 8
+      GoKind: 25
+      RawFields: [{Name: k, Offset: 0, Type: 7 BaseType int}]
     - __kind: StructureType
       ID: 317
       Name: main.emptyStruct
@@ -21364,16 +21621,16 @@ Types:
           Type: 153 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 1202 StructureType sync.Mutex
+          Type: 1218 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 1205 StructureType sync.Once
+          Type: 1221 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 1208 StructureType sync.WaitGroup
+          Type: 1224 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 1211 StructureType sync/atomic.Int32
+          Type: 1227 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 153
       Name: main.esotericStack
@@ -21403,7 +21660,7 @@ Types:
           Offset: 56
           Type: 59 GoSubroutineType func()
     - __kind: StructureType
-      ID: 319
+      ID: 335
       Name: main.firstBehavior
       ByteSize: 16
       GoRuntimeType: 1.410464e+06
@@ -21449,6 +21706,90 @@ Types:
           Offset: 72
           Type: 7 BaseType int
     - __kind: StructureType
+      ID: 331
+      Name: main.lotsOfFields
+      ByteSize: 26
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 3 BaseType uint8
+        - Name: b
+          Offset: 1
+          Type: 3 BaseType uint8
+        - Name: c
+          Offset: 2
+          Type: 3 BaseType uint8
+        - Name: d
+          Offset: 3
+          Type: 3 BaseType uint8
+        - Name: e
+          Offset: 4
+          Type: 3 BaseType uint8
+        - Name: f
+          Offset: 5
+          Type: 3 BaseType uint8
+        - Name: g
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: h
+          Offset: 7
+          Type: 3 BaseType uint8
+        - Name: i
+          Offset: 8
+          Type: 3 BaseType uint8
+        - Name: j
+          Offset: 9
+          Type: 3 BaseType uint8
+        - Name: k
+          Offset: 10
+          Type: 3 BaseType uint8
+        - Name: l
+          Offset: 11
+          Type: 3 BaseType uint8
+        - Name: m
+          Offset: 12
+          Type: 3 BaseType uint8
+        - Name: n
+          Offset: 13
+          Type: 3 BaseType uint8
+        - Name: o
+          Offset: 14
+          Type: 3 BaseType uint8
+        - Name: p
+          Offset: 15
+          Type: 3 BaseType uint8
+        - Name: q
+          Offset: 16
+          Type: 3 BaseType uint8
+        - Name: r
+          Offset: 17
+          Type: 3 BaseType uint8
+        - Name: s
+          Offset: 18
+          Type: 3 BaseType uint8
+        - Name: t
+          Offset: 19
+          Type: 3 BaseType uint8
+        - Name: u
+          Offset: 20
+          Type: 3 BaseType uint8
+        - Name: v
+          Offset: 21
+          Type: 3 BaseType uint8
+        - Name: w
+          Offset: 22
+          Type: 3 BaseType uint8
+        - Name: x
+          Offset: 23
+          Type: 3 BaseType uint8
+        - Name: y
+          Offset: 24
+          Type: 3 BaseType uint8
+        - Name: z
+          Offset: 25
+          Type: 3 BaseType uint8
+    - __kind: StructureType
       ID: 252
       Name: main.mixedStruct
       ByteSize: 24
@@ -21463,6 +21804,21 @@ Types:
         - Name: c
           Offset: 16
           Type: 7 BaseType int
+    - __kind: StructureType
+      ID: 319
+      Name: main.nStruct
+      ByteSize: 24
+      GoKind: 25
+      RawFields:
+        - Name: aBool
+          Offset: 0
+          Type: 4 BaseType bool
+        - Name: aInt
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: aInt16
+          Offset: 16
+          Type: 102 BaseType int16
     - __kind: StructureType
       ID: 121
       Name: main.nestedStruct
@@ -21499,7 +21855,13 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1214
+      ID: 321
+      Name: main.receiver
+      ByteSize: 8
+      GoKind: 25
+      RawFields: [{Name: u, Offset: 0, Type: 16 BaseType uint}]
+    - __kind: StructureType
+      ID: 1230
       Name: main.secondBehavior
       ByteSize: 8
       GoRuntimeType: 1.410624e+06
@@ -21519,7 +21881,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1201
+      ID: 1217
       Name: main.somethingImpl
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -21530,31 +21892,31 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1198 PointerType *main.stringType1.str
+          Type: 1214 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 1197 GoStringDataType main.stringType1.str
+      Data: 1213 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 1197
+      ID: 1213
       Name: main.stringType1.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 1199
+      ID: 1215
       Name: main.stringType2
       ByteSize: 16
       GoKind: 24
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1303 PointerType *main.stringType2.str
+          Type: 1319 PointerType *main.stringType2.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 1302 GoStringDataType main.stringType2.str
+      Data: 1318 GoStringDataType main.stringType2.str
     - __kind: GoStringDataType
-      ID: 1302
+      ID: 1318
       Name: main.stringType2.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -21651,6 +22013,21 @@ Types:
           Offset: 1
           Type: 4 BaseType bool
     - __kind: StructureType
+      ID: 332
+      Name: main.structWithTwoArrays
+      ByteSize: 72
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 333 ArrayType [3]uint64
+        - Name: b
+          Offset: 24
+          Type: 3 BaseType uint8
+        - Name: c
+          Offset: 32
+          Type: 334 ArrayType [5]int64
+    - __kind: StructureType
       ID: 243
       Name: main.structWithTwoValues
       ByteSize: 16
@@ -21670,23 +22047,74 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1215 PointerType **main.t
+          Type: 1231 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1216 GoSliceDataType main.t.array
+      Data: 1232 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 1216
+      ID: 1232
       Name: main.t.array
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 246 PointerType *main.t
     - __kind: StructureType
+      ID: 324
+      Name: main.tenStrings
+      ByteSize: 160
+      GoKind: 25
+      RawFields:
+        - Name: first
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: second
+          Offset: 16
+          Type: 9 GoStringHeaderType string
+        - Name: third
+          Offset: 32
+          Type: 9 GoStringHeaderType string
+        - Name: fourth
+          Offset: 48
+          Type: 9 GoStringHeaderType string
+        - Name: fifth
+          Offset: 64
+          Type: 9 GoStringHeaderType string
+        - Name: sixth
+          Offset: 80
+          Type: 9 GoStringHeaderType string
+        - Name: seventh
+          Offset: 96
+          Type: 9 GoStringHeaderType string
+        - Name: eighth
+          Offset: 112
+          Type: 9 GoStringHeaderType string
+        - Name: ninth
+          Offset: 128
+          Type: 9 GoStringHeaderType string
+        - Name: tenth
+          Offset: 144
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
       ID: 266
       Name: main.threeStringStruct
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: b
+          Offset: 16
+          Type: 9 GoStringHeaderType string
+        - Name: c
+          Offset: 32
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 322
+      Name: main.threestrings
       ByteSize: 48
       GoKind: 25
       RawFields:
@@ -21773,8 +22201,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 439 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 436 StructureType noalg.map.group[[4]int][4]int
+      TablePtrSliceType: 455 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 452 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
       ID: 218
       Name: map<[4]int,uint8>
@@ -21805,8 +22233,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 431 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 428 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 447 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 444 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 186
       Name: map<[4]string,[2]int>
@@ -21837,8 +22265,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 380 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 376 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 396 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 392 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
       ID: 198
       Name: map<bool,main.node>
@@ -21869,8 +22297,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 398 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 395 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 414 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 411 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
       ID: 144
       Name: map<int,*main.deepMap2>
@@ -21901,10 +22329,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 339 GoSliceDataType []*table<int,*main.deepMap2>.array
-      GroupType: 334 StructureType noalg.map.group[int]*main.deepMap2
+      TablePtrSliceType: 355 GoSliceDataType []*table<int,*main.deepMap2>.array
+      GroupType: 350 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSwissMapHeaderType
-      ID: 1226
+      ID: 1242
       Name: map<int,*main.deepMap3>
       ByteSize: 48
       GoKind: 25
@@ -21917,7 +22345,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1227 PointerType **table<int,*main.deepMap3>
+          Type: 1243 PointerType **table<int,*main.deepMap3>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -21933,10 +22361,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1237 GoSliceDataType []*table<int,*main.deepMap3>.array
-      GroupType: 1232 StructureType noalg.map.group[int]*main.deepMap3
+      TablePtrSliceType: 1253 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 1248 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSwissMapHeaderType
-      ID: 1260
+      ID: 1276
       Name: map<int,*main.deepMap8>
       ByteSize: 48
       GoKind: 25
@@ -21949,7 +22377,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1261 PointerType **table<int,*main.deepMap8>
+          Type: 1277 PointerType **table<int,*main.deepMap8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -21965,10 +22393,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1271 GoSliceDataType []*table<int,*main.deepMap8>.array
-      GroupType: 1266 StructureType noalg.map.group[int]*main.deepMap8
+      TablePtrSliceType: 1287 GoSliceDataType []*table<int,*main.deepMap8>.array
+      GroupType: 1282 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSwissMapHeaderType
-      ID: 1275
+      ID: 1291
       Name: map<int,*main.deepMap9>
       ByteSize: 48
       GoKind: 25
@@ -21981,7 +22409,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1276 PointerType **table<int,*main.deepMap9>
+          Type: 1292 PointerType **table<int,*main.deepMap9>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -21997,8 +22425,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1286 GoSliceDataType []*table<int,*main.deepMap9>.array
-      GroupType: 1281 StructureType noalg.map.group[int]*main.deepMap9
+      TablePtrSliceType: 1302 GoSliceDataType []*table<int,*main.deepMap9>.array
+      GroupType: 1297 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSwissMapHeaderType
       ID: 166
       Name: map<int,int>
@@ -22029,10 +22457,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 347 GoSliceDataType []*table<int,int>.array
-      GroupType: 344 StructureType noalg.map.group[int]int
+      TablePtrSliceType: 363 GoSliceDataType []*table<int,int>.array
+      GroupType: 360 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
-      ID: 1290
+      ID: 1306
       Name: map<int,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -22045,7 +22473,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1291 PointerType **table<int,interface {}>
+          Type: 1307 PointerType **table<int,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -22061,8 +22489,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1299 GoSliceDataType []*table<int,interface {}>.array
-      GroupType: 1296 StructureType noalg.map.group[int]interface {}
+      TablePtrSliceType: 1315 GoSliceDataType []*table<int,interface {}>.array
+      GroupType: 1312 StructureType noalg.map.group[int]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 233
       Name: map<int,struct {}>
@@ -22093,8 +22521,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 455 GoSliceDataType []*table<int,struct {}>.array
-      GroupType: 452 StructureType noalg.map.group[int]struct {}
+      TablePtrSliceType: 471 GoSliceDataType []*table<int,struct {}>.array
+      GroupType: 468 StructureType noalg.map.group[int]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 203
       Name: map<int,uint8>
@@ -22125,8 +22553,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 406 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 403 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 422 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 419 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 193
       Name: map<string,[]main.structWithMap>
@@ -22157,8 +22585,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 390 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 385 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 406 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 401 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
       ID: 181
       Name: map<string,[]string>
@@ -22189,10 +22617,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 371 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 368 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 387 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 384 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 961
+      ID: 977
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -22205,7 +22633,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 962 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 978 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -22221,8 +22649,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 996 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 993 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 1012 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 1009 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
       ID: 176
       Name: map<string,int>
@@ -22253,8 +22681,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 363 GoSliceDataType []*table<string,int>.array
-      GroupType: 360 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 379 GoSliceDataType []*table<string,int>.array
+      GroupType: 376 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
       ID: 171
       Name: map<string,main.nestedStruct>
@@ -22285,8 +22713,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 355 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 352 StructureType noalg.map.group[string]main.nestedStruct
+      TablePtrSliceType: 371 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 368 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSwissMapHeaderType
       ID: 228
       Name: map<struct {},int>
@@ -22317,8 +22745,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 447 GoSliceDataType []*table<struct {},int>.array
-      GroupType: 444 StructureType noalg.map.group[struct {}]int
+      TablePtrSliceType: 463 GoSliceDataType []*table<struct {},int>.array
+      GroupType: 460 StructureType noalg.map.group[struct {}]int
     - __kind: GoSwissMapHeaderType
       ID: 286
       Name: map<struct {},main.structWithCyclicMaps>
@@ -22349,8 +22777,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 497 GoSliceDataType []*table<struct {},main.structWithCyclicMaps>.array
-      GroupType: 494 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 513 GoSliceDataType []*table<struct {},main.structWithCyclicMaps>.array
+      GroupType: 510 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 291
       Name: map<struct {},map[struct {}]main.structWithCyclicMaps>
@@ -22381,8 +22809,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 505 GoSliceDataType []*table<struct {},map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 502 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 521 GoSliceDataType []*table<struct {},map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 518 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 296
       Name: map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -22413,8 +22841,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 513 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 510 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 529 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 526 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 301
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -22445,8 +22873,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 521 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 518 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 537 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 534 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 306
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -22477,8 +22905,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 529 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 526 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 545 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 542 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 311
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -22509,8 +22937,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 537 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 534 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 553 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 550 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 238
       Name: map<struct {},struct {}>
@@ -22541,8 +22969,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 463 GoSliceDataType []*table<struct {},struct {}>.array
-      GroupType: 460 StructureType noalg.map.group[struct {}]struct {}
+      TablePtrSliceType: 479 GoSliceDataType []*table<struct {},struct {}>.array
+      GroupType: 476 StructureType noalg.map.group[struct {}]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 213
       Name: map<uint8,[4]int>
@@ -22573,8 +23001,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 423 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 419 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 439 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 435 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
       ID: 208
       Name: map<uint8,uint8>
@@ -22605,8 +23033,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 414 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 411 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 430 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 427 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
       ID: 221
       Name: map[[4]int][4]int
@@ -22643,26 +23071,26 @@ Types:
       GoKind: 21
       HeaderType: 144 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 1224
+      ID: 1240
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 1.125696e+06
       GoKind: 21
-      HeaderType: 1226 GoSwissMapHeaderType map<int,*main.deepMap3>
+      HeaderType: 1242 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 1258
+      ID: 1274
       Name: map[int]*main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.125056e+06
       GoKind: 21
-      HeaderType: 1260 GoSwissMapHeaderType map<int,*main.deepMap8>
+      HeaderType: 1276 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
-      ID: 1273
+      ID: 1289
       Name: map[int]*main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.124928e+06
       GoKind: 21
-      HeaderType: 1275 GoSwissMapHeaderType map<int,*main.deepMap9>
+      HeaderType: 1291 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 164
       Name: map[int]int
@@ -22671,12 +23099,12 @@ Types:
       GoKind: 21
       HeaderType: 166 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
-      ID: 1288
+      ID: 1304
       Name: map[int]interface {}
       ByteSize: 8
       GoRuntimeType: 1.1248e+06
       GoKind: 21
-      HeaderType: 1290 GoSwissMapHeaderType map<int,interface {}>
+      HeaderType: 1306 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
       ID: 231
       Name: map[int]struct {}
@@ -22784,7 +23212,7 @@ Types:
       GoKind: 21
       HeaderType: 208 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: StructureType
-      ID: 715
+      ID: 731
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1.426464e+06
@@ -22794,7 +23222,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1011
+      ID: 1027
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
       GoRuntimeType: 1.423264e+06
@@ -22804,11 +23232,11 @@ Types:
           Offset: 0
           Type: 129 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 918
+      ID: 934
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 981
+      ID: 997
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1.593184e+06
@@ -22821,35 +23249,35 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 944
+      ID: 960
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1156
+      ID: 1172
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 942
+      ID: 958
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 920
+      ID: 936
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1166
+      ID: 1182
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1176
+      ID: 1192
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1164
+      ID: 1180
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 879
+      ID: 895
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1.109952e+06
@@ -22857,28 +23285,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 881 PointerType *net.UnknownNetworkError.str
+          Type: 897 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 880 GoStringDataType net.UnknownNetworkError.str
+      Data: 896 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 880
+      ID: 896
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 848
+      ID: 864
       Name: net.canceledError
       GoRuntimeType: 1.281152e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1132
+      ID: 1148
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 986
+      ID: 1002
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2.1008e+06
@@ -22886,7 +23314,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 981 GoInterfaceType net.Conn
+          Type: 997 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 13 GoInterfaceType error
@@ -22897,27 +23325,27 @@ Types:
           Offset: 33
           Type: 4 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 1178
+      ID: 1194
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 1172
+      ID: 1188
       Name: net.noReadFrom
       GoRuntimeType: 1.110208e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1171
+      ID: 1187
       Name: net.noWriteTo
       GoRuntimeType: 1.11008e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 648
+      ID: 664
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
-      ID: 650
+      ID: 666
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1.723744e+06
@@ -22925,7 +23353,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 969 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 985 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 9 GoStringHeaderType string
@@ -22933,7 +23361,7 @@ Types:
           Offset: 96
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 1160
+      ID: 1176
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.285536e+06
@@ -22941,12 +23369,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1172 StructureType net.noReadFrom
+          Type: 1188 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 1165 PointerType *net.TCPConn
+          Type: 1181 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 1158
+      ID: 1174
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.284992e+06
@@ -22954,24 +23382,24 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1171 StructureType net.noWriteTo
+          Type: 1187 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 1165 PointerType *net.TCPConn
+          Type: 1181 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 922
+      ID: 938
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 946
+      ID: 962
       Name: net.timeoutError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 838
+      ID: 854
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1005
+      ID: 1021
       Name: net/http.bufioFlushWriter
       ByteSize: 16
       GoRuntimeType: 1.414784e+06
@@ -22981,19 +23409,19 @@ Types:
           Offset: 0
           Type: 129 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 544
+      ID: 560
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 829824
       GoKind: 10
     - __kind: BaseType
-      ID: 958
+      ID: 974
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 987360
       GoKind: 10
     - __kind: StructureType
-      ID: 626
+      ID: 642
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1.722016e+06
@@ -23004,12 +23432,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 958 BaseType net/http.http2ErrCode
+          Type: 974 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 938
+      ID: 954
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1.8936e+06
@@ -23020,12 +23448,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 958 BaseType net/http.http2ErrCode
+          Type: 974 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 630
+      ID: 646
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1.592704e+06
@@ -23033,16 +23461,16 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 958 BaseType net/http.http2ErrCode
+          Type: 974 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1067
+      ID: 1083
       Name: net/http.http2dataBuffer
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 548
+      ID: 564
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 830016
@@ -23050,18 +23478,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 550 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 566 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 549 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 565 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 549
+      ID: 565
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 554
+      ID: 570
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 830208
@@ -23069,18 +23497,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 556 PointerType *net/http.http2headerFieldNameError.str
+          Type: 572 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 555 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 571 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 555
+      ID: 571
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 551
+      ID: 567
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 830112
@@ -23088,32 +23516,32 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 553 PointerType *net/http.http2headerFieldValueError.str
+          Type: 569 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 552 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 568 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 552
+      ID: 568
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 913
+      ID: 929
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 844
+      ID: 860
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1.280384e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1121
+      ID: 1137
       Name: net/http.http2pipe
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 545
+      ID: 561
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 829920
@@ -23121,18 +23549,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 547 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 563 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 546 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 562 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 546
+      ID: 562
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1007
+      ID: 1023
       Name: net/http.http2stickyErrWriter
       ByteSize: 48
       GoRuntimeType: 1.817888e+06
@@ -23140,18 +23568,18 @@ Types:
       RawFields:
         - Name: group
           Offset: 0
-          Type: 1100 GoInterfaceType net/http.http2synctestGroupInterface
+          Type: 1116 GoInterfaceType net/http.http2synctestGroupInterface
         - Name: conn
           Offset: 16
-          Type: 981 GoInterfaceType net.Conn
+          Type: 997 GoInterfaceType net.Conn
         - Name: timeout
           Offset: 32
-          Type: 1101 BaseType time.Duration
+          Type: 1117 BaseType time.Duration
         - Name: err
           Offset: 40
           Type: 104 PointerType *error
     - __kind: GoInterfaceType
-      ID: 1100
+      ID: 1116
       Name: net/http.http2synctestGroupInterface
       ByteSize: 16
       GoRuntimeType: 1.414144e+06
@@ -23164,14 +23592,14 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: ArrayType
-      ID: 1086
+      ID: 1102
       Name: net/http.incomparable
       GoRuntimeType: 899776
       GoKind: 17
       HasCount: true
       Element: 59 GoSubroutineType func()
     - __kind: StructureType
-      ID: 840
+      ID: 856
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1.551744e+06
@@ -23181,11 +23609,11 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1069
+      ID: 1085
       Name: net/http.persistConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 1025
+      ID: 1041
       Name: net/http.persistConnWriter
       ByteSize: 8
       GoRuntimeType: 1.551584e+06
@@ -23193,9 +23621,9 @@ Types:
       RawFields:
         - Name: pc
           Offset: 0
-          Type: 1068 PointerType *net/http.persistConn
+          Type: 1084 PointerType *net/http.persistConn
     - __kind: StructureType
-      ID: 1051
+      ID: 1067
       Name: net/http.readWriteCloserBody
       ByteSize: 24
       GoRuntimeType: 1.793888e+06
@@ -23203,15 +23631,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1086 ArrayType net/http.incomparable
+          Type: 1102 ArrayType net/http.incomparable
         - Name: br
           Offset: 0
-          Type: 1087 PointerType *bufio.Reader
+          Type: 1103 PointerType *bufio.Reader
         - Name: ReadWriteCloser
           Offset: 8
-          Type: 1089 GoInterfaceType io.ReadWriteCloser
+          Type: 1105 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 634
+      ID: 650
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1.415744e+06
@@ -23221,17 +23649,17 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 940
+      ID: 956
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 911
+      ID: 927
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1.475744e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 842
+      ID: 858
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1.551904e+06
@@ -23241,7 +23669,7 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 1103
+      ID: 1119
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
       GoRuntimeType: 2.019776e+06
@@ -23249,16 +23677,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 981 GoInterfaceType net.Conn
+          Type: 997 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 981 GoInterfaceType net.Conn
+          Type: 997 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 623
+      ID: 639
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1123
+      ID: 1139
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
       GoRuntimeType: 2.035808e+06
@@ -23266,13 +23694,13 @@ Types:
       RawFields:
         - Name: Writer
           Offset: 0
-          Type: 1116 PointerType *bufio.Writer
+          Type: 1132 PointerType *bufio.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1035
+      ID: 1051
       Name: net/http/internal.chunkedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 707
+      ID: 723
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1.726816e+06
@@ -23288,7 +23716,7 @@ Types:
           Offset: 32
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 705
+      ID: 721
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1.594624e+06
@@ -23301,11 +23729,11 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1077
+      ID: 1093
       Name: net/smtp.Client
       ByteSize: 8
     - __kind: StructureType
-      ID: 1037
+      ID: 1053
       Name: net/smtp.dataCloser
       ByteSize: 24
       GoRuntimeType: 1.596544e+06
@@ -23313,16 +23741,16 @@ Types:
       RawFields:
         - Name: c
           Offset: 0
-          Type: 1076 PointerType *net/smtp.Client
+          Type: 1092 PointerType *net/smtp.Client
         - Name: WriteCloser
           Offset: 8
-          Type: 1078 GoInterfaceType io.WriteCloser
+          Type: 1094 GoInterfaceType io.WriteCloser
     - __kind: UnresolvedPointeeType
-      ID: 691
+      ID: 707
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 579
+      ID: 595
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 832800
@@ -23330,26 +23758,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 581 PointerType *net/textproto.ProtocolError.str
+          Type: 597 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 580 GoStringDataType net/textproto.ProtocolError.str
+      Data: 596 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 580
+      ID: 596
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1033
+      ID: 1049
       Name: net/textproto.dotWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 948
+      ID: 964
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 557
+      ID: 573
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 830784
@@ -23357,18 +23785,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 559 PointerType *net/url.EscapeError.str
+          Type: 575 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 558 GoStringDataType net/url.EscapeError.str
+      Data: 574 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 558
+      ID: 574
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 560
+      ID: 576
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 830880
@@ -23376,254 +23804,254 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 562 PointerType *net/url.InvalidHostError.str
+          Type: 578 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 561 GoStringDataType net/url.InvalidHostError.str
+      Data: 577 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 561
+      ID: 577
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: ArrayType
-      ID: 437
+      ID: 453
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
       GoRuntimeType: 679936
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 438 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 454 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 429
+      ID: 445
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
       GoRuntimeType: 680032
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 430 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 446 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 377
+      ID: 393
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
       GoRuntimeType: 680320
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 378 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 394 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 396
+      ID: 412
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
       GoRuntimeType: 680416
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 397 StructureType noalg.struct { key bool; elem main.node }
+      Element: 413 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 335
+      ID: 351
       Name: noalg.[8]struct { key int; elem *main.deepMap2 }
       ByteSize: 128
       GoRuntimeType: 679264
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 336 StructureType noalg.struct { key int; elem *main.deepMap2 }
+      Element: 352 StructureType noalg.struct { key int; elem *main.deepMap2 }
     - __kind: ArrayType
-      ID: 1233
+      ID: 1249
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
       GoRuntimeType: 679168
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1234 StructureType noalg.struct { key int; elem *main.deepMap3 }
+      Element: 1250 StructureType noalg.struct { key int; elem *main.deepMap3 }
     - __kind: ArrayType
-      ID: 1267
+      ID: 1283
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
       ByteSize: 128
       GoRuntimeType: 678688
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1268 StructureType noalg.struct { key int; elem *main.deepMap8 }
+      Element: 1284 StructureType noalg.struct { key int; elem *main.deepMap8 }
     - __kind: ArrayType
-      ID: 1282
+      ID: 1298
       Name: noalg.[8]struct { key int; elem *main.deepMap9 }
       ByteSize: 128
       GoRuntimeType: 678592
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1283 StructureType noalg.struct { key int; elem *main.deepMap9 }
+      Element: 1299 StructureType noalg.struct { key int; elem *main.deepMap9 }
     - __kind: ArrayType
-      ID: 345
+      ID: 361
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
       GoRuntimeType: 677440
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 346 StructureType noalg.struct { key int; elem int }
+      Element: 362 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 1297
+      ID: 1313
       Name: noalg.[8]struct { key int; elem interface {} }
       ByteSize: 192
       GoRuntimeType: 678496
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1298 StructureType noalg.struct { key int; elem interface {} }
+      Element: 1314 StructureType noalg.struct { key int; elem interface {} }
     - __kind: ArrayType
-      ID: 453
+      ID: 469
       Name: noalg.[8]struct { key int; elem struct {} }
       ByteSize: 128
       GoRuntimeType: 680512
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 454 StructureType noalg.struct { key int; elem struct {} }
+      Element: 470 StructureType noalg.struct { key int; elem struct {} }
     - __kind: ArrayType
-      ID: 404
+      ID: 420
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
       GoRuntimeType: 680608
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 405 StructureType noalg.struct { key int; elem uint8 }
+      Element: 421 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 386
+      ID: 402
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
       GoRuntimeType: 680704
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 387 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 403 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 369
+      ID: 385
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 680800
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 370 StructureType noalg.struct { key string; elem []string }
+      Element: 386 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 994
+      ID: 1010
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 756096
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 995 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 1011 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
-      ID: 361
+      ID: 377
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 680896
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 362 StructureType noalg.struct { key string; elem int }
+      Element: 378 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 353
+      ID: 369
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
       GoRuntimeType: 680992
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 354 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 370 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 445
+      ID: 461
       Name: noalg.[8]struct { key struct {}; elem int }
       ByteSize: 64
       GoRuntimeType: 681088
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 446 StructureType noalg.struct { key struct {}; elem int }
+      Element: 462 StructureType noalg.struct { key struct {}; elem int }
     - __kind: ArrayType
-      ID: 495
+      ID: 511
       Name: noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
       ByteSize: 384
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 496 StructureType noalg.struct { key struct {}; elem main.structWithCyclicMaps }
+      Element: 512 StructureType noalg.struct { key struct {}; elem main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 503
+      ID: 519
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 504 StructureType noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+      Element: 520 StructureType noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 511
+      ID: 527
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 512 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 528 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 519
+      ID: 535
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 520 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 536 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 527
+      ID: 543
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 528 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 544 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 535
+      ID: 551
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 536 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 552 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 461
+      ID: 477
       Name: noalg.[8]struct { key struct {}; elem struct {} }
       GoRuntimeType: 681184
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 462 StructureType noalg.struct { key struct {}; elem struct {} }
+      Element: 478 StructureType noalg.struct { key struct {}; elem struct {} }
     - __kind: ArrayType
-      ID: 420
+      ID: 436
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
       GoRuntimeType: 681280
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 421 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 437 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 412
+      ID: 428
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 681376
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 413 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 429 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 436
+      ID: 452
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
       GoRuntimeType: 1.29216e+06
@@ -23634,9 +24062,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 437 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 453 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 428
+      ID: 444
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
       GoRuntimeType: 1.292416e+06
@@ -23647,9 +24075,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 429 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 445 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 376
+      ID: 392
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
       GoRuntimeType: 1.292672e+06
@@ -23660,9 +24088,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 377 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 393 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 395
+      ID: 411
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
       GoRuntimeType: 1.292928e+06
@@ -23673,9 +24101,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 396 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 412 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 334
+      ID: 350
       Name: noalg.map.group[int]*main.deepMap2
       ByteSize: 136
       GoRuntimeType: 1.291904e+06
@@ -23686,9 +24114,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 335 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
+          Type: 351 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
     - __kind: StructureType
-      ID: 1232
+      ID: 1248
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
       GoRuntimeType: 1.291648e+06
@@ -23699,9 +24127,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1233 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+          Type: 1249 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
     - __kind: StructureType
-      ID: 1266
+      ID: 1282
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
       GoRuntimeType: 1.290368e+06
@@ -23712,9 +24140,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1267 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
+          Type: 1283 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
     - __kind: StructureType
-      ID: 1281
+      ID: 1297
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
       GoRuntimeType: 1.290112e+06
@@ -23725,9 +24153,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1282 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
+          Type: 1298 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
     - __kind: StructureType
-      ID: 344
+      ID: 360
       Name: noalg.map.group[int]int
       ByteSize: 136
       GoRuntimeType: 1.289088e+06
@@ -23738,9 +24166,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 345 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 361 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 1296
+      ID: 1312
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
       GoRuntimeType: 1.289856e+06
@@ -23751,9 +24179,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1297 ArrayType noalg.[8]struct { key int; elem interface {} }
+          Type: 1313 ArrayType noalg.[8]struct { key int; elem interface {} }
     - __kind: StructureType
-      ID: 452
+      ID: 468
       Name: noalg.map.group[int]struct {}
       ByteSize: 136
       GoRuntimeType: 1.293184e+06
@@ -23764,9 +24192,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 453 ArrayType noalg.[8]struct { key int; elem struct {} }
+          Type: 469 ArrayType noalg.[8]struct { key int; elem struct {} }
     - __kind: StructureType
-      ID: 403
+      ID: 419
       Name: noalg.map.group[int]uint8
       ByteSize: 136
       GoRuntimeType: 1.29344e+06
@@ -23777,9 +24205,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 404 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 420 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 385
+      ID: 401
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
       GoRuntimeType: 1.293696e+06
@@ -23790,9 +24218,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 386 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 402 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 368
+      ID: 384
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.293952e+06
@@ -23803,9 +24231,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 369 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 385 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 993
+      ID: 1009
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1.355648e+06
@@ -23816,9 +24244,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 994 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 1010 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
-      ID: 360
+      ID: 376
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 1.294208e+06
@@ -23829,9 +24257,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 361 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 377 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 352
+      ID: 368
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
       GoRuntimeType: 1.294464e+06
@@ -23842,9 +24270,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 353 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 369 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 444
+      ID: 460
       Name: noalg.map.group[struct {}]int
       ByteSize: 72
       GoRuntimeType: 1.29472e+06
@@ -23855,9 +24283,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 445 ArrayType noalg.[8]struct { key struct {}; elem int }
+          Type: 461 ArrayType noalg.[8]struct { key struct {}; elem int }
     - __kind: StructureType
-      ID: 494
+      ID: 510
       Name: noalg.map.group[struct {}]main.structWithCyclicMaps
       ByteSize: 392
       GoKind: 25
@@ -23867,9 +24295,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 495 ArrayType noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
+          Type: 511 ArrayType noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 502
+      ID: 518
       Name: noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -23879,9 +24307,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 503 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+          Type: 519 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 510
+      ID: 526
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -23891,9 +24319,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 511 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 527 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 518
+      ID: 534
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -23903,9 +24331,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 519 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 535 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 526
+      ID: 542
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -23915,9 +24343,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 527 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 543 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 534
+      ID: 550
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -23927,9 +24355,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 535 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 551 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 460
+      ID: 476
       Name: noalg.map.group[struct {}]struct {}
       ByteSize: 16
       GoRuntimeType: 1.294976e+06
@@ -23940,9 +24368,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 461 ArrayType noalg.[8]struct { key struct {}; elem struct {} }
+          Type: 477 ArrayType noalg.[8]struct { key struct {}; elem struct {} }
     - __kind: StructureType
-      ID: 419
+      ID: 435
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
       GoRuntimeType: 1.295232e+06
@@ -23953,9 +24381,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 420 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 436 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 411
+      ID: 427
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
       GoRuntimeType: 1.295488e+06
@@ -23966,9 +24394,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 412 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 428 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 438
+      ID: 454
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
       GoRuntimeType: 1.292032e+06
@@ -23976,12 +24404,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 422 ArrayType [4]int
+          Type: 438 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 422 ArrayType [4]int
+          Type: 438 ArrayType [4]int
     - __kind: StructureType
-      ID: 430
+      ID: 446
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
       GoRuntimeType: 1.292288e+06
@@ -23989,12 +24417,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 422 ArrayType [4]int
+          Type: 438 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 378
+      ID: 394
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
       GoRuntimeType: 1.292544e+06
@@ -24002,12 +24430,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 379 ArrayType [4]string
+          Type: 395 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 111 ArrayType [2]int
     - __kind: StructureType
-      ID: 397
+      ID: 413
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
       GoRuntimeType: 1.2928e+06
@@ -24020,7 +24448,7 @@ Types:
           Offset: 8
           Type: 244 StructureType main.node
     - __kind: StructureType
-      ID: 336
+      ID: 352
       Name: noalg.struct { key int; elem *main.deepMap2 }
       ByteSize: 16
       GoRuntimeType: 1.291776e+06
@@ -24031,9 +24459,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 337 PointerType *main.deepMap2
+          Type: 353 PointerType *main.deepMap2
     - __kind: StructureType
-      ID: 1234
+      ID: 1250
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
       GoRuntimeType: 1.29152e+06
@@ -24044,9 +24472,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1235 PointerType *main.deepMap3
+          Type: 1251 PointerType *main.deepMap3
     - __kind: StructureType
-      ID: 1268
+      ID: 1284
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
       GoRuntimeType: 1.29024e+06
@@ -24057,9 +24485,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1269 PointerType *main.deepMap8
+          Type: 1285 PointerType *main.deepMap8
     - __kind: StructureType
-      ID: 1283
+      ID: 1299
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
       GoRuntimeType: 1.289984e+06
@@ -24070,9 +24498,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1284 PointerType *main.deepMap9
+          Type: 1300 PointerType *main.deepMap9
     - __kind: StructureType
-      ID: 346
+      ID: 362
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
       GoRuntimeType: 1.28896e+06
@@ -24085,7 +24513,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 1298
+      ID: 1314
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
       GoRuntimeType: 1.289728e+06
@@ -24098,7 +24526,7 @@ Types:
           Offset: 8
           Type: 155 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 454
+      ID: 470
       Name: noalg.struct { key int; elem struct {} }
       ByteSize: 16
       GoRuntimeType: 1.293056e+06
@@ -24111,7 +24539,7 @@ Types:
           Offset: 8
           Type: 123 StructureType struct {}
     - __kind: StructureType
-      ID: 405
+      ID: 421
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 1.293312e+06
@@ -24124,7 +24552,7 @@ Types:
           Offset: 8
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 387
+      ID: 403
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
       GoRuntimeType: 1.293568e+06
@@ -24135,9 +24563,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 388 GoSliceHeaderType []main.structWithMap
+          Type: 404 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 370
+      ID: 386
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.293824e+06
@@ -24150,7 +24578,7 @@ Types:
           Offset: 16
           Type: 261 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 995
+      ID: 1011
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1.35552e+06
@@ -24161,9 +24589,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 982 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 998 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 362
+      ID: 378
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 1.29408e+06
@@ -24176,7 +24604,7 @@ Types:
           Offset: 16
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 354
+      ID: 370
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
       GoRuntimeType: 1.294336e+06
@@ -24189,7 +24617,7 @@ Types:
           Offset: 16
           Type: 121 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 446
+      ID: 462
       Name: noalg.struct { key struct {}; elem int }
       ByteSize: 8
       GoRuntimeType: 1.294592e+06
@@ -24202,7 +24630,7 @@ Types:
           Offset: 0
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 496
+      ID: 512
       Name: noalg.struct { key struct {}; elem main.structWithCyclicMaps }
       ByteSize: 48
       GoKind: 25
@@ -24214,7 +24642,7 @@ Types:
           Offset: 0
           Type: 283 StructureType main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 504
+      ID: 520
       Name: noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -24226,7 +24654,7 @@ Types:
           Offset: 0
           Type: 284 GoMapType map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 512
+      ID: 528
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -24238,7 +24666,7 @@ Types:
           Offset: 0
           Type: 289 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 520
+      ID: 536
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -24250,7 +24678,7 @@ Types:
           Offset: 0
           Type: 294 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 528
+      ID: 544
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -24262,7 +24690,7 @@ Types:
           Offset: 0
           Type: 299 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 536
+      ID: 552
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -24274,7 +24702,7 @@ Types:
           Offset: 0
           Type: 304 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 462
+      ID: 478
       Name: noalg.struct { key struct {}; elem struct {} }
       GoRuntimeType: 1.294848e+06
       GoKind: 25
@@ -24286,7 +24714,7 @@ Types:
           Offset: 0
           Type: 123 StructureType struct {}
     - __kind: StructureType
-      ID: 421
+      ID: 437
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
       GoRuntimeType: 1.295104e+06
@@ -24297,9 +24725,9 @@ Types:
           Type: 3 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 422 ArrayType [4]int
+          Type: 438 ArrayType [4]int
     - __kind: StructureType
-      ID: 413
+      ID: 429
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
       GoRuntimeType: 1.29536e+06
@@ -24312,19 +24740,19 @@ Types:
           Offset: 1
           Type: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1184
+      ID: 1200
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 819
+      ID: 835
       Name: os.LinkError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 883
+      ID: 899
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1182
+      ID: 1198
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.354144e+06
@@ -24332,12 +24760,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1188 StructureType os.noReadFrom
+          Type: 1204 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 1183 PointerType *os.File
+          Type: 1199 PointerType *os.File
     - __kind: StructureType
-      ID: 1180
+      ID: 1196
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.353344e+06
@@ -24345,36 +24773,36 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1187 StructureType os.noWriteTo
+          Type: 1203 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 1183 PointerType *os.File
+          Type: 1199 PointerType *os.File
     - __kind: StructureType
-      ID: 1188
+      ID: 1204
       Name: os.noReadFrom
       GoRuntimeType: 1.10752e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1187
+      ID: 1203
       Name: os.noWriteTo
       GoRuntimeType: 1.107392e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 850
+      ID: 866
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 989
+      ID: 1005
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1055
+      ID: 1071
       Name: os/exec.prefixSuffixSaver
       ByteSize: 8
     - __kind: StructureType
-      ID: 852
+      ID: 868
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1.69856e+06
@@ -24387,7 +24815,7 @@ Types:
           Offset: 16
           Type: 13 GoInterfaceType error
     - __kind: GoStringHeaderType
-      ID: 593
+      ID: 609
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 836064
@@ -24395,36 +24823,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 595 PointerType *os/user.UnknownGroupIdError.str
+          Type: 611 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 594 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 610 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 594
+      ID: 610
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 592
+      ID: 608
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 835968
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 618
+      ID: 634
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 713
+      ID: 729
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 823
+      ID: 839
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 827
+      ID: 843
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -24436,7 +24864,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 825
+      ID: 841
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1.882016e+06
@@ -24453,9 +24881,9 @@ Types:
           Type: 4 BaseType bool
         - Name: code
           Offset: 17
-          Type: 987 BaseType runtime.boundsErrorCode
+          Type: 1003 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 987
+      ID: 1003
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 582240
@@ -24475,7 +24903,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 885
+      ID: 901
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1.746368e+06
@@ -24488,7 +24916,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 803
+      ID: 819
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 986016
@@ -24496,13 +24924,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 805 PointerType *runtime.errorString.str
+          Type: 821 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 804 GoStringDataType runtime.errorString.str
+      Data: 820 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 804
+      ID: 820
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -25158,7 +25586,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 806
+      ID: 822
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 986112
@@ -25166,13 +25594,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 808 PointerType *runtime.plainError.str
+          Type: 824 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 807 GoStringDataType runtime.plainError.str
+      Data: 823 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 807
+      ID: 823
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -25258,7 +25686,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 829
+      ID: 845
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -25270,26 +25698,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 321 PointerType *string.str
+          Type: 337 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 320 GoStringDataType string.str
+      Data: 336 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 320
+      ID: 336
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1119
+      ID: 1135
       Name: strings.Builder
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1023
+      ID: 1039
       Name: strings.appendSliceWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1019
+      ID: 1035
       Name: struct { io.Writer }
       ByteSize: 16
       GoRuntimeType: 1.452544e+06
@@ -25305,7 +25733,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1202
+      ID: 1218
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.461024e+06
@@ -25313,12 +25741,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1203 StructureType sync.noCopy
+          Type: 1219 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 1204 StructureType internal/sync.Mutex
+          Type: 1220 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 1205
+      ID: 1221
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.609376e+06
@@ -25326,15 +25754,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1203 StructureType sync.noCopy
+          Type: 1219 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 1206 StructureType sync/atomic.Uint32
+          Type: 1222 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 1202 StructureType sync.Mutex
+          Type: 1218 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 1208
+      ID: 1224
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.609568e+06
@@ -25342,21 +25770,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 1203 StructureType sync.noCopy
+          Type: 1219 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 1209 StructureType sync/atomic.Uint64
+          Type: 1225 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1203
+      ID: 1219
       Name: sync.noCopy
       GoRuntimeType: 984960
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1211
+      ID: 1227
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.462304e+06
@@ -25364,12 +25792,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1207 StructureType sync/atomic.noCopy
+          Type: 1223 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 10 BaseType int32
     - __kind: StructureType
-      ID: 1206
+      ID: 1222
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1.462464e+06
@@ -25377,12 +25805,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1207 StructureType sync/atomic.noCopy
+          Type: 1223 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1209
+      ID: 1225
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.609952e+06
@@ -25390,33 +25818,33 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1207 StructureType sync/atomic.noCopy
+          Type: 1223 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 1210 StructureType sync/atomic.align64
+          Type: 1226 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 8 BaseType uint64
     - __kind: StructureType
-      ID: 1210
+      ID: 1226
       Name: sync/atomic.align64
       GoRuntimeType: 985152
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1207
+      ID: 1223
       Name: sync/atomic.noCopy
       GoRuntimeType: 985056
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 935
+      ID: 951
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1.279744e+06
       GoKind: 12
     - __kind: StructureType
-      ID: 433
+      ID: 449
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -25438,9 +25866,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 434 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 450 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
-      ID: 425
+      ID: 441
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -25462,9 +25890,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 426 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 442 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
-      ID: 373
+      ID: 389
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
@@ -25486,9 +25914,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 374 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 390 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
-      ID: 392
+      ID: 408
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
@@ -25510,9 +25938,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 393 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 409 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
-      ID: 331
+      ID: 347
       Name: table<int,*main.deepMap2>
       ByteSize: 32
       GoKind: 25
@@ -25534,9 +25962,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 332 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
+          Type: 348 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
     - __kind: StructureType
-      ID: 1229
+      ID: 1245
       Name: table<int,*main.deepMap3>
       ByteSize: 32
       GoKind: 25
@@ -25558,9 +25986,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1230 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+          Type: 1246 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
     - __kind: StructureType
-      ID: 1263
+      ID: 1279
       Name: table<int,*main.deepMap8>
       ByteSize: 32
       GoKind: 25
@@ -25582,9 +26010,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1264 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
+          Type: 1280 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
     - __kind: StructureType
-      ID: 1278
+      ID: 1294
       Name: table<int,*main.deepMap9>
       ByteSize: 32
       GoKind: 25
@@ -25606,9 +26034,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1279 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
+          Type: 1295 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
     - __kind: StructureType
-      ID: 341
+      ID: 357
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
@@ -25630,9 +26058,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 342 GoSwissMapGroupsType groupReference<int,int>
+          Type: 358 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 1293
+      ID: 1309
       Name: table<int,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -25654,9 +26082,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1294 GoSwissMapGroupsType groupReference<int,interface {}>
+          Type: 1310 GoSwissMapGroupsType groupReference<int,interface {}>
     - __kind: StructureType
-      ID: 449
+      ID: 465
       Name: table<int,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -25678,9 +26106,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 450 GoSwissMapGroupsType groupReference<int,struct {}>
+          Type: 466 GoSwissMapGroupsType groupReference<int,struct {}>
     - __kind: StructureType
-      ID: 400
+      ID: 416
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -25702,9 +26130,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 401 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 417 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
-      ID: 382
+      ID: 398
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
@@ -25726,9 +26154,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 383 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 399 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 365
+      ID: 381
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -25750,9 +26178,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 366 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 382 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 990
+      ID: 1006
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -25774,9 +26202,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 991 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 1007 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
-      ID: 357
+      ID: 373
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -25798,9 +26226,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 358 GoSwissMapGroupsType groupReference<string,int>
+          Type: 374 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 349
+      ID: 365
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
@@ -25822,9 +26250,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 350 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 366 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 441
+      ID: 457
       Name: table<struct {},int>
       ByteSize: 32
       GoKind: 25
@@ -25846,9 +26274,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 442 GoSwissMapGroupsType groupReference<struct {},int>
+          Type: 458 GoSwissMapGroupsType groupReference<struct {},int>
     - __kind: StructureType
-      ID: 491
+      ID: 507
       Name: table<struct {},main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -25870,9 +26298,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 492 GoSwissMapGroupsType groupReference<struct {},main.structWithCyclicMaps>
+          Type: 508 GoSwissMapGroupsType groupReference<struct {},main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 499
+      ID: 515
       Name: table<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -25894,9 +26322,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 500 GoSwissMapGroupsType groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
+          Type: 516 GoSwissMapGroupsType groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 507
+      ID: 523
       Name: table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -25918,9 +26346,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 508 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 524 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 515
+      ID: 531
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -25942,9 +26370,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 516 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 532 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 523
+      ID: 539
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -25966,9 +26394,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 524 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 540 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 531
+      ID: 547
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -25990,9 +26418,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 532 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 548 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 457
+      ID: 473
       Name: table<struct {},struct {}>
       ByteSize: 32
       GoKind: 25
@@ -26014,9 +26442,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 458 GoSwissMapGroupsType groupReference<struct {},struct {}>
+          Type: 474 GoSwissMapGroupsType groupReference<struct {},struct {}>
     - __kind: StructureType
-      ID: 416
+      ID: 432
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -26038,9 +26466,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 417 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 433 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
-      ID: 408
+      ID: 424
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
@@ -26062,13 +26490,13 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 409 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 425 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: UnresolvedPointeeType
-      ID: 1154
+      ID: 1170
       Name: text/tabwriter.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 878
+      ID: 894
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1.702976e+06
@@ -26081,21 +26509,21 @@ Types:
           Offset: 16
           Type: 13 GoInterfaceType error
     - __kind: BaseType
-      ID: 1101
+      ID: 1117
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1.90816e+06
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 953
+      ID: 969
       Name: time.Location
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 621
+      ID: 637
       Name: time.ParseError
       ByteSize: 8
     - __kind: StructureType
-      ID: 951
+      ID: 967
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.369024e+06
@@ -26109,9 +26537,9 @@ Types:
           Type: 12 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 952 PointerType *time.Location
+          Type: 968 PointerType *time.Location
     - __kind: GoStringHeaderType
-      ID: 541
+      ID: 557
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 828960
@@ -26119,13 +26547,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 543 PointerType *time.fileSizeError.str
+          Type: 559 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 542 GoStringDataType time.fileSizeError.str
+      Data: 558 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 542
+      ID: 558
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -26172,7 +26600,7 @@ Types:
       GoRuntimeType: 582176
       GoKind: 26
     - __kind: StructureType
-      ID: 969
+      ID: 985
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2.057216e+06
@@ -26183,10 +26611,10 @@ Types:
           Type: 38 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 970 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 986 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 971 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 987 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: off
           Offset: 40
           Type: 7 BaseType int
@@ -26201,18 +26629,18 @@ Types:
           Type: 7 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 972 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 988 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 6 BaseType uint16
     - __kind: BaseType
-      ID: 972
+      ID: 988
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 991584
       GoKind: 9
     - __kind: StructureType
-      ID: 970
+      ID: 986
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1.918912e+06
@@ -26237,21 +26665,21 @@ Types:
           Offset: 10
           Type: 6 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 709
+      ID: 725
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 971
+      ID: 987
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 585824
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1146
+      ID: 1162
       Name: vendor/golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 693
+      ID: 709
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.423584e+06
@@ -26261,13 +26689,13 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: BaseType
-      ID: 582
+      ID: 598
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 832896
       GoKind: 2
     - __kind: StructureType
-      ID: 857
+      ID: 873
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1.698752e+06
@@ -26280,12 +26708,12 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 811
+      ID: 827
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 990432
       GoKind: 5
-MaxTypeID: 1551
+MaxTypeID: 1568
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x18013a0", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -11,11 +11,11 @@ Probes:
       subprogram: {subprogram: 142}
       events:
         - Kind: Entry
-          Type: 1526 EventRootType Probe[main.stackC]
+          Type: 1542 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0xce018a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1527 EventRootType Probe[main.stackC]Return
+          Type: 1543 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0xce01c5", Frameless: false}]
           Condition: null
       probeTemplate: {TemplateString: stackC, Segments: [stackC]}
@@ -30,11 +30,11 @@ Probes:
       subprogram: {subprogram: 56}
       events:
         - Kind: Entry
-          Type: 1390 EventRootType Probe[main.testAny]
+          Type: 1406 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0xcda9ea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1391 EventRootType Probe[main.testAny]Return
+          Type: 1407 EventRootType Probe[main.testAny]Return
           InjectionPoints: [{PC: "0xcdaa25", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -55,11 +55,11 @@ Probes:
       subprogram: {subprogram: 58}
       events:
         - Kind: Entry
-          Type: 1393 EventRootType Probe[main.testAnyPtr]
+          Type: 1409 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0xcdaa8a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1394 EventRootType Probe[main.testAnyPtr]Return
+          Type: 1410 EventRootType Probe[main.testAnyPtr]Return
           InjectionPoints: [{PC: "0xcdaabd", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -79,11 +79,11 @@ Probes:
       subprogram: {subprogram: 122}
       events:
         - Kind: Entry
-          Type: 1497 EventRootType Probe[main.testArrayArgAndReturn]
+          Type: 1513 EventRootType Probe[main.testArrayArgAndReturn]
           InjectionPoints: [{PC: "0xcdebee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1498 EventRootType Probe[main.testArrayArgAndReturn]Return
+          Type: 1514 EventRootType Probe[main.testArrayArgAndReturn]Return
           InjectionPoints: [{PC: "0xcdeca2", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -104,7 +104,7 @@ Probes:
       subprogram: {subprogram: 19}
       events:
         - Kind: Entry
-          Type: 1341 EventRootType Probe[main.testArrayEmptyStructs]
+          Type: 1357 EventRootType Probe[main.testArrayEmptyStructs]
           InjectionPoints: [{PC: "0xcd8c60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -125,7 +125,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - Kind: Entry
-          Type: 1337 EventRootType Probe[main.testArrayOfArrays]
+          Type: 1353 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0xcd8be0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -146,7 +146,7 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - Kind: Entry
-          Type: 1339 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          Type: 1355 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0xcd8c20", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -167,7 +167,7 @@ Probes:
       subprogram: {subprogram: 66}
       events:
         - Kind: Entry
-          Type: 1402 EventRootType Probe[main.testArrayOfMaps]
+          Type: 1418 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0xcdb1a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -188,7 +188,7 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - Kind: Entry
-          Type: 1338 EventRootType Probe[main.testArrayOfStrings]
+          Type: 1354 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0xcd8c00", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -208,7 +208,7 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - Kind: Entry
-          Type: 1340 EventRootType Probe[main.testArrayOfStructs]
+          Type: 1356 EventRootType Probe[main.testArrayOfStructs]
           InjectionPoints: [{PC: "0xcd8c40", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -229,11 +229,11 @@ Probes:
       subprogram: {subprogram: 86}
       events:
         - Kind: Entry
-          Type: 1424 EventRootType Probe[main.testAtomicAdd]
+          Type: 1440 EventRootType Probe[main.testAtomicAdd]
           InjectionPoints: [{PC: "0xcdd080", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1425 EventRootType Probe[main.testAtomicAdd]Return
+          Type: 1441 EventRootType Probe[main.testAtomicAdd]Return
           InjectionPoints: [{PC: "0xcdd092", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -254,11 +254,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 1359 EventRootType Probe[main.testBigStruct]
+          Type: 1375 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0xcd9360", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1360 EventRootType Probe[main.testBigStruct]Return
+          Type: 1376 EventRootType Probe[main.testBigStruct]Return
           InjectionPoints: [{PC: "0xcd937e", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -279,7 +279,7 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - Kind: Entry
-          Type: 1326 EventRootType Probe[main.testBoolArray]
+          Type: 1342 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0xcd8a80", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -300,7 +300,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - Kind: Entry
-          Type: 1323 EventRootType Probe[main.testByteArray]
+          Type: 1339 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0xcd8a20", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -326,11 +326,11 @@ Probes:
       subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1545 EventRootType Probe[main.testStruct]
+          Type: 1561 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0xce05c0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1546 EventRootType Probe[main.testStruct]Return
+          Type: 1562 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0xce05e2", Frameless: true}]
           Condition: null
     - id: testCaptureExprLine
@@ -345,10 +345,10 @@ Probes:
       segments: []
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1555 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1572 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0xcda20e"
               Frameless: false
@@ -373,10 +373,10 @@ Probes:
       segments: [x=, {json: {ref: x}, dsl: x}]
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1556 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1573 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0xcda20e"
               Frameless: false
@@ -412,7 +412,7 @@ Probes:
       subprogram: {subprogram: 84}
       events:
         - Kind: Entry
-          Type: 1421 EventRootType Probe[main.testCombinedString]
+          Type: 1437 EventRootType Probe[main.testCombinedString]
           InjectionPoints: [{PC: "0xcdcce0", Frameless: true}]
           Condition: null
     - id: testCaptureExprWithTemplate
@@ -430,7 +430,7 @@ Probes:
       subprogram: {subprogram: 84}
       events:
         - Kind: Entry
-          Type: 1422 EventRootType Probe[main.testCombinedString]
+          Type: 1438 EventRootType Probe[main.testCombinedString]
           InjectionPoints: [{PC: "0xcdcce0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -452,7 +452,7 @@ Probes:
       subprogram: {subprogram: 87}
       events:
         - Kind: Entry
-          Type: 1426 EventRootType Probe[main.testChannel]
+          Type: 1442 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0xcdd0a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -481,7 +481,7 @@ Probes:
       subprogram: {subprogram: 83}
       events:
         - Kind: Entry
-          Type: 1420 EventRootType Probe[main.testCombinedByte]
+          Type: 1436 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0xcdcca0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -512,7 +512,7 @@ Probes:
       subprogram: {subprogram: 95}
       events:
         - Kind: Entry
-          Type: 1434 EventRootType Probe[main.testCycle]
+          Type: 1450 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0xcdd460", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -533,7 +533,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - Kind: Entry
-          Type: 1365 EventRootType Probe[main.testDeepMap1]
+          Type: 1381 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0xcd9740", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -554,7 +554,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - Kind: Entry
-          Type: 1366 EventRootType Probe[main.testDeepMap7]
+          Type: 1382 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0xcd9760", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -575,7 +575,7 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - Kind: Entry
-          Type: 1361 EventRootType Probe[main.testDeepPtr1]
+          Type: 1377 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0xcd9420", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -596,7 +596,7 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - Kind: Entry
-          Type: 1362 EventRootType Probe[main.testDeepPtr7]
+          Type: 1378 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0xcd9440", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -617,7 +617,7 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - Kind: Entry
-          Type: 1363 EventRootType Probe[main.testDeepSlice1]
+          Type: 1379 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0xcd95c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -638,7 +638,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - Kind: Entry
-          Type: 1364 EventRootType Probe[main.testDeepSlice7]
+          Type: 1380 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0xcd95e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -659,7 +659,7 @@ Probes:
       subprogram: {subprogram: 131}
       events:
         - Kind: Entry
-          Type: 1514 EventRootType Probe[main.testEmptySlice]
+          Type: 1530 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0xcdfca0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -685,7 +685,7 @@ Probes:
       subprogram: {subprogram: 134}
       events:
         - Kind: Entry
-          Type: 1517 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 1533 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0xcdfd00", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -712,7 +712,7 @@ Probes:
       subprogram: {subprogram: 150}
       events:
         - Kind: Entry
-          Type: 1540 EventRootType Probe[main.testEmptyString]
+          Type: 1556 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0xce02c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -733,7 +733,7 @@ Probes:
       subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1553 EventRootType Probe[main.testEmptyStruct]
+          Type: 1569 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0xce0740", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -753,7 +753,7 @@ Probes:
       subprogram: {subprogram: 157}
       events:
         - Kind: Entry
-          Type: 1554 EventRootType Probe[main.testEmptyStructPointer]
+          Type: 1570 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0xce0760", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -774,7 +774,7 @@ Probes:
       subprogram: {subprogram: 57}
       events:
         - Kind: Entry
-          Type: 1392 EventRootType Probe[main.testError]
+          Type: 1408 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0xcdaa60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -795,11 +795,11 @@ Probes:
       subprogram: {subprogram: 48}
       events:
         - Kind: Entry
-          Type: 1374 EventRootType Probe[main.testEsotericHeap]
+          Type: 1390 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0xcd9f6a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1375 EventRootType Probe[main.testEsotericHeap]Return
+          Type: 1391 EventRootType Probe[main.testEsotericHeap]Return
           InjectionPoints: [{PC: "0xcd9fac", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -820,11 +820,11 @@ Probes:
       subprogram: {subprogram: 47}
       events:
         - Kind: Entry
-          Type: 1372 EventRootType Probe[main.testEsotericStack]
+          Type: 1388 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0xcd9e4e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1373 EventRootType Probe[main.testEsotericStack]Return
+          Type: 1389 EventRootType Probe[main.testEsotericStack]Return
           InjectionPoints: [{PC: "0xcd9edb", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -845,11 +845,11 @@ Probes:
       subprogram: {subprogram: 53}
       events:
         - Kind: Entry
-          Type: 1384 EventRootType Probe[main.testFrameless]
+          Type: 1400 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0xcda6c0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1385 EventRootType Probe[main.testFrameless]Return
+          Type: 1401 EventRootType Probe[main.testFrameless]Return
           InjectionPoints: [{PC: "0xcda6c5", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -870,11 +870,11 @@ Probes:
       subprogram: {subprogram: 54}
       events:
         - Kind: Entry
-          Type: 1386 EventRootType Probe[main.testFramelessArray]
+          Type: 1402 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0xcda6e4", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1387 EventRootType Probe[main.testFramelessArray]Return
+          Type: 1403 EventRootType Probe[main.testFramelessArray]Return
           InjectionPoints: [{PC: "0xcda71d", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -898,7 +898,7 @@ Probes:
       subprogram: {subprogram: 54}
       events:
         - Kind: Line
-          Type: 1388 EventRootType Probe[main.testFramelessArray]Line
+          Type: 1404 EventRootType Probe[main.testFramelessArray]Line
           InjectionPoints: [{PC: "0xcda6e8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -919,11 +919,11 @@ Probes:
       subprogram: {subprogram: 49}
       events:
         - Kind: Entry
-          Type: 1376 EventRootType Probe[main.testInlinedBA]
+          Type: 1392 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0xcda3aa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1377 EventRootType Probe[main.testInlinedBA]Return
+          Type: 1393 EventRootType Probe[main.testInlinedBA]Return
           InjectionPoints: [{PC: "0xcda40e", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -949,11 +949,11 @@ Probes:
       subprogram: {subprogram: 50}
       events:
         - Kind: Entry
-          Type: 1378 EventRootType Probe[main.testInlinedBB]
+          Type: 1394 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0xcda44e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1379 EventRootType Probe[main.testInlinedBB]Return
+          Type: 1395 EventRootType Probe[main.testInlinedBB]Return
           InjectionPoints: [{PC: "0xcda4de", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -979,11 +979,11 @@ Probes:
       subprogram: {subprogram: 51}
       events:
         - Kind: Entry
-          Type: 1380 EventRootType Probe[main.testInlinedBBA]
+          Type: 1396 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0xcda52a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1381 EventRootType Probe[main.testInlinedBBA]Return
+          Type: 1397 EventRootType Probe[main.testInlinedBBA]Return
           InjectionPoints: [{PC: "0xcda56b", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1001,10 +1001,10 @@ Probes:
       template: testInlinedBBB
       segments: [testInlinedBBB]
       captureSnapshot: true
-      subprogram: {subprogram: 159}
+      subprogram: {subprogram: 160}
       events:
         - Kind: Entry
-          Type: 1560 EventRootType Probe[main.testInlinedBBB]
+          Type: 1577 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xcda4a6", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1021,11 +1021,11 @@ Probes:
       subprogram: {subprogram: 52}
       events:
         - Kind: Entry
-          Type: 1382 EventRootType Probe[main.testInlinedBC]
+          Type: 1398 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0xcda5ae", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1383 EventRootType Probe[main.testInlinedBC]Return
+          Type: 1399 EventRootType Probe[main.testInlinedBC]Return
           InjectionPoints: [{PC: "0xcda693", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1039,10 +1039,10 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Entry
-          Type: 1561 EventRootType Probe[main.testInlinedBCA]
+          Type: 1578 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xcda5b3", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1059,10 +1059,10 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Line
-          Type: 1562 EventRootType Probe[main.testInlinedBCA]Line
+          Type: 1579 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0xcda5b3", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1076,10 +1076,10 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Entry
-          Type: 1563 EventRootType Probe[main.testInlinedBCB]
+          Type: 1580 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xcda65b", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1096,10 +1096,10 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Line
-          Type: 1564 EventRootType Probe[main.testInlinedBCB]Line
+          Type: 1581 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0xcda65b", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1113,10 +1113,10 @@ Probes:
       template: testInlinedFuncFromOtherPackage
       segments: [testInlinedFuncFromOtherPackage]
       captureSnapshot: true
-      subprogram: {subprogram: 165}
+      subprogram: {subprogram: 166}
       events:
         - Kind: Entry
-          Type: 1570 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
+          Type: 1587 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
           InjectionPoints:
             - PC: "0xcd8541"
               Frameless: true
@@ -1135,10 +1135,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Entry
-          Type: 1557 EventRootType Probe[main.testInlinedPrint]
+          Type: 1574 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0xcda20a"
               Frameless: false
@@ -1152,7 +1152,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1558 EventRootType Probe[main.testInlinedPrint]Return
+          Type: 1575 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0xcda24a", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1173,10 +1173,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1559 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1576 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0xcda20e"
               Frameless: false
@@ -1204,10 +1204,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 162}
+      subprogram: {subprogram: 163}
       events:
         - Kind: Entry
-          Type: 1565 EventRootType Probe[main.testInlinedSq]
+          Type: 1582 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xcda6c1", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1228,10 +1228,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 162}
+      subprogram: {subprogram: 163}
       events:
         - Kind: Line
-          Type: 1566 EventRootType Probe[main.testInlinedSq]Line
+          Type: 1583 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0xcda6c1", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1250,10 +1250,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 163}
+      subprogram: {subprogram: 164}
       events:
         - Kind: Entry
-          Type: 1567 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1584 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0xcda705"
               Frameless: false
@@ -1278,7 +1278,7 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - Kind: Entry
-          Type: 1329 EventRootType Probe[main.testInt16Array]
+          Type: 1345 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0xcd8ae0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1299,7 +1299,7 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - Kind: Entry
-          Type: 1330 EventRootType Probe[main.testInt32Array]
+          Type: 1346 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0xcd8b00", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1320,7 +1320,7 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - Kind: Entry
-          Type: 1331 EventRootType Probe[main.testInt64Array]
+          Type: 1347 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0xcd8b20", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1341,7 +1341,7 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - Kind: Entry
-          Type: 1328 EventRootType Probe[main.testInt8Array]
+          Type: 1344 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0xcd8ac0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1362,7 +1362,7 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - Kind: Entry
-          Type: 1327 EventRootType Probe[main.testIntArray]
+          Type: 1343 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0xcd8aa0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1383,7 +1383,7 @@ Probes:
       subprogram: {subprogram: 55}
       events:
         - Kind: Entry
-          Type: 1389 EventRootType Probe[main.testInterface]
+          Type: 1405 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0xcda9c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1403,11 +1403,11 @@ Probes:
       subprogram: {subprogram: 121}
       events:
         - Kind: Entry
-          Type: 1495 EventRootType Probe[main.testLargeArgAndReturn]
+          Type: 1511 EventRootType Probe[main.testLargeArgAndReturn]
           InjectionPoints: [{PC: "0xcdea4e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1496 EventRootType Probe[main.testLargeArgAndReturn]Return
+          Type: 1512 EventRootType Probe[main.testLargeArgAndReturn]Return
           InjectionPoints: [{PC: "0xcdebb3", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1417,6 +1417,49 @@ Probes:
               DSL: arg
               EventKind: Entry
               EventExpressionIndex: 1
+    - id: testLineProbeTemplateWithStructFields
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.executeStructFuncs
+        sourceFile: structs.go
+        lines: ["208"]
+      template: 'sta.a: {sta.a} sta.b: {sta.b} sta.c: {sta.c}'
+      segments:
+        - 'sta.a: '
+        - json: {getmember: [{ref: sta}, a]}
+          dsl: sta.a
+        - ' sta.b: '
+        - json: {getmember: [{ref: sta}, b]}
+          dsl: sta.b
+        - ' sta.c: '
+        - json: {getmember: [{ref: sta}, c]}
+          dsl: sta.c
+      captureSnapshot: false
+      subprogram: {subprogram: 158}
+      events:
+        - Kind: Line
+          Type: 1571 EventRootType Probe[main.executeStructFuncs]Line
+          InjectionPoints: [{PC: "0xce0dda", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: 'sta.a: {sta.a} sta.b: {sta.b} sta.c: {sta.c}'
+        Segments:
+            - 'sta.a: '
+            - JSON: {Base: {Ref: sta}, Member: a}
+              DSL: sta.a
+              EventKind: Line
+              EventExpressionIndex: 0
+            - ' sta.b: '
+            - JSON: {Base: {Ref: sta}, Member: b}
+              DSL: sta.b
+              EventKind: Line
+              EventExpressionIndex: 1
+            - ' sta.c: '
+            - JSON: {Base: {Ref: sta}, Member: c}
+              DSL: sta.c
+              EventKind: Line
+              EventExpressionIndex: 2
     - id: testLinkedList
       version: 0
       type: LOG_PROBE
@@ -1428,7 +1471,7 @@ Probes:
       subprogram: {subprogram: 89}
       events:
         - Kind: Entry
-          Type: 1428 EventRootType Probe[main.testLinkedList]
+          Type: 1444 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0xcdd280", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1452,7 +1495,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - Kind: Line
-          Type: 1369 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          Type: 1385 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xcd97da", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1473,7 +1516,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - Kind: Line
-          Type: 1370 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          Type: 1386 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xcd988d", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1494,7 +1537,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - Kind: Line
-          Type: 1371 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          Type: 1387 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xcd9954", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1536,11 +1579,11 @@ Probes:
       subprogram: {subprogram: 124}
       events:
         - Kind: Entry
-          Type: 1501 EventRootType Probe[main.testManyArgsArrayReturn]
+          Type: 1517 EventRootType Probe[main.testManyArgsArrayReturn]
           InjectionPoints: [{PC: "0xcdef13", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1502 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          Type: 1518 EventRootType Probe[main.testManyArgsArrayReturn]Return
           InjectionPoints: [{PC: "0xcdf122", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1601,7 +1644,7 @@ Probes:
       subprogram: {subprogram: 64}
       events:
         - Kind: Entry
-          Type: 1400 EventRootType Probe[main.testMapArrayToArray]
+          Type: 1416 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0xcdb160", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1622,7 +1665,7 @@ Probes:
       subprogram: {subprogram: 70}
       events:
         - Kind: Entry
-          Type: 1407 EventRootType Probe[main.testMapEmbeddedMaps]
+          Type: 1423 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0xcdb220", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1643,7 +1686,7 @@ Probes:
       subprogram: {subprogram: 80}
       events:
         - Kind: Entry
-          Type: 1417 EventRootType Probe[main.testMapEmptyKey]
+          Type: 1433 EventRootType Probe[main.testMapEmptyKey]
           InjectionPoints: [{PC: "0xcdb360", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1664,7 +1707,7 @@ Probes:
       subprogram: {subprogram: 82}
       events:
         - Kind: Entry
-          Type: 1419 EventRootType Probe[main.testMapEmptyKeyAndValue]
+          Type: 1435 EventRootType Probe[main.testMapEmptyKeyAndValue]
           InjectionPoints: [{PC: "0xcdb3a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1685,7 +1728,7 @@ Probes:
       subprogram: {subprogram: 81}
       events:
         - Kind: Entry
-          Type: 1418 EventRootType Probe[main.testMapEmptyValue]
+          Type: 1434 EventRootType Probe[main.testMapEmptyValue]
           InjectionPoints: [{PC: "0xcdb380", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1706,7 +1749,7 @@ Probes:
       subprogram: {subprogram: 68}
       events:
         - Kind: Entry
-          Type: 1404 EventRootType Probe[main.testMapIntToInt]
+          Type: 1420 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0xcdb1e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1727,7 +1770,7 @@ Probes:
       subprogram: {subprogram: 79}
       events:
         - Kind: Entry
-          Type: 1416 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          Type: 1432 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0xcdb340", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1748,7 +1791,7 @@ Probes:
       subprogram: {subprogram: 78}
       events:
         - Kind: Entry
-          Type: 1415 EventRootType Probe[main.testMapLargeKeySmallValue]
+          Type: 1431 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0xcdb320", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1771,7 +1814,7 @@ Probes:
       subprogram: {subprogram: 69}
       events:
         - Kind: Entry
-          Type: 1405 EventRootType Probe[main.testMapMassive]
+          Type: 1421 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0xcdb200", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1794,7 +1837,7 @@ Probes:
       subprogram: {subprogram: 69}
       events:
         - Kind: Entry
-          Type: 1406 EventRootType Probe[main.testMapMassive]
+          Type: 1422 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0xcdb200", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1815,7 +1858,7 @@ Probes:
       subprogram: {subprogram: 77}
       events:
         - Kind: Entry
-          Type: 1414 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          Type: 1430 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0xcdb300", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1836,7 +1879,7 @@ Probes:
       subprogram: {subprogram: 76}
       events:
         - Kind: Entry
-          Type: 1413 EventRootType Probe[main.testMapSmallKeySmallValue]
+          Type: 1429 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0xcdb2e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1857,7 +1900,7 @@ Probes:
       subprogram: {subprogram: 62}
       events:
         - Kind: Entry
-          Type: 1398 EventRootType Probe[main.testMapStringToInt]
+          Type: 1414 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0xcdb120", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1878,7 +1921,7 @@ Probes:
       subprogram: {subprogram: 63}
       events:
         - Kind: Entry
-          Type: 1399 EventRootType Probe[main.testMapStringToSlice]
+          Type: 1415 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0xcdb140", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1899,7 +1942,7 @@ Probes:
       subprogram: {subprogram: 61}
       events:
         - Kind: Entry
-          Type: 1397 EventRootType Probe[main.testMapStringToStruct]
+          Type: 1413 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0xcdb100", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1920,7 +1963,7 @@ Probes:
       subprogram: {subprogram: 71}
       events:
         - Kind: Entry
-          Type: 1408 EventRootType Probe[main.testMapWithLinkedList]
+          Type: 1424 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0xcdb240", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1941,7 +1984,7 @@ Probes:
       subprogram: {subprogram: 74}
       events:
         - Kind: Entry
-          Type: 1411 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          Type: 1427 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0xcdb2a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1962,7 +2005,7 @@ Probes:
       subprogram: {subprogram: 75}
       events:
         - Kind: Entry
-          Type: 1412 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          Type: 1428 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0xcdb2c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1983,7 +2026,7 @@ Probes:
       subprogram: {subprogram: 72}
       events:
         - Kind: Entry
-          Type: 1409 EventRootType Probe[main.testMapWithSmallValue]
+          Type: 1425 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0xcdb260", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2006,7 +2049,7 @@ Probes:
       subprogram: {subprogram: 73}
       events:
         - Kind: Entry
-          Type: 1410 EventRootType Probe[main.testMapWithSmallValueMassive]
+          Type: 1426 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0xcdb280", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2027,7 +2070,7 @@ Probes:
       subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1537 EventRootType Probe[main.testMassiveString]
+          Type: 1553 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xce0280", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2049,7 +2092,7 @@ Probes:
       subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1538 EventRootType Probe[main.testMassiveString]
+          Type: 1554 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xce0280", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2095,11 +2138,11 @@ Probes:
       subprogram: {subprogram: 125}
       events:
         - Kind: Entry
-          Type: 1503 EventRootType Probe[main.testMixedArgsStackReturn]
+          Type: 1519 EventRootType Probe[main.testMixedArgsStackReturn]
           InjectionPoints: [{PC: "0xcdf1b3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1504 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          Type: 1520 EventRootType Probe[main.testMixedArgsStackReturn]Return
           InjectionPoints: [{PC: "0xcdf3eb", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2164,11 +2207,11 @@ Probes:
       subprogram: {subprogram: 127}
       events:
         - Kind: Entry
-          Type: 1507 EventRootType Probe[main.testMultipleArrayArgs]
+          Type: 1523 EventRootType Probe[main.testMultipleArrayArgs]
           InjectionPoints: [{PC: "0xcdf52e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1508 EventRootType Probe[main.testMultipleArrayArgs]Return
+          Type: 1524 EventRootType Probe[main.testMultipleArrayArgs]Return
           InjectionPoints: [{PC: "0xcdf5ff", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2198,11 +2241,11 @@ Probes:
       subprogram: {subprogram: 123}
       events:
         - Kind: Entry
-          Type: 1499 EventRootType Probe[main.testMultipleLargeArgs]
+          Type: 1515 EventRootType Probe[main.testMultipleLargeArgs]
           InjectionPoints: [{PC: "0xcdecce", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1500 EventRootType Probe[main.testMultipleLargeArgs]Return
+          Type: 1516 EventRootType Probe[main.testMultipleLargeArgs]Return
           InjectionPoints: [{PC: "0xcdeeea", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2227,11 +2270,11 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1453 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1469 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xcde06e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1454 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1470 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcde10f", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2266,7 +2309,7 @@ Probes:
       subprogram: {subprogram: 85}
       events:
         - Kind: Entry
-          Type: 1423 EventRootType Probe[main.testMultipleSimpleParams]
+          Type: 1439 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0xcdce60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2306,11 +2349,11 @@ Probes:
       subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1449 EventRootType Probe[main.testNamedReturn]
+          Type: 1465 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0xcddfca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1450 EventRootType Probe[main.testNamedReturn]Return
+          Type: 1466 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0xcde035", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2336,11 +2379,11 @@ Probes:
       subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1451 EventRootType Probe[main.testNamedReturn]
+          Type: 1467 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0xcddfca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1452 EventRootType Probe[main.testNamedReturn]Return
+          Type: 1468 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0xcde035", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2367,7 +2410,7 @@ Probes:
       subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1549 EventRootType Probe[main.testNestedPointer]
+          Type: 1565 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0xce06c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2391,7 +2434,7 @@ Probes:
       subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1550 EventRootType Probe[main.testNestedPointer]
+          Type: 1566 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0xce06c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2421,7 +2464,7 @@ Probes:
       subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1551 EventRootType Probe[main.testNestedPointer]
+          Type: 1567 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0xce06c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2445,7 +2488,7 @@ Probes:
       subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1552 EventRootType Probe[main.testNestedPointer]
+          Type: 1568 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0xce06c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2471,7 +2514,7 @@ Probes:
       subprogram: {subprogram: 94}
       events:
         - Kind: Entry
-          Type: 1433 EventRootType Probe[main.testNilPointer]
+          Type: 1449 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0xcdd420", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2497,7 +2540,7 @@ Probes:
       subprogram: {subprogram: 138}
       events:
         - Kind: Entry
-          Type: 1521 EventRootType Probe[main.testNilSlice]
+          Type: 1537 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0xcdfd80", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2523,7 +2566,7 @@ Probes:
       subprogram: {subprogram: 135}
       events:
         - Kind: Entry
-          Type: 1518 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 1534 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0xcdfd20", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2557,7 +2600,7 @@ Probes:
       subprogram: {subprogram: 137}
       events:
         - Kind: Entry
-          Type: 1520 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 1536 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0xcdfd60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2588,7 +2631,7 @@ Probes:
       subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1536 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 1552 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0xce0260", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2609,7 +2652,7 @@ Probes:
       subprogram: {subprogram: 90}
       events:
         - Kind: Entry
-          Type: 1429 EventRootType Probe[main.testPointerLoop]
+          Type: 1445 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0xcdd2a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2630,7 +2673,7 @@ Probes:
       subprogram: {subprogram: 67}
       events:
         - Kind: Entry
-          Type: 1403 EventRootType Probe[main.testPointerToMap]
+          Type: 1419 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0xcdb1c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2651,7 +2694,7 @@ Probes:
       subprogram: {subprogram: 88}
       events:
         - Kind: Entry
-          Type: 1427 EventRootType Probe[main.testPointerToSimpleStruct]
+          Type: 1443 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0xcdd260", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2672,11 +2715,11 @@ Probes:
       subprogram: {subprogram: 101}
       events:
         - Kind: Entry
-          Type: 1445 EventRootType Probe[main.testReturnsAny]
+          Type: 1461 EventRootType Probe[main.testReturnsAny]
           InjectionPoints: [{PC: "0xcddc6e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1446 EventRootType Probe[main.testReturnsAny]Return
+          Type: 1462 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints:
             - PC: "0xcddd15"
               Frameless: false
@@ -2710,11 +2753,11 @@ Probes:
       subprogram: {subprogram: 100}
       events:
         - Kind: Entry
-          Type: 1443 EventRootType Probe[main.testReturnsAnyAndError]
+          Type: 1459 EventRootType Probe[main.testReturnsAnyAndError]
           InjectionPoints: [{PC: "0xcddb0e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1444 EventRootType Probe[main.testReturnsAnyAndError]Return
+          Type: 1460 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
             - PC: "0xcddb64"
               Frameless: false
@@ -2747,11 +2790,11 @@ Probes:
       subprogram: {subprogram: 110}
       events:
         - Kind: Entry
-          Type: 1473 EventRootType Probe[main.testReturnsArray]
+          Type: 1489 EventRootType Probe[main.testReturnsArray]
           InjectionPoints: [{PC: "0xcde4ea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1474 EventRootType Probe[main.testReturnsArray]Return
+          Type: 1490 EventRootType Probe[main.testReturnsArray]Return
           InjectionPoints: [{PC: "0xcde54d", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2767,11 +2810,11 @@ Probes:
       subprogram: {subprogram: 111}
       events:
         - Kind: Entry
-          Type: 1475 EventRootType Probe[main.testReturnsArrayOne]
+          Type: 1491 EventRootType Probe[main.testReturnsArrayOne]
           InjectionPoints: [{PC: "0xcde56a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1476 EventRootType Probe[main.testReturnsArrayOne]Return
+          Type: 1492 EventRootType Probe[main.testReturnsArrayOne]Return
           InjectionPoints: [{PC: "0xcde5ab", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2787,11 +2830,11 @@ Probes:
       subprogram: {subprogram: 112}
       events:
         - Kind: Entry
-          Type: 1477 EventRootType Probe[main.testReturnsArrayZero]
+          Type: 1493 EventRootType Probe[main.testReturnsArrayZero]
           InjectionPoints: [{PC: "0xcde5ca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1478 EventRootType Probe[main.testReturnsArrayZero]Return
+          Type: 1494 EventRootType Probe[main.testReturnsArrayZero]Return
           InjectionPoints: [{PC: "0xcde606", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2807,11 +2850,11 @@ Probes:
       subprogram: {subprogram: 114}
       events:
         - Kind: Entry
-          Type: 1481 EventRootType Probe[main.testReturnsBacktrackInt]
+          Type: 1497 EventRootType Probe[main.testReturnsBacktrackInt]
           InjectionPoints: [{PC: "0xcde6ae", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1482 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          Type: 1498 EventRootType Probe[main.testReturnsBacktrackInt]Return
           InjectionPoints: [{PC: "0xcde72a", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2827,11 +2870,11 @@ Probes:
       subprogram: {subprogram: 120}
       events:
         - Kind: Entry
-          Type: 1493 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          Type: 1509 EventRootType Probe[main.testReturnsBoolAndUintptr]
           InjectionPoints: [{PC: "0xcde9ea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1494 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          Type: 1510 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
           InjectionPoints: [{PC: "0xcdea30", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2847,11 +2890,11 @@ Probes:
       subprogram: {subprogram: 108}
       events:
         - Kind: Entry
-          Type: 1469 EventRootType Probe[main.testReturnsComplex]
+          Type: 1485 EventRootType Probe[main.testReturnsComplex]
           InjectionPoints: [{PC: "0xcde3aa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1470 EventRootType Probe[main.testReturnsComplex]Return
+          Type: 1486 EventRootType Probe[main.testReturnsComplex]Return
           InjectionPoints: [{PC: "0xcde406", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2868,11 +2911,11 @@ Probes:
       subprogram: {subprogram: 99}
       events:
         - Kind: Entry
-          Type: 1441 EventRootType Probe[main.testReturnsError]
+          Type: 1457 EventRootType Probe[main.testReturnsError]
           InjectionPoints: [{PC: "0xcddaaa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1442 EventRootType Probe[main.testReturnsError]Return
+          Type: 1458 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
             - PC: "0xcddada"
               Frameless: false
@@ -2896,11 +2939,11 @@ Probes:
       subprogram: {subprogram: 96}
       events:
         - Kind: Entry
-          Type: 1435 EventRootType Probe[main.testReturnsInt]
+          Type: 1451 EventRootType Probe[main.testReturnsInt]
           InjectionPoints: [{PC: "0xcdd8aa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1436 EventRootType Probe[main.testReturnsInt]Return
+          Type: 1452 EventRootType Probe[main.testReturnsInt]Return
           InjectionPoints: [{PC: "0xcdd8fb", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2920,11 +2963,11 @@ Probes:
       subprogram: {subprogram: 98}
       events:
         - Kind: Entry
-          Type: 1439 EventRootType Probe[main.testReturnsIntAndFloat]
+          Type: 1455 EventRootType Probe[main.testReturnsIntAndFloat]
           InjectionPoints: [{PC: "0xcdd9ce", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1440 EventRootType Probe[main.testReturnsIntAndFloat]Return
+          Type: 1456 EventRootType Probe[main.testReturnsIntAndFloat]Return
           InjectionPoints: [{PC: "0xcdda84", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2944,11 +2987,11 @@ Probes:
       subprogram: {subprogram: 97}
       events:
         - Kind: Entry
-          Type: 1437 EventRootType Probe[main.testReturnsIntPointer]
+          Type: 1453 EventRootType Probe[main.testReturnsIntPointer]
           InjectionPoints: [{PC: "0xcdd92a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1438 EventRootType Probe[main.testReturnsIntPointer]Return
+          Type: 1454 EventRootType Probe[main.testReturnsIntPointer]Return
           InjectionPoints: [{PC: "0xcdd994", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2969,11 +3012,11 @@ Probes:
       subprogram: {subprogram: 102}
       events:
         - Kind: Entry
-          Type: 1447 EventRootType Probe[main.testReturnsInterface]
+          Type: 1463 EventRootType Probe[main.testReturnsInterface]
           InjectionPoints: [{PC: "0xcdde6e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1448 EventRootType Probe[main.testReturnsInterface]Return
+          Type: 1464 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
             - PC: "0xcddf3f"
               Frameless: false
@@ -2997,11 +3040,11 @@ Probes:
       subprogram: {subprogram: 109}
       events:
         - Kind: Entry
-          Type: 1471 EventRootType Probe[main.testReturnsLargeStruct]
+          Type: 1487 EventRootType Probe[main.testReturnsLargeStruct]
           InjectionPoints: [{PC: "0xcde42e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1472 EventRootType Probe[main.testReturnsLargeStruct]Return
+          Type: 1488 EventRootType Probe[main.testReturnsLargeStruct]Return
           InjectionPoints: [{PC: "0xcde4b3", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3017,11 +3060,11 @@ Probes:
       subprogram: {subprogram: 107}
       events:
         - Kind: Entry
-          Type: 1467 EventRootType Probe[main.testReturnsManyFloats]
+          Type: 1483 EventRootType Probe[main.testReturnsManyFloats]
           InjectionPoints: [{PC: "0xcde2ae", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1468 EventRootType Probe[main.testReturnsManyFloats]Return
+          Type: 1484 EventRootType Probe[main.testReturnsManyFloats]Return
           InjectionPoints: [{PC: "0xcde387", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3037,11 +3080,11 @@ Probes:
       subprogram: {subprogram: 116}
       events:
         - Kind: Entry
-          Type: 1485 EventRootType Probe[main.testReturnsMixed]
+          Type: 1501 EventRootType Probe[main.testReturnsMixed]
           InjectionPoints: [{PC: "0xcde80a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1486 EventRootType Probe[main.testReturnsMixed]Return
+          Type: 1502 EventRootType Probe[main.testReturnsMixed]Return
           InjectionPoints: [{PC: "0xcde86c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3057,11 +3100,11 @@ Probes:
       subprogram: {subprogram: 113}
       events:
         - Kind: Entry
-          Type: 1479 EventRootType Probe[main.testReturnsMixedStruct]
+          Type: 1495 EventRootType Probe[main.testReturnsMixedStruct]
           InjectionPoints: [{PC: "0xcde62a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1480 EventRootType Probe[main.testReturnsMixedStruct]Return
+          Type: 1496 EventRootType Probe[main.testReturnsMixedStruct]Return
           InjectionPoints: [{PC: "0xcde678", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3077,11 +3120,11 @@ Probes:
       subprogram: {subprogram: 119}
       events:
         - Kind: Entry
-          Type: 1491 EventRootType Probe[main.testReturnsMultipleFloats]
+          Type: 1507 EventRootType Probe[main.testReturnsMultipleFloats]
           InjectionPoints: [{PC: "0xcde96a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1492 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          Type: 1508 EventRootType Probe[main.testReturnsMultipleFloats]Return
           InjectionPoints: [{PC: "0xcde9b6", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3097,11 +3140,11 @@ Probes:
       subprogram: {subprogram: 118}
       events:
         - Kind: Entry
-          Type: 1489 EventRootType Probe[main.testReturnsOnlyFloat]
+          Type: 1505 EventRootType Probe[main.testReturnsOnlyFloat]
           InjectionPoints: [{PC: "0xcde90a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1490 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          Type: 1506 EventRootType Probe[main.testReturnsOnlyFloat]Return
           InjectionPoints: [{PC: "0xcde94e", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3117,11 +3160,11 @@ Probes:
       subprogram: {subprogram: 106}
       events:
         - Kind: Entry
-          Type: 1465 EventRootType Probe[main.testReturnsPrimitives]
+          Type: 1481 EventRootType Probe[main.testReturnsPrimitives]
           InjectionPoints: [{PC: "0xcde22a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1466 EventRootType Probe[main.testReturnsPrimitives]Return
+          Type: 1482 EventRootType Probe[main.testReturnsPrimitives]Return
           InjectionPoints: [{PC: "0xcde291", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3137,11 +3180,11 @@ Probes:
       subprogram: {subprogram: 117}
       events:
         - Kind: Entry
-          Type: 1487 EventRootType Probe[main.testReturnsStructWithArray]
+          Type: 1503 EventRootType Probe[main.testReturnsStructWithArray]
           InjectionPoints: [{PC: "0xcde88a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1488 EventRootType Probe[main.testReturnsStructWithArray]Return
+          Type: 1504 EventRootType Probe[main.testReturnsStructWithArray]Return
           InjectionPoints: [{PC: "0xcde8ed", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3157,11 +3200,11 @@ Probes:
       subprogram: {subprogram: 115}
       events:
         - Kind: Entry
-          Type: 1483 EventRootType Probe[main.testReturnsWideStruct]
+          Type: 1499 EventRootType Probe[main.testReturnsWideStruct]
           InjectionPoints: [{PC: "0xcde74e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1484 EventRootType Probe[main.testReturnsWideStruct]Return
+          Type: 1500 EventRootType Probe[main.testReturnsWideStruct]Return
           InjectionPoints: [{PC: "0xcde7d4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3178,7 +3221,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - Kind: Entry
-          Type: 1324 EventRootType Probe[main.testRuneArray]
+          Type: 1340 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0xcd8a40", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3212,11 +3255,11 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1455 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1471 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xcde06e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1456 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1472 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcde10f", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3261,7 +3304,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 1345 EventRootType Probe[main.testSingleBool]
+          Type: 1361 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0xcd9060", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3282,7 +3325,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - Kind: Entry
-          Type: 1343 EventRootType Probe[main.testSingleByte]
+          Type: 1359 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0xcd9020", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3303,7 +3346,7 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 1356 EventRootType Probe[main.testSingleFloat32]
+          Type: 1372 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0xcd91c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3324,7 +3367,7 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - Kind: Entry
-          Type: 1357 EventRootType Probe[main.testSingleFloat64]
+          Type: 1373 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0xcd91e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3345,7 +3388,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 1346 EventRootType Probe[main.testSingleInt]
+          Type: 1362 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0xcd9080", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3366,7 +3409,7 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - Kind: Entry
-          Type: 1348 EventRootType Probe[main.testSingleInt16]
+          Type: 1364 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0xcd90c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3388,7 +3431,7 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - Kind: Entry
-          Type: 1349 EventRootType Probe[main.testSingleInt32]
+          Type: 1365 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0xcd90e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3409,7 +3452,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - Kind: Entry
-          Type: 1350 EventRootType Probe[main.testSingleInt64]
+          Type: 1366 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0xcd9100", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3437,7 +3480,7 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - Kind: Entry
-          Type: 1347 EventRootType Probe[main.testSingleInt8]
+          Type: 1363 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0xcd90a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3467,7 +3510,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 1344 EventRootType Probe[main.testSingleRune]
+          Type: 1360 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0xcd9040", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3488,7 +3531,7 @@ Probes:
       subprogram: {subprogram: 143}
       events:
         - Kind: Entry
-          Type: 1528 EventRootType Probe[main.testSingleString]
+          Type: 1544 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0xce01e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3509,7 +3552,7 @@ Probes:
       subprogram: {subprogram: 29}
       events:
         - Kind: Entry
-          Type: 1351 EventRootType Probe[main.testSingleUint]
+          Type: 1367 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0xcd9120", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3530,7 +3573,7 @@ Probes:
       subprogram: {subprogram: 31}
       events:
         - Kind: Entry
-          Type: 1353 EventRootType Probe[main.testSingleUint16]
+          Type: 1369 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0xcd9160", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3551,7 +3594,7 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - Kind: Entry
-          Type: 1354 EventRootType Probe[main.testSingleUint32]
+          Type: 1370 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0xcd9180", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3572,7 +3615,7 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 1355 EventRootType Probe[main.testSingleUint64]
+          Type: 1371 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0xcd91a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3593,7 +3636,7 @@ Probes:
       subprogram: {subprogram: 30}
       events:
         - Kind: Entry
-          Type: 1352 EventRootType Probe[main.testSingleUint8]
+          Type: 1368 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0xcd9140", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3614,7 +3657,7 @@ Probes:
       subprogram: {subprogram: 140}
       events:
         - Kind: Entry
-          Type: 1524 EventRootType Probe[main.testSliceEmptyStructs]
+          Type: 1540 EventRootType Probe[main.testSliceEmptyStructs]
           InjectionPoints: [{PC: "0xcdfdc0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3635,7 +3678,7 @@ Probes:
       subprogram: {subprogram: 132}
       events:
         - Kind: Entry
-          Type: 1515 EventRootType Probe[main.testSliceOfSlices]
+          Type: 1531 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0xcdfcc0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3656,7 +3699,7 @@ Probes:
       subprogram: {subprogram: 65}
       events:
         - Kind: Entry
-          Type: 1401 EventRootType Probe[main.testSmallMap]
+          Type: 1417 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0xcdb180", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3676,11 +3719,11 @@ Probes:
       subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1463 EventRootType Probe[main.testSomeNamedReturn]
+          Type: 1479 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0xcde14e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1464 EventRootType Probe[main.testSomeNamedReturn]Return
+          Type: 1480 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0xcde1ed", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3700,11 +3743,11 @@ Probes:
       subprogram: {subprogram: 126}
       events:
         - Kind: Entry
-          Type: 1505 EventRootType Probe[main.testStackArgRegReturns]
+          Type: 1521 EventRootType Probe[main.testStackArgRegReturns]
           InjectionPoints: [{PC: "0xcdf48a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1506 EventRootType Probe[main.testStackArgRegReturns]Return
+          Type: 1522 EventRootType Probe[main.testStackArgRegReturns]Return
           InjectionPoints: [{PC: "0xcdf4fc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3725,7 +3768,7 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - Kind: Entry
-          Type: 1325 EventRootType Probe[main.testStringArray]
+          Type: 1341 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0xcd8a60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3746,7 +3789,7 @@ Probes:
       subprogram: {subprogram: 93}
       events:
         - Kind: Entry
-          Type: 1432 EventRootType Probe[main.testStringPointer]
+          Type: 1448 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0xcdd3e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3767,7 +3810,7 @@ Probes:
       subprogram: {subprogram: 136}
       events:
         - Kind: Entry
-          Type: 1519 EventRootType Probe[main.testStringSlice]
+          Type: 1535 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0xcdfd40", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3788,7 +3831,7 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - Kind: Entry
-          Type: 1367 EventRootType Probe[main.testStringType1]
+          Type: 1383 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0xcd9780", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3809,7 +3852,7 @@ Probes:
       subprogram: {subprogram: 45}
       events:
         - Kind: Entry
-          Type: 1368 EventRootType Probe[main.testStringType2]
+          Type: 1384 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0xcd97a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3830,11 +3873,11 @@ Probes:
       subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1547 EventRootType Probe[main.testStruct]
+          Type: 1563 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0xce05c0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1548 EventRootType Probe[main.testStruct]Return
+          Type: 1564 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0xce05e2", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3860,7 +3903,7 @@ Probes:
       subprogram: {subprogram: 133}
       events:
         - Kind: Entry
-          Type: 1516 EventRootType Probe[main.testStructSlice]
+          Type: 1532 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0xcdfce0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3886,7 +3929,7 @@ Probes:
       subprogram: {subprogram: 59}
       events:
         - Kind: Entry
-          Type: 1395 EventRootType Probe[main.testStructWithAny]
+          Type: 1411 EventRootType Probe[main.testStructWithAny]
           InjectionPoints: [{PC: "0xcdaae0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3906,11 +3949,11 @@ Probes:
       subprogram: {subprogram: 128}
       events:
         - Kind: Entry
-          Type: 1509 EventRootType Probe[main.testStructWithArrayArg]
+          Type: 1525 EventRootType Probe[main.testStructWithArrayArg]
           InjectionPoints: [{PC: "0xcdf62e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1510 EventRootType Probe[main.testStructWithArrayArg]Return
+          Type: 1526 EventRootType Probe[main.testStructWithArrayArg]Return
           InjectionPoints: [{PC: "0xcdf6dc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3931,11 +3974,11 @@ Probes:
       subprogram: {subprogram: 153}
       events:
         - Kind: Entry
-          Type: 1543 EventRootType Probe[main.testStructWithCyclicMaps]
+          Type: 1559 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0xce0480", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1544 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          Type: 1560 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0xce049e", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3955,7 +3998,7 @@ Probes:
       subprogram: {subprogram: 152}
       events:
         - Kind: Entry
-          Type: 1542 EventRootType Probe[main.testStructWithCyclicSlices]
+          Type: 1558 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0xce0460", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3981,7 +4024,7 @@ Probes:
       subprogram: {subprogram: 60}
       events:
         - Kind: Entry
-          Type: 1396 EventRootType Probe[main.testStructWithMap]
+          Type: 1412 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0xcdb0e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4012,7 +4055,7 @@ Probes:
       subprogram: {subprogram: 141}
       events:
         - Kind: Entry
-          Type: 1525 EventRootType Probe[main.testSubslices]
+          Type: 1541 EventRootType Probe[main.testSubslices]
           InjectionPoints: [{PC: "0xcdfde0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4051,7 +4094,7 @@ Probes:
       subprogram: {subprogram: 151}
       events:
         - Kind: Entry
-          Type: 1541 EventRootType Probe[main.testSubstrings]
+          Type: 1557 EventRootType Probe[main.testSubstrings]
           InjectionPoints: [{PC: "0xce02e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4083,11 +4126,11 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1457 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1473 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xcde06e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1458 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1474 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcde10f", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -4107,11 +4150,11 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1459 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1475 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xcde06e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1460 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1476 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcde10f", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -4133,11 +4176,11 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1461 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1477 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xcde06e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1462 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1478 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcde10f", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -4165,7 +4208,7 @@ Probes:
       subprogram: {subprogram: 144}
       events:
         - Kind: Entry
-          Type: 1529 EventRootType Probe[main.testThreeStrings]
+          Type: 1545 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0xce0200", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4196,11 +4239,11 @@ Probes:
       subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1530 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1546 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0xce0220", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1531 EventRootType Probe[main.testThreeStringsInStruct]Return
+          Type: 1547 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0xce023e", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4229,11 +4272,11 @@ Probes:
       subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1532 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1548 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0xce0220", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1533 EventRootType Probe[main.testThreeStringsInStruct]Return
+          Type: 1549 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0xce023e", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4264,7 +4307,7 @@ Probes:
       subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1534 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1550 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0xce0240", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4293,7 +4336,7 @@ Probes:
       subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1535 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1551 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0xce0240", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4324,7 +4367,7 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 1358 EventRootType Probe[main.testTypeAlias]
+          Type: 1374 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0xcd9200", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4345,7 +4388,7 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - Kind: Entry
-          Type: 1334 EventRootType Probe[main.testUint16Array]
+          Type: 1350 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0xcd8b80", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4366,7 +4409,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - Kind: Entry
-          Type: 1335 EventRootType Probe[main.testUint32Array]
+          Type: 1351 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0xcd8ba0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4387,7 +4430,7 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - Kind: Entry
-          Type: 1336 EventRootType Probe[main.testUint64Array]
+          Type: 1352 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0xcd8bc0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4408,7 +4451,7 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - Kind: Entry
-          Type: 1333 EventRootType Probe[main.testUint8Array]
+          Type: 1349 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0xcd8b60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4429,7 +4472,7 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - Kind: Entry
-          Type: 1332 EventRootType Probe[main.testUintArray]
+          Type: 1348 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0xcd8b40", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4450,7 +4493,7 @@ Probes:
       subprogram: {subprogram: 92}
       events:
         - Kind: Entry
-          Type: 1431 EventRootType Probe[main.testUintPointer]
+          Type: 1447 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0xcdd300", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4471,7 +4514,7 @@ Probes:
       subprogram: {subprogram: 130}
       events:
         - Kind: Entry
-          Type: 1513 EventRootType Probe[main.testUintSlice]
+          Type: 1529 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0xcdfc80", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4492,7 +4535,7 @@ Probes:
       subprogram: {subprogram: 149}
       events:
         - Kind: Entry
-          Type: 1539 EventRootType Probe[main.testUnitializedString]
+          Type: 1555 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0xce02a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4513,7 +4556,7 @@ Probes:
       subprogram: {subprogram: 91}
       events:
         - Kind: Entry
-          Type: 1430 EventRootType Probe[main.testUnsafePointer]
+          Type: 1446 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0xcdd2c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4534,7 +4577,7 @@ Probes:
       subprogram: {subprogram: 20}
       events:
         - Kind: Entry
-          Type: 1342 EventRootType Probe[main.testVeryLargeArray]
+          Type: 1358 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0xcd8ca0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4555,7 +4598,7 @@ Probes:
       subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1522 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1538 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xcdfda0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4576,7 +4619,7 @@ Probes:
       subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1523 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1539 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xcdfda0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4593,10 +4636,10 @@ Probes:
       template: testWhollyInlinedSubroutine
       segments: [testWhollyInlinedSubroutine]
       captureSnapshot: true
-      subprogram: {subprogram: 164}
+      subprogram: {subprogram: 165}
       events:
         - Kind: Entry
-          Type: 1568 EventRootType Probe[main.firstBehavior.DoSomething]
+          Type: 1585 EventRootType Probe[main.firstBehavior.DoSomething]
           InjectionPoints:
             - PC: "0xcda8ea"
               Frameless: false
@@ -4604,7 +4647,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1569 EventRootType Probe[main.firstBehavior.DoSomething]Return
+          Type: 1586 EventRootType Probe[main.firstBehavior.DoSomething]Return
           InjectionPoints: [{PC: "0xcda925", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -4625,11 +4668,11 @@ Probes:
       subprogram: {subprogram: 129}
       events:
         - Kind: Entry
-          Type: 1511 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          Type: 1527 EventRootType Probe[main.testZeroSizeArgAndReturn]
           InjectionPoints: [{PC: "0xcdf70e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1512 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          Type: 1528 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
           InjectionPoints: [{PC: "0xcdf78c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -7913,6 +7956,69 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 158
+      Name: main.executeStructFuncs
+      OutOfLinePCRanges: [0xce07a0..0xce191d]
+      InlinePCRanges: []
+      Variables:
+        - Name: n
+          Type: 321 StructureType main.nStruct
+          Locations: [{Range: 0xce07a0..0xce191d, Pieces: []}]
+          Role: Local
+        - Name: ns
+          Type: 262 StructureType main.structWithNoStrings
+          Locations: [{Range: 0xce07a0..0xce191d, Pieces: []}]
+          Role: Local
+        - Name: cs
+          Type: 322 StructureType main.cStruct
+          Locations: [{Range: 0xce07a0..0xce191d, Pieces: []}]
+          Role: Local
+        - Name: rcvr
+          Type: 323 StructureType main.receiver
+          Locations: [{Range: 0xce07a0..0xce191d, Pieces: []}]
+          Role: Local
+        - Name: ts
+          Type: 324 StructureType main.threestrings
+          Locations:
+            - Range: 0xce07c4..0xce191d
+              Pieces: [{Size: 48, Op: {CfaOffset: -2080}}]
+          Role: Local
+        - Name: s
+          Type: 316 StructureType main.aStruct
+          Locations:
+            - Range: 0xce084e..0xce191d
+              Pieces: [{Size: 56, Op: {CfaOffset: -1920}}]
+          Role: Local
+        - Name: b
+          Type: 325 StructureType main.bStruct
+          Locations:
+            - Range: 0xce08f5..0xce191d
+              Pieces: [{Size: 72, Op: {CfaOffset: -2080}}]
+          Role: Local
+        - Name: tenStr
+          Type: 326 StructureType main.tenStrings
+          Locations:
+            - Range: 0xce0be1..0xce191d
+              Pieces: [{Size: 160, Op: {CfaOffset: -2080}}]
+          Role: Local
+        - Name: deep
+          Type: 327 StructureType main.deepStruct1
+          Locations:
+            - Range: 0xce0c2a..0xce191d
+              Pieces: [{Size: 48, Op: {CfaOffset: -2168}}]
+          Role: Local
+        - Name: fields
+          Type: 333 StructureType main.lotsOfFields
+          Locations:
+            - Range: 0xce0cb7..0xce191d
+              Pieces: [{Size: 26, Op: {CfaOffset: -2168}}]
+          Role: Local
+        - Name: sta
+          Type: 334 StructureType main.structWithTwoArrays
+          Locations:
+            - Range: 0xce0d4e..0xce191d
+              Pieces: [{Size: 72, Op: {CfaOffset: -2168}}]
+          Role: Local
+    - ID: 159
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0xcda200..0xcda262]
       InlinePCRanges:
@@ -7941,28 +8047,28 @@ Subprograms:
             - Range: 0xcda520..0xcda53a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 159
+    - ID: 160
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xcda4a6..0xcda4de]
           RootRanges: [0xcda440..0xcda505]
       Variables: []
-    - ID: 160
+    - ID: 161
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xcda5b3..0xcda5f1]
           RootRanges: [0xcda5a0..0xcda6a5]
       Variables: []
-    - ID: 161
+    - ID: 162
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xcda65b..0xcda693]
           RootRanges: [0xcda5a0..0xcda6a5]
       Variables: []
-    - ID: 162
+    - ID: 163
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -7975,7 +8081,7 @@ Subprograms:
             - Range: 0xcda6c0..0xcda6c5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 163
+    - ID: 164
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -7992,7 +8098,7 @@ Subprograms:
             - Range: 0xcda78c..0xcda8c5
               Pieces: [{Size: 40, Op: {CfaOffset: -128}}]
           Role: Parameter
-    - ID: 164
+    - ID: 165
       Name: main.firstBehavior.DoSomething
       OutOfLinePCRanges: [0xcda8e0..0xcda946]
       InlinePCRanges:
@@ -8000,7 +8106,7 @@ Subprograms:
           RootRanges: [0xce1ae0..0xce1b5f]
       Variables:
         - Name: b
-          Type: 321 StructureType main.firstBehavior
+          Type: 337 StructureType main.firstBehavior
           Locations:
             - Range: 0xcda8e0..0xcda8fe
               Pieces:
@@ -8023,7 +8129,7 @@ Subprograms:
             - Range: 0xcda926..0xcda946
               Pieces: []
           Role: Return
-    - ID: 165
+    - ID: 166
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -8039,20 +8145,20 @@ Types:
       ByteSize: 8
       Pointee: 140 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 1238
+      ID: 1254
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 1239 PointerType *main.deepSlice3
+      Pointee: 1255 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 1263
+      ID: 1279
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 1264 PointerType *main.deepSlice8
+      Pointee: 1280 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 1269
+      ID: 1285
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 1270 PointerType *main.deepSlice9
+      Pointee: 1286 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 153
       Name: '**main.stringType2'
@@ -8060,7 +8166,7 @@ Types:
       GoKind: 22
       Pointee: 154 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 1234
+      ID: 1250
       Name: '**main.t'
       ByteSize: 8
       Pointee: 248 PointerType *main.t
@@ -8103,30 +8209,30 @@ Types:
       ByteSize: 8
       Pointee: 148 PointerType *table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1246
+      ID: 1262
       Name: '**table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1247 PointerType *table<int,*main.deepMap3>
+      Pointee: 1263 PointerType *table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1280
+      ID: 1296
       Name: '**table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1281 PointerType *table<int,*main.deepMap8>
+      Pointee: 1297 PointerType *table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1295
+      ID: 1311
       Name: '**table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1296 PointerType *table<int,*main.deepMap9>
+      Pointee: 1312 PointerType *table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 169
       Name: '**table<int,int>'
       ByteSize: 8
       Pointee: 170 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 1310
+      ID: 1326
       Name: '**table<int,interface {}>'
       ByteSize: 8
-      Pointee: 1311 PointerType *table<int,interface {}>
+      Pointee: 1327 PointerType *table<int,interface {}>
     - __kind: PointerType
       ID: 236
       Name: '**table<int,struct {}>'
@@ -8148,10 +8254,10 @@ Types:
       ByteSize: 8
       Pointee: 185 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 981
+      ID: 997
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 982 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 998 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 179
       Name: '**table<string,int>'
@@ -8213,120 +8319,120 @@ Types:
       ByteSize: 8
       Pointee: 212 PointerType *table<uint8,uint8>
     - __kind: PointerType
-      ID: 335
+      ID: 351
       Name: '*[]*main.deepSlice2.array'
       ByteSize: 8
-      Pointee: 334 GoSliceDataType []*main.deepSlice2.array
+      Pointee: 350 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 1242
+      ID: 1258
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 1241 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 1257 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 1267
+      ID: 1283
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 1266 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 1282 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 1273
+      ID: 1289
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 1272 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 1288 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
-      ID: 330
+      ID: 346
       Name: '*[]*runtime.p.array'
       ByteSize: 8
-      Pointee: 329 GoSliceDataType []*runtime.p.array
+      Pointee: 345 GoSliceDataType []*runtime.p.array
     - __kind: PointerType
-      ID: 332
+      ID: 348
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 331 GoSliceDataType []*string.array
+      Pointee: 347 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 495
+      ID: 511
       Name: '*[][][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 494 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Pointee: 510 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 284
       Name: '*[][][][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 281 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 493
+      ID: 509
       Name: '*[][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 492 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Pointee: 508 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 282
       Name: '*[][][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 279 GoSliceHeaderType [][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 491
+      ID: 507
       Name: '*[][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 490 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Pointee: 506 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 280
       Name: '*[][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 277 GoSliceHeaderType [][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 489
+      ID: 505
       Name: '*[][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 488 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Pointee: 504 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 278
       Name: '*[][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 275 GoSliceHeaderType [][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 487
+      ID: 503
       Name: '*[][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 486 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Pointee: 502 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 473
+      ID: 489
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 472 GoSliceDataType [][]uint.array
+      Pointee: 488 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 479
+      ID: 495
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 478 GoSliceDataType []bool.array
+      Pointee: 494 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 1018
+      ID: 1034
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 1017 GoSliceDataType []float64.array
+      Pointee: 1033 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 1276
+      ID: 1292
       Name: '*[]interface {}.array'
       ByteSize: 8
-      Pointee: 1275 GoSliceDataType []interface {}.array
+      Pointee: 1291 GoSliceDataType []interface {}.array
     - __kind: PointerType
       ID: 276
       Name: '*[]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 273 GoSliceHeaderType []main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 485
+      ID: 501
       Name: '*[]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 484 GoSliceDataType []main.structWithCyclicSlices.array
+      Pointee: 500 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 545
+      ID: 561
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 544 GoSliceDataType []main.structWithMap.array
+      Pointee: 560 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 475
+      ID: 491
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 474 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 490 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
       ID: 39
       Name: '*[]runtime.ancestorInfo'
@@ -8335,101 +8441,101 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 477
+      ID: 493
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 476 GoSliceDataType []string.array
+      Pointee: 492 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 483
+      ID: 499
       Name: '*[]struct {}.array'
       ByteSize: 8
-      Pointee: 482 GoSliceDataType []struct {}.array
+      Pointee: 498 GoSliceDataType []struct {}.array
     - __kind: PointerType
       ID: 259
       Name: '*[]uint'
       ByteSize: 8
       Pointee: 257 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 471
+      ID: 487
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 470 GoSliceDataType []uint.array
+      Pointee: 486 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 481
+      ID: 497
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 480 GoSliceDataType []uint16.array
+      Pointee: 496 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 325
+      ID: 341
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 324 GoSliceDataType []uint8.array
+      Pointee: 340 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 327
+      ID: 343
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 326 GoSliceDataType []uintptr.array
+      Pointee: 342 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 1148
+      ID: 1164
       Name: '*archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1.988096e+06
       GoKind: 22
-      Pointee: 1149 UnresolvedPointeeType archive/tar.Writer
+      Pointee: 1165 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
-      ID: 783
+      ID: 799
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 932384
       GoKind: 22
-      Pointee: 784 GoSliceHeaderType archive/tar.headerError
+      Pointee: 800 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 786
+      ID: 802
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 785 GoSliceDataType archive/tar.headerError.array
+      Pointee: 801 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 1083
+      ID: 1099
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.437216e+06
       GoKind: 22
-      Pointee: 1084 UnresolvedPointeeType archive/tar.regFileWriter
+      Pointee: 1100 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
-      ID: 1031
+      ID: 1047
       Name: '*archive/zip.countWriter'
       ByteSize: 8
       GoRuntimeType: 932576
       GoKind: 22
-      Pointee: 1032 UnresolvedPointeeType archive/zip.countWriter
+      Pointee: 1048 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
-      ID: 1033
+      ID: 1049
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
       GoRuntimeType: 932672
       GoKind: 22
-      Pointee: 1034 StructureType archive/zip.dirWriter
+      Pointee: 1050 StructureType archive/zip.dirWriter
     - __kind: PointerType
-      ID: 1127
+      ID: 1143
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.90624e+06
       GoKind: 22
-      Pointee: 1128 UnresolvedPointeeType archive/zip.fileWriter
+      Pointee: 1144 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
-      ID: 1059
+      ID: 1075
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1.058784e+06
       GoKind: 22
-      Pointee: 1060 StructureType archive/zip.nopCloser
+      Pointee: 1076 StructureType archive/zip.nopCloser
     - __kind: PointerType
-      ID: 1061
+      ID: 1077
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
       GoRuntimeType: 1.05904e+06
       GoKind: 22
-      Pointee: 1062 UnresolvedPointeeType archive/zip.pooledFlateWriter
+      Pointee: 1078 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -8438,435 +8544,435 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 1106
+      ID: 1122
       Name: '*bufio.Reader'
       ByteSize: 8
       GoRuntimeType: 2.176192e+06
       GoKind: 22
-      Pointee: 1107 UnresolvedPointeeType bufio.Reader
+      Pointee: 1123 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
-      ID: 1135
+      ID: 1151
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1.950976e+06
       GoKind: 22
-      Pointee: 1136 UnresolvedPointeeType bufio.Writer
+      Pointee: 1152 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
-      ID: 1186
+      ID: 1202
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.269056e+06
       GoKind: 22
-      Pointee: 1187 UnresolvedPointeeType bytes.Buffer
+      Pointee: 1203 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 693
+      ID: 709
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 914816
       GoKind: 22
-      Pointee: 582 BaseType compress/flate.CorruptInputError
+      Pointee: 598 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 694
+      ID: 710
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 914912
       GoKind: 22
-      Pointee: 583 GoStringHeaderType compress/flate.InternalError
+      Pointee: 599 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 585
+      ID: 601
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 584 GoStringDataType compress/flate.InternalError.str
+      Pointee: 600 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 1081
+      ID: 1097
       Name: '*compress/flate.Writer'
       ByteSize: 8
       GoRuntimeType: 1.426816e+06
       GoKind: 22
-      Pointee: 1082 UnresolvedPointeeType compress/flate.Writer
+      Pointee: 1098 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
-      ID: 1027
+      ID: 1043
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
       GoRuntimeType: 915008
       GoKind: 22
-      Pointee: 1028 UnresolvedPointeeType compress/flate.dictWriter
+      Pointee: 1044 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
-      ID: 1103
+      ID: 1119
       Name: '*compress/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.72752e+06
       GoKind: 22
-      Pointee: 1104 UnresolvedPointeeType compress/gzip.Writer
+      Pointee: 1120 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
-      ID: 931
+      ID: 947
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.204704e+06
       GoKind: 22
-      Pointee: 932 StructureType context.deadlineExceededError
+      Pointee: 948 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 775
+      ID: 791
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 927008
       GoKind: 22
-      Pointee: 596 BaseType crypto/aes.KeySizeError
+      Pointee: 612 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 776
+      ID: 792
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 927200
       GoKind: 22
-      Pointee: 597 BaseType crypto/des.KeySizeError
+      Pointee: 613 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 777
+      ID: 793
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 927488
       GoKind: 22
-      Pointee: 598 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 614 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 1098
+      ID: 1114
       Name: '*crypto/internal/fips140/hmac.HMAC'
       ByteSize: 8
       GoRuntimeType: 1.668256e+06
       GoKind: 22
-      Pointee: 1099 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
+      Pointee: 1115 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
     - __kind: PointerType
-      ID: 880
+      ID: 896
       Name: '*crypto/internal/fips140/hmac.errCloneUnsupported'
       ByteSize: 8
       GoRuntimeType: 1.066592e+06
       GoKind: 22
-      Pointee: 881 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
+      Pointee: 897 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
     - __kind: PointerType
-      ID: 1129
+      ID: 1145
       Name: '*crypto/internal/fips140/sha256.Digest'
       ByteSize: 8
       GoRuntimeType: 1.906752e+06
       GoKind: 22
-      Pointee: 1130 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
+      Pointee: 1146 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
     - __kind: PointerType
-      ID: 1159
+      ID: 1175
       Name: '*crypto/internal/fips140/sha3.Digest'
       ByteSize: 8
       GoRuntimeType: 2.121344e+06
       GoKind: 22
-      Pointee: 1160 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
+      Pointee: 1176 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
     - __kind: PointerType
-      ID: 1133
+      ID: 1149
       Name: '*crypto/internal/fips140/sha3.SHAKE'
       ByteSize: 8
       GoRuntimeType: 1.907264e+06
       GoKind: 22
-      Pointee: 1134 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
+      Pointee: 1150 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
     - __kind: PointerType
-      ID: 1131
+      ID: 1147
       Name: '*crypto/internal/fips140/sha512.Digest'
       ByteSize: 8
       GoRuntimeType: 1.907008e+06
       GoKind: 22
-      Pointee: 1132 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
+      Pointee: 1148 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
     - __kind: PointerType
-      ID: 1125
+      ID: 1141
       Name: '*crypto/md5.digest'
       ByteSize: 8
       GoRuntimeType: 1.904448e+06
       GoKind: 22
-      Pointee: 1126 UnresolvedPointeeType crypto/md5.digest
+      Pointee: 1142 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
-      ID: 778
+      ID: 794
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 927776
       GoKind: 22
-      Pointee: 599 BaseType crypto/rc4.KeySizeError
+      Pointee: 615 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 1146
+      ID: 1162
       Name: '*crypto/sha1.digest'
       ByteSize: 8
       GoRuntimeType: 1.985216e+06
       GoKind: 22
-      Pointee: 1147 UnresolvedPointeeType crypto/sha1.digest
+      Pointee: 1163 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
-      ID: 1121
+      ID: 1137
       Name: '*crypto/sha3.SHA3'
       ByteSize: 8
       GoRuntimeType: 1.873824e+06
       GoKind: 22
-      Pointee: 1122 UnresolvedPointeeType crypto/sha3.SHA3
+      Pointee: 1138 UnresolvedPointeeType crypto/sha3.SHA3
     - __kind: PointerType
-      ID: 701
+      ID: 717
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 916640
       GoKind: 22
-      Pointee: 586 BaseType crypto/tls.AlertError
+      Pointee: 602 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 869
+      ID: 885
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1.047392e+06
       GoKind: 22
-      Pointee: 870 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 886 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 1212
+      ID: 1228
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2.380576e+06
       GoKind: 22
-      Pointee: 1213 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 1229 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 697
+      ID: 713
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 916352
       GoKind: 22
-      Pointee: 698 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 714 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 695
+      ID: 711
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 916256
       GoKind: 22
-      Pointee: 696 StructureType crypto/tls.RecordHeaderError
+      Pointee: 712 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 868
+      ID: 884
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1.045728e+06
       GoKind: 22
-      Pointee: 823 BaseType crypto/tls.alert
+      Pointee: 839 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 1091
+      ID: 1107
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
       GoRuntimeType: 1.56112e+06
       GoKind: 22
-      Pointee: 1092 UnresolvedPointeeType crypto/tls.cthWrapper
+      Pointee: 1108 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
-      ID: 699
+      ID: 715
       Name: '*crypto/tls.echConfigErr'
       ByteSize: 8
       GoRuntimeType: 916448
       GoKind: 22
-      Pointee: 700 UnresolvedPointeeType crypto/tls.echConfigErr
+      Pointee: 716 UnresolvedPointeeType crypto/tls.echConfigErr
     - __kind: PointerType
-      ID: 1096
+      ID: 1112
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
       GoRuntimeType: 1.643296e+06
       GoKind: 22
-      Pointee: 1097 UnresolvedPointeeType crypto/tls.finishedHash
+      Pointee: 1113 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
-      ID: 966
+      ID: 982
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1.427296e+06
       GoKind: 22
-      Pointee: 967 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 983 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 983
+      ID: 999
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.044384e+06
       GoKind: 22
-      Pointee: 984 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 1000 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 771
+      ID: 787
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 926048
       GoKind: 22
-      Pointee: 772 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 788 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 765
+      ID: 781
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 925568
       GoKind: 22
-      Pointee: 766 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 782 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 767
+      ID: 783
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 925664
       GoKind: 22
-      Pointee: 768 StructureType crypto/x509.HostnameError
+      Pointee: 784 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 764
+      ID: 780
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 925472
       GoKind: 22
-      Pointee: 595 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 611 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 874
+      ID: 890
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1.053152e+06
       GoKind: 22
-      Pointee: 875 StructureType crypto/x509.SystemRootsError
+      Pointee: 891 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 773
+      ID: 789
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 926144
       GoKind: 22
-      Pointee: 774 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 790 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 769
+      ID: 785
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 925952
       GoKind: 22
-      Pointee: 770 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 786 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 787
+      ID: 803
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 932864
       GoKind: 22
-      Pointee: 788 StructureType encoding/asn1.StructuralError
+      Pointee: 804 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 791
+      ID: 807
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 933056
       GoKind: 22
-      Pointee: 792 StructureType encoding/asn1.SyntaxError
+      Pointee: 808 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 789
+      ID: 805
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 932960
       GoKind: 22
-      Pointee: 790 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 806 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 682
+      ID: 698
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 912800
       GoKind: 22
-      Pointee: 577 BaseType encoding/base64.CorruptInputError
+      Pointee: 593 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 1049
+      ID: 1065
       Name: '*encoding/base64.encoder'
       ByteSize: 8
       GoRuntimeType: 1.042784e+06
       GoKind: 22
-      Pointee: 1050 UnresolvedPointeeType encoding/base64.encoder
+      Pointee: 1066 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
-      ID: 685
+      ID: 701
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 913664
       GoKind: 22
-      Pointee: 578 BaseType encoding/hex.InvalidByteError
+      Pointee: 594 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 653
+      ID: 669
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 907616
       GoKind: 22
-      Pointee: 654 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 670 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 858
+      ID: 874
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1.038944e+06
       GoKind: 22
-      Pointee: 859 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 875 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 645
+      ID: 661
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 907232
       GoKind: 22
-      Pointee: 646 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 662 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 651
+      ID: 667
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 907520
       GoKind: 22
-      Pointee: 652 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 668 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 649
+      ID: 665
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 907424
       GoKind: 22
-      Pointee: 650 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 666 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 647
+      ID: 663
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 907328
       GoKind: 22
-      Pointee: 648 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 664 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 1192
+      ID: 1208
       Name: '*encoding/json.encodeState'
       ByteSize: 8
       GoRuntimeType: 2.294592e+06
       GoKind: 22
-      Pointee: 1193 UnresolvedPointeeType encoding/json.encodeState
+      Pointee: 1209 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 655
+      ID: 671
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 908000
       GoKind: 22
-      Pointee: 656 StructureType encoding/json.jsonError
+      Pointee: 672 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 1057
+      ID: 1073
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
       GoRuntimeType: 1.055712e+06
       GoKind: 22
-      Pointee: 1058 UnresolvedPointeeType encoding/pem.lineBreaker
+      Pointee: 1074 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
-      ID: 759
+      ID: 775
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 924512
       GoKind: 22
-      Pointee: 760 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 776 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 757
+      ID: 773
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 924416
       GoKind: 22
-      Pointee: 758 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 774 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 761
+      ID: 777
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 924608
       GoKind: 22
-      Pointee: 592 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 608 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 594
+      ID: 610
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 593 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 609 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 762
+      ID: 778
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 924704
       GoKind: 22
-      Pointee: 763 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 779 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
-      ID: 1170
+      ID: 1186
       Name: '*encoding/xml.printer'
       ByteSize: 8
       GoRuntimeType: 2.161184e+06
       GoKind: 22
-      Pointee: 1171 UnresolvedPointeeType encoding/xml.printer
+      Pointee: 1187 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
       ID: 106
       Name: '*error'
@@ -8875,19 +8981,19 @@ Types:
       GoKind: 22
       Pointee: 13 GoInterfaceType error
     - __kind: PointerType
-      ID: 621
+      ID: 637
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 897632
       GoKind: 22
-      Pointee: 622 UnresolvedPointeeType errors.errorString
+      Pointee: 638 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 825
+      ID: 841
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1.02384e+06
       GoKind: 22
-      Pointee: 826 UnresolvedPointeeType errors.joinError
+      Pointee: 842 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 108
       Name: '*float32'
@@ -8903,813 +9009,813 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType float64
     - __kind: PointerType
-      ID: 1180
+      ID: 1196
       Name: '*fmt.pp'
       ByteSize: 8
       GoRuntimeType: 2.261376e+06
       GoKind: 22
-      Pointee: 1181 UnresolvedPointeeType fmt.pp
+      Pointee: 1197 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
-      ID: 827
+      ID: 843
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.023968e+06
       GoKind: 22
-      Pointee: 828 UnresolvedPointeeType fmt.wrapError
+      Pointee: 844 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 829
+      ID: 845
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1.024096e+06
       GoKind: 22
-      Pointee: 830 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 846 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 683
+      ID: 699
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 913184
       GoKind: 22
-      Pointee: 684 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 700 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 664
+      ID: 680
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 910400
       GoKind: 22
-      Pointee: 665 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 681 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 666
+      ID: 682
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 910496
       GoKind: 22
-      Pointee: 667 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 683 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 995
+      ID: 1011
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 910208
       GoKind: 22
-      Pointee: 996 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 1012 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 670
+      ID: 686
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 910784
       GoKind: 22
-      Pointee: 671 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 687 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 997
+      ID: 1013
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 910304
       GoKind: 22
-      Pointee: 998 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 1014 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 668
+      ID: 684
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 910592
       GoKind: 22
-      Pointee: 571 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 587 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 573
+      ID: 589
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 572 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 588 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 663
+      ID: 679
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 910112
       GoKind: 22
-      Pointee: 568 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 584 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 570
+      ID: 586
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 569 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 585 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 669
+      ID: 685
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 910688
       GoKind: 22
-      Pointee: 574 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 590 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 576
+      ID: 592
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 575 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 591 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 1069
+      ID: 1085
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
       GoRuntimeType: 1.210208e+06
       GoKind: 22
-      Pointee: 1070 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      Pointee: 1086 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
-      ID: 1156
+      ID: 1172
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
       GoRuntimeType: 2.059392e+06
       GoKind: 22
-      Pointee: 1157 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      Pointee: 1173 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
-      ID: 781
+      ID: 797
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 931328
       GoKind: 22
-      Pointee: 782 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 798 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 940
+      ID: 956
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1.213792e+06
       GoKind: 22
-      Pointee: 941 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 957 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 1188
+      ID: 1204
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
       GoRuntimeType: 2.271104e+06
       GoKind: 22
-      Pointee: 1189 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      Pointee: 1205 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
-      ID: 708
+      ID: 724
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 920000
       GoKind: 22
-      Pointee: 709 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 725 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 715
+      ID: 731
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 921056
       GoKind: 22
-      Pointee: 716 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 732 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 710
+      ID: 726
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 920768
       GoKind: 22
-      Pointee: 591 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 607 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 713
+      ID: 729
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 920960
       GoKind: 22
-      Pointee: 714 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 730 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 711
+      ID: 727
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 920864
       GoKind: 22
-      Pointee: 712 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 728 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 731
+      ID: 747
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 922976
       GoKind: 22
-      Pointee: 732 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 748 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 735
+      ID: 751
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 923168
       GoKind: 22
-      Pointee: 736 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 752 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 733
+      ID: 749
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 923072
       GoKind: 22
-      Pointee: 734 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 750 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 729
+      ID: 745
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 922880
       GoKind: 22
-      Pointee: 730 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 746 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 1020
+      ID: 1036
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 1019 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 1035 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 743
+      ID: 759
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 923552
       GoKind: 22
-      Pointee: 744 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 760 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 737
+      ID: 753
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 923264
       GoKind: 22
-      Pointee: 738 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 754 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 741
+      ID: 757
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 923456
       GoKind: 22
-      Pointee: 742 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 758 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 739
+      ID: 755
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 923360
       GoKind: 22
-      Pointee: 740 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 756 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 745
+      ID: 761
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 923648
       GoKind: 22
-      Pointee: 746 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 762 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 751
+      ID: 767
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 923936
       GoKind: 22
-      Pointee: 752 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 768 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 753
+      ID: 769
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 924032
       GoKind: 22
-      Pointee: 754 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 770 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 749
+      ID: 765
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 923840
       GoKind: 22
-      Pointee: 750 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 766 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 747
+      ID: 763
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 923744
       GoKind: 22
-      Pointee: 748 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 764 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 755
+      ID: 771
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 924224
       GoKind: 22
-      Pointee: 756 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 772 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 672
+      ID: 688
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 911936
       GoKind: 22
-      Pointee: 673 StructureType github.com/cihub/seelog.baseError
+      Pointee: 689 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 1109
+      ID: 1125
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1.804384e+06
       GoKind: 22
-      Pointee: 1110 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 1126 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 674
+      ID: 690
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 912032
       GoKind: 22
-      Pointee: 675 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 691 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 1089
+      ID: 1105
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
       GoRuntimeType: 1.55984e+06
       GoKind: 22
-      Pointee: 1090 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+      Pointee: 1106 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
-      ID: 1045
+      ID: 1061
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
       GoRuntimeType: 1.041632e+06
       GoKind: 22
-      Pointee: 1046 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+      Pointee: 1062 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
-      ID: 1079
+      ID: 1095
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.424896e+06
       GoKind: 22
-      Pointee: 1080 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+      Pointee: 1096 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
-      ID: 678
+      ID: 694
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 912224
       GoKind: 22
-      Pointee: 679 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 695 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 1144
+      ID: 1160
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.97744e+06
       GoKind: 22
-      Pointee: 1145 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+      Pointee: 1161 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
-      ID: 1163
+      ID: 1179
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
       GoRuntimeType: 2.133984e+06
       GoKind: 22
-      Pointee: 1158 StructureType github.com/cihub/seelog.rollingFileWriterSize
+      Pointee: 1174 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
-      ID: 1162
+      ID: 1178
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
       GoRuntimeType: 2.1336e+06
       GoKind: 22
-      Pointee: 1161 StructureType github.com/cihub/seelog.rollingFileWriterTime
+      Pointee: 1177 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
-      ID: 1047
+      ID: 1063
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
       GoRuntimeType: 1.04176e+06
       GoKind: 22
-      Pointee: 1048 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+      Pointee: 1064 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
-      ID: 676
+      ID: 692
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 912128
       GoKind: 22
-      Pointee: 677 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 693 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 680
+      ID: 696
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 912320
       GoKind: 22
-      Pointee: 681 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 697 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 1111
+      ID: 1127
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.806176e+06
       GoKind: 22
-      Pointee: 1112 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+      Pointee: 1128 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
-      ID: 1152
+      ID: 1168
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 2.013568e+06
       GoKind: 22
-      Pointee: 1153 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+      Pointee: 1169 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
-      ID: 1154
+      ID: 1170
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
       GoRuntimeType: 2.044064e+06
       GoKind: 22
-      Pointee: 1155 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+      Pointee: 1171 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
-      ID: 971
+      ID: 987
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1.439616e+06
       GoKind: 22
-      Pointee: 972 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 988 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 884
+      ID: 900
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.06736e+06
       GoKind: 22
-      Pointee: 885 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 901 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 882
+      ID: 898
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1.067232e+06
       GoKind: 22
-      Pointee: 883 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 899 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 886
+      ID: 902
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.071328e+06
       GoKind: 22
-      Pointee: 887 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 903 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 888
+      ID: 904
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1.071456e+06
       GoKind: 22
-      Pointee: 889 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 905 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 1100
+      ID: 1116
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
       GoRuntimeType: 1.67056e+06
       GoKind: 22
-      Pointee: 1101 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+      Pointee: 1117 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
-      ID: 876
+      ID: 892
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.053792e+06
       GoKind: 22
-      Pointee: 877 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 893 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 686
+      ID: 702
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 913856
       GoKind: 22
-      Pointee: 687 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 703 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 1204
+      ID: 1220
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
       GoRuntimeType: 2.357024e+06
       GoKind: 22
-      Pointee: 1205 UnresolvedPointeeType github.com/json-iterator/go.Stream
+      Pointee: 1221 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
-      ID: 942
+      ID: 958
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1.222368e+06
       GoKind: 22
-      Pointee: 943 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 959 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 915
+      ID: 931
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1.201248e+06
       GoKind: 22
-      Pointee: 916 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 932 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 909
+      ID: 925
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1.200864e+06
       GoKind: 22
-      Pointee: 910 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 926 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 844
+      ID: 860
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1.032928e+06
       GoKind: 22
-      Pointee: 845 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 861 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 921
+      ID: 937
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1.201632e+06
       GoKind: 22
-      Pointee: 922 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 938 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 843
+      ID: 859
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1.0328e+06
       GoKind: 22
-      Pointee: 822 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 838 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 913
+      ID: 929
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1.20112e+06
       GoKind: 22
-      Pointee: 914 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 930 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 911
+      ID: 927
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1.200992e+06
       GoKind: 22
-      Pointee: 912 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 928 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 919
+      ID: 935
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1.201504e+06
       GoKind: 22
-      Pointee: 920 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 936 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 917
+      ID: 933
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1.201376e+06
       GoKind: 22
-      Pointee: 918 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 934 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 1208
+      ID: 1224
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
       GoRuntimeType: 2.369632e+06
       GoKind: 22
-      Pointee: 1209 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+      Pointee: 1225 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
-      ID: 925
+      ID: 941
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1.202016e+06
       GoKind: 22
-      Pointee: 926 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 942 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 848
+      ID: 864
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1.033184e+06
       GoKind: 22
-      Pointee: 849 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 865 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 846
+      ID: 862
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1.033056e+06
       GoKind: 22
-      Pointee: 847 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 863 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 923
+      ID: 939
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1.201888e+06
       GoKind: 22
-      Pointee: 924 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 940 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 803
+      ID: 819
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 945824
       GoKind: 22
-      Pointee: 604 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 620 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 606
+      ID: 622
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 605 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 621 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 986
+      ID: 1002
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1.669024e+06
       GoKind: 22
-      Pointee: 987 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 1003 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 892
+      ID: 908
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1.086176e+06
       GoKind: 22
-      Pointee: 893 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 909 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 1075
+      ID: 1091
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
       GoRuntimeType: 1.262176e+06
       GoKind: 22
-      Pointee: 1076 StructureType go.uber.org/zap.nopCloserSink
+      Pointee: 1092 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
-      ID: 1168
+      ID: 1184
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.149344e+06
       GoKind: 22
-      Pointee: 1169 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+      Pointee: 1185 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
-      ID: 1063
+      ID: 1079
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
       GoRuntimeType: 1.08848e+06
       GoKind: 22
-      Pointee: 1064 StructureType go.uber.org/zap/zapcore.writerWrapper
+      Pointee: 1080 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
-      ID: 804
+      ID: 820
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 947072
       GoKind: 22
-      Pointee: 607 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 623 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 950
+      ID: 966
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1.26384e+06
       GoKind: 22
-      Pointee: 951 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 967 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 807
+      ID: 823
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 947360
       GoKind: 22
-      Pointee: 808 StructureType golang.org/x/net/http2.connError
+      Pointee: 824 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 806
+      ID: 822
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 947264
       GoKind: 22
-      Pointee: 611 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 627 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 613
+      ID: 629
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 612 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 628 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 810
+      ID: 826
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 947552
       GoKind: 22
-      Pointee: 617 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 633 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 619
+      ID: 635
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 618 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 634 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 809
+      ID: 825
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 947456
       GoKind: 22
-      Pointee: 614 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 630 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 616
+      ID: 632
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 615 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 631 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 805
+      ID: 821
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 947168
       GoKind: 22
-      Pointee: 608 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 624 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 610
+      ID: 626
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 609 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 625 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1166
+      ID: 1182
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.147424e+06
       GoKind: 22
-      Pointee: 1167 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1183 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 811
+      ID: 827
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 947648
       GoKind: 22
-      Pointee: 812 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 828 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 813
+      ID: 829
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 947744
       GoKind: 22
-      Pointee: 620 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 636 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 799
+      ID: 815
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 941024
       GoKind: 22
-      Pointee: 800 StructureType google.golang.org/grpc.dropError
+      Pointee: 816 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 948
+      ID: 964
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1.260896e+06
       GoKind: 22
-      Pointee: 949 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 965 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 973
+      ID: 989
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1.446976e+06
       GoKind: 22
-      Pointee: 974 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 990 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 801
+      ID: 817
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 944096
       GoKind: 22
-      Pointee: 802 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 818 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 1115
+      ID: 1131
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1.811776e+06
       GoKind: 22
-      Pointee: 1116 StructureType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 1132 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 1073
+      ID: 1089
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
       GoRuntimeType: 1.25744e+06
       GoKind: 22
-      Pointee: 1074 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+      Pointee: 1090 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
-      ID: 890
+      ID: 906
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1.080416e+06
       GoKind: 22
-      Pointee: 891 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 907 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 1035
+      ID: 1051
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
       GoRuntimeType: 944192
       GoKind: 22
-      Pointee: 1036 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+      Pointee: 1052 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
-      ID: 779
+      ID: 795
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 929216
       GoKind: 22
-      Pointee: 780 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 796 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 878
+      ID: 894
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1.05712e+06
       GoKind: 22
-      Pointee: 879 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 895 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 946
+      ID: 962
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.228768e+06
       GoKind: 22
-      Pointee: 947 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 963 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 944
+      ID: 960
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1.228512e+06
       GoKind: 22
-      Pointee: 945 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 961 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 793
+      ID: 809
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 933920
       GoKind: 22
-      Pointee: 794 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 810 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 795
+      ID: 811
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 934016
       GoKind: 22
-      Pointee: 796 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 812 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 723
+      ID: 739
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 921440
       GoKind: 22
-      Pointee: 724 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 740 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 1123
+      ID: 1139
       Name: '*hash/crc32.digest'
       ByteSize: 8
       GoRuntimeType: 1.9024e+06
       GoKind: 22
-      Pointee: 1124 UnresolvedPointeeType hash/crc32.digest
+      Pointee: 1140 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
-      ID: 814
+      ID: 830
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 948512
       GoKind: 22
-      Pointee: 815 UnresolvedPointeeType html/template.Error
+      Pointee: 831 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 99
       Name: '*int'
@@ -9753,115 +9859,115 @@ Types:
       GoKind: 22
       Pointee: 157 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 975
+      ID: 991
       Name: '*internal/abi.Type'
       ByteSize: 8
       GoRuntimeType: 2.213696e+06
       GoKind: 22
-      Pointee: 976 UnresolvedPointeeType internal/abi.Type
+      Pointee: 992 UnresolvedPointeeType internal/abi.Type
     - __kind: PointerType
-      ID: 691
+      ID: 707
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 914528
       GoKind: 22
-      Pointee: 692 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 708 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 689
+      ID: 705
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 914432
       GoKind: 22
-      Pointee: 690 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 706 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 1021
+      ID: 1037
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
       GoRuntimeType: 902432
       GoKind: 22
-      Pointee: 1022 UnresolvedPointeeType internal/godebug.runtimeStderr
+      Pointee: 1038 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
-      ID: 907
+      ID: 923
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.200096e+06
       GoKind: 22
-      Pointee: 908 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 924 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 1210
+      ID: 1226
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2.375296e+06
       GoKind: 22
-      Pointee: 1211 UnresolvedPointeeType internal/poll.FD
+      Pointee: 1227 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 905
+      ID: 921
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1.199968e+06
       GoKind: 22
-      Pointee: 906 StructureType internal/poll.errNetClosing
+      Pointee: 922 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 625
+      ID: 641
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 901664
       GoKind: 22
-      Pointee: 626 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 642 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 688
+      ID: 704
       Name: '*internal/runtime/cgroup.stringError'
       ByteSize: 8
       GoRuntimeType: 914240
       GoKind: 22
-      Pointee: 579 GoStringHeaderType internal/runtime/cgroup.stringError
+      Pointee: 595 GoStringHeaderType internal/runtime/cgroup.stringError
     - __kind: PointerType
-      ID: 581
+      ID: 597
       Name: '*internal/runtime/cgroup.stringError.str'
       ByteSize: 8
-      Pointee: 580 GoStringDataType internal/runtime/cgroup.stringError.str
+      Pointee: 596 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: PointerType
-      ID: 862
+      ID: 878
       Name: '*internal/runtime/maps.unhashableTypeError'
       ByteSize: 8
       GoRuntimeType: 1.044064e+06
       GoKind: 22
-      Pointee: 863 StructureType internal/runtime/maps.unhashableTypeError
+      Pointee: 879 StructureType internal/runtime/maps.unhashableTypeError
     - __kind: PointerType
-      ID: 1067
+      ID: 1083
       Name: '*io.PipeWriter'
       ByteSize: 8
       GoRuntimeType: 1.191648e+06
       GoKind: 22
-      Pointee: 1068 UnresolvedPointeeType io.PipeWriter
+      Pointee: 1084 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
-      ID: 1065
+      ID: 1081
       Name: '*io.discard'
       ByteSize: 8
       GoRuntimeType: 1.191264e+06
       GoKind: 22
-      Pointee: 1066 StructureType io.discard
+      Pointee: 1082 StructureType io.discard
     - __kind: PointerType
-      ID: 1039
+      ID: 1055
       Name: '*io.multiWriter'
       ByteSize: 8
       GoRuntimeType: 1.024864e+06
       GoKind: 22
-      Pointee: 1040 UnresolvedPointeeType io.multiWriter
+      Pointee: 1056 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
-      ID: 903
+      ID: 919
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1.199456e+06
       GoKind: 22
-      Pointee: 904 UnresolvedPointeeType io/fs.PathError
+      Pointee: 920 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 1113
+      ID: 1129
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 1.8064e+06
       GoKind: 22
-      Pointee: 1114 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+      Pointee: 1130 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
       ID: 317
       Name: '*main.anotherStruct'
@@ -9869,19 +9975,19 @@ Types:
       GoKind: 22
       Pointee: 318 StructureType main.anotherStruct
     - __kind: PointerType
-      ID: 342
+      ID: 358
       Name: '*main.deepMap2'
       ByteSize: 8
       GoRuntimeType: 386560
       GoKind: 22
-      Pointee: 343 StructureType main.deepMap2
+      Pointee: 359 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 1254
+      ID: 1270
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 386496
       GoKind: 22
-      Pointee: 1255 UnresolvedPointeeType main.deepMap3
+      Pointee: 1271 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 149
       Name: '*main.deepMap7'
@@ -9890,19 +9996,19 @@ Types:
       GoKind: 22
       Pointee: 150 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 1288
+      ID: 1304
       Name: '*main.deepMap8'
       ByteSize: 8
       GoRuntimeType: 386176
       GoKind: 22
-      Pointee: 1289 StructureType main.deepMap8
+      Pointee: 1305 StructureType main.deepMap8
     - __kind: PointerType
-      ID: 1303
+      ID: 1319
       Name: '*main.deepMap9'
       ByteSize: 8
       GoRuntimeType: 386112
       GoKind: 22
-      Pointee: 1304 StructureType main.deepMap9
+      Pointee: 1320 StructureType main.deepMap9
     - __kind: PointerType
       ID: 133
       Name: '*main.deepPtr2'
@@ -9911,12 +10017,12 @@ Types:
       GoKind: 22
       Pointee: 134 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 1214
+      ID: 1230
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 387072
       GoKind: 22
-      Pointee: 1215 UnresolvedPointeeType main.deepPtr3
+      Pointee: 1231 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 135
       Name: '*main.deepPtr7'
@@ -9925,33 +10031,33 @@ Types:
       GoKind: 22
       Pointee: 136 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 1258
+      ID: 1274
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 386752
       GoKind: 22
-      Pointee: 1259 StructureType main.deepPtr8
+      Pointee: 1275 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 1260
+      ID: 1276
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 386688
       GoKind: 22
-      Pointee: 1261 StructureType main.deepPtr9
+      Pointee: 1277 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 140
       Name: '*main.deepSlice2'
       ByteSize: 8
       GoRuntimeType: 387712
       GoKind: 22
-      Pointee: 333 StructureType main.deepSlice2
+      Pointee: 349 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 1239
+      ID: 1255
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 387648
       GoKind: 22
-      Pointee: 1240 UnresolvedPointeeType main.deepSlice3
+      Pointee: 1256 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 141
       Name: '*main.deepSlice7'
@@ -9960,19 +10066,19 @@ Types:
       GoKind: 22
       Pointee: 142 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 1264
+      ID: 1280
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 387328
       GoKind: 22
-      Pointee: 1265 StructureType main.deepSlice8
+      Pointee: 1281 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 1270
+      ID: 1286
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 387264
       GoKind: 22
-      Pointee: 1271 StructureType main.deepSlice9
+      Pointee: 1287 StructureType main.deepSlice9
     - __kind: PointerType
       ID: 320
       Name: '*main.emptyStruct'
@@ -9987,14 +10093,14 @@ Types:
       GoKind: 22
       Pointee: 160 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 1231
+      ID: 1247
       Name: '*main.firstBehavior'
       ByteSize: 8
       GoRuntimeType: 897344
       GoKind: 22
-      Pointee: 321 StructureType main.firstBehavior
+      Pointee: 337 StructureType main.firstBehavior
     - __kind: PointerType
-      ID: 1320
+      ID: 1336
       Name: '*main.nestedStruct'
       ByteSize: 8
       GoRuntimeType: 387968
@@ -10014,19 +10120,19 @@ Types:
       GoKind: 22
       Pointee: 271 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 1232
+      ID: 1248
       Name: '*main.secondBehavior'
       ByteSize: 8
       GoRuntimeType: 897440
       GoKind: 22
-      Pointee: 1233 StructureType main.secondBehavior
+      Pointee: 1249 StructureType main.secondBehavior
     - __kind: PointerType
-      ID: 1219
+      ID: 1235
       Name: '*main.somethingImpl'
       ByteSize: 8
       GoRuntimeType: 897536
       GoKind: 22
-      Pointee: 1220 UnresolvedPointeeType main.somethingImpl
+      Pointee: 1236 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
       ID: 151
       Name: '*main.stringType1'
@@ -10034,28 +10140,28 @@ Types:
       GoKind: 22
       Pointee: 152 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 1217
+      ID: 1233
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 1216 GoStringDataType main.stringType1.str
+      Pointee: 1232 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 154
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 1218 GoStringHeaderType main.stringType2
+      Pointee: 1234 GoStringHeaderType main.stringType2
     - __kind: PointerType
-      ID: 1322
+      ID: 1338
       Name: '*main.stringType2.str'
       ByteSize: 8
-      Pointee: 1321 GoStringDataType main.stringType2.str
+      Pointee: 1337 GoStringDataType main.stringType2.str
     - __kind: PointerType
       ID: 274
       Name: '*main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 272 StructureType main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 394
+      ID: 410
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 386048
@@ -10079,10 +10185,10 @@ Types:
       GoKind: 22
       Pointee: 249 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 1236
+      ID: 1252
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 1235 GoSliceDataType main.t.array
+      Pointee: 1251 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 269
       Name: '*main.threeStringStruct'
@@ -10115,30 +10221,30 @@ Types:
       ByteSize: 8
       Pointee: 146 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1244
+      ID: 1260
       Name: '*map<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1245 GoSwissMapHeaderType map<int,*main.deepMap3>
+      Pointee: 1261 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1278
+      ID: 1294
       Name: '*map<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1279 GoSwissMapHeaderType map<int,*main.deepMap8>
+      Pointee: 1295 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1293
+      ID: 1309
       Name: '*map<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1294 GoSwissMapHeaderType map<int,*main.deepMap9>
+      Pointee: 1310 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: PointerType
       ID: 167
       Name: '*map<int,int>'
       ByteSize: 8
       Pointee: 168 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 1308
+      ID: 1324
       Name: '*map<int,interface {}>'
       ByteSize: 8
-      Pointee: 1309 GoSwissMapHeaderType map<int,interface {}>
+      Pointee: 1325 GoSwissMapHeaderType map<int,interface {}>
     - __kind: PointerType
       ID: 234
       Name: '*map<int,struct {}>'
@@ -10160,10 +10266,10 @@ Types:
       ByteSize: 8
       Pointee: 183 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 979
+      ID: 995
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 980 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 996 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 177
       Name: '*map<string,int>'
@@ -10231,696 +10337,696 @@ Types:
       GoKind: 22
       Pointee: 176 GoMapType map[string]int
     - __kind: PointerType
-      ID: 727
+      ID: 743
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 922304
       GoKind: 22
-      Pointee: 728 StructureType math/big.ErrNaN
+      Pointee: 744 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 1029
+      ID: 1045
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
       GoRuntimeType: 917120
       GoKind: 22
-      Pointee: 1030 StructureType mime/multipart.writerOnly·1
+      Pointee: 1046 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
-      ID: 934
+      ID: 950
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1.208032e+06
       GoKind: 22
-      Pointee: 935 UnresolvedPointeeType net.AddrError
+      Pointee: 951 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 960
+      ID: 976
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1.423136e+06
       GoKind: 22
-      Pointee: 961 UnresolvedPointeeType net.DNSError
+      Pointee: 977 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 1174
+      ID: 1190
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2.234048e+06
       GoKind: 22
-      Pointee: 1175 UnresolvedPointeeType net.IPConn
+      Pointee: 1191 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 958
+      ID: 974
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1.422816e+06
       GoKind: 22
-      Pointee: 959 UnresolvedPointeeType net.OpError
+      Pointee: 975 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 936
+      ID: 952
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.20816e+06
       GoKind: 22
-      Pointee: 937 UnresolvedPointeeType net.ParseError
+      Pointee: 953 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 1184
+      ID: 1200
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2.2624e+06
       GoKind: 22
-      Pointee: 1185 UnresolvedPointeeType net.TCPConn
+      Pointee: 1201 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 1194
+      ID: 1210
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2.307904e+06
       GoKind: 22
-      Pointee: 1195 UnresolvedPointeeType net.UDPConn
+      Pointee: 1211 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 1182
+      ID: 1198
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2.261888e+06
       GoKind: 22
-      Pointee: 1183 UnresolvedPointeeType net.UnixConn
+      Pointee: 1199 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 933
+      ID: 949
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1.207264e+06
       GoKind: 22
-      Pointee: 896 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 912 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 898
+      ID: 914
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 897 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 913 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 860
+      ID: 876
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1.03984e+06
       GoKind: 22
-      Pointee: 861 StructureType net.canceledError
+      Pointee: 877 StructureType net.canceledError
     - __kind: PointerType
-      ID: 1150
+      ID: 1166
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 2.010976e+06
       GoKind: 22
-      Pointee: 1151 UnresolvedPointeeType net.conn
+      Pointee: 1167 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 1004
+      ID: 1020
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1.849184e+06
       GoKind: 22
-      Pointee: 1005 StructureType net.dialResult·1
+      Pointee: 1021 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 1196
+      ID: 1212
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2.31216e+06
       GoKind: 22
-      Pointee: 1197 UnresolvedPointeeType net.netFD
+      Pointee: 1213 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 657
+      ID: 673
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 908960
       GoKind: 22
-      Pointee: 658 UnresolvedPointeeType net.notFoundError
+      Pointee: 674 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 659
+      ID: 675
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 909632
       GoKind: 22
-      Pointee: 660 StructureType net.result·2
+      Pointee: 676 StructureType net.result·2
     - __kind: PointerType
-      ID: 1178
+      ID: 1194
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.248416e+06
       GoKind: 22
-      Pointee: 1179 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 1195 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 1176
+      ID: 1192
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.247936e+06
       GoKind: 22
-      Pointee: 1177 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 1193 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 938
+      ID: 954
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1.2088e+06
       GoKind: 22
-      Pointee: 939 UnresolvedPointeeType net.temporaryError
+      Pointee: 955 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 962
+      ID: 978
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.423296e+06
       GoKind: 22
-      Pointee: 963 UnresolvedPointeeType net.timeoutError
+      Pointee: 979 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 850
+      ID: 866
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1.035616e+06
       GoKind: 22
-      Pointee: 851 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 867 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
-      ID: 1023
+      ID: 1039
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
       GoRuntimeType: 904736
       GoKind: 22
-      Pointee: 1024 StructureType net/http.bufioFlushWriter
+      Pointee: 1040 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
-      ID: 634
+      ID: 650
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 905408
       GoKind: 22
-      Pointee: 549 BaseType net/http.http2ConnectionError
+      Pointee: 565 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 635
+      ID: 651
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 905504
       GoKind: 22
-      Pointee: 636 StructureType net/http.http2GoAwayError
+      Pointee: 652 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 954
+      ID: 970
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1.418816e+06
       GoKind: 22
-      Pointee: 955 StructureType net/http.http2StreamError
+      Pointee: 971 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 639
+      ID: 655
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 906080
       GoKind: 22
-      Pointee: 640 StructureType net/http.http2connError
+      Pointee: 656 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 1085
+      ID: 1101
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
       GoRuntimeType: 1.55632e+06
       GoKind: 22
-      Pointee: 1086 UnresolvedPointeeType net/http.http2dataBuffer
+      Pointee: 1102 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 638
+      ID: 654
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 905984
       GoKind: 22
-      Pointee: 553 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 569 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 555
+      ID: 571
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 554 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 570 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 642
+      ID: 658
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 906272
       GoKind: 22
-      Pointee: 559 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 575 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 561
+      ID: 577
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 560 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 576 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 641
+      ID: 657
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 906176
       GoKind: 22
-      Pointee: 556 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 572 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 558
+      ID: 574
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 557 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 573 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 929
+      ID: 945
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1.203936e+06
       GoKind: 22
-      Pointee: 930 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 946 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 856
+      ID: 872
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1.036256e+06
       GoKind: 22
-      Pointee: 857 StructureType net/http.http2noCachedConnError
+      Pointee: 873 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 1139
+      ID: 1155
       Name: '*net/http.http2pipe'
       ByteSize: 8
       GoRuntimeType: 1.95328e+06
       GoKind: 22
-      Pointee: 1140 UnresolvedPointeeType net/http.http2pipe
+      Pointee: 1156 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 637
+      ID: 653
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 905888
       GoKind: 22
-      Pointee: 550 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 566 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 552
+      ID: 568
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 551 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 567 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1025
+      ID: 1041
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
       GoRuntimeType: 906368
       GoKind: 22
-      Pointee: 1026 StructureType net/http.http2stickyErrWriter
+      Pointee: 1042 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
-      ID: 852
+      ID: 868
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1.035872e+06
       GoKind: 22
-      Pointee: 853 StructureType net/http.nothingWrittenError
+      Pointee: 869 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 1087
+      ID: 1103
       Name: '*net/http.persistConn'
       ByteSize: 8
       GoRuntimeType: 2.17744e+06
       GoKind: 22
-      Pointee: 1088 UnresolvedPointeeType net/http.persistConn
+      Pointee: 1104 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
-      ID: 1043
+      ID: 1059
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
       GoRuntimeType: 1.035744e+06
       GoKind: 22
-      Pointee: 1044 StructureType net/http.persistConnWriter
+      Pointee: 1060 StructureType net/http.persistConnWriter
     - __kind: PointerType
-      ID: 1077
+      ID: 1093
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1.418976e+06
       GoKind: 22
-      Pointee: 1078 StructureType net/http.readWriteCloserBody
+      Pointee: 1094 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 643
+      ID: 659
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 906464
       GoKind: 22
-      Pointee: 644 StructureType net/http.requestBodyReadError
+      Pointee: 660 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 956
+      ID: 972
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.420096e+06
       GoKind: 22
-      Pointee: 957 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 973 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 927
+      ID: 943
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1.203808e+06
       GoKind: 22
-      Pointee: 928 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 944 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 854
+      ID: 870
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1.036e+06
       GoKind: 22
-      Pointee: 855 StructureType net/http.transportReadFromServerError
+      Pointee: 871 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 1119
+      ID: 1135
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
       GoRuntimeType: 1.845824e+06
       GoKind: 22
-      Pointee: 1120 StructureType net/http.unencryptedNetConnInTLSConn
+      Pointee: 1136 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 632
+      ID: 648
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 904640
       GoKind: 22
-      Pointee: 633 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 649 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 1141
+      ID: 1157
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
       GoRuntimeType: 1.955072e+06
       GoKind: 22
-      Pointee: 1142 StructureType net/http/internal.FlushAfterChunkWriter
+      Pointee: 1158 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
-      ID: 1053
+      ID: 1069
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
       GoRuntimeType: 1.048544e+06
       GoKind: 22
-      Pointee: 1054 UnresolvedPointeeType net/http/internal.chunkedWriter
+      Pointee: 1070 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
-      ID: 719
+      ID: 735
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 921248
       GoKind: 22
-      Pointee: 720 StructureType net/netip.parseAddrError
+      Pointee: 736 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 717
+      ID: 733
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 921152
       GoKind: 22
-      Pointee: 718 StructureType net/netip.parsePrefixError
+      Pointee: 734 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 1093
+      ID: 1109
       Name: '*net/smtp.Client'
       ByteSize: 8
       GoRuntimeType: 2.119936e+06
       GoKind: 22
-      Pointee: 1094 UnresolvedPointeeType net/smtp.Client
+      Pointee: 1110 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
-      ID: 1055
+      ID: 1071
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
       GoRuntimeType: 1.053408e+06
       GoKind: 22
-      Pointee: 1056 StructureType net/smtp.dataCloser
+      Pointee: 1072 StructureType net/smtp.dataCloser
     - __kind: PointerType
-      ID: 703
+      ID: 719
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 917312
       GoKind: 22
-      Pointee: 704 UnresolvedPointeeType net/textproto.Error
+      Pointee: 720 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 702
+      ID: 718
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 917216
       GoKind: 22
-      Pointee: 587 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 603 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 589
+      ID: 605
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 588 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 604 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 1051
+      ID: 1067
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
       GoRuntimeType: 1.047776e+06
       GoKind: 22
-      Pointee: 1052 UnresolvedPointeeType net/textproto.dotWriter
+      Pointee: 1068 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
-      ID: 964
+      ID: 980
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1.423616e+06
       GoKind: 22
-      Pointee: 965 UnresolvedPointeeType net/url.Error
+      Pointee: 981 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 661
+      ID: 677
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 909728
       GoKind: 22
-      Pointee: 562 GoStringHeaderType net/url.EscapeError
+      Pointee: 578 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 564
+      ID: 580
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 563 GoStringDataType net/url.EscapeError.str
+      Pointee: 579 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 662
+      ID: 678
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 909824
       GoKind: 22
-      Pointee: 565 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 581 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 567
+      ID: 583
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 566 GoStringDataType net/url.InvalidHostError.str
-    - __kind: PointerType
-      ID: 440
-      Name: '*noalg.map.group[[4]int][4]int'
-      ByteSize: 8
-      Pointee: 441 StructureType noalg.map.group[[4]int][4]int
-    - __kind: PointerType
-      ID: 432
-      Name: '*noalg.map.group[[4]int]uint8'
-      ByteSize: 8
-      Pointee: 433 StructureType noalg.map.group[[4]int]uint8
-    - __kind: PointerType
-      ID: 380
-      Name: '*noalg.map.group[[4]string][2]int'
-      ByteSize: 8
-      Pointee: 381 StructureType noalg.map.group[[4]string][2]int
-    - __kind: PointerType
-      ID: 399
-      Name: '*noalg.map.group[bool]main.node'
-      ByteSize: 8
-      Pointee: 400 StructureType noalg.map.group[bool]main.node
-    - __kind: PointerType
-      ID: 338
-      Name: '*noalg.map.group[int]*main.deepMap2'
-      ByteSize: 8
-      Pointee: 339 StructureType noalg.map.group[int]*main.deepMap2
-    - __kind: PointerType
-      ID: 1250
-      Name: '*noalg.map.group[int]*main.deepMap3'
-      ByteSize: 8
-      Pointee: 1251 StructureType noalg.map.group[int]*main.deepMap3
-    - __kind: PointerType
-      ID: 1284
-      Name: '*noalg.map.group[int]*main.deepMap8'
-      ByteSize: 8
-      Pointee: 1285 StructureType noalg.map.group[int]*main.deepMap8
-    - __kind: PointerType
-      ID: 1299
-      Name: '*noalg.map.group[int]*main.deepMap9'
-      ByteSize: 8
-      Pointee: 1300 StructureType noalg.map.group[int]*main.deepMap9
-    - __kind: PointerType
-      ID: 348
-      Name: '*noalg.map.group[int]int'
-      ByteSize: 8
-      Pointee: 349 StructureType noalg.map.group[int]int
-    - __kind: PointerType
-      ID: 1314
-      Name: '*noalg.map.group[int]interface {}'
-      ByteSize: 8
-      Pointee: 1315 StructureType noalg.map.group[int]interface {}
+      Pointee: 582 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
       ID: 456
-      Name: '*noalg.map.group[int]struct {}'
+      Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 457 StructureType noalg.map.group[int]struct {}
-    - __kind: PointerType
-      ID: 407
-      Name: '*noalg.map.group[int]uint8'
-      ByteSize: 8
-      Pointee: 408 StructureType noalg.map.group[int]uint8
-    - __kind: PointerType
-      ID: 389
-      Name: '*noalg.map.group[string][]main.structWithMap'
-      ByteSize: 8
-      Pointee: 390 StructureType noalg.map.group[string][]main.structWithMap
-    - __kind: PointerType
-      ID: 372
-      Name: '*noalg.map.group[string][]string'
-      ByteSize: 8
-      Pointee: 373 StructureType noalg.map.group[string][]string
-    - __kind: PointerType
-      ID: 1011
-      Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
-      ByteSize: 8
-      Pointee: 1012 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-    - __kind: PointerType
-      ID: 364
-      Name: '*noalg.map.group[string]int'
-      ByteSize: 8
-      Pointee: 365 StructureType noalg.map.group[string]int
-    - __kind: PointerType
-      ID: 356
-      Name: '*noalg.map.group[string]main.nestedStruct'
-      ByteSize: 8
-      Pointee: 357 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 457 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
       ID: 448
-      Name: '*noalg.map.group[struct {}]int'
+      Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 449 StructureType noalg.map.group[struct {}]int
+      Pointee: 449 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 498
-      Name: '*noalg.map.group[struct {}]main.structWithCyclicMaps'
+      ID: 396
+      Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 499 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
-    - __kind: PointerType
-      ID: 506
-      Name: '*noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps'
-      ByteSize: 8
-      Pointee: 507 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
-    - __kind: PointerType
-      ID: 514
-      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
-      ByteSize: 8
-      Pointee: 515 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-    - __kind: PointerType
-      ID: 522
-      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
-      ByteSize: 8
-      Pointee: 523 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-    - __kind: PointerType
-      ID: 530
-      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
-      ByteSize: 8
-      Pointee: 531 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-    - __kind: PointerType
-      ID: 538
-      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
-      ByteSize: 8
-      Pointee: 539 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-    - __kind: PointerType
-      ID: 464
-      Name: '*noalg.map.group[struct {}]struct {}'
-      ByteSize: 8
-      Pointee: 465 StructureType noalg.map.group[struct {}]struct {}
-    - __kind: PointerType
-      ID: 423
-      Name: '*noalg.map.group[uint8][4]int'
-      ByteSize: 8
-      Pointee: 424 StructureType noalg.map.group[uint8][4]int
+      Pointee: 397 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
       ID: 415
+      Name: '*noalg.map.group[bool]main.node'
+      ByteSize: 8
+      Pointee: 416 StructureType noalg.map.group[bool]main.node
+    - __kind: PointerType
+      ID: 354
+      Name: '*noalg.map.group[int]*main.deepMap2'
+      ByteSize: 8
+      Pointee: 355 StructureType noalg.map.group[int]*main.deepMap2
+    - __kind: PointerType
+      ID: 1266
+      Name: '*noalg.map.group[int]*main.deepMap3'
+      ByteSize: 8
+      Pointee: 1267 StructureType noalg.map.group[int]*main.deepMap3
+    - __kind: PointerType
+      ID: 1300
+      Name: '*noalg.map.group[int]*main.deepMap8'
+      ByteSize: 8
+      Pointee: 1301 StructureType noalg.map.group[int]*main.deepMap8
+    - __kind: PointerType
+      ID: 1315
+      Name: '*noalg.map.group[int]*main.deepMap9'
+      ByteSize: 8
+      Pointee: 1316 StructureType noalg.map.group[int]*main.deepMap9
+    - __kind: PointerType
+      ID: 364
+      Name: '*noalg.map.group[int]int'
+      ByteSize: 8
+      Pointee: 365 StructureType noalg.map.group[int]int
+    - __kind: PointerType
+      ID: 1330
+      Name: '*noalg.map.group[int]interface {}'
+      ByteSize: 8
+      Pointee: 1331 StructureType noalg.map.group[int]interface {}
+    - __kind: PointerType
+      ID: 472
+      Name: '*noalg.map.group[int]struct {}'
+      ByteSize: 8
+      Pointee: 473 StructureType noalg.map.group[int]struct {}
+    - __kind: PointerType
+      ID: 423
+      Name: '*noalg.map.group[int]uint8'
+      ByteSize: 8
+      Pointee: 424 StructureType noalg.map.group[int]uint8
+    - __kind: PointerType
+      ID: 405
+      Name: '*noalg.map.group[string][]main.structWithMap'
+      ByteSize: 8
+      Pointee: 406 StructureType noalg.map.group[string][]main.structWithMap
+    - __kind: PointerType
+      ID: 388
+      Name: '*noalg.map.group[string][]string'
+      ByteSize: 8
+      Pointee: 389 StructureType noalg.map.group[string][]string
+    - __kind: PointerType
+      ID: 1027
+      Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
+      ByteSize: 8
+      Pointee: 1028 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+    - __kind: PointerType
+      ID: 380
+      Name: '*noalg.map.group[string]int'
+      ByteSize: 8
+      Pointee: 381 StructureType noalg.map.group[string]int
+    - __kind: PointerType
+      ID: 372
+      Name: '*noalg.map.group[string]main.nestedStruct'
+      ByteSize: 8
+      Pointee: 373 StructureType noalg.map.group[string]main.nestedStruct
+    - __kind: PointerType
+      ID: 464
+      Name: '*noalg.map.group[struct {}]int'
+      ByteSize: 8
+      Pointee: 465 StructureType noalg.map.group[struct {}]int
+    - __kind: PointerType
+      ID: 514
+      Name: '*noalg.map.group[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 515 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 522
+      Name: '*noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 523 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 530
+      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 531 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 538
+      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 539 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 546
+      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 547 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 554
+      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 555 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 480
+      Name: '*noalg.map.group[struct {}]struct {}'
+      ByteSize: 8
+      Pointee: 481 StructureType noalg.map.group[struct {}]struct {}
+    - __kind: PointerType
+      ID: 439
+      Name: '*noalg.map.group[uint8][4]int'
+      ByteSize: 8
+      Pointee: 440 StructureType noalg.map.group[uint8][4]int
+    - __kind: PointerType
+      ID: 431
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 416 StructureType noalg.map.group[uint8]uint8
+      Pointee: 432 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
-      ID: 1202
+      ID: 1218
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2.351648e+06
       GoKind: 22
-      Pointee: 1203 UnresolvedPointeeType os.File
+      Pointee: 1219 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 831
+      ID: 847
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1.026912e+06
       GoKind: 22
-      Pointee: 832 UnresolvedPointeeType os.LinkError
+      Pointee: 848 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 899
+      ID: 915
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1.1928e+06
       GoKind: 22
-      Pointee: 900 UnresolvedPointeeType os.SyscallError
+      Pointee: 916 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 1200
+      ID: 1216
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.350176e+06
       GoKind: 22
-      Pointee: 1201 StructureType os.fileWithoutReadFrom
+      Pointee: 1217 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 1198
+      ID: 1214
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.34944e+06
       GoKind: 22
-      Pointee: 1199 StructureType os.fileWithoutWriteTo
+      Pointee: 1215 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 864
+      ID: 880
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1.044448e+06
       GoKind: 22
-      Pointee: 865 UnresolvedPointeeType os/exec.Error
+      Pointee: 881 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 1007
+      ID: 1023
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2.0912e+06
       GoKind: 22
-      Pointee: 1008 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 1024 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 1071
+      ID: 1087
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
       GoRuntimeType: 1.215072e+06
       GoKind: 22
-      Pointee: 1072 UnresolvedPointeeType os/exec.prefixSuffixSaver
+      Pointee: 1088 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
-      ID: 866
+      ID: 882
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1.044576e+06
       GoKind: 22
-      Pointee: 867 StructureType os/exec.wrappedError
+      Pointee: 883 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 798
+      ID: 814
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 939104
       GoKind: 22
-      Pointee: 601 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 617 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 603
+      ID: 619
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 602 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 618 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 797
+      ID: 813
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 939008
       GoKind: 22
-      Pointee: 600 BaseType os/user.UnknownUserIdError
+      Pointee: 616 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 627
+      ID: 643
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 902336
       GoKind: 22
-      Pointee: 628 UnresolvedPointeeType reflect.ValueError
+      Pointee: 644 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 725
+      ID: 741
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 921920
       GoKind: 22
-      Pointee: 726 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 742 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 835
+      ID: 851
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1.028448e+06
       GoKind: 22
-      Pointee: 836 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 852 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 839
+      ID: 855
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1.03024e+06
       GoKind: 22
-      Pointee: 840 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 856 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
@@ -10936,12 +11042,12 @@ Types:
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 837
+      ID: 853
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1.028576e+06
       GoKind: 22
-      Pointee: 838 StructureType runtime.boundsError
+      Pointee: 854 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 65
       Name: '*runtime.cgoCallers'
@@ -10957,24 +11063,24 @@ Types:
       GoKind: 22
       Pointee: 48 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 901
+      ID: 917
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1.198304e+06
       GoKind: 22
-      Pointee: 902 StructureType runtime.errorAddressString
+      Pointee: 918 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 833
+      ID: 849
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1.028064e+06
       GoKind: 22
-      Pointee: 816 GoStringHeaderType runtime.errorString
+      Pointee: 832 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 818
+      ID: 834
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 817 GoStringDataType runtime.errorString.str
+      Pointee: 833 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 55
       Name: '*runtime.g'
@@ -10995,19 +11101,19 @@ Types:
       ByteSize: 8
       GoRuntimeType: 1.0296e+06
       GoKind: 22
-      Pointee: 328 UnresolvedPointeeType runtime.p
+      Pointee: 344 UnresolvedPointeeType runtime.p
     - __kind: PointerType
-      ID: 834
+      ID: 850
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1.028192e+06
       GoKind: 22
-      Pointee: 819 GoStringHeaderType runtime.plainError
+      Pointee: 835 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 821
+      ID: 837
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 820 GoStringDataType runtime.plainError.str
+      Pointee: 836 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
@@ -11023,12 +11129,12 @@ Types:
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
-      ID: 623
+      ID: 639
       Name: '*runtime.synctestDeadlockError'
       ByteSize: 8
       GoRuntimeType: 900992
       GoKind: 22
-      Pointee: 624 StructureType runtime.synctestDeadlockError
+      Pointee: 640 StructureType runtime.synctestDeadlockError
     - __kind: PointerType
       ID: 44
       Name: '*runtime.timer'
@@ -11044,12 +11150,12 @@ Types:
       GoKind: 22
       Pointee: 80 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 841
+      ID: 857
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1.030496e+06
       GoKind: 22
-      Pointee: 842 UnresolvedPointeeType strconv.NumError
+      Pointee: 858 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 95
       Name: '*string'
@@ -11058,31 +11164,31 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 323
+      ID: 339
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 322 GoStringDataType string.str
+      Pointee: 338 GoStringDataType string.str
     - __kind: PointerType
-      ID: 1137
+      ID: 1153
       Name: '*strings.Builder'
       ByteSize: 8
       GoRuntimeType: 1.952e+06
       GoKind: 22
-      Pointee: 1138 UnresolvedPointeeType strings.Builder
+      Pointee: 1154 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
-      ID: 1041
+      ID: 1057
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
       GoRuntimeType: 1.030624e+06
       GoKind: 22
-      Pointee: 1042 UnresolvedPointeeType strings.appendSliceWriter
+      Pointee: 1058 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
-      ID: 1037
+      ID: 1053
       Name: '*struct { io.Writer }'
       ByteSize: 8
       GoRuntimeType: 972096
       GoKind: 22
-      Pointee: 1038 StructureType struct { io.Writer }
+      Pointee: 1054 StructureType struct { io.Writer }
     - __kind: PointerType
       ID: 267
       Name: '*struct {}'
@@ -11091,187 +11197,187 @@ Types:
       GoKind: 22
       Pointee: 125 StructureType struct {}
     - __kind: PointerType
-      ID: 953
+      ID: 969
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1.418176e+06
       GoKind: 22
-      Pointee: 952 BaseType syscall.Errno
+      Pointee: 968 BaseType syscall.Errno
     - __kind: PointerType
       ID: 227
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 438 StructureType table<[4]int,[4]int>
+      Pointee: 454 StructureType table<[4]int,[4]int>
     - __kind: PointerType
       ID: 222
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 430 StructureType table<[4]int,uint8>
+      Pointee: 446 StructureType table<[4]int,uint8>
     - __kind: PointerType
       ID: 190
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 378 StructureType table<[4]string,[2]int>
+      Pointee: 394 StructureType table<[4]string,[2]int>
     - __kind: PointerType
       ID: 202
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 397 StructureType table<bool,main.node>
+      Pointee: 413 StructureType table<bool,main.node>
     - __kind: PointerType
       ID: 148
       Name: '*table<int,*main.deepMap2>'
       ByteSize: 8
-      Pointee: 336 StructureType table<int,*main.deepMap2>
+      Pointee: 352 StructureType table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1247
+      ID: 1263
       Name: '*table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1248 StructureType table<int,*main.deepMap3>
+      Pointee: 1264 StructureType table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1281
+      ID: 1297
       Name: '*table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1282 StructureType table<int,*main.deepMap8>
+      Pointee: 1298 StructureType table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1296
+      ID: 1312
       Name: '*table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1297 StructureType table<int,*main.deepMap9>
+      Pointee: 1313 StructureType table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 170
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 346 StructureType table<int,int>
+      Pointee: 362 StructureType table<int,int>
     - __kind: PointerType
-      ID: 1311
+      ID: 1327
       Name: '*table<int,interface {}>'
       ByteSize: 8
-      Pointee: 1312 StructureType table<int,interface {}>
+      Pointee: 1328 StructureType table<int,interface {}>
     - __kind: PointerType
       ID: 237
       Name: '*table<int,struct {}>'
       ByteSize: 8
-      Pointee: 454 StructureType table<int,struct {}>
+      Pointee: 470 StructureType table<int,struct {}>
     - __kind: PointerType
       ID: 207
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 405 StructureType table<int,uint8>
+      Pointee: 421 StructureType table<int,uint8>
     - __kind: PointerType
       ID: 197
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 387 StructureType table<string,[]main.structWithMap>
+      Pointee: 403 StructureType table<string,[]main.structWithMap>
     - __kind: PointerType
       ID: 185
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 370 StructureType table<string,[]string>
+      Pointee: 386 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 982
+      ID: 998
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 1009 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 1025 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 180
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 362 StructureType table<string,int>
+      Pointee: 378 StructureType table<string,int>
     - __kind: PointerType
       ID: 175
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 354 StructureType table<string,main.nestedStruct>
+      Pointee: 370 StructureType table<string,main.nestedStruct>
     - __kind: PointerType
       ID: 232
       Name: '*table<struct {},int>'
       ByteSize: 8
-      Pointee: 446 StructureType table<struct {},int>
+      Pointee: 462 StructureType table<struct {},int>
     - __kind: PointerType
       ID: 290
       Name: '*table<struct {},main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 496 StructureType table<struct {},main.structWithCyclicMaps>
+      Pointee: 512 StructureType table<struct {},main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 295
       Name: '*table<struct {},map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 504 StructureType table<struct {},map[struct {}]main.structWithCyclicMaps>
+      Pointee: 520 StructureType table<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 300
       Name: '*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 512 StructureType table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 528 StructureType table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 305
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 520 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 536 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 310
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 528 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 544 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 315
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 536 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 552 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 242
       Name: '*table<struct {},struct {}>'
       ByteSize: 8
-      Pointee: 462 StructureType table<struct {},struct {}>
+      Pointee: 478 StructureType table<struct {},struct {}>
     - __kind: PointerType
       ID: 217
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 421 StructureType table<uint8,[4]int>
+      Pointee: 437 StructureType table<uint8,[4]int>
     - __kind: PointerType
       ID: 212
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 413 StructureType table<uint8,uint8>
+      Pointee: 429 StructureType table<uint8,uint8>
     - __kind: PointerType
-      ID: 1172
+      ID: 1188
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
       GoRuntimeType: 2.161568e+06
       GoKind: 22
-      Pointee: 1173 UnresolvedPointeeType text/tabwriter.Writer
+      Pointee: 1189 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
-      ID: 894
+      ID: 910
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1.090016e+06
       GoKind: 22
-      Pointee: 895 StructureType text/template.ExecError
+      Pointee: 911 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 969
+      ID: 985
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.624288e+06
       GoKind: 22
-      Pointee: 970 UnresolvedPointeeType time.Location
+      Pointee: 986 UnresolvedPointeeType time.Location
     - __kind: PointerType
-      ID: 630
+      ID: 646
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 903200
       GoKind: 22
-      Pointee: 631 UnresolvedPointeeType time.ParseError
+      Pointee: 647 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 629
+      ID: 645
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 903104
       GoKind: 22
-      Pointee: 546 GoStringHeaderType time.fileSizeError
+      Pointee: 562 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 548
+      ID: 564
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 547 GoStringDataType time.fileSizeError.str
+      Pointee: 563 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
       ID: 107
       Name: '*uint'
@@ -11315,52 +11421,88 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: PointerType
-      ID: 721
+      ID: 737
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 921344
       GoKind: 22
-      Pointee: 722 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 738 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 1164
+      ID: 1180
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.137056e+06
       GoKind: 22
-      Pointee: 1165 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1181 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 705
+      ID: 721
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 917504
       GoKind: 22
-      Pointee: 706 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 722 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 707
+      ID: 723
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 917600
       GoKind: 22
-      Pointee: 590 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 606 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 871
+      ID: 887
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1.048288e+06
       GoKind: 22
-      Pointee: 872 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 888 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 873
+      ID: 889
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1.048416e+06
       GoKind: 22
-      Pointee: 824 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 840 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1570
+      ID: 1587
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
     - __kind: EventRootType
-      ID: 1568
+      ID: 1571
+      Name: Probe[main.executeStructFuncs]Line
+      ByteSize: 66
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: sta.a
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 335 ArrayType [3]uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 10, name: sta}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: sta.b
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 10, name: sta}
+                  Offset: 24
+                  ByteSize: 1
+        - Name: sta.c
+          Offset: 26
+          Kind: template_segment
+          Expression:
+            Type: 336 ArrayType [5]int64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 10, name: sta}
+                  Offset: 32
+                  ByteSize: 40
+    - __kind: EventRootType
+      ID: 1585
       Name: Probe[main.firstBehavior.DoSomething]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11369,14 +11511,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 321 StructureType main.firstBehavior
+            Type: 337 StructureType main.firstBehavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 0, name: b}
+                  Variable: {subprogram: 165, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1569
+      ID: 1586
       Name: Probe[main.firstBehavior.DoSomething]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11388,14 +11530,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 1, name: ~r0}
+                  Variable: {subprogram: 165, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1526
+      ID: 1542
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1527
+      ID: 1543
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11411,7 +11553,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1393
+      ID: 1409
       Name: Probe[main.testAnyPtr]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11437,7 +11579,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1394
+      ID: 1410
       Name: Probe[main.testAnyPtr]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11453,7 +11595,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1390
+      ID: 1406
       Name: Probe[main.testAny]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11479,7 +11621,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1391
+      ID: 1407
       Name: Probe[main.testAny]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11495,7 +11637,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1497
+      ID: 1513
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11521,7 +11663,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1498
+      ID: 1514
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11537,7 +11679,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1341
+      ID: 1357
       Name: Probe[main.testArrayEmptyStructs]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11563,7 +11705,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1339
+      ID: 1355
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 129
       PresenceBitsetSize: 1
@@ -11589,7 +11731,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1337
+      ID: 1353
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -11615,7 +11757,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1402
+      ID: 1418
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11641,7 +11783,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1338
+      ID: 1354
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -11667,7 +11809,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1340
+      ID: 1356
       Name: Probe[main.testArrayOfStructs]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -11693,7 +11835,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1424
+      ID: 1440
       Name: Probe[main.testAtomicAdd]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11719,7 +11861,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1425
+      ID: 1441
       Name: Probe[main.testAtomicAdd]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11735,7 +11877,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1359
+      ID: 1375
       Name: Probe[main.testBigStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -11761,10 +11903,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1360
+      ID: 1376
       Name: Probe[main.testBigStruct]Return
     - __kind: EventRootType
-      ID: 1326
+      ID: 1342
       Name: Probe[main.testBoolArray]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -11790,7 +11932,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1323
+      ID: 1339
       Name: Probe[main.testByteArray]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -11816,7 +11958,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1426
+      ID: 1442
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11842,7 +11984,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1420
+      ID: 1436
       Name: Probe[main.testCombinedByte]
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -11908,7 +12050,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1421
+      ID: 1437
       Name: Probe[main.testCombinedString]
       ByteSize: 18
       PresenceBitsetSize: 1
@@ -11934,7 +12076,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1422
+      ID: 1438
       Name: Probe[main.testCombinedString]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -11970,7 +12112,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1434
+      ID: 1450
       Name: Probe[main.testCycle]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11996,7 +12138,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1365
+      ID: 1381
       Name: Probe[main.testDeepMap1]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12022,7 +12164,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1366
+      ID: 1382
       Name: Probe[main.testDeepMap7]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12048,7 +12190,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1361
+      ID: 1377
       Name: Probe[main.testDeepPtr1]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12074,7 +12216,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1362
+      ID: 1378
       Name: Probe[main.testDeepPtr7]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12100,7 +12242,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1363
+      ID: 1379
       Name: Probe[main.testDeepSlice1]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12126,7 +12268,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1364
+      ID: 1380
       Name: Probe[main.testDeepSlice7]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12152,7 +12294,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1517
+      ID: 1533
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -12198,7 +12340,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1514
+      ID: 1530
       Name: Probe[main.testEmptySlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12224,7 +12366,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1540
+      ID: 1556
       Name: Probe[main.testEmptyString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12250,7 +12392,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1554
+      ID: 1570
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12276,7 +12418,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1553
+      ID: 1569
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -12302,7 +12444,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1392
+      ID: 1408
       Name: Probe[main.testError]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12328,7 +12470,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1374
+      ID: 1390
       Name: Probe[main.testEsotericHeap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12354,10 +12496,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1375
+      ID: 1391
       Name: Probe[main.testEsotericHeap]Return
     - __kind: EventRootType
-      ID: 1372
+      ID: 1388
       Name: Probe[main.testEsotericStack]
       ByteSize: 129
       PresenceBitsetSize: 1
@@ -12383,10 +12525,10 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1373
+      ID: 1389
       Name: Probe[main.testEsotericStack]Return
     - __kind: EventRootType
-      ID: 1386
+      ID: 1402
       Name: Probe[main.testFramelessArray]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12412,7 +12554,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1388
+      ID: 1404
       Name: Probe[main.testFramelessArray]Line
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -12448,7 +12590,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1387
+      ID: 1403
       Name: Probe[main.testFramelessArray]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12464,7 +12606,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1384
+      ID: 1400
       Name: Probe[main.testFrameless]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12490,7 +12632,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1385
+      ID: 1401
       Name: Probe[main.testFrameless]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12506,7 +12648,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1376
+      ID: 1392
       Name: Probe[main.testInlinedBA]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12532,10 +12674,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1377
+      ID: 1393
       Name: Probe[main.testInlinedBA]Return
     - __kind: EventRootType
-      ID: 1380
+      ID: 1396
       Name: Probe[main.testInlinedBBA]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12561,13 +12703,13 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1381
+      ID: 1397
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1560
+      ID: 1577
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 1378
+      ID: 1394
       Name: Probe[main.testInlinedBB]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12613,28 +12755,28 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1379
+      ID: 1395
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1561
+      ID: 1578
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1562
+      ID: 1579
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1563
+      ID: 1580
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1564
+      ID: 1581
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
-      ID: 1382
+      ID: 1398
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 1383
+      ID: 1399
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1557
+      ID: 1574
       Name: Probe[main.testInlinedPrint]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12646,7 +12788,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12656,11 +12798,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1555
+      ID: 1572
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12672,11 +12814,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1556
+      ID: 1573
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12688,7 +12830,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x_val
@@ -12698,11 +12840,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1559
+      ID: 1576
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12714,7 +12856,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12724,14 +12866,14 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1558
+      ID: 1575
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1565
+      ID: 1582
       Name: Probe[main.testInlinedSq]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12743,7 +12885,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12753,11 +12895,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1566
+      ID: 1583
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12769,7 +12911,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12779,11 +12921,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1567
+      ID: 1584
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12795,7 +12937,7 @@ Types:
             Type: 161 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: a}
+                  Variable: {subprogram: 164, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: a
@@ -12805,11 +12947,11 @@ Types:
             Type: 161 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: a}
+                  Variable: {subprogram: 164, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1329
+      ID: 1345
       Name: Probe[main.testInt16Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12835,7 +12977,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1330
+      ID: 1346
       Name: Probe[main.testInt32Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12861,7 +13003,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1331
+      ID: 1347
       Name: Probe[main.testInt64Array]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12887,7 +13029,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1328
+      ID: 1344
       Name: Probe[main.testInt8Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -12913,7 +13055,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1327
+      ID: 1343
       Name: Probe[main.testIntArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12939,7 +13081,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1389
+      ID: 1405
       Name: Probe[main.testInterface]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12965,7 +13107,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1495
+      ID: 1511
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 161
       PresenceBitsetSize: 1
@@ -12991,7 +13133,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1496
+      ID: 1512
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13007,7 +13149,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1428
+      ID: 1444
       Name: Probe[main.testLinkedList]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13033,36 +13175,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1369
+      ID: 1385
       Name: Probe[main.testLongFunctionWithChangingState]Line
     - __kind: EventRootType
-      ID: 1370
-      Name: Probe[main.testLongFunctionWithChangingState]Line
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: aPerArch
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 1, name: aPerArch}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: b
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 2, name: b}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1371
+      ID: 1386
       Name: Probe[main.testLongFunctionWithChangingState]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13088,7 +13204,33 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1501
+      ID: 1387
+      Name: Probe[main.testLongFunctionWithChangingState]Line
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: aPerArch
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 1, name: aPerArch}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1517
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 147
       PresenceBitsetSize: 3
@@ -13274,7 +13416,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1502
+      ID: 1518
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13290,7 +13432,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1400
+      ID: 1416
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13316,7 +13458,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1407
+      ID: 1423
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13342,7 +13484,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1419
+      ID: 1435
       Name: Probe[main.testMapEmptyKeyAndValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13368,7 +13510,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1417
+      ID: 1433
       Name: Probe[main.testMapEmptyKey]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13394,7 +13536,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1418
+      ID: 1434
       Name: Probe[main.testMapEmptyValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13420,7 +13562,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1404
+      ID: 1420
       Name: Probe[main.testMapIntToInt]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13446,7 +13588,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1416
+      ID: 1432
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13472,7 +13614,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1415
+      ID: 1431
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13498,7 +13640,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1405
+      ID: 1421
       Name: Probe[main.testMapMassive]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13524,7 +13666,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1406
+      ID: 1422
       Name: Probe[main.testMapMassive]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13550,7 +13692,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1414
+      ID: 1430
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13576,7 +13718,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1413
+      ID: 1429
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13602,7 +13744,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1398
+      ID: 1414
       Name: Probe[main.testMapStringToInt]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13628,7 +13770,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1399
+      ID: 1415
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13654,7 +13796,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1397
+      ID: 1413
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13680,7 +13822,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1408
+      ID: 1424
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13706,7 +13848,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1412
+      ID: 1428
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13732,7 +13874,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1411
+      ID: 1427
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13758,7 +13900,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1410
+      ID: 1426
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13784,7 +13926,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1409
+      ID: 1425
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13810,7 +13952,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1537
+      ID: 1553
       Name: Probe[main.testMassiveString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13836,7 +13978,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1538
+      ID: 1554
       Name: Probe[main.testMassiveString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13862,7 +14004,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1503
+      ID: 1519
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 163
       PresenceBitsetSize: 3
@@ -14048,7 +14190,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1504
+      ID: 1520
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -14064,7 +14206,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1507
+      ID: 1523
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -14110,7 +14252,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1508
+      ID: 1524
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -14136,7 +14278,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1499
+      ID: 1515
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 321
       PresenceBitsetSize: 1
@@ -14182,7 +14324,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1500
+      ID: 1516
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -14198,7 +14340,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1453
+      ID: 1469
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14224,7 +14366,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1455
+      ID: 1471
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14270,7 +14412,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1457
+      ID: 1473
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14286,7 +14428,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1459
+      ID: 1475
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14302,7 +14444,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1461
+      ID: 1477
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14318,7 +14460,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1454
+      ID: 1470
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14344,7 +14486,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1456
+      ID: 1472
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -14410,7 +14552,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1458
+      ID: 1474
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14436,7 +14578,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1460
+      ID: 1476
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14462,7 +14604,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1462
+      ID: 1478
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14488,7 +14630,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1423
+      ID: 1439
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 62
       PresenceBitsetSize: 2
@@ -14594,7 +14736,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1449
+      ID: 1465
       Name: Probe[main.testNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14620,7 +14762,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1451
+      ID: 1467
       Name: Probe[main.testNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14646,7 +14788,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1450
+      ID: 1466
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14662,7 +14804,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1452
+      ID: 1468
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14688,7 +14830,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1549
+      ID: 1565
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14714,7 +14856,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1550
+      ID: 1566
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14736,10 +14878,10 @@ Types:
                   Bias: 8
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1551
+      ID: 1567
       Name: Probe[main.testNestedPointer]
     - __kind: EventRootType
-      ID: 1552
+      ID: 1568
       Name: Probe[main.testNestedPointer]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -14761,7 +14903,7 @@ Types:
                   Bias: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1433
+      ID: 1449
       Name: Probe[main.testNilPointer]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14807,7 +14949,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1518
+      ID: 1534
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -14853,7 +14995,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1520
+      ID: 1536
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 67
       PresenceBitsetSize: 1
@@ -14919,7 +15061,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1521
+      ID: 1537
       Name: Probe[main.testNilSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -14945,7 +15087,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1536
+      ID: 1552
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14971,7 +15113,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1429
+      ID: 1445
       Name: Probe[main.testPointerLoop]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14997,7 +15139,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1403
+      ID: 1419
       Name: Probe[main.testPointerToMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15023,7 +15165,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1427
+      ID: 1443
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15049,7 +15191,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1443
+      ID: 1459
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 35
       PresenceBitsetSize: 1
@@ -15095,7 +15237,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1444
+      ID: 1460
       Name: Probe[main.testReturnsAnyAndError]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15121,7 +15263,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1445
+      ID: 1461
       Name: Probe[main.testReturnsAny]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15147,7 +15289,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1446
+      ID: 1462
       Name: Probe[main.testReturnsAny]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15163,10 +15305,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1475
+      ID: 1491
       Name: Probe[main.testReturnsArrayOne]
     - __kind: EventRootType
-      ID: 1476
+      ID: 1492
       Name: Probe[main.testReturnsArrayOne]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15182,10 +15324,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1477
+      ID: 1493
       Name: Probe[main.testReturnsArrayZero]
     - __kind: EventRootType
-      ID: 1478
+      ID: 1494
       Name: Probe[main.testReturnsArrayZero]Return
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -15201,10 +15343,10 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1473
+      ID: 1489
       Name: Probe[main.testReturnsArray]
     - __kind: EventRootType
-      ID: 1474
+      ID: 1490
       Name: Probe[main.testReturnsArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15220,10 +15362,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1481
+      ID: 1497
       Name: Probe[main.testReturnsBacktrackInt]
     - __kind: EventRootType
-      ID: 1482
+      ID: 1498
       Name: Probe[main.testReturnsBacktrackInt]Return
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -15319,10 +15461,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1493
+      ID: 1509
       Name: Probe[main.testReturnsBoolAndUintptr]
     - __kind: EventRootType
-      ID: 1494
+      ID: 1510
       Name: Probe[main.testReturnsBoolAndUintptr]Return
       ByteSize: 10
       PresenceBitsetSize: 1
@@ -15348,10 +15490,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1469
+      ID: 1485
       Name: Probe[main.testReturnsComplex]
     - __kind: EventRootType
-      ID: 1470
+      ID: 1486
       Name: Probe[main.testReturnsComplex]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15377,7 +15519,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1441
+      ID: 1457
       Name: Probe[main.testReturnsError]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -15403,7 +15545,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1442
+      ID: 1458
       Name: Probe[main.testReturnsError]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15419,7 +15561,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1439
+      ID: 1455
       Name: Probe[main.testReturnsIntAndFloat]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15445,7 +15587,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1440
+      ID: 1456
       Name: Probe[main.testReturnsIntAndFloat]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15471,7 +15613,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1437
+      ID: 1453
       Name: Probe[main.testReturnsIntPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15497,7 +15639,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1438
+      ID: 1454
       Name: Probe[main.testReturnsIntPointer]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15513,7 +15655,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1435
+      ID: 1451
       Name: Probe[main.testReturnsInt]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15539,7 +15681,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1436
+      ID: 1452
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15555,7 +15697,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1447
+      ID: 1463
       Name: Probe[main.testReturnsInterface]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15581,7 +15723,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1448
+      ID: 1464
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15597,10 +15739,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1471
+      ID: 1487
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1472
+      ID: 1488
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -15616,10 +15758,10 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1467
+      ID: 1483
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1468
+      ID: 1484
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 139
       PresenceBitsetSize: 3
@@ -15795,10 +15937,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1479
+      ID: 1495
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1480
+      ID: 1496
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15814,10 +15956,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1485
+      ID: 1501
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1486
+      ID: 1502
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -15873,10 +16015,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1491
+      ID: 1507
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1492
+      ID: 1508
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -15902,10 +16044,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1489
+      ID: 1505
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1490
+      ID: 1506
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15921,10 +16063,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1465
+      ID: 1481
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1466
+      ID: 1482
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -16010,10 +16152,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1487
+      ID: 1503
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1488
+      ID: 1504
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16029,10 +16171,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1483
+      ID: 1499
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1484
+      ID: 1500
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -16048,7 +16190,7 @@ Types:
                   Offset: 0
                   ByteSize: 88
     - __kind: EventRootType
-      ID: 1324
+      ID: 1340
       Name: Probe[main.testRuneArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16074,7 +16216,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1345
+      ID: 1361
       Name: Probe[main.testSingleBool]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -16100,7 +16242,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1343
+      ID: 1359
       Name: Probe[main.testSingleByte]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -16126,7 +16268,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1356
+      ID: 1372
       Name: Probe[main.testSingleFloat32]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -16152,7 +16294,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1357
+      ID: 1373
       Name: Probe[main.testSingleFloat64]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16178,7 +16320,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1348
+      ID: 1364
       Name: Probe[main.testSingleInt16]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -16204,7 +16346,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1349
+      ID: 1365
       Name: Probe[main.testSingleInt32]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -16230,7 +16372,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1350
+      ID: 1366
       Name: Probe[main.testSingleInt64]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16256,7 +16398,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1347
+      ID: 1363
       Name: Probe[main.testSingleInt8]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -16302,7 +16444,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1346
+      ID: 1362
       Name: Probe[main.testSingleInt]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16328,7 +16470,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1344
+      ID: 1360
       Name: Probe[main.testSingleRune]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -16354,7 +16496,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1528
+      ID: 1544
       Name: Probe[main.testSingleString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16380,7 +16522,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1353
+      ID: 1369
       Name: Probe[main.testSingleUint16]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -16406,7 +16548,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1354
+      ID: 1370
       Name: Probe[main.testSingleUint32]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -16432,7 +16574,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1355
+      ID: 1371
       Name: Probe[main.testSingleUint64]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16458,7 +16600,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1352
+      ID: 1368
       Name: Probe[main.testSingleUint8]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -16484,7 +16626,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1351
+      ID: 1367
       Name: Probe[main.testSingleUint]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16510,7 +16652,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1524
+      ID: 1540
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16536,7 +16678,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1515
+      ID: 1531
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16562,7 +16704,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1401
+      ID: 1417
       Name: Probe[main.testSmallMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16588,7 +16730,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1463
+      ID: 1479
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16614,7 +16756,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1464
+      ID: 1480
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16650,7 +16792,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1505
+      ID: 1521
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -16676,7 +16818,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1506
+      ID: 1522
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16712,7 +16854,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1325
+      ID: 1341
       Name: Probe[main.testStringArray]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -16738,7 +16880,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1432
+      ID: 1448
       Name: Probe[main.testStringPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16764,7 +16906,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1519
+      ID: 1535
       Name: Probe[main.testStringSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16790,7 +16932,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1367
+      ID: 1383
       Name: Probe[main.testStringType1]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16816,7 +16958,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1368
+      ID: 1384
       Name: Probe[main.testStringType2]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16842,7 +16984,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1516
+      ID: 1532
       Name: Probe[main.testStructSlice]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -16888,7 +17030,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1395
+      ID: 1411
       Name: Probe[main.testStructWithAny]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16914,7 +17056,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1509
+      ID: 1525
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16940,7 +17082,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1510
+      ID: 1526
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16966,7 +17108,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1543
+      ID: 1559
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16992,10 +17134,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1544
+      ID: 1560
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1542
+      ID: 1558
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 289
       PresenceBitsetSize: 1
@@ -17021,7 +17163,7 @@ Types:
                   Offset: 0
                   ByteSize: 144
     - __kind: EventRootType
-      ID: 1396
+      ID: 1412
       Name: Probe[main.testStructWithMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17047,7 +17189,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1545
+      ID: 1561
       Name: Probe[main.testStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17063,7 +17205,7 @@ Types:
                   Offset: 8
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1547
+      ID: 1563
       Name: Probe[main.testStruct]
       ByteSize: 113
       PresenceBitsetSize: 1
@@ -17089,13 +17231,13 @@ Types:
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1546
+      ID: 1562
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1548
+      ID: 1564
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1525
+      ID: 1541
       Name: Probe[main.testSubslices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -17161,7 +17303,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1541
+      ID: 1557
       Name: Probe[main.testSubstrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17227,7 +17369,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1534
+      ID: 1550
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17253,7 +17395,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1535
+      ID: 1551
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17298,7 +17440,7 @@ Types:
                   Bias: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1530
+      ID: 1546
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17324,7 +17466,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1532
+      ID: 1548
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17360,13 +17502,13 @@ Types:
                   Offset: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1531
+      ID: 1547
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1533
+      ID: 1549
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1529
+      ID: 1545
       Name: Probe[main.testThreeStrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17432,7 +17574,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1358
+      ID: 1374
       Name: Probe[main.testTypeAlias]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -17458,7 +17600,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1334
+      ID: 1350
       Name: Probe[main.testUint16Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -17484,7 +17626,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1335
+      ID: 1351
       Name: Probe[main.testUint32Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17510,7 +17652,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1336
+      ID: 1352
       Name: Probe[main.testUint64Array]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17536,7 +17678,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1333
+      ID: 1349
       Name: Probe[main.testUint8Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -17562,7 +17704,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1332
+      ID: 1348
       Name: Probe[main.testUintArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17588,7 +17730,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1431
+      ID: 1447
       Name: Probe[main.testUintPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17614,7 +17756,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1513
+      ID: 1529
       Name: Probe[main.testUintSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17640,7 +17782,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1539
+      ID: 1555
       Name: Probe[main.testUnitializedString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17666,7 +17808,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1430
+      ID: 1446
       Name: Probe[main.testUnsafePointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17692,7 +17834,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1342
+      ID: 1358
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 1601
       PresenceBitsetSize: 1
@@ -17718,7 +17860,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1522
+      ID: 1538
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17744,7 +17886,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1523
+      ID: 1539
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17770,7 +17912,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1511
+      ID: 1527
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17816,7 +17958,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1512
+      ID: 1528
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -18077,7 +18219,15 @@ Types:
       HasCount: true
       Element: 32 StructureType internal/runtime/atomic.Uint32
     - __kind: ArrayType
-      ID: 427
+      ID: 335
+      Name: '[3]uint64'
+      ByteSize: 24
+      GoKind: 17
+      Count: 3
+      HasCount: true
+      Element: 8 BaseType uint64
+    - __kind: ArrayType
+      ID: 443
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 683584
@@ -18086,7 +18236,7 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 384
+      ID: 400
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 683872
@@ -18112,7 +18262,15 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 999
+      ID: 336
+      Name: '[5]int64'
+      ByteSize: 40
+      GoKind: 17
+      Count: 5
+      HasCount: true
+      Element: 12 BaseType int64
+    - __kind: ArrayType
+      ID: 1015
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 685408
@@ -18154,15 +18312,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 334 GoSliceDataType []*main.deepSlice2.array
+      Data: 350 GoSliceDataType []*main.deepSlice2.array
     - __kind: GoSliceDataType
-      ID: 334
+      ID: 350
       Name: '[]*main.deepSlice2.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 140 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 1237
+      ID: 1253
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 478336
@@ -18170,22 +18328,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1238 PointerType **main.deepSlice3
+          Type: 1254 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1241 GoSliceDataType []*main.deepSlice3.array
+      Data: 1257 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 1241
+      ID: 1257
       Name: '[]*main.deepSlice3.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1239 PointerType *main.deepSlice3
+      Element: 1255 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 1262
+      ID: 1278
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 478016
@@ -18193,22 +18351,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1263 PointerType **main.deepSlice8
+          Type: 1279 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1266 GoSliceDataType []*main.deepSlice8.array
+      Data: 1282 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 1266
+      ID: 1282
       Name: '[]*main.deepSlice8.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1264 PointerType *main.deepSlice8
+      Element: 1280 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 1268
+      ID: 1284
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 477952
@@ -18216,20 +18374,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1269 PointerType **main.deepSlice9
+          Type: 1285 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1272 GoSliceDataType []*main.deepSlice9.array
+      Data: 1288 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 1272
+      ID: 1288
       Name: '[]*main.deepSlice9.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1270 PointerType *main.deepSlice9
+      Element: 1286 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 62
       Name: '[]*runtime.p'
@@ -18246,9 +18404,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 329 GoSliceDataType []*runtime.p.array
+      Data: 345 GoSliceDataType []*runtime.p.array
     - __kind: GoSliceDataType
-      ID: 329
+      ID: 345
       Name: '[]*runtime.p.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -18269,171 +18427,171 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 331 GoSliceDataType []*string.array
+      Data: 347 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 331
+      ID: 347
       Name: '[]*string.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 95 PointerType *string
     - __kind: GoSliceDataType
-      ID: 444
+      ID: 460
       Name: '[]*table<[4]int,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 227 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 436
+      ID: 452
       Name: '[]*table<[4]int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 222 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 385
+      ID: 401
       Name: '[]*table<[4]string,[2]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 190 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 403
+      ID: 419
       Name: '[]*table<bool,main.node>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 202 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 344
+      ID: 360
       Name: '[]*table<int,*main.deepMap2>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 148 PointerType *table<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 1256
+      ID: 1272
       Name: '[]*table<int,*main.deepMap3>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1247 PointerType *table<int,*main.deepMap3>
+      Element: 1263 PointerType *table<int,*main.deepMap3>
     - __kind: GoSliceDataType
-      ID: 1290
+      ID: 1306
       Name: '[]*table<int,*main.deepMap8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1281 PointerType *table<int,*main.deepMap8>
+      Element: 1297 PointerType *table<int,*main.deepMap8>
     - __kind: GoSliceDataType
-      ID: 1305
+      ID: 1321
       Name: '[]*table<int,*main.deepMap9>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1296 PointerType *table<int,*main.deepMap9>
+      Element: 1312 PointerType *table<int,*main.deepMap9>
     - __kind: GoSliceDataType
-      ID: 352
+      ID: 368
       Name: '[]*table<int,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 170 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 1318
+      ID: 1334
       Name: '[]*table<int,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1311 PointerType *table<int,interface {}>
+      Element: 1327 PointerType *table<int,interface {}>
     - __kind: GoSliceDataType
-      ID: 460
+      ID: 476
       Name: '[]*table<int,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 237 PointerType *table<int,struct {}>
     - __kind: GoSliceDataType
-      ID: 411
+      ID: 427
       Name: '[]*table<int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 207 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 395
+      ID: 411
       Name: '[]*table<string,[]main.structWithMap>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 197 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 376
+      ID: 392
       Name: '[]*table<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 185 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 1015
+      ID: 1031
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 982 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 998 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 368
+      ID: 384
       Name: '[]*table<string,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 180 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 360
+      ID: 376
       Name: '[]*table<string,main.nestedStruct>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 175 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 452
+      ID: 468
       Name: '[]*table<struct {},int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 232 PointerType *table<struct {},int>
     - __kind: GoSliceDataType
-      ID: 502
+      ID: 518
       Name: '[]*table<struct {},main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 290 PointerType *table<struct {},main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 510
+      ID: 526
       Name: '[]*table<struct {},map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 295 PointerType *table<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 518
+      ID: 534
       Name: '[]*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 300 PointerType *table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 526
+      ID: 542
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 305 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 534
+      ID: 550
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 310 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 542
+      ID: 558
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 315 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 468
+      ID: 484
       Name: '[]*table<struct {},struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 242 PointerType *table<struct {},struct {}>
     - __kind: GoSliceDataType
-      ID: 428
+      ID: 444
       Name: '[]*table<uint8,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 217 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 419
+      ID: 435
       Name: '[]*table<uint8,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
@@ -18453,9 +18611,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 494 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Data: 510 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 494
+      ID: 510
       Name: '[][][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -18475,9 +18633,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 492 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Data: 508 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 492
+      ID: 508
       Name: '[][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -18497,9 +18655,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 490 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Data: 506 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 490
+      ID: 506
       Name: '[][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -18519,9 +18677,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 488 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Data: 504 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 488
+      ID: 504
       Name: '[][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -18541,9 +18699,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 486 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Data: 502 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 486
+      ID: 502
       Name: '[][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -18563,9 +18721,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 472 GoSliceDataType [][]uint.array
+      Data: 488 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 472
+      ID: 488
       Name: '[][]uint.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -18586,15 +18744,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 478 GoSliceDataType []bool.array
+      Data: 494 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 478
+      ID: 494
       Name: '[]bool.array'
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 994
+      ID: 1010
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 487808
@@ -18609,15 +18767,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1017 GoSliceDataType []float64.array
+      Data: 1033 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 1017
+      ID: 1033
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 15 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 1274
+      ID: 1290
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 488256
@@ -18632,9 +18790,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1275 GoSliceDataType []interface {}.array
+      Data: 1291 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 1275
+      ID: 1291
       Name: '[]interface {}.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -18654,15 +18812,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 484 GoSliceDataType []main.structWithCyclicSlices.array
+      Data: 500 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 484
+      ID: 500
       Name: '[]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 144
       Element: 272 StructureType main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 393
+      ID: 409
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 478656
@@ -18670,16 +18828,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 394 PointerType *main.structWithMap
+          Type: 410 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 544 GoSliceDataType []main.structWithMap.array
+      Data: 560 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 544
+      ID: 560
       Name: '[]main.structWithMap.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -18699,175 +18857,175 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 474 GoSliceDataType []main.structWithNoStrings.array
+      Data: 490 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 474
+      ID: 490
       Name: '[]main.structWithNoStrings.array'
       DynamicSizeClass: slice
       ByteSize: 2
       Element: 262 StructureType main.structWithNoStrings
     - __kind: GoSliceDataType
-      ID: 445
+      ID: 461
       Name: '[]noalg.map.group[[4]int][4]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 520
-      Element: 441 StructureType noalg.map.group[[4]int][4]int
+      Element: 457 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 437
+      ID: 453
       Name: '[]noalg.map.group[[4]int]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 433 StructureType noalg.map.group[[4]int]uint8
+      Element: 449 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 386
+      ID: 402
       Name: '[]noalg.map.group[[4]string][2]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 648
-      Element: 381 StructureType noalg.map.group[[4]string][2]int
+      Element: 397 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 404
+      ID: 420
       Name: '[]noalg.map.group[bool]main.node.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 400 StructureType noalg.map.group[bool]main.node
+      Element: 416 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
-      ID: 345
+      ID: 361
       Name: '[]noalg.map.group[int]*main.deepMap2.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 339 StructureType noalg.map.group[int]*main.deepMap2
+      Element: 355 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSliceDataType
-      ID: 1257
+      ID: 1273
       Name: '[]noalg.map.group[int]*main.deepMap3.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1251 StructureType noalg.map.group[int]*main.deepMap3
+      Element: 1267 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSliceDataType
-      ID: 1291
+      ID: 1307
       Name: '[]noalg.map.group[int]*main.deepMap8.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1285 StructureType noalg.map.group[int]*main.deepMap8
+      Element: 1301 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSliceDataType
-      ID: 1306
+      ID: 1322
       Name: '[]noalg.map.group[int]*main.deepMap9.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1300 StructureType noalg.map.group[int]*main.deepMap9
+      Element: 1316 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSliceDataType
-      ID: 353
+      ID: 369
       Name: '[]noalg.map.group[int]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 349 StructureType noalg.map.group[int]int
+      Element: 365 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 1319
+      ID: 1335
       Name: '[]noalg.map.group[int]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 1315 StructureType noalg.map.group[int]interface {}
+      Element: 1331 StructureType noalg.map.group[int]interface {}
     - __kind: GoSliceDataType
-      ID: 461
+      ID: 477
       Name: '[]noalg.map.group[int]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 457 StructureType noalg.map.group[int]struct {}
+      Element: 473 StructureType noalg.map.group[int]struct {}
     - __kind: GoSliceDataType
-      ID: 412
+      ID: 428
       Name: '[]noalg.map.group[int]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 408 StructureType noalg.map.group[int]uint8
+      Element: 424 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
-      ID: 396
+      ID: 412
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 390 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 406 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
-      ID: 377
+      ID: 393
       Name: '[]noalg.map.group[string][]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 373 StructureType noalg.map.group[string][]string
+      Element: 389 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 1016
+      ID: 1032
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 1012 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 1028 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
-      ID: 369
+      ID: 385
       Name: '[]noalg.map.group[string]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 365 StructureType noalg.map.group[string]int
+      Element: 381 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 361
+      ID: 377
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 357 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 373 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 453
+      ID: 469
       Name: '[]noalg.map.group[struct {}]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 449 StructureType noalg.map.group[struct {}]int
+      Element: 465 StructureType noalg.map.group[struct {}]int
     - __kind: GoSliceDataType
-      ID: 503
+      ID: 519
       Name: '[]noalg.map.group[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 392
-      Element: 499 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      Element: 515 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 511
+      ID: 527
       Name: '[]noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 507 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 523 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 519
+      ID: 535
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 515 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 531 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 527
+      ID: 543
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 523 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 539 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 535
+      ID: 551
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 531 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 547 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 543
+      ID: 559
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 539 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 555 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 469
+      ID: 485
       Name: '[]noalg.map.group[struct {}]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 16
-      Element: 465 StructureType noalg.map.group[struct {}]struct {}
+      Element: 481 StructureType noalg.map.group[struct {}]struct {}
     - __kind: GoSliceDataType
-      ID: 429
+      ID: 445
       Name: '[]noalg.map.group[uint8][4]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 424 StructureType noalg.map.group[uint8][4]int
+      Element: 440 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 420
+      ID: 436
       Name: '[]noalg.map.group[uint8]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 24
-      Element: 416 StructureType noalg.map.group[uint8]uint8
+      Element: 432 StructureType noalg.map.group[uint8]uint8
     - __kind: UnresolvedPointeeType
       ID: 40
       Name: '[]runtime.ancestorInfo'
@@ -18888,9 +19046,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 476 GoSliceDataType []string.array
+      Data: 492 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 476
+      ID: 492
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -18910,9 +19068,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 482 GoSliceDataType []struct {}.array
+      Data: 498 GoSliceDataType []struct {}.array
     - __kind: GoSliceDataType
-      ID: 482
+      ID: 498
       Name: '[]struct {}.array'
       DynamicSizeClass: slice
       Element: 125 StructureType struct {}
@@ -18932,9 +19090,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 470 GoSliceDataType []uint.array
+      Data: 486 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 470
+      ID: 486
       Name: '[]uint.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -18955,9 +19113,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 480 GoSliceDataType []uint16.array
+      Data: 496 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 480
+      ID: 496
       Name: '[]uint16.array'
       DynamicSizeClass: slice
       ByteSize: 2
@@ -18978,9 +19136,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 324 GoSliceDataType []uint8.array
+      Data: 340 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 324
+      ID: 340
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -19001,19 +19159,19 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 326 GoSliceDataType []uintptr.array
+      Data: 342 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 326
+      ID: 342
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 1 BaseType uintptr
     - __kind: UnresolvedPointeeType
-      ID: 1149
+      ID: 1165
       Name: archive/tar.Writer
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 784
+      ID: 800
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 932480
@@ -19028,33 +19186,33 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 785 GoSliceDataType archive/tar.headerError.array
+      Data: 801 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 785
+      ID: 801
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1084
+      ID: 1100
       Name: archive/tar.regFileWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1032
+      ID: 1048
       Name: archive/zip.countWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1034
+      ID: 1050
       Name: archive/zip.dirWriter
       GoRuntimeType: 1.121312e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1128
+      ID: 1144
       Name: archive/zip.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1060
+      ID: 1076
       Name: archive/zip.nopCloser
       ByteSize: 16
       GoRuntimeType: 1.56704e+06
@@ -19064,7 +19222,7 @@ Types:
           Offset: 0
           Type: 131 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1062
+      ID: 1078
       Name: archive/zip.pooledFlateWriter
       ByteSize: 8
     - __kind: BaseType
@@ -19074,15 +19232,15 @@ Types:
       GoRuntimeType: 585888
       GoKind: 1
     - __kind: UnresolvedPointeeType
-      ID: 1107
+      ID: 1123
       Name: bufio.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1136
+      ID: 1152
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1187
+      ID: 1203
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
@@ -19108,13 +19266,13 @@ Types:
       GoRuntimeType: 585632
       GoKind: 15
     - __kind: BaseType
-      ID: 582
+      ID: 598
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 835648
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 583
+      ID: 599
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 835744
@@ -19122,116 +19280,116 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 585 PointerType *compress/flate.InternalError.str
+          Type: 601 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 584 GoStringDataType compress/flate.InternalError.str
+      Data: 600 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 584
+      ID: 600
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1082
+      ID: 1098
       Name: compress/flate.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1028
+      ID: 1044
       Name: compress/flate.dictWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1104
+      ID: 1120
       Name: compress/gzip.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 932
+      ID: 948
       Name: context.deadlineExceededError
       GoRuntimeType: 1.48144e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 596
+      ID: 612
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 838240
       GoKind: 2
     - __kind: BaseType
-      ID: 597
+      ID: 613
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 838336
       GoKind: 2
     - __kind: BaseType
-      ID: 598
+      ID: 614
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 838432
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1099
+      ID: 1115
       Name: crypto/internal/fips140/hmac.HMAC
       ByteSize: 8
     - __kind: StructureType
-      ID: 881
+      ID: 897
       Name: crypto/internal/fips140/hmac.errCloneUnsupported
       GoRuntimeType: 1.290656e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1130
+      ID: 1146
       Name: crypto/internal/fips140/sha256.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1160
+      ID: 1176
       Name: crypto/internal/fips140/sha3.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1134
+      ID: 1150
       Name: crypto/internal/fips140/sha3.SHAKE
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1132
+      ID: 1148
       Name: crypto/internal/fips140/sha512.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1126
+      ID: 1142
       Name: crypto/md5.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 599
+      ID: 615
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 838528
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1147
+      ID: 1163
       Name: crypto/sha1.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1122
+      ID: 1138
       Name: crypto/sha3.SHA3
       ByteSize: 8
     - __kind: BaseType
-      ID: 586
+      ID: 602
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 836224
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 870
+      ID: 886
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1213
+      ID: 1229
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 698
+      ID: 714
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 696
+      ID: 712
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1.732128e+06
@@ -19242,38 +19400,38 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 999 ArrayType [5]uint8
+          Type: 1015 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 1000 GoInterfaceType net.Conn
+          Type: 1016 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 823
+      ID: 839
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 994464
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1092
+      ID: 1108
       Name: crypto/tls.cthWrapper
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 700
+      ID: 716
       Name: crypto/tls.echConfigErr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1097
+      ID: 1113
       Name: crypto/tls.finishedHash
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 967
+      ID: 983
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 984
+      ID: 1000
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 772
+      ID: 788
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1.735008e+06
@@ -19281,21 +19439,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 983 PointerType *crypto/x509.Certificate
+          Type: 999 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 1002 BaseType crypto/x509.InvalidReason
+          Type: 1018 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 766
+      ID: 782
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1.11888e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 768
+      ID: 784
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1.601152e+06
@@ -19303,24 +19461,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 983 PointerType *crypto/x509.Certificate
+          Type: 999 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 595
+      ID: 611
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 837856
       GoKind: 2
     - __kind: BaseType
-      ID: 1002
+      ID: 1018
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 591072
       GoKind: 2
     - __kind: StructureType
-      ID: 875
+      ID: 891
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1.56304e+06
@@ -19330,13 +19488,13 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 774
+      ID: 790
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1.119136e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 770
+      ID: 786
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1.734816e+06
@@ -19344,15 +19502,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 983 PointerType *crypto/x509.Certificate
+          Type: 999 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 13 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 983 PointerType *crypto/x509.Certificate
+          Type: 999 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 788
+      ID: 804
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1.437856e+06
@@ -19362,7 +19520,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 792
+      ID: 808
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1.438016e+06
@@ -19372,55 +19530,55 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 790
+      ID: 806
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 577
+      ID: 593
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 835168
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 1050
+      ID: 1066
       Name: encoding/base64.encoder
       ByteSize: 8
     - __kind: BaseType
-      ID: 578
+      ID: 594
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 835360
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 654
+      ID: 670
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 859
+      ID: 875
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 646
+      ID: 662
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 652
+      ID: 668
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 650
+      ID: 666
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 648
+      ID: 664
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1193
+      ID: 1209
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 656
+      ID: 672
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1.421856e+06
@@ -19430,19 +19588,19 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1058
+      ID: 1074
       Name: encoding/pem.lineBreaker
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 760
+      ID: 776
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 758
+      ID: 774
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 592
+      ID: 608
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 837760
@@ -19450,22 +19608,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 594 PointerType *encoding/xml.UnmarshalError.str
+          Type: 610 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 593 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 609 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 593
+      ID: 609
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 763
+      ID: 779
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1171
+      ID: 1187
       Name: encoding/xml.printer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -19482,11 +19640,11 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 622
+      ID: 638
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 826
+      ID: 842
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -19502,15 +19660,15 @@ Types:
       GoRuntimeType: 585824
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 1181
+      ID: 1197
       Name: fmt.pp
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 828
+      ID: 844
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 830
+      ID: 846
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -19526,11 +19684,11 @@ Types:
       GoRuntimeType: 849376
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 684
+      ID: 700
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 665
+      ID: 681
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1.730976e+06
@@ -19538,7 +19696,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 992 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 1008 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 7 BaseType int
@@ -19546,25 +19704,25 @@ Types:
           Offset: 200
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 667
+      ID: 683
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 996
+      ID: 1012
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 671
+      ID: 687
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1.115168e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 998
+      ID: 1014
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 571
+      ID: 587
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 834592
@@ -19572,18 +19730,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 573 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 589 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 572 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 588 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 572
+      ID: 588
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 992
+      ID: 1008
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2.220864e+06
@@ -19591,7 +19749,7 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 993 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 1009 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -19606,7 +19764,7 @@ Types:
           Type: 15 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 994 GoSliceHeaderType []float64
+          Type: 1010 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 12 BaseType int64
@@ -19615,10 +19773,10 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 995 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 1011 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 997 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 1013 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
           Type: 263 GoSliceHeaderType []string
@@ -19632,13 +19790,13 @@ Types:
           Offset: 184
           Type: 12 BaseType int64
     - __kind: BaseType
-      ID: 993
+      ID: 1009
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 587680
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 568
+      ID: 584
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 834496
@@ -19646,18 +19804,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 570 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 586 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 569 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 585 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 569
+      ID: 585
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 574
+      ID: 590
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 834688
@@ -19665,60 +19823,60 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 576 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 592 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 575 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 591 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 575
+      ID: 591
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1070
+      ID: 1086
       Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1157
+      ID: 1173
       Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 782
+      ID: 798
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 941
+      ID: 957
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1189
+      ID: 1205
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 709
+      ID: 725
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 716
+      ID: 732
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1.118112e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 591
+      ID: 607
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 836896
       GoKind: 2
     - __kind: StructureType
-      ID: 714
+      ID: 730
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1.117984e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 712
+      ID: 728
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1.599232e+06
@@ -19731,7 +19889,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 732
+      ID: 748
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1.600032e+06
@@ -19744,7 +19902,7 @@ Types:
           Offset: 16
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 736
+      ID: 752
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1.73424e+06
@@ -19760,7 +19918,7 @@ Types:
           Offset: 24
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 734
+      ID: 750
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1.431776e+06
@@ -19770,7 +19928,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 730
+      ID: 746
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1.431456e+06
@@ -19780,14 +19938,14 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 978
+      ID: 994
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1.50224e+06
       GoKind: 21
-      HeaderType: 980 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 996 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 1001
+      ID: 1017
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1.051872e+06
@@ -19802,15 +19960,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1019 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 1035 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 1019
+      ID: 1035
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 744
+      ID: 760
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1.600352e+06
@@ -19818,12 +19976,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 978 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 994 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 978 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 994 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 738
+      ID: 754
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1.431936e+06
@@ -19833,7 +19991,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 742
+      ID: 758
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1.734432e+06
@@ -19844,12 +20002,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 1001 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1017 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 1001 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1017 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 740
+      ID: 756
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1.600192e+06
@@ -19862,7 +20020,7 @@ Types:
           Offset: 8
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 746
+      ID: 762
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1.432096e+06
@@ -19870,9 +20028,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 968 StructureType time.Time
+          Type: 984 StructureType time.Time
     - __kind: StructureType
-      ID: 752
+      ID: 768
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1.600672e+06
@@ -19885,7 +20043,7 @@ Types:
           Offset: 8
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 754
+      ID: 770
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1.432416e+06
@@ -19895,7 +20053,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 750
+      ID: 766
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1.600512e+06
@@ -19908,7 +20066,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 748
+      ID: 764
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1.432256e+06
@@ -19918,7 +20076,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 756
+      ID: 772
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1.600832e+06
@@ -19931,7 +20089,7 @@ Types:
           Offset: 8
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 673
+      ID: 689
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1.424096e+06
@@ -19941,11 +20099,11 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1110
+      ID: 1126
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 675
+      ID: 691
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1.424256e+06
@@ -19953,21 +20111,21 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 673 StructureType github.com/cihub/seelog.baseError
+          Type: 689 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1090
+      ID: 1106
       Name: github.com/cihub/seelog.connWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1046
+      ID: 1062
       Name: github.com/cihub/seelog.consoleWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1080
+      ID: 1096
       Name: github.com/cihub/seelog.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 679
+      ID: 695
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1.424576e+06
@@ -19975,13 +20133,13 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 673 StructureType github.com/cihub/seelog.baseError
+          Type: 689 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1145
+      ID: 1161
       Name: github.com/cihub/seelog.rollingFileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1158
+      ID: 1174
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
       GoRuntimeType: 2.108352e+06
@@ -19989,12 +20147,12 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1144 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1160 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: maxFileSize
           Offset: 8
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 1161
+      ID: 1177
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
       GoRuntimeType: 2.133216e+06
@@ -20002,7 +20160,7 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1144 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1160 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: timePattern
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -20010,11 +20168,11 @@ Types:
           Offset: 24
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1048
+      ID: 1064
       Name: github.com/cihub/seelog.smtpWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 677
+      ID: 693
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1.424416e+06
@@ -20022,9 +20180,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 673 StructureType github.com/cihub/seelog.baseError
+          Type: 689 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 681
+      ID: 697
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1.424736e+06
@@ -20032,64 +20190,64 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 673 StructureType github.com/cihub/seelog.baseError
+          Type: 689 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1112
+      ID: 1128
       Name: github.com/cihub/seelog/archive/gzip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1153
+      ID: 1169
       Name: github.com/cihub/seelog/archive/tar.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1155
+      ID: 1171
       Name: github.com/cihub/seelog/archive/zip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 972
+      ID: 988
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 885
+      ID: 901
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 883
+      ID: 899
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 887
+      ID: 903
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 889
+      ID: 905
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1101
+      ID: 1117
       Name: github.com/gogo/protobuf/proto.textWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 877
+      ID: 893
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 687
+      ID: 703
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1.425696e+06
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 7 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 1205
+      ID: 1221
       Name: github.com/json-iterator/go.Stream
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 943
+      ID: 959
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 916
+      ID: 932
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1.844032e+06
@@ -20105,11 +20263,11 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 910
+      ID: 926
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 845
+      ID: 861
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1.70368e+06
@@ -20122,7 +20280,7 @@ Types:
           Offset: 1
           Type: 16 BaseType int8
     - __kind: StructureType
-      ID: 922
+      ID: 938
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1.84448e+06
@@ -20138,13 +20296,13 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 822
+      ID: 838
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 991776
       GoKind: 8
     - __kind: StructureType
-      ID: 914
+      ID: 930
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1.843808e+06
@@ -20160,13 +20318,13 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 1003
+      ID: 1019
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 832768
       GoKind: 8
     - __kind: StructureType
-      ID: 912
+      ID: 928
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1.843584e+06
@@ -20174,15 +20332,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 1003 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 1019 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 1003 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 1019 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 920
+      ID: 936
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1.757632e+06
@@ -20195,7 +20353,7 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 918
+      ID: 934
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1.844256e+06
@@ -20211,11 +20369,11 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1209
+      ID: 1225
       Name: github.com/tinylib/msgp/msgp.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 926
+      ID: 942
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1.625248e+06
@@ -20225,19 +20383,19 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 849
+      ID: 865
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1.28464e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 847
+      ID: 863
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1.284512e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 924
+      ID: 940
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1.757824e+06
@@ -20250,7 +20408,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 604
+      ID: 620
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 840352
@@ -20258,22 +20416,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 606 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 622 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 605 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 621 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 605
+      ID: 621
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 987
+      ID: 1003
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 893
+      ID: 909
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1.449696e+06
@@ -20283,7 +20441,7 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 1076
+      ID: 1092
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
       GoRuntimeType: 1.679392e+06
@@ -20291,13 +20449,13 @@ Types:
       RawFields:
         - Name: WriteSyncer
           Offset: 0
-          Type: 1102 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+          Type: 1118 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
     - __kind: UnresolvedPointeeType
-      ID: 1169
+      ID: 1185
       Name: go.uber.org/zap/buffer.Buffer
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1102
+      ID: 1118
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
       GoRuntimeType: 1.128864e+06
@@ -20310,7 +20468,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1064
+      ID: 1080
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
       GoRuntimeType: 1.57184e+06
@@ -20320,19 +20478,19 @@ Types:
           Offset: 0
           Type: 131 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 607
+      ID: 623
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 840928
       GoKind: 10
     - __kind: BaseType
-      ID: 985
+      ID: 1001
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 1.004928e+06
       GoKind: 10
     - __kind: StructureType
-      ID: 951
+      ID: 967
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1.88256e+06
@@ -20343,12 +20501,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 985 BaseType golang.org/x/net/http2.ErrCode
+          Type: 1001 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 808
+      ID: 824
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1.607872e+06
@@ -20356,12 +20514,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 985 BaseType golang.org/x/net/http2.ErrCode
+          Type: 1001 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 611
+      ID: 627
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 841120
@@ -20369,18 +20527,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 613 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 629 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 612 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 628 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 612
+      ID: 628
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 617
+      ID: 633
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 841312
@@ -20388,18 +20546,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 619 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 635 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 618 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 634 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 618
+      ID: 634
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 614
+      ID: 630
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 841216
@@ -20407,18 +20565,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 616 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 632 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 615 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 631 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 615
+      ID: 631
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 608
+      ID: 624
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 841024
@@ -20426,22 +20584,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 610 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 626 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 609 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 625 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 609
+      ID: 625
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1167
+      ID: 1183
       Name: golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 812
+      ID: 828
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.450336e+06
@@ -20451,13 +20609,13 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: BaseType
-      ID: 620
+      ID: 636
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 841408
       GoKind: 2
     - __kind: StructureType
-      ID: 800
+      ID: 816
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1.445376e+06
@@ -20467,11 +20625,11 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 949
+      ID: 965
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 974
+      ID: 990
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1.910336e+06
@@ -20487,7 +20645,7 @@ Types:
           Offset: 24
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 802
+      ID: 818
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1.607392e+06
@@ -20500,7 +20658,7 @@ Types:
           Offset: 16
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 1116
+      ID: 1132
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
       GoRuntimeType: 1.968384e+06
@@ -20508,16 +20666,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 1000 GoInterfaceType net.Conn
+          Type: 1016 GoInterfaceType net.Conn
         - Name: r
           Offset: 16
-          Type: 1143 GoInterfaceType io.Reader
+          Type: 1159 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 1074
+      ID: 1090
       Name: google.golang.org/grpc/internal/transport.bufWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 891
+      ID: 907
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1.56944e+06
@@ -20527,29 +20685,29 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1036
+      ID: 1052
       Name: google.golang.org/grpc/mem.writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 780
+      ID: 796
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 879
+      ID: 895
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 947
+      ID: 963
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 945
+      ID: 961
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1.51296e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 794
+      ID: 810
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1.438656e+06
@@ -20559,7 +20717,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 796
+      ID: 812
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1.438816e+06
@@ -20569,393 +20727,393 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 724
+      ID: 740
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 439
+      ID: 455
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 440 PointerType *noalg.map.group[[4]int][4]int
+          Type: 456 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 441 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 445 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      GroupType: 457 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 461 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 431
+      ID: 447
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 432 PointerType *noalg.map.group[[4]int]uint8
+          Type: 448 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 433 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 437 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 449 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 453 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 379
+      ID: 395
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 380 PointerType *noalg.map.group[[4]string][2]int
+          Type: 396 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 381 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 386 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 397 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 402 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 398
+      ID: 414
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 399 PointerType *noalg.map.group[bool]main.node
+          Type: 415 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 400 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 404 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 416 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 420 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 337
+      ID: 353
       Name: groupReference<int,*main.deepMap2>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 338 PointerType *noalg.map.group[int]*main.deepMap2
+          Type: 354 PointerType *noalg.map.group[int]*main.deepMap2
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 339 StructureType noalg.map.group[int]*main.deepMap2
-      GroupSliceType: 345 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
+      GroupType: 355 StructureType noalg.map.group[int]*main.deepMap2
+      GroupSliceType: 361 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
     - __kind: GoSwissMapGroupsType
-      ID: 1249
+      ID: 1265
       Name: groupReference<int,*main.deepMap3>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1250 PointerType *noalg.map.group[int]*main.deepMap3
+          Type: 1266 PointerType *noalg.map.group[int]*main.deepMap3
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1251 StructureType noalg.map.group[int]*main.deepMap3
-      GroupSliceType: 1257 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+      GroupType: 1267 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 1273 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
     - __kind: GoSwissMapGroupsType
-      ID: 1283
+      ID: 1299
       Name: groupReference<int,*main.deepMap8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1284 PointerType *noalg.map.group[int]*main.deepMap8
+          Type: 1300 PointerType *noalg.map.group[int]*main.deepMap8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1285 StructureType noalg.map.group[int]*main.deepMap8
-      GroupSliceType: 1291 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
+      GroupType: 1301 StructureType noalg.map.group[int]*main.deepMap8
+      GroupSliceType: 1307 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
     - __kind: GoSwissMapGroupsType
-      ID: 1298
+      ID: 1314
       Name: groupReference<int,*main.deepMap9>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1299 PointerType *noalg.map.group[int]*main.deepMap9
+          Type: 1315 PointerType *noalg.map.group[int]*main.deepMap9
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1300 StructureType noalg.map.group[int]*main.deepMap9
-      GroupSliceType: 1306 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
+      GroupType: 1316 StructureType noalg.map.group[int]*main.deepMap9
+      GroupSliceType: 1322 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
     - __kind: GoSwissMapGroupsType
-      ID: 347
+      ID: 363
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 348 PointerType *noalg.map.group[int]int
+          Type: 364 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 349 StructureType noalg.map.group[int]int
-      GroupSliceType: 353 GoSliceDataType []noalg.map.group[int]int.array
+      GroupType: 365 StructureType noalg.map.group[int]int
+      GroupSliceType: 369 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 1313
+      ID: 1329
       Name: groupReference<int,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1314 PointerType *noalg.map.group[int]interface {}
+          Type: 1330 PointerType *noalg.map.group[int]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1315 StructureType noalg.map.group[int]interface {}
-      GroupSliceType: 1319 GoSliceDataType []noalg.map.group[int]interface {}.array
+      GroupType: 1331 StructureType noalg.map.group[int]interface {}
+      GroupSliceType: 1335 GoSliceDataType []noalg.map.group[int]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 455
+      ID: 471
       Name: groupReference<int,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 456 PointerType *noalg.map.group[int]struct {}
+          Type: 472 PointerType *noalg.map.group[int]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 457 StructureType noalg.map.group[int]struct {}
-      GroupSliceType: 461 GoSliceDataType []noalg.map.group[int]struct {}.array
+      GroupType: 473 StructureType noalg.map.group[int]struct {}
+      GroupSliceType: 477 GoSliceDataType []noalg.map.group[int]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 406
+      ID: 422
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 407 PointerType *noalg.map.group[int]uint8
+          Type: 423 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 408 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 412 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 424 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 428 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 388
+      ID: 404
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 389 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 405 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 390 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 396 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 406 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 412 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 371
+      ID: 387
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 372 PointerType *noalg.map.group[string][]string
+          Type: 388 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 373 StructureType noalg.map.group[string][]string
-      GroupSliceType: 377 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 389 StructureType noalg.map.group[string][]string
+      GroupSliceType: 393 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 1010
+      ID: 1026
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1011 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1027 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1012 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 1016 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 1028 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 1032 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
-      ID: 363
+      ID: 379
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 364 PointerType *noalg.map.group[string]int
+          Type: 380 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 365 StructureType noalg.map.group[string]int
-      GroupSliceType: 369 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 381 StructureType noalg.map.group[string]int
+      GroupSliceType: 385 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 355
+      ID: 371
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 356 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 372 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 357 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 361 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+      GroupType: 373 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 377 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 447
+      ID: 463
       Name: groupReference<struct {},int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 448 PointerType *noalg.map.group[struct {}]int
+          Type: 464 PointerType *noalg.map.group[struct {}]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 449 StructureType noalg.map.group[struct {}]int
-      GroupSliceType: 453 GoSliceDataType []noalg.map.group[struct {}]int.array
+      GroupType: 465 StructureType noalg.map.group[struct {}]int
+      GroupSliceType: 469 GoSliceDataType []noalg.map.group[struct {}]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 497
+      ID: 513
       Name: groupReference<struct {},main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 498 PointerType *noalg.map.group[struct {}]main.structWithCyclicMaps
+          Type: 514 PointerType *noalg.map.group[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 499 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 503 GoSliceDataType []noalg.map.group[struct {}]main.structWithCyclicMaps.array
+      GroupType: 515 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 519 GoSliceDataType []noalg.map.group[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 505
+      ID: 521
       Name: groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 506 PointerType *noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 522 PointerType *noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 507 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 511 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 523 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 527 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 513
+      ID: 529
       Name: groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 514 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 530 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 515 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 519 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 531 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 535 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 521
+      ID: 537
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 522 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 538 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 523 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 527 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 539 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 543 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 529
+      ID: 545
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 530 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 546 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 531 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 535 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 547 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 551 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 537
+      ID: 553
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 538 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 554 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 539 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 543 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 555 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 559 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 463
+      ID: 479
       Name: groupReference<struct {},struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 464 PointerType *noalg.map.group[struct {}]struct {}
+          Type: 480 PointerType *noalg.map.group[struct {}]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 465 StructureType noalg.map.group[struct {}]struct {}
-      GroupSliceType: 469 GoSliceDataType []noalg.map.group[struct {}]struct {}.array
+      GroupType: 481 StructureType noalg.map.group[struct {}]struct {}
+      GroupSliceType: 485 GoSliceDataType []noalg.map.group[struct {}]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 422
+      ID: 438
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 423 PointerType *noalg.map.group[uint8][4]int
+          Type: 439 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 424 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 429 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 440 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 445 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 414
+      ID: 430
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 415 PointerType *noalg.map.group[uint8]uint8
+          Type: 431 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 416 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 420 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 432 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 436 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: UnresolvedPointeeType
-      ID: 1124
+      ID: 1140
       Name: hash/crc32.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 815
+      ID: 831
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -21002,11 +21160,11 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 976
+      ID: 992
       Name: internal/abi.Type
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 692
+      ID: 708
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -21032,29 +21190,29 @@ Types:
           Offset: 296
           Type: 2 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 690
+      ID: 706
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1022
+      ID: 1038
       Name: internal/godebug.runtimeStderr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 908
+      ID: 924
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1211
+      ID: 1227
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 906
+      ID: 922
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1.47824e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 626
+      ID: 642
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -21135,7 +21293,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 579
+      ID: 595
       Name: internal/runtime/cgroup.stringError
       ByteSize: 16
       GoRuntimeType: 835552
@@ -21143,18 +21301,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 581 PointerType *internal/runtime/cgroup.stringError.str
+          Type: 597 PointerType *internal/runtime/cgroup.stringError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 580 GoStringDataType internal/runtime/cgroup.stringError.str
+      Data: 596 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: GoStringDataType
-      ID: 580
+      ID: 596
       Name: internal/runtime/cgroup.stringError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 863
+      ID: 879
       Name: internal/runtime/maps.unhashableTypeError
       ByteSize: 8
       GoRuntimeType: 1.5608e+06
@@ -21162,9 +21320,9 @@ Types:
       RawFields:
         - Name: typ
           Offset: 0
-          Type: 975 PointerType *internal/abi.Type
+          Type: 991 PointerType *internal/abi.Type
     - __kind: StructureType
-      ID: 1223
+      ID: 1239
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.47568e+06
@@ -21177,11 +21335,11 @@ Types:
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 1068
+      ID: 1084
       Name: io.PipeWriter
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1108
+      ID: 1124
       Name: io.ReadWriteCloser
       ByteSize: 16
       GoRuntimeType: 1.191392e+06
@@ -21194,7 +21352,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1143
+      ID: 1159
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 1.024992e+06
@@ -21207,7 +21365,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1095
+      ID: 1111
       Name: io.WriteCloser
       ByteSize: 16
       GoRuntimeType: 1.111456e+06
@@ -21233,21 +21391,21 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1066
+      ID: 1082
       Name: io.discard
       GoRuntimeType: 1.46528e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1040
+      ID: 1056
       Name: io.multiWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 904
+      ID: 920
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1114
+      ID: 1130
       Name: log/slog/internal/buffer.Buffer
       ByteSize: 8
     - __kind: StructureType
@@ -21276,7 +21434,25 @@ Types:
       RawFields:
         - Name: nested
           Offset: 0
-          Type: 1320 PointerType *main.nestedStruct
+          Type: 1336 PointerType *main.nestedStruct
+    - __kind: StructureType
+      ID: 325
+      Name: main.bStruct
+      ByteSize: 72
+      GoKind: 25
+      RawFields:
+        - Name: aInt16
+          Offset: 0
+          Type: 104 BaseType int16
+        - Name: nested
+          Offset: 8
+          Type: 316 StructureType main.aStruct
+        - Name: aBool
+          Offset: 64
+          Type: 4 BaseType bool
+        - Name: aInt32
+          Offset: 68
+          Type: 10 BaseType int32
     - __kind: GoInterfaceType
       ID: 162
       Name: main.behavior
@@ -21306,6 +21482,21 @@ Types:
           Offset: 32
           Type: 131 GoInterfaceType io.Writer
     - __kind: StructureType
+      ID: 322
+      Name: main.cStruct
+      ByteSize: 24
+      GoKind: 25
+      RawFields:
+        - Name: aInt32
+          Offset: 0
+          Type: 10 BaseType int32
+        - Name: aUint
+          Offset: 8
+          Type: 17 BaseType uint
+        - Name: nested
+          Offset: 16
+          Type: 262 StructureType main.structWithNoStrings
+    - __kind: StructureType
       ID: 143
       Name: main.deepMap1
       ByteSize: 8
@@ -21316,7 +21507,7 @@ Types:
           Offset: 0
           Type: 144 GoMapType map[int]*main.deepMap2
     - __kind: StructureType
-      ID: 343
+      ID: 359
       Name: main.deepMap2
       ByteSize: 8
       GoRuntimeType: 1.18768e+06
@@ -21324,9 +21515,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1243 GoMapType map[int]*main.deepMap3
+          Type: 1259 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 1255
+      ID: 1271
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -21338,9 +21529,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1277 GoMapType map[int]*main.deepMap8
+          Type: 1293 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 1289
+      ID: 1305
       Name: main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.186912e+06
@@ -21348,9 +21539,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1292 GoMapType map[int]*main.deepMap9
+          Type: 1308 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 1304
+      ID: 1320
       Name: main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.186784e+06
@@ -21358,7 +21549,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1307 GoMapType map[int]interface {}
+          Type: 1323 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 132
       Name: main.deepPtr1
@@ -21378,9 +21569,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1214 PointerType *main.deepPtr3
+          Type: 1230 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 1215
+      ID: 1231
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -21392,9 +21583,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1258 PointerType *main.deepPtr8
+          Type: 1274 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 1259
+      ID: 1275
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1.188064e+06
@@ -21402,9 +21593,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1260 PointerType *main.deepPtr9
+          Type: 1276 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 1261
+      ID: 1277
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1.187936e+06
@@ -21424,7 +21615,7 @@ Types:
           Offset: 0
           Type: 138 GoSliceHeaderType []*main.deepSlice2
     - __kind: StructureType
-      ID: 333
+      ID: 349
       Name: main.deepSlice2
       ByteSize: 24
       GoRuntimeType: 1.189984e+06
@@ -21432,9 +21623,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1237 GoSliceHeaderType []*main.deepSlice3
+          Type: 1253 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 1240
+      ID: 1256
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -21446,9 +21637,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1262 GoSliceHeaderType []*main.deepSlice8
+          Type: 1278 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 1265
+      ID: 1281
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1.189216e+06
@@ -21456,9 +21647,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1268 GoSliceHeaderType []*main.deepSlice9
+          Type: 1284 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 1271
+      ID: 1287
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1.189088e+06
@@ -21466,7 +21657,73 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1274 GoSliceHeaderType []interface {}
+          Type: 1290 GoSliceHeaderType []interface {}
+    - __kind: StructureType
+      ID: 327
+      Name: main.deepStruct1
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: b
+          Offset: 8
+          Type: 328 StructureType main.deepStruct2
+    - __kind: StructureType
+      ID: 328
+      Name: main.deepStruct2
+      ByteSize: 40
+      GoKind: 25
+      RawFields:
+        - Name: c
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: d
+          Offset: 8
+          Type: 329 StructureType main.deepStruct3
+    - __kind: StructureType
+      ID: 329
+      Name: main.deepStruct3
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: e
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: f
+          Offset: 8
+          Type: 330 StructureType main.deepStruct4
+    - __kind: StructureType
+      ID: 330
+      Name: main.deepStruct4
+      ByteSize: 24
+      GoKind: 25
+      RawFields:
+        - Name: g
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: h
+          Offset: 8
+          Type: 331 StructureType main.deepStruct5
+    - __kind: StructureType
+      ID: 331
+      Name: main.deepStruct5
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: i
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: j
+          Offset: 8
+          Type: 332 StructureType main.deepStruct6
+    - __kind: StructureType
+      ID: 332
+      Name: main.deepStruct6
+      ByteSize: 8
+      GoKind: 25
+      RawFields: [{Name: k, Offset: 0, Type: 7 BaseType int}]
     - __kind: StructureType
       ID: 319
       Name: main.emptyStruct
@@ -21484,16 +21741,16 @@ Types:
           Type: 155 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 1221 StructureType sync.Mutex
+          Type: 1237 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 1224 StructureType sync.Once
+          Type: 1240 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 1227 StructureType sync.WaitGroup
+          Type: 1243 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 1230 StructureType sync/atomic.Int32
+          Type: 1246 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 155
       Name: main.esotericStack
@@ -21523,7 +21780,7 @@ Types:
           Offset: 56
           Type: 59 GoSubroutineType func()
     - __kind: StructureType
-      ID: 321
+      ID: 337
       Name: main.firstBehavior
       ByteSize: 16
       GoRuntimeType: 1.414336e+06
@@ -21569,6 +21826,90 @@ Types:
           Offset: 72
           Type: 7 BaseType int
     - __kind: StructureType
+      ID: 333
+      Name: main.lotsOfFields
+      ByteSize: 26
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 3 BaseType uint8
+        - Name: b
+          Offset: 1
+          Type: 3 BaseType uint8
+        - Name: c
+          Offset: 2
+          Type: 3 BaseType uint8
+        - Name: d
+          Offset: 3
+          Type: 3 BaseType uint8
+        - Name: e
+          Offset: 4
+          Type: 3 BaseType uint8
+        - Name: f
+          Offset: 5
+          Type: 3 BaseType uint8
+        - Name: g
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: h
+          Offset: 7
+          Type: 3 BaseType uint8
+        - Name: i
+          Offset: 8
+          Type: 3 BaseType uint8
+        - Name: j
+          Offset: 9
+          Type: 3 BaseType uint8
+        - Name: k
+          Offset: 10
+          Type: 3 BaseType uint8
+        - Name: l
+          Offset: 11
+          Type: 3 BaseType uint8
+        - Name: m
+          Offset: 12
+          Type: 3 BaseType uint8
+        - Name: n
+          Offset: 13
+          Type: 3 BaseType uint8
+        - Name: o
+          Offset: 14
+          Type: 3 BaseType uint8
+        - Name: p
+          Offset: 15
+          Type: 3 BaseType uint8
+        - Name: q
+          Offset: 16
+          Type: 3 BaseType uint8
+        - Name: r
+          Offset: 17
+          Type: 3 BaseType uint8
+        - Name: s
+          Offset: 18
+          Type: 3 BaseType uint8
+        - Name: t
+          Offset: 19
+          Type: 3 BaseType uint8
+        - Name: u
+          Offset: 20
+          Type: 3 BaseType uint8
+        - Name: v
+          Offset: 21
+          Type: 3 BaseType uint8
+        - Name: w
+          Offset: 22
+          Type: 3 BaseType uint8
+        - Name: x
+          Offset: 23
+          Type: 3 BaseType uint8
+        - Name: y
+          Offset: 24
+          Type: 3 BaseType uint8
+        - Name: z
+          Offset: 25
+          Type: 3 BaseType uint8
+    - __kind: StructureType
       ID: 254
       Name: main.mixedStruct
       ByteSize: 24
@@ -21583,6 +21924,21 @@ Types:
         - Name: c
           Offset: 16
           Type: 7 BaseType int
+    - __kind: StructureType
+      ID: 321
+      Name: main.nStruct
+      ByteSize: 24
+      GoKind: 25
+      RawFields:
+        - Name: aBool
+          Offset: 0
+          Type: 4 BaseType bool
+        - Name: aInt
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: aInt16
+          Offset: 16
+          Type: 104 BaseType int16
     - __kind: StructureType
       ID: 123
       Name: main.nestedStruct
@@ -21619,7 +21975,13 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1233
+      ID: 323
+      Name: main.receiver
+      ByteSize: 8
+      GoKind: 25
+      RawFields: [{Name: u, Offset: 0, Type: 17 BaseType uint}]
+    - __kind: StructureType
+      ID: 1249
       Name: main.secondBehavior
       ByteSize: 8
       GoRuntimeType: 1.414496e+06
@@ -21639,7 +22001,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1220
+      ID: 1236
       Name: main.somethingImpl
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -21650,31 +22012,31 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1217 PointerType *main.stringType1.str
+          Type: 1233 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 1216 GoStringDataType main.stringType1.str
+      Data: 1232 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 1216
+      ID: 1232
       Name: main.stringType1.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 1218
+      ID: 1234
       Name: main.stringType2
       ByteSize: 16
       GoKind: 24
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1322 PointerType *main.stringType2.str
+          Type: 1338 PointerType *main.stringType2.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 1321 GoStringDataType main.stringType2.str
+      Data: 1337 GoStringDataType main.stringType2.str
     - __kind: GoStringDataType
-      ID: 1321
+      ID: 1337
       Name: main.stringType2.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -21771,6 +22133,21 @@ Types:
           Offset: 1
           Type: 4 BaseType bool
     - __kind: StructureType
+      ID: 334
+      Name: main.structWithTwoArrays
+      ByteSize: 72
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 335 ArrayType [3]uint64
+        - Name: b
+          Offset: 24
+          Type: 3 BaseType uint8
+        - Name: c
+          Offset: 32
+          Type: 336 ArrayType [5]int64
+    - __kind: StructureType
       ID: 245
       Name: main.structWithTwoValues
       ByteSize: 16
@@ -21790,23 +22167,74 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1234 PointerType **main.t
+          Type: 1250 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1235 GoSliceDataType main.t.array
+      Data: 1251 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 1235
+      ID: 1251
       Name: main.t.array
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 248 PointerType *main.t
     - __kind: StructureType
+      ID: 326
+      Name: main.tenStrings
+      ByteSize: 160
+      GoKind: 25
+      RawFields:
+        - Name: first
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: second
+          Offset: 16
+          Type: 9 GoStringHeaderType string
+        - Name: third
+          Offset: 32
+          Type: 9 GoStringHeaderType string
+        - Name: fourth
+          Offset: 48
+          Type: 9 GoStringHeaderType string
+        - Name: fifth
+          Offset: 64
+          Type: 9 GoStringHeaderType string
+        - Name: sixth
+          Offset: 80
+          Type: 9 GoStringHeaderType string
+        - Name: seventh
+          Offset: 96
+          Type: 9 GoStringHeaderType string
+        - Name: eighth
+          Offset: 112
+          Type: 9 GoStringHeaderType string
+        - Name: ninth
+          Offset: 128
+          Type: 9 GoStringHeaderType string
+        - Name: tenth
+          Offset: 144
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
       ID: 268
       Name: main.threeStringStruct
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: b
+          Offset: 16
+          Type: 9 GoStringHeaderType string
+        - Name: c
+          Offset: 32
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 324
+      Name: main.threestrings
       ByteSize: 48
       GoKind: 25
       RawFields:
@@ -21896,8 +22324,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 444 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 441 StructureType noalg.map.group[[4]int][4]int
+      TablePtrSliceType: 460 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 457 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
       ID: 220
       Name: map<[4]int,uint8>
@@ -21931,8 +22359,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 436 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 433 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 452 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 449 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 188
       Name: map<[4]string,[2]int>
@@ -21966,8 +22394,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 385 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 381 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 401 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 397 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
       ID: 200
       Name: map<bool,main.node>
@@ -22001,8 +22429,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 403 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 400 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 419 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 416 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
       ID: 146
       Name: map<int,*main.deepMap2>
@@ -22036,10 +22464,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 344 GoSliceDataType []*table<int,*main.deepMap2>.array
-      GroupType: 339 StructureType noalg.map.group[int]*main.deepMap2
+      TablePtrSliceType: 360 GoSliceDataType []*table<int,*main.deepMap2>.array
+      GroupType: 355 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSwissMapHeaderType
-      ID: 1245
+      ID: 1261
       Name: map<int,*main.deepMap3>
       ByteSize: 48
       GoKind: 25
@@ -22052,7 +22480,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1246 PointerType **table<int,*main.deepMap3>
+          Type: 1262 PointerType **table<int,*main.deepMap3>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -22071,10 +22499,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1256 GoSliceDataType []*table<int,*main.deepMap3>.array
-      GroupType: 1251 StructureType noalg.map.group[int]*main.deepMap3
+      TablePtrSliceType: 1272 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 1267 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSwissMapHeaderType
-      ID: 1279
+      ID: 1295
       Name: map<int,*main.deepMap8>
       ByteSize: 48
       GoKind: 25
@@ -22087,7 +22515,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1280 PointerType **table<int,*main.deepMap8>
+          Type: 1296 PointerType **table<int,*main.deepMap8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -22106,10 +22534,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1290 GoSliceDataType []*table<int,*main.deepMap8>.array
-      GroupType: 1285 StructureType noalg.map.group[int]*main.deepMap8
+      TablePtrSliceType: 1306 GoSliceDataType []*table<int,*main.deepMap8>.array
+      GroupType: 1301 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSwissMapHeaderType
-      ID: 1294
+      ID: 1310
       Name: map<int,*main.deepMap9>
       ByteSize: 48
       GoKind: 25
@@ -22122,7 +22550,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1295 PointerType **table<int,*main.deepMap9>
+          Type: 1311 PointerType **table<int,*main.deepMap9>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -22141,8 +22569,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1305 GoSliceDataType []*table<int,*main.deepMap9>.array
-      GroupType: 1300 StructureType noalg.map.group[int]*main.deepMap9
+      TablePtrSliceType: 1321 GoSliceDataType []*table<int,*main.deepMap9>.array
+      GroupType: 1316 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSwissMapHeaderType
       ID: 168
       Name: map<int,int>
@@ -22176,10 +22604,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 352 GoSliceDataType []*table<int,int>.array
-      GroupType: 349 StructureType noalg.map.group[int]int
+      TablePtrSliceType: 368 GoSliceDataType []*table<int,int>.array
+      GroupType: 365 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
-      ID: 1309
+      ID: 1325
       Name: map<int,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -22192,7 +22620,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1310 PointerType **table<int,interface {}>
+          Type: 1326 PointerType **table<int,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -22211,8 +22639,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1318 GoSliceDataType []*table<int,interface {}>.array
-      GroupType: 1315 StructureType noalg.map.group[int]interface {}
+      TablePtrSliceType: 1334 GoSliceDataType []*table<int,interface {}>.array
+      GroupType: 1331 StructureType noalg.map.group[int]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 235
       Name: map<int,struct {}>
@@ -22246,8 +22674,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 460 GoSliceDataType []*table<int,struct {}>.array
-      GroupType: 457 StructureType noalg.map.group[int]struct {}
+      TablePtrSliceType: 476 GoSliceDataType []*table<int,struct {}>.array
+      GroupType: 473 StructureType noalg.map.group[int]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 205
       Name: map<int,uint8>
@@ -22281,8 +22709,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 411 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 408 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 427 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 424 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 195
       Name: map<string,[]main.structWithMap>
@@ -22316,8 +22744,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 395 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 390 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 411 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 406 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
       ID: 183
       Name: map<string,[]string>
@@ -22351,10 +22779,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 376 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 373 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 392 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 389 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 980
+      ID: 996
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -22367,7 +22795,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 981 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 997 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -22386,8 +22814,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1015 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 1012 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 1031 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 1028 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
       ID: 178
       Name: map<string,int>
@@ -22421,8 +22849,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 368 GoSliceDataType []*table<string,int>.array
-      GroupType: 365 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 384 GoSliceDataType []*table<string,int>.array
+      GroupType: 381 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
       ID: 173
       Name: map<string,main.nestedStruct>
@@ -22456,8 +22884,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 360 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 357 StructureType noalg.map.group[string]main.nestedStruct
+      TablePtrSliceType: 376 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 373 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSwissMapHeaderType
       ID: 230
       Name: map<struct {},int>
@@ -22491,8 +22919,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 452 GoSliceDataType []*table<struct {},int>.array
-      GroupType: 449 StructureType noalg.map.group[struct {}]int
+      TablePtrSliceType: 468 GoSliceDataType []*table<struct {},int>.array
+      GroupType: 465 StructureType noalg.map.group[struct {}]int
     - __kind: GoSwissMapHeaderType
       ID: 288
       Name: map<struct {},main.structWithCyclicMaps>
@@ -22526,8 +22954,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 502 GoSliceDataType []*table<struct {},main.structWithCyclicMaps>.array
-      GroupType: 499 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 518 GoSliceDataType []*table<struct {},main.structWithCyclicMaps>.array
+      GroupType: 515 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 293
       Name: map<struct {},map[struct {}]main.structWithCyclicMaps>
@@ -22561,8 +22989,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 510 GoSliceDataType []*table<struct {},map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 507 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 526 GoSliceDataType []*table<struct {},map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 523 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 298
       Name: map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -22596,8 +23024,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 518 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 515 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 534 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 531 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 303
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -22631,8 +23059,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 526 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 523 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 542 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 539 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 308
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -22666,8 +23094,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 534 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 531 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 550 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 547 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 313
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -22701,8 +23129,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 542 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 539 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 558 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 555 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 240
       Name: map<struct {},struct {}>
@@ -22736,8 +23164,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 468 GoSliceDataType []*table<struct {},struct {}>.array
-      GroupType: 465 StructureType noalg.map.group[struct {}]struct {}
+      TablePtrSliceType: 484 GoSliceDataType []*table<struct {},struct {}>.array
+      GroupType: 481 StructureType noalg.map.group[struct {}]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 215
       Name: map<uint8,[4]int>
@@ -22771,8 +23199,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 428 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 424 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 444 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 440 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
       ID: 210
       Name: map<uint8,uint8>
@@ -22806,8 +23234,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 419 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 416 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 435 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 432 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
       ID: 223
       Name: map[[4]int][4]int
@@ -22844,26 +23272,26 @@ Types:
       GoKind: 21
       HeaderType: 146 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 1243
+      ID: 1259
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 1.130528e+06
       GoKind: 21
-      HeaderType: 1245 GoSwissMapHeaderType map<int,*main.deepMap3>
+      HeaderType: 1261 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 1277
+      ID: 1293
       Name: map[int]*main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.129888e+06
       GoKind: 21
-      HeaderType: 1279 GoSwissMapHeaderType map<int,*main.deepMap8>
+      HeaderType: 1295 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
-      ID: 1292
+      ID: 1308
       Name: map[int]*main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.12976e+06
       GoKind: 21
-      HeaderType: 1294 GoSwissMapHeaderType map<int,*main.deepMap9>
+      HeaderType: 1310 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 166
       Name: map[int]int
@@ -22872,12 +23300,12 @@ Types:
       GoKind: 21
       HeaderType: 168 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
-      ID: 1307
+      ID: 1323
       Name: map[int]interface {}
       ByteSize: 8
       GoRuntimeType: 1.129632e+06
       GoKind: 21
-      HeaderType: 1309 GoSwissMapHeaderType map<int,interface {}>
+      HeaderType: 1325 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
       ID: 233
       Name: map[int]struct {}
@@ -22985,7 +23413,7 @@ Types:
       GoKind: 21
       HeaderType: 210 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: StructureType
-      ID: 728
+      ID: 744
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1.430976e+06
@@ -22995,7 +23423,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1030
+      ID: 1046
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
       GoRuntimeType: 1.427776e+06
@@ -23005,11 +23433,11 @@ Types:
           Offset: 0
           Type: 131 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 935
+      ID: 951
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1000
+      ID: 1016
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1.597952e+06
@@ -23022,35 +23450,35 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 961
+      ID: 977
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1175
+      ID: 1191
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 959
+      ID: 975
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 937
+      ID: 953
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1185
+      ID: 1201
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1195
+      ID: 1211
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1183
+      ID: 1199
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 896
+      ID: 912
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1.114784e+06
@@ -23058,28 +23486,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 898 PointerType *net.UnknownNetworkError.str
+          Type: 914 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 897 GoStringDataType net.UnknownNetworkError.str
+      Data: 913 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 897
+      ID: 913
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 861
+      ID: 877
       Name: net.canceledError
       GoRuntimeType: 1.285664e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1151
+      ID: 1167
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 1005
+      ID: 1021
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2.107648e+06
@@ -23087,7 +23515,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 1000 GoInterfaceType net.Conn
+          Type: 1016 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 13 GoInterfaceType error
@@ -23098,27 +23526,27 @@ Types:
           Offset: 33
           Type: 4 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 1197
+      ID: 1213
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 1191
+      ID: 1207
       Name: net.noReadFrom
       GoRuntimeType: 1.11504e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1190
+      ID: 1206
       Name: net.noWriteTo
       GoRuntimeType: 1.114912e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 658
+      ID: 674
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
-      ID: 660
+      ID: 676
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1.730784e+06
@@ -23126,7 +23554,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 988 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 1004 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 9 GoStringHeaderType string
@@ -23134,7 +23562,7 @@ Types:
           Offset: 96
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 1179
+      ID: 1195
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.290656e+06
@@ -23142,12 +23570,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1191 StructureType net.noReadFrom
+          Type: 1207 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 1184 PointerType *net.TCPConn
+          Type: 1200 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 1177
+      ID: 1193
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.290112e+06
@@ -23155,24 +23583,24 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1190 StructureType net.noWriteTo
+          Type: 1206 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 1184 PointerType *net.TCPConn
+          Type: 1200 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 939
+      ID: 955
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 963
+      ID: 979
       Name: net.timeoutError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 851
+      ID: 867
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1024
+      ID: 1040
       Name: net/http.bufioFlushWriter
       ByteSize: 16
       GoRuntimeType: 1.419296e+06
@@ -23182,19 +23610,19 @@ Types:
           Offset: 0
           Type: 131 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 549
+      ID: 565
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 833248
       GoKind: 10
     - __kind: BaseType
-      ID: 977
+      ID: 993
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 991872
       GoKind: 10
     - __kind: StructureType
-      ID: 636
+      ID: 652
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1.729056e+06
@@ -23205,12 +23633,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 977 BaseType net/http.http2ErrCode
+          Type: 993 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 955
+      ID: 971
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1.900864e+06
@@ -23221,12 +23649,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 977 BaseType net/http.http2ErrCode
+          Type: 993 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 640
+      ID: 656
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1.597472e+06
@@ -23234,16 +23662,16 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 977 BaseType net/http.http2ErrCode
+          Type: 993 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1086
+      ID: 1102
       Name: net/http.http2dataBuffer
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 553
+      ID: 569
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 833440
@@ -23251,18 +23679,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 555 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 571 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 554 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 570 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 554
+      ID: 570
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 559
+      ID: 575
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 833632
@@ -23270,18 +23698,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 561 PointerType *net/http.http2headerFieldNameError.str
+          Type: 577 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 560 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 576 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 560
+      ID: 576
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 556
+      ID: 572
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 833536
@@ -23289,32 +23717,32 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 558 PointerType *net/http.http2headerFieldValueError.str
+          Type: 574 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 557 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 573 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 557
+      ID: 573
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 930
+      ID: 946
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 857
+      ID: 873
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1.284896e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1140
+      ID: 1156
       Name: net/http.http2pipe
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 550
+      ID: 566
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 833344
@@ -23322,18 +23750,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 552 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 568 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 551 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 567 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 551
+      ID: 567
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1026
+      ID: 1042
       Name: net/http.http2stickyErrWriter
       ByteSize: 48
       GoRuntimeType: 1.82672e+06
@@ -23341,18 +23769,18 @@ Types:
       RawFields:
         - Name: group
           Offset: 0
-          Type: 1117 GoInterfaceType net/http.http2synctestGroupInterface
+          Type: 1133 GoInterfaceType net/http.http2synctestGroupInterface
         - Name: conn
           Offset: 16
-          Type: 1000 GoInterfaceType net.Conn
+          Type: 1016 GoInterfaceType net.Conn
         - Name: timeout
           Offset: 32
-          Type: 1118 BaseType time.Duration
+          Type: 1134 BaseType time.Duration
         - Name: err
           Offset: 40
           Type: 106 PointerType *error
     - __kind: GoInterfaceType
-      ID: 1117
+      ID: 1133
       Name: net/http.http2synctestGroupInterface
       ByteSize: 16
       GoRuntimeType: 1.418496e+06
@@ -23365,14 +23793,14 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: ArrayType
-      ID: 1105
+      ID: 1121
       Name: net/http.incomparable
       GoRuntimeType: 904448
       GoKind: 17
       HasCount: true
       Element: 59 GoSubroutineType func()
     - __kind: StructureType
-      ID: 853
+      ID: 869
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1.55696e+06
@@ -23382,11 +23810,11 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1088
+      ID: 1104
       Name: net/http.persistConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 1044
+      ID: 1060
       Name: net/http.persistConnWriter
       ByteSize: 8
       GoRuntimeType: 1.5568e+06
@@ -23394,9 +23822,9 @@ Types:
       RawFields:
         - Name: pc
           Offset: 0
-          Type: 1087 PointerType *net/http.persistConn
+          Type: 1103 PointerType *net/http.persistConn
     - __kind: StructureType
-      ID: 1078
+      ID: 1094
       Name: net/http.readWriteCloserBody
       ByteSize: 24
       GoRuntimeType: 1.801696e+06
@@ -23404,15 +23832,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1105 ArrayType net/http.incomparable
+          Type: 1121 ArrayType net/http.incomparable
         - Name: br
           Offset: 0
-          Type: 1106 PointerType *bufio.Reader
+          Type: 1122 PointerType *bufio.Reader
         - Name: ReadWriteCloser
           Offset: 8
-          Type: 1108 GoInterfaceType io.ReadWriteCloser
+          Type: 1124 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 644
+      ID: 660
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1.420256e+06
@@ -23422,17 +23850,17 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 957
+      ID: 973
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 928
+      ID: 944
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1.48112e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 855
+      ID: 871
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1.55712e+06
@@ -23442,7 +23870,7 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 1120
+      ID: 1136
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
       GoRuntimeType: 2.02736e+06
@@ -23450,16 +23878,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 1000 GoInterfaceType net.Conn
+          Type: 1016 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 1000 GoInterfaceType net.Conn
+          Type: 1016 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 633
+      ID: 649
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1142
+      ID: 1158
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
       GoRuntimeType: 2.043104e+06
@@ -23467,13 +23895,13 @@ Types:
       RawFields:
         - Name: Writer
           Offset: 0
-          Type: 1135 PointerType *bufio.Writer
+          Type: 1151 PointerType *bufio.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1054
+      ID: 1070
       Name: net/http/internal.chunkedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 720
+      ID: 736
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1.733856e+06
@@ -23489,7 +23917,7 @@ Types:
           Offset: 32
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 718
+      ID: 734
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1.599392e+06
@@ -23502,11 +23930,11 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1094
+      ID: 1110
       Name: net/smtp.Client
       ByteSize: 8
     - __kind: StructureType
-      ID: 1056
+      ID: 1072
       Name: net/smtp.dataCloser
       ByteSize: 24
       GoRuntimeType: 1.601312e+06
@@ -23514,16 +23942,16 @@ Types:
       RawFields:
         - Name: c
           Offset: 0
-          Type: 1093 PointerType *net/smtp.Client
+          Type: 1109 PointerType *net/smtp.Client
         - Name: WriteCloser
           Offset: 8
-          Type: 1095 GoInterfaceType io.WriteCloser
+          Type: 1111 GoInterfaceType io.WriteCloser
     - __kind: UnresolvedPointeeType
-      ID: 704
+      ID: 720
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 587
+      ID: 603
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 836320
@@ -23531,26 +23959,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 589 PointerType *net/textproto.ProtocolError.str
+          Type: 605 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 588 GoStringDataType net/textproto.ProtocolError.str
+      Data: 604 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 588
+      ID: 604
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1052
+      ID: 1068
       Name: net/textproto.dotWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 965
+      ID: 981
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 562
+      ID: 578
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 834208
@@ -23558,18 +23986,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 564 PointerType *net/url.EscapeError.str
+          Type: 580 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 563 GoStringDataType net/url.EscapeError.str
+      Data: 579 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 563
+      ID: 579
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 565
+      ID: 581
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 834304
@@ -23577,254 +24005,254 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 567 PointerType *net/url.InvalidHostError.str
+          Type: 583 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 566 GoStringDataType net/url.InvalidHostError.str
+      Data: 582 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 566
+      ID: 582
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: ArrayType
-      ID: 442
+      ID: 458
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
       GoRuntimeType: 683680
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 443 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 459 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 434
+      ID: 450
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
       GoRuntimeType: 683776
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 435 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 451 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 382
+      ID: 398
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
       GoRuntimeType: 684064
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 383 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 399 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 401
+      ID: 417
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
       GoRuntimeType: 684160
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 402 StructureType noalg.struct { key bool; elem main.node }
+      Element: 418 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 340
+      ID: 356
       Name: noalg.[8]struct { key int; elem *main.deepMap2 }
       ByteSize: 128
       GoRuntimeType: 683008
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 341 StructureType noalg.struct { key int; elem *main.deepMap2 }
+      Element: 357 StructureType noalg.struct { key int; elem *main.deepMap2 }
     - __kind: ArrayType
-      ID: 1252
+      ID: 1268
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
       GoRuntimeType: 682912
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1253 StructureType noalg.struct { key int; elem *main.deepMap3 }
+      Element: 1269 StructureType noalg.struct { key int; elem *main.deepMap3 }
     - __kind: ArrayType
-      ID: 1286
+      ID: 1302
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
       ByteSize: 128
       GoRuntimeType: 682432
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1287 StructureType noalg.struct { key int; elem *main.deepMap8 }
+      Element: 1303 StructureType noalg.struct { key int; elem *main.deepMap8 }
     - __kind: ArrayType
-      ID: 1301
+      ID: 1317
       Name: noalg.[8]struct { key int; elem *main.deepMap9 }
       ByteSize: 128
       GoRuntimeType: 682336
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1302 StructureType noalg.struct { key int; elem *main.deepMap9 }
+      Element: 1318 StructureType noalg.struct { key int; elem *main.deepMap9 }
     - __kind: ArrayType
-      ID: 350
+      ID: 366
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
       GoRuntimeType: 681184
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 351 StructureType noalg.struct { key int; elem int }
+      Element: 367 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 1316
+      ID: 1332
       Name: noalg.[8]struct { key int; elem interface {} }
       ByteSize: 192
       GoRuntimeType: 682240
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1317 StructureType noalg.struct { key int; elem interface {} }
+      Element: 1333 StructureType noalg.struct { key int; elem interface {} }
     - __kind: ArrayType
-      ID: 458
+      ID: 474
       Name: noalg.[8]struct { key int; elem struct {} }
       ByteSize: 128
       GoRuntimeType: 684256
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 459 StructureType noalg.struct { key int; elem struct {} }
+      Element: 475 StructureType noalg.struct { key int; elem struct {} }
     - __kind: ArrayType
-      ID: 409
+      ID: 425
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
       GoRuntimeType: 684352
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 410 StructureType noalg.struct { key int; elem uint8 }
+      Element: 426 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 391
+      ID: 407
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
       GoRuntimeType: 684448
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 392 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 408 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 374
+      ID: 390
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 684544
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 375 StructureType noalg.struct { key string; elem []string }
+      Element: 391 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 1013
+      ID: 1029
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 760480
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1014 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 1030 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
-      ID: 366
+      ID: 382
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 684640
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 367 StructureType noalg.struct { key string; elem int }
+      Element: 383 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 358
+      ID: 374
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
       GoRuntimeType: 684736
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 359 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 375 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 450
+      ID: 466
       Name: noalg.[8]struct { key struct {}; elem int }
       ByteSize: 64
       GoRuntimeType: 684832
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 451 StructureType noalg.struct { key struct {}; elem int }
+      Element: 467 StructureType noalg.struct { key struct {}; elem int }
     - __kind: ArrayType
-      ID: 500
+      ID: 516
       Name: noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
       ByteSize: 384
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 501 StructureType noalg.struct { key struct {}; elem main.structWithCyclicMaps }
+      Element: 517 StructureType noalg.struct { key struct {}; elem main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 508
+      ID: 524
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 509 StructureType noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+      Element: 525 StructureType noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 516
+      ID: 532
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 517 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 533 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 524
+      ID: 540
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 525 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 541 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 532
+      ID: 548
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 533 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 549 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 540
+      ID: 556
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 541 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 557 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 466
+      ID: 482
       Name: noalg.[8]struct { key struct {}; elem struct {} }
       GoRuntimeType: 684928
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 467 StructureType noalg.struct { key struct {}; elem struct {} }
+      Element: 483 StructureType noalg.struct { key struct {}; elem struct {} }
     - __kind: ArrayType
-      ID: 425
+      ID: 441
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
       GoRuntimeType: 685024
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 426 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 442 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 417
+      ID: 433
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 685120
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 418 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 434 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 441
+      ID: 457
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
       GoRuntimeType: 1.296672e+06
@@ -23835,9 +24263,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 442 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 458 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 433
+      ID: 449
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
       GoRuntimeType: 1.296928e+06
@@ -23848,9 +24276,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 434 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 450 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 381
+      ID: 397
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
       GoRuntimeType: 1.297184e+06
@@ -23861,9 +24289,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 382 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 398 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 400
+      ID: 416
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
       GoRuntimeType: 1.29744e+06
@@ -23874,9 +24302,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 401 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 417 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 339
+      ID: 355
       Name: noalg.map.group[int]*main.deepMap2
       ByteSize: 136
       GoRuntimeType: 1.296416e+06
@@ -23887,9 +24315,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 340 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
+          Type: 356 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
     - __kind: StructureType
-      ID: 1251
+      ID: 1267
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
       GoRuntimeType: 1.29616e+06
@@ -23900,9 +24328,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1252 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+          Type: 1268 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
     - __kind: StructureType
-      ID: 1285
+      ID: 1301
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
       GoRuntimeType: 1.29488e+06
@@ -23913,9 +24341,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1286 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
+          Type: 1302 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
     - __kind: StructureType
-      ID: 1300
+      ID: 1316
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
       GoRuntimeType: 1.294624e+06
@@ -23926,9 +24354,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1301 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
+          Type: 1317 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
     - __kind: StructureType
-      ID: 349
+      ID: 365
       Name: noalg.map.group[int]int
       ByteSize: 136
       GoRuntimeType: 1.2936e+06
@@ -23939,9 +24367,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 350 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 366 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 1315
+      ID: 1331
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
       GoRuntimeType: 1.294368e+06
@@ -23952,9 +24380,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1316 ArrayType noalg.[8]struct { key int; elem interface {} }
+          Type: 1332 ArrayType noalg.[8]struct { key int; elem interface {} }
     - __kind: StructureType
-      ID: 457
+      ID: 473
       Name: noalg.map.group[int]struct {}
       ByteSize: 136
       GoRuntimeType: 1.297696e+06
@@ -23965,9 +24393,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 458 ArrayType noalg.[8]struct { key int; elem struct {} }
+          Type: 474 ArrayType noalg.[8]struct { key int; elem struct {} }
     - __kind: StructureType
-      ID: 408
+      ID: 424
       Name: noalg.map.group[int]uint8
       ByteSize: 136
       GoRuntimeType: 1.297952e+06
@@ -23978,9 +24406,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 409 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 425 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 390
+      ID: 406
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
       GoRuntimeType: 1.298208e+06
@@ -23991,9 +24419,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 391 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 407 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 373
+      ID: 389
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.298464e+06
@@ -24004,9 +24432,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 374 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 390 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 1012
+      ID: 1028
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1.359904e+06
@@ -24017,9 +24445,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1013 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 1029 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
-      ID: 365
+      ID: 381
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 1.29872e+06
@@ -24030,9 +24458,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 366 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 382 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 357
+      ID: 373
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
       GoRuntimeType: 1.298976e+06
@@ -24043,9 +24471,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 358 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 374 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 449
+      ID: 465
       Name: noalg.map.group[struct {}]int
       ByteSize: 72
       GoRuntimeType: 1.299232e+06
@@ -24056,9 +24484,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 450 ArrayType noalg.[8]struct { key struct {}; elem int }
+          Type: 466 ArrayType noalg.[8]struct { key struct {}; elem int }
     - __kind: StructureType
-      ID: 499
+      ID: 515
       Name: noalg.map.group[struct {}]main.structWithCyclicMaps
       ByteSize: 392
       GoKind: 25
@@ -24068,9 +24496,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 500 ArrayType noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
+          Type: 516 ArrayType noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 507
+      ID: 523
       Name: noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -24080,9 +24508,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 508 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+          Type: 524 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 515
+      ID: 531
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -24092,9 +24520,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 516 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 532 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 523
+      ID: 539
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -24104,9 +24532,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 524 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 540 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 531
+      ID: 547
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -24116,9 +24544,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 532 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 548 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 539
+      ID: 555
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -24128,9 +24556,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 540 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 556 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 465
+      ID: 481
       Name: noalg.map.group[struct {}]struct {}
       ByteSize: 16
       GoRuntimeType: 1.299488e+06
@@ -24141,9 +24569,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 466 ArrayType noalg.[8]struct { key struct {}; elem struct {} }
+          Type: 482 ArrayType noalg.[8]struct { key struct {}; elem struct {} }
     - __kind: StructureType
-      ID: 424
+      ID: 440
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
       GoRuntimeType: 1.299744e+06
@@ -24154,9 +24582,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 425 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 441 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 416
+      ID: 432
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
       GoRuntimeType: 1.3e+06
@@ -24167,9 +24595,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 417 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 433 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 443
+      ID: 459
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
       GoRuntimeType: 1.296544e+06
@@ -24177,12 +24605,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 427 ArrayType [4]int
+          Type: 443 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 427 ArrayType [4]int
+          Type: 443 ArrayType [4]int
     - __kind: StructureType
-      ID: 435
+      ID: 451
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
       GoRuntimeType: 1.2968e+06
@@ -24190,12 +24618,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 427 ArrayType [4]int
+          Type: 443 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 383
+      ID: 399
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
       GoRuntimeType: 1.297056e+06
@@ -24203,12 +24631,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 384 ArrayType [4]string
+          Type: 400 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 113 ArrayType [2]int
     - __kind: StructureType
-      ID: 402
+      ID: 418
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
       GoRuntimeType: 1.297312e+06
@@ -24221,7 +24649,7 @@ Types:
           Offset: 8
           Type: 246 StructureType main.node
     - __kind: StructureType
-      ID: 341
+      ID: 357
       Name: noalg.struct { key int; elem *main.deepMap2 }
       ByteSize: 16
       GoRuntimeType: 1.296288e+06
@@ -24232,9 +24660,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 342 PointerType *main.deepMap2
+          Type: 358 PointerType *main.deepMap2
     - __kind: StructureType
-      ID: 1253
+      ID: 1269
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
       GoRuntimeType: 1.296032e+06
@@ -24245,9 +24673,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1254 PointerType *main.deepMap3
+          Type: 1270 PointerType *main.deepMap3
     - __kind: StructureType
-      ID: 1287
+      ID: 1303
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
       GoRuntimeType: 1.294752e+06
@@ -24258,9 +24686,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1288 PointerType *main.deepMap8
+          Type: 1304 PointerType *main.deepMap8
     - __kind: StructureType
-      ID: 1302
+      ID: 1318
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
       GoRuntimeType: 1.294496e+06
@@ -24271,9 +24699,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1303 PointerType *main.deepMap9
+          Type: 1319 PointerType *main.deepMap9
     - __kind: StructureType
-      ID: 351
+      ID: 367
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
       GoRuntimeType: 1.293472e+06
@@ -24286,7 +24714,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 1317
+      ID: 1333
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
       GoRuntimeType: 1.29424e+06
@@ -24299,7 +24727,7 @@ Types:
           Offset: 8
           Type: 157 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 459
+      ID: 475
       Name: noalg.struct { key int; elem struct {} }
       ByteSize: 16
       GoRuntimeType: 1.297568e+06
@@ -24312,7 +24740,7 @@ Types:
           Offset: 8
           Type: 125 StructureType struct {}
     - __kind: StructureType
-      ID: 410
+      ID: 426
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 1.297824e+06
@@ -24325,7 +24753,7 @@ Types:
           Offset: 8
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 392
+      ID: 408
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
       GoRuntimeType: 1.29808e+06
@@ -24336,9 +24764,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 393 GoSliceHeaderType []main.structWithMap
+          Type: 409 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 375
+      ID: 391
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.298336e+06
@@ -24351,7 +24779,7 @@ Types:
           Offset: 16
           Type: 263 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 1014
+      ID: 1030
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1.359776e+06
@@ -24362,9 +24790,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 1001 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1017 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 367
+      ID: 383
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 1.298592e+06
@@ -24377,7 +24805,7 @@ Types:
           Offset: 16
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 359
+      ID: 375
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
       GoRuntimeType: 1.298848e+06
@@ -24390,7 +24818,7 @@ Types:
           Offset: 16
           Type: 123 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 451
+      ID: 467
       Name: noalg.struct { key struct {}; elem int }
       ByteSize: 8
       GoRuntimeType: 1.299104e+06
@@ -24403,7 +24831,7 @@ Types:
           Offset: 0
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 501
+      ID: 517
       Name: noalg.struct { key struct {}; elem main.structWithCyclicMaps }
       ByteSize: 48
       GoKind: 25
@@ -24415,7 +24843,7 @@ Types:
           Offset: 0
           Type: 285 StructureType main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 509
+      ID: 525
       Name: noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -24427,7 +24855,7 @@ Types:
           Offset: 0
           Type: 286 GoMapType map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 517
+      ID: 533
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -24439,7 +24867,7 @@ Types:
           Offset: 0
           Type: 291 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 525
+      ID: 541
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -24451,7 +24879,7 @@ Types:
           Offset: 0
           Type: 296 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 533
+      ID: 549
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -24463,7 +24891,7 @@ Types:
           Offset: 0
           Type: 301 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 541
+      ID: 557
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -24475,7 +24903,7 @@ Types:
           Offset: 0
           Type: 306 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 467
+      ID: 483
       Name: noalg.struct { key struct {}; elem struct {} }
       GoRuntimeType: 1.29936e+06
       GoKind: 25
@@ -24487,7 +24915,7 @@ Types:
           Offset: 0
           Type: 125 StructureType struct {}
     - __kind: StructureType
-      ID: 426
+      ID: 442
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
       GoRuntimeType: 1.299616e+06
@@ -24498,9 +24926,9 @@ Types:
           Type: 3 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 427 ArrayType [4]int
+          Type: 443 ArrayType [4]int
     - __kind: StructureType
-      ID: 418
+      ID: 434
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
       GoRuntimeType: 1.299872e+06
@@ -24513,19 +24941,19 @@ Types:
           Offset: 1
           Type: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1203
+      ID: 1219
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 832
+      ID: 848
       Name: os.LinkError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 900
+      ID: 916
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1201
+      ID: 1217
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.361024e+06
@@ -24533,12 +24961,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1207 StructureType os.noReadFrom
+          Type: 1223 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 1202 PointerType *os.File
+          Type: 1218 PointerType *os.File
     - __kind: StructureType
-      ID: 1199
+      ID: 1215
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.360224e+06
@@ -24546,36 +24974,36 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1206 StructureType os.noWriteTo
+          Type: 1222 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 1202 PointerType *os.File
+          Type: 1218 PointerType *os.File
     - __kind: StructureType
-      ID: 1207
+      ID: 1223
       Name: os.noReadFrom
       GoRuntimeType: 1.112352e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1206
+      ID: 1222
       Name: os.noWriteTo
       GoRuntimeType: 1.112224e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 865
+      ID: 881
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1008
+      ID: 1024
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1072
+      ID: 1088
       Name: os/exec.prefixSuffixSaver
       ByteSize: 8
     - __kind: StructureType
-      ID: 867
+      ID: 883
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1.704256e+06
@@ -24588,7 +25016,7 @@ Types:
           Offset: 16
           Type: 13 GoInterfaceType error
     - __kind: GoStringHeaderType
-      ID: 601
+      ID: 617
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 839584
@@ -24596,36 +25024,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 603 PointerType *os/user.UnknownGroupIdError.str
+          Type: 619 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 602 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 618 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 602
+      ID: 618
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 600
+      ID: 616
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 839488
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 628
+      ID: 644
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 726
+      ID: 742
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 836
+      ID: 852
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 840
+      ID: 856
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -24637,7 +25065,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 838
+      ID: 854
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1.889728e+06
@@ -24654,9 +25082,9 @@ Types:
           Type: 4 BaseType bool
         - Name: code
           Offset: 17
-          Type: 1006 BaseType runtime.boundsErrorCode
+          Type: 1022 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 1006
+      ID: 1022
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 586016
@@ -24676,7 +25104,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 902
+      ID: 918
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1.75456e+06
@@ -24689,7 +25117,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 816
+      ID: 832
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 990432
@@ -24697,13 +25125,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 818 PointerType *runtime.errorString.str
+          Type: 834 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 817 GoStringDataType runtime.errorString.str
+      Data: 833 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 817
+      ID: 833
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -25330,7 +25758,7 @@ Types:
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
-      ID: 328
+      ID: 344
       Name: runtime.p
       ByteSize: 8
     - __kind: StructureType
@@ -25366,7 +25794,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 819
+      ID: 835
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 990528
@@ -25374,13 +25802,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 821 PointerType *runtime.plainError.str
+          Type: 837 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 820 GoStringDataType runtime.plainError.str
+      Data: 836 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 820
+      ID: 836
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -25421,7 +25849,7 @@ Types:
       Name: runtime.synctestBubble
       ByteSize: 8
     - __kind: StructureType
-      ID: 624
+      ID: 640
       Name: runtime.synctestDeadlockError
       ByteSize: 24
       GoRuntimeType: 1.597152e+06
@@ -25479,7 +25907,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 842
+      ID: 858
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -25491,26 +25919,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 323 PointerType *string.str
+          Type: 339 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 322 GoStringDataType string.str
+      Data: 338 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 322
+      ID: 338
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1138
+      ID: 1154
       Name: strings.Builder
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1042
+      ID: 1058
       Name: strings.appendSliceWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1038
+      ID: 1054
       Name: struct { io.Writer }
       ByteSize: 16
       GoRuntimeType: 1.457056e+06
@@ -25526,7 +25954,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1221
+      ID: 1237
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.4656e+06
@@ -25534,12 +25962,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1222 StructureType sync.noCopy
+          Type: 1238 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 1223 StructureType internal/sync.Mutex
+          Type: 1239 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 1224
+      ID: 1240
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.614496e+06
@@ -25547,15 +25975,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1222 StructureType sync.noCopy
+          Type: 1238 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 1225 StructureType sync/atomic.Bool
+          Type: 1241 StructureType sync/atomic.Bool
         - Name: m
           Offset: 4
-          Type: 1221 StructureType sync.Mutex
+          Type: 1237 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 1227
+      ID: 1243
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.614304e+06
@@ -25563,21 +25991,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 1222 StructureType sync.noCopy
+          Type: 1238 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 1228 StructureType sync/atomic.Uint64
+          Type: 1244 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1222
+      ID: 1238
       Name: sync.noCopy
       GoRuntimeType: 989376
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1225
+      ID: 1241
       Name: sync/atomic.Bool
       ByteSize: 4
       GoRuntimeType: 1.46672e+06
@@ -25585,12 +26013,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1226 StructureType sync/atomic.noCopy
+          Type: 1242 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1230
+      ID: 1246
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.46688e+06
@@ -25598,12 +26026,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1226 StructureType sync/atomic.noCopy
+          Type: 1242 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 10 BaseType int32
     - __kind: StructureType
-      ID: 1228
+      ID: 1244
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.61488e+06
@@ -25611,33 +26039,33 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1226 StructureType sync/atomic.noCopy
+          Type: 1242 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 1229 StructureType sync/atomic.align64
+          Type: 1245 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 8 BaseType uint64
     - __kind: StructureType
-      ID: 1229
+      ID: 1245
       Name: sync/atomic.align64
       GoRuntimeType: 989568
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1226
+      ID: 1242
       Name: sync/atomic.noCopy
       GoRuntimeType: 989472
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 952
+      ID: 968
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1.284256e+06
       GoKind: 12
     - __kind: StructureType
-      ID: 438
+      ID: 454
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -25659,9 +26087,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 439 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 455 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
-      ID: 430
+      ID: 446
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -25683,9 +26111,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 431 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 447 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
-      ID: 378
+      ID: 394
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
@@ -25707,9 +26135,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 379 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 395 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
-      ID: 397
+      ID: 413
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
@@ -25731,9 +26159,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 398 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 414 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
-      ID: 336
+      ID: 352
       Name: table<int,*main.deepMap2>
       ByteSize: 32
       GoKind: 25
@@ -25755,9 +26183,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 337 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
+          Type: 353 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
     - __kind: StructureType
-      ID: 1248
+      ID: 1264
       Name: table<int,*main.deepMap3>
       ByteSize: 32
       GoKind: 25
@@ -25779,9 +26207,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1249 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+          Type: 1265 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
     - __kind: StructureType
-      ID: 1282
+      ID: 1298
       Name: table<int,*main.deepMap8>
       ByteSize: 32
       GoKind: 25
@@ -25803,9 +26231,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1283 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
+          Type: 1299 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
     - __kind: StructureType
-      ID: 1297
+      ID: 1313
       Name: table<int,*main.deepMap9>
       ByteSize: 32
       GoKind: 25
@@ -25827,9 +26255,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1298 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
+          Type: 1314 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
     - __kind: StructureType
-      ID: 346
+      ID: 362
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
@@ -25851,9 +26279,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 347 GoSwissMapGroupsType groupReference<int,int>
+          Type: 363 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 1312
+      ID: 1328
       Name: table<int,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -25875,9 +26303,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1313 GoSwissMapGroupsType groupReference<int,interface {}>
+          Type: 1329 GoSwissMapGroupsType groupReference<int,interface {}>
     - __kind: StructureType
-      ID: 454
+      ID: 470
       Name: table<int,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -25899,9 +26327,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 455 GoSwissMapGroupsType groupReference<int,struct {}>
+          Type: 471 GoSwissMapGroupsType groupReference<int,struct {}>
     - __kind: StructureType
-      ID: 405
+      ID: 421
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -25923,9 +26351,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 406 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 422 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
-      ID: 387
+      ID: 403
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
@@ -25947,9 +26375,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 388 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 404 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 370
+      ID: 386
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -25971,9 +26399,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 371 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 387 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 1009
+      ID: 1025
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -25995,9 +26423,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1010 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 1026 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
-      ID: 362
+      ID: 378
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -26019,9 +26447,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 363 GoSwissMapGroupsType groupReference<string,int>
+          Type: 379 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 354
+      ID: 370
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
@@ -26043,9 +26471,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 355 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 371 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 446
+      ID: 462
       Name: table<struct {},int>
       ByteSize: 32
       GoKind: 25
@@ -26067,9 +26495,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 447 GoSwissMapGroupsType groupReference<struct {},int>
+          Type: 463 GoSwissMapGroupsType groupReference<struct {},int>
     - __kind: StructureType
-      ID: 496
+      ID: 512
       Name: table<struct {},main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -26091,9 +26519,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 497 GoSwissMapGroupsType groupReference<struct {},main.structWithCyclicMaps>
+          Type: 513 GoSwissMapGroupsType groupReference<struct {},main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 504
+      ID: 520
       Name: table<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -26115,9 +26543,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 505 GoSwissMapGroupsType groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
+          Type: 521 GoSwissMapGroupsType groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 512
+      ID: 528
       Name: table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -26139,9 +26567,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 513 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 529 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 520
+      ID: 536
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -26163,9 +26591,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 521 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 537 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 528
+      ID: 544
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -26187,9 +26615,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 529 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 545 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 536
+      ID: 552
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -26211,9 +26639,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 537 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 553 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 462
+      ID: 478
       Name: table<struct {},struct {}>
       ByteSize: 32
       GoKind: 25
@@ -26235,9 +26663,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 463 GoSwissMapGroupsType groupReference<struct {},struct {}>
+          Type: 479 GoSwissMapGroupsType groupReference<struct {},struct {}>
     - __kind: StructureType
-      ID: 421
+      ID: 437
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -26259,9 +26687,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 422 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 438 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
-      ID: 413
+      ID: 429
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
@@ -26283,13 +26711,13 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 414 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 430 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: UnresolvedPointeeType
-      ID: 1173
+      ID: 1189
       Name: text/tabwriter.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 895
+      ID: 911
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1.708672e+06
@@ -26302,21 +26730,21 @@ Types:
           Offset: 16
           Type: 13 GoInterfaceType error
     - __kind: BaseType
-      ID: 1118
+      ID: 1134
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1.917184e+06
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 970
+      ID: 986
       Name: time.Location
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 631
+      ID: 647
       Name: time.ParseError
       ByteSize: 8
     - __kind: StructureType
-      ID: 968
+      ID: 984
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.374336e+06
@@ -26330,9 +26758,9 @@ Types:
           Type: 12 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 969 PointerType *time.Location
+          Type: 985 PointerType *time.Location
     - __kind: GoStringHeaderType
-      ID: 546
+      ID: 562
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 832384
@@ -26340,13 +26768,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 548 PointerType *time.fileSizeError.str
+          Type: 564 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 547 GoStringDataType time.fileSizeError.str
+      Data: 563 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 547
+      ID: 563
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -26393,7 +26821,7 @@ Types:
       GoRuntimeType: 585952
       GoKind: 26
     - __kind: StructureType
-      ID: 988
+      ID: 1004
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2.064832e+06
@@ -26404,10 +26832,10 @@ Types:
           Type: 38 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 989 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 1005 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 990 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 1006 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: off
           Offset: 40
           Type: 7 BaseType int
@@ -26422,18 +26850,18 @@ Types:
           Type: 7 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 991 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 1007 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 6 BaseType uint16
     - __kind: BaseType
-      ID: 991
+      ID: 1007
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 996096
       GoKind: 9
     - __kind: StructureType
-      ID: 989
+      ID: 1005
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1.928192e+06
@@ -26458,21 +26886,21 @@ Types:
           Offset: 10
           Type: 6 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 722
+      ID: 738
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 990
+      ID: 1006
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 589600
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1165
+      ID: 1181
       Name: vendor/golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 706
+      ID: 722
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.428096e+06
@@ -26482,13 +26910,13 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: BaseType
-      ID: 590
+      ID: 606
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 836416
       GoKind: 2
     - __kind: StructureType
-      ID: 872
+      ID: 888
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1.704448e+06
@@ -26501,12 +26929,12 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 824
+      ID: 840
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 994944
       GoKind: 5
-MaxTypeID: 1570
+MaxTypeID: 1587
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x1805520", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.26rc1.yaml
@@ -11,11 +11,11 @@ Probes:
       subprogram: {subprogram: 142}
       events:
         - Kind: Entry
-          Type: 1526 EventRootType Probe[main.stackC]
+          Type: 1542 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0xcec4ca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1527 EventRootType Probe[main.stackC]Return
+          Type: 1543 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0xcec505", Frameless: false}]
           Condition: null
       probeTemplate: {TemplateString: stackC, Segments: [stackC]}
@@ -30,11 +30,11 @@ Probes:
       subprogram: {subprogram: 56}
       events:
         - Kind: Entry
-          Type: 1390 EventRootType Probe[main.testAny]
+          Type: 1406 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0xce6d4a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1391 EventRootType Probe[main.testAny]Return
+          Type: 1407 EventRootType Probe[main.testAny]Return
           InjectionPoints: [{PC: "0xce6d85", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -55,11 +55,11 @@ Probes:
       subprogram: {subprogram: 58}
       events:
         - Kind: Entry
-          Type: 1393 EventRootType Probe[main.testAnyPtr]
+          Type: 1409 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0xce6dea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1394 EventRootType Probe[main.testAnyPtr]Return
+          Type: 1410 EventRootType Probe[main.testAnyPtr]Return
           InjectionPoints: [{PC: "0xce6e1d", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -79,11 +79,11 @@ Probes:
       subprogram: {subprogram: 122}
       events:
         - Kind: Entry
-          Type: 1497 EventRootType Probe[main.testArrayArgAndReturn]
+          Type: 1513 EventRootType Probe[main.testArrayArgAndReturn]
           InjectionPoints: [{PC: "0xceaeee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1498 EventRootType Probe[main.testArrayArgAndReturn]Return
+          Type: 1514 EventRootType Probe[main.testArrayArgAndReturn]Return
           InjectionPoints: [{PC: "0xceafaa", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -104,7 +104,7 @@ Probes:
       subprogram: {subprogram: 19}
       events:
         - Kind: Entry
-          Type: 1342 EventRootType Probe[main.testArrayEmptyStructs]
+          Type: 1358 EventRootType Probe[main.testArrayEmptyStructs]
           InjectionPoints: [{PC: "0xce4fe0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -125,7 +125,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - Kind: Entry
-          Type: 1338 EventRootType Probe[main.testArrayOfArrays]
+          Type: 1354 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0xce4f60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -146,7 +146,7 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - Kind: Entry
-          Type: 1340 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          Type: 1356 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0xce4fa0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -167,7 +167,7 @@ Probes:
       subprogram: {subprogram: 66}
       events:
         - Kind: Entry
-          Type: 1402 EventRootType Probe[main.testArrayOfMaps]
+          Type: 1418 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0xce7560", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -188,7 +188,7 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - Kind: Entry
-          Type: 1339 EventRootType Probe[main.testArrayOfStrings]
+          Type: 1355 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0xce4f80", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -208,7 +208,7 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - Kind: Entry
-          Type: 1341 EventRootType Probe[main.testArrayOfStructs]
+          Type: 1357 EventRootType Probe[main.testArrayOfStructs]
           InjectionPoints: [{PC: "0xce4fc0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -229,11 +229,11 @@ Probes:
       subprogram: {subprogram: 86}
       events:
         - Kind: Entry
-          Type: 1424 EventRootType Probe[main.testAtomicAdd]
+          Type: 1440 EventRootType Probe[main.testAtomicAdd]
           InjectionPoints: [{PC: "0xce9380", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1425 EventRootType Probe[main.testAtomicAdd]Return
+          Type: 1441 EventRootType Probe[main.testAtomicAdd]Return
           InjectionPoints: [{PC: "0xce9392", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -254,7 +254,7 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 1360 EventRootType Probe[main.testBigStruct]
+          Type: 1376 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0xce5720", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -275,7 +275,7 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - Kind: Entry
-          Type: 1327 EventRootType Probe[main.testBoolArray]
+          Type: 1343 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0xce4e00", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -296,7 +296,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - Kind: Entry
-          Type: 1324 EventRootType Probe[main.testByteArray]
+          Type: 1340 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0xce4da0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -322,7 +322,7 @@ Probes:
       subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1542 EventRootType Probe[main.testStruct]
+          Type: 1558 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0xcec900", Frameless: true}]
           Condition: null
     - id: testCaptureExprLine
@@ -337,10 +337,10 @@ Probes:
       segments: []
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1550 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1567 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0xce656e"
               Frameless: false
@@ -365,10 +365,10 @@ Probes:
       segments: [x=, {json: {ref: x}, dsl: x}]
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1551 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1568 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0xce656e"
               Frameless: false
@@ -404,7 +404,7 @@ Probes:
       subprogram: {subprogram: 84}
       events:
         - Kind: Entry
-          Type: 1421 EventRootType Probe[main.testCombinedString]
+          Type: 1437 EventRootType Probe[main.testCombinedString]
           InjectionPoints: [{PC: "0xce8fe0", Frameless: true}]
           Condition: null
     - id: testCaptureExprWithTemplate
@@ -422,7 +422,7 @@ Probes:
       subprogram: {subprogram: 84}
       events:
         - Kind: Entry
-          Type: 1422 EventRootType Probe[main.testCombinedString]
+          Type: 1438 EventRootType Probe[main.testCombinedString]
           InjectionPoints: [{PC: "0xce8fe0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -444,7 +444,7 @@ Probes:
       subprogram: {subprogram: 87}
       events:
         - Kind: Entry
-          Type: 1426 EventRootType Probe[main.testChannel]
+          Type: 1442 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0xce93a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -473,7 +473,7 @@ Probes:
       subprogram: {subprogram: 83}
       events:
         - Kind: Entry
-          Type: 1420 EventRootType Probe[main.testCombinedByte]
+          Type: 1436 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0xce8fa0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -504,7 +504,7 @@ Probes:
       subprogram: {subprogram: 95}
       events:
         - Kind: Entry
-          Type: 1434 EventRootType Probe[main.testCycle]
+          Type: 1450 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0xce9760", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -525,7 +525,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - Kind: Entry
-          Type: 1365 EventRootType Probe[main.testDeepMap1]
+          Type: 1381 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0xce5ae0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -546,7 +546,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - Kind: Entry
-          Type: 1366 EventRootType Probe[main.testDeepMap7]
+          Type: 1382 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0xce5b00", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -567,7 +567,7 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - Kind: Entry
-          Type: 1361 EventRootType Probe[main.testDeepPtr1]
+          Type: 1377 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0xce57e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -588,7 +588,7 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - Kind: Entry
-          Type: 1362 EventRootType Probe[main.testDeepPtr7]
+          Type: 1378 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0xce5800", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -609,7 +609,7 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - Kind: Entry
-          Type: 1363 EventRootType Probe[main.testDeepSlice1]
+          Type: 1379 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0xce5960", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -630,7 +630,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - Kind: Entry
-          Type: 1364 EventRootType Probe[main.testDeepSlice7]
+          Type: 1380 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0xce5980", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -651,7 +651,7 @@ Probes:
       subprogram: {subprogram: 131}
       events:
         - Kind: Entry
-          Type: 1514 EventRootType Probe[main.testEmptySlice]
+          Type: 1530 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0xcec020", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -677,7 +677,7 @@ Probes:
       subprogram: {subprogram: 134}
       events:
         - Kind: Entry
-          Type: 1517 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 1533 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0xcec080", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -704,7 +704,7 @@ Probes:
       subprogram: {subprogram: 150}
       events:
         - Kind: Entry
-          Type: 1538 EventRootType Probe[main.testEmptyString]
+          Type: 1554 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0xcec600", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -725,7 +725,7 @@ Probes:
       subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1548 EventRootType Probe[main.testEmptyStruct]
+          Type: 1564 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0xceca40", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -745,7 +745,7 @@ Probes:
       subprogram: {subprogram: 157}
       events:
         - Kind: Entry
-          Type: 1549 EventRootType Probe[main.testEmptyStructPointer]
+          Type: 1565 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0xceca60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -766,7 +766,7 @@ Probes:
       subprogram: {subprogram: 57}
       events:
         - Kind: Entry
-          Type: 1392 EventRootType Probe[main.testError]
+          Type: 1408 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0xce6dc0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -787,11 +787,11 @@ Probes:
       subprogram: {subprogram: 48}
       events:
         - Kind: Entry
-          Type: 1374 EventRootType Probe[main.testEsotericHeap]
+          Type: 1390 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0xce62aa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1375 EventRootType Probe[main.testEsotericHeap]Return
+          Type: 1391 EventRootType Probe[main.testEsotericHeap]Return
           InjectionPoints: [{PC: "0xce62ec", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -812,11 +812,11 @@ Probes:
       subprogram: {subprogram: 47}
       events:
         - Kind: Entry
-          Type: 1372 EventRootType Probe[main.testEsotericStack]
+          Type: 1388 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0xce618e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1373 EventRootType Probe[main.testEsotericStack]Return
+          Type: 1389 EventRootType Probe[main.testEsotericStack]Return
           InjectionPoints: [{PC: "0xce621b", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -837,11 +837,11 @@ Probes:
       subprogram: {subprogram: 53}
       events:
         - Kind: Entry
-          Type: 1384 EventRootType Probe[main.testFrameless]
+          Type: 1400 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0xce6a20", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1385 EventRootType Probe[main.testFrameless]Return
+          Type: 1401 EventRootType Probe[main.testFrameless]Return
           InjectionPoints: [{PC: "0xce6a25", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -862,11 +862,11 @@ Probes:
       subprogram: {subprogram: 54}
       events:
         - Kind: Entry
-          Type: 1386 EventRootType Probe[main.testFramelessArray]
+          Type: 1402 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0xce6a44", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1387 EventRootType Probe[main.testFramelessArray]Return
+          Type: 1403 EventRootType Probe[main.testFramelessArray]Return
           InjectionPoints: [{PC: "0xce6a85", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -890,7 +890,7 @@ Probes:
       subprogram: {subprogram: 54}
       events:
         - Kind: Line
-          Type: 1388 EventRootType Probe[main.testFramelessArray]Line
+          Type: 1404 EventRootType Probe[main.testFramelessArray]Line
           InjectionPoints: [{PC: "0xce6a48", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -911,11 +911,11 @@ Probes:
       subprogram: {subprogram: 49}
       events:
         - Kind: Entry
-          Type: 1376 EventRootType Probe[main.testInlinedBA]
+          Type: 1392 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0xce670a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1377 EventRootType Probe[main.testInlinedBA]Return
+          Type: 1393 EventRootType Probe[main.testInlinedBA]Return
           InjectionPoints: [{PC: "0xce676e", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -941,11 +941,11 @@ Probes:
       subprogram: {subprogram: 50}
       events:
         - Kind: Entry
-          Type: 1378 EventRootType Probe[main.testInlinedBB]
+          Type: 1394 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0xce67ae", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1379 EventRootType Probe[main.testInlinedBB]Return
+          Type: 1395 EventRootType Probe[main.testInlinedBB]Return
           InjectionPoints: [{PC: "0xce683e", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -971,11 +971,11 @@ Probes:
       subprogram: {subprogram: 51}
       events:
         - Kind: Entry
-          Type: 1380 EventRootType Probe[main.testInlinedBBA]
+          Type: 1396 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0xce688a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1381 EventRootType Probe[main.testInlinedBBA]Return
+          Type: 1397 EventRootType Probe[main.testInlinedBBA]Return
           InjectionPoints: [{PC: "0xce68cb", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -993,10 +993,10 @@ Probes:
       template: testInlinedBBB
       segments: [testInlinedBBB]
       captureSnapshot: true
-      subprogram: {subprogram: 159}
+      subprogram: {subprogram: 160}
       events:
         - Kind: Entry
-          Type: 1555 EventRootType Probe[main.testInlinedBBB]
+          Type: 1572 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xce6806", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1013,11 +1013,11 @@ Probes:
       subprogram: {subprogram: 52}
       events:
         - Kind: Entry
-          Type: 1382 EventRootType Probe[main.testInlinedBC]
+          Type: 1398 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0xce690e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1383 EventRootType Probe[main.testInlinedBC]Return
+          Type: 1399 EventRootType Probe[main.testInlinedBC]Return
           InjectionPoints: [{PC: "0xce69f3", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1031,10 +1031,10 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Entry
-          Type: 1556 EventRootType Probe[main.testInlinedBCA]
+          Type: 1573 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xce6913", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1051,10 +1051,10 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Line
-          Type: 1557 EventRootType Probe[main.testInlinedBCA]Line
+          Type: 1574 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0xce6913", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1068,10 +1068,10 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Entry
-          Type: 1558 EventRootType Probe[main.testInlinedBCB]
+          Type: 1575 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xce69bb", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1088,10 +1088,10 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Line
-          Type: 1559 EventRootType Probe[main.testInlinedBCB]Line
+          Type: 1576 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0xce69bb", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1105,10 +1105,10 @@ Probes:
       template: testInlinedFuncFromOtherPackage
       segments: [testInlinedFuncFromOtherPackage]
       captureSnapshot: true
-      subprogram: {subprogram: 165}
+      subprogram: {subprogram: 166}
       events:
         - Kind: Entry
-          Type: 1565 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
+          Type: 1582 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
           InjectionPoints:
             - PC: "0xce4881"
               Frameless: true
@@ -1127,10 +1127,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Entry
-          Type: 1552 EventRootType Probe[main.testInlinedPrint]
+          Type: 1569 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0xce656a"
               Frameless: false
@@ -1144,7 +1144,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1553 EventRootType Probe[main.testInlinedPrint]Return
+          Type: 1570 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0xce65aa", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1165,10 +1165,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1554 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1571 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0xce656e"
               Frameless: false
@@ -1196,10 +1196,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 162}
+      subprogram: {subprogram: 163}
       events:
         - Kind: Entry
-          Type: 1560 EventRootType Probe[main.testInlinedSq]
+          Type: 1577 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xce6a21", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1220,10 +1220,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 162}
+      subprogram: {subprogram: 163}
       events:
         - Kind: Line
-          Type: 1561 EventRootType Probe[main.testInlinedSq]Line
+          Type: 1578 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0xce6a21", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1242,10 +1242,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 163}
+      subprogram: {subprogram: 164}
       events:
         - Kind: Entry
-          Type: 1562 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1579 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0xce6a6d"
               Frameless: false
@@ -1270,7 +1270,7 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - Kind: Entry
-          Type: 1330 EventRootType Probe[main.testInt16Array]
+          Type: 1346 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0xce4e60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1291,7 +1291,7 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - Kind: Entry
-          Type: 1331 EventRootType Probe[main.testInt32Array]
+          Type: 1347 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0xce4e80", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1312,7 +1312,7 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - Kind: Entry
-          Type: 1332 EventRootType Probe[main.testInt64Array]
+          Type: 1348 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0xce4ea0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1333,7 +1333,7 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - Kind: Entry
-          Type: 1329 EventRootType Probe[main.testInt8Array]
+          Type: 1345 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0xce4e40", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1354,7 +1354,7 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - Kind: Entry
-          Type: 1328 EventRootType Probe[main.testIntArray]
+          Type: 1344 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0xce4e20", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1375,7 +1375,7 @@ Probes:
       subprogram: {subprogram: 55}
       events:
         - Kind: Entry
-          Type: 1389 EventRootType Probe[main.testInterface]
+          Type: 1405 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0xce6d20", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1395,11 +1395,11 @@ Probes:
       subprogram: {subprogram: 121}
       events:
         - Kind: Entry
-          Type: 1495 EventRootType Probe[main.testLargeArgAndReturn]
+          Type: 1511 EventRootType Probe[main.testLargeArgAndReturn]
           InjectionPoints: [{PC: "0xcead6e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1496 EventRootType Probe[main.testLargeArgAndReturn]Return
+          Type: 1512 EventRootType Probe[main.testLargeArgAndReturn]Return
           InjectionPoints: [{PC: "0xceaecd", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1409,6 +1409,49 @@ Probes:
               DSL: arg
               EventKind: Entry
               EventExpressionIndex: 1
+    - id: testLineProbeTemplateWithStructFields
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.executeStructFuncs
+        sourceFile: structs.go
+        lines: ["208"]
+      template: 'sta.a: {sta.a} sta.b: {sta.b} sta.c: {sta.c}'
+      segments:
+        - 'sta.a: '
+        - json: {getmember: [{ref: sta}, a]}
+          dsl: sta.a
+        - ' sta.b: '
+        - json: {getmember: [{ref: sta}, b]}
+          dsl: sta.b
+        - ' sta.c: '
+        - json: {getmember: [{ref: sta}, c]}
+          dsl: sta.c
+      captureSnapshot: false
+      subprogram: {subprogram: 158}
+      events:
+        - Kind: Line
+          Type: 1566 EventRootType Probe[main.executeStructFuncs]Line
+          InjectionPoints: [{PC: "0xced124", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: 'sta.a: {sta.a} sta.b: {sta.b} sta.c: {sta.c}'
+        Segments:
+            - 'sta.a: '
+            - JSON: {Base: {Ref: sta}, Member: a}
+              DSL: sta.a
+              EventKind: Line
+              EventExpressionIndex: 0
+            - ' sta.b: '
+            - JSON: {Base: {Ref: sta}, Member: b}
+              DSL: sta.b
+              EventKind: Line
+              EventExpressionIndex: 1
+            - ' sta.c: '
+            - JSON: {Base: {Ref: sta}, Member: c}
+              DSL: sta.c
+              EventKind: Line
+              EventExpressionIndex: 2
     - id: testLinkedList
       version: 0
       type: LOG_PROBE
@@ -1420,7 +1463,7 @@ Probes:
       subprogram: {subprogram: 89}
       events:
         - Kind: Entry
-          Type: 1428 EventRootType Probe[main.testLinkedList]
+          Type: 1444 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0xce9580", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1444,7 +1487,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - Kind: Line
-          Type: 1369 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          Type: 1385 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xce5b7a", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1465,7 +1508,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - Kind: Line
-          Type: 1370 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          Type: 1386 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xce5c3f", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1486,7 +1529,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - Kind: Line
-          Type: 1371 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          Type: 1387 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xce5d05", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1528,11 +1571,11 @@ Probes:
       subprogram: {subprogram: 124}
       events:
         - Kind: Entry
-          Type: 1501 EventRootType Probe[main.testManyArgsArrayReturn]
+          Type: 1517 EventRootType Probe[main.testManyArgsArrayReturn]
           InjectionPoints: [{PC: "0xceb213", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1502 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          Type: 1518 EventRootType Probe[main.testManyArgsArrayReturn]Return
           InjectionPoints: [{PC: "0xceb442", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1593,7 +1636,7 @@ Probes:
       subprogram: {subprogram: 64}
       events:
         - Kind: Entry
-          Type: 1400 EventRootType Probe[main.testMapArrayToArray]
+          Type: 1416 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0xce7520", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1614,7 +1657,7 @@ Probes:
       subprogram: {subprogram: 70}
       events:
         - Kind: Entry
-          Type: 1407 EventRootType Probe[main.testMapEmbeddedMaps]
+          Type: 1423 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0xce75e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1635,7 +1678,7 @@ Probes:
       subprogram: {subprogram: 80}
       events:
         - Kind: Entry
-          Type: 1417 EventRootType Probe[main.testMapEmptyKey]
+          Type: 1433 EventRootType Probe[main.testMapEmptyKey]
           InjectionPoints: [{PC: "0xce7720", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1656,7 +1699,7 @@ Probes:
       subprogram: {subprogram: 82}
       events:
         - Kind: Entry
-          Type: 1419 EventRootType Probe[main.testMapEmptyKeyAndValue]
+          Type: 1435 EventRootType Probe[main.testMapEmptyKeyAndValue]
           InjectionPoints: [{PC: "0xce7760", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1677,7 +1720,7 @@ Probes:
       subprogram: {subprogram: 81}
       events:
         - Kind: Entry
-          Type: 1418 EventRootType Probe[main.testMapEmptyValue]
+          Type: 1434 EventRootType Probe[main.testMapEmptyValue]
           InjectionPoints: [{PC: "0xce7740", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1698,7 +1741,7 @@ Probes:
       subprogram: {subprogram: 68}
       events:
         - Kind: Entry
-          Type: 1404 EventRootType Probe[main.testMapIntToInt]
+          Type: 1420 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0xce75a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1719,7 +1762,7 @@ Probes:
       subprogram: {subprogram: 79}
       events:
         - Kind: Entry
-          Type: 1416 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          Type: 1432 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0xce7700", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1740,7 +1783,7 @@ Probes:
       subprogram: {subprogram: 78}
       events:
         - Kind: Entry
-          Type: 1415 EventRootType Probe[main.testMapLargeKeySmallValue]
+          Type: 1431 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0xce76e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1763,7 +1806,7 @@ Probes:
       subprogram: {subprogram: 69}
       events:
         - Kind: Entry
-          Type: 1405 EventRootType Probe[main.testMapMassive]
+          Type: 1421 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0xce75c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1786,7 +1829,7 @@ Probes:
       subprogram: {subprogram: 69}
       events:
         - Kind: Entry
-          Type: 1406 EventRootType Probe[main.testMapMassive]
+          Type: 1422 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0xce75c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1807,7 +1850,7 @@ Probes:
       subprogram: {subprogram: 77}
       events:
         - Kind: Entry
-          Type: 1414 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          Type: 1430 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0xce76c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1828,7 +1871,7 @@ Probes:
       subprogram: {subprogram: 76}
       events:
         - Kind: Entry
-          Type: 1413 EventRootType Probe[main.testMapSmallKeySmallValue]
+          Type: 1429 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0xce76a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1849,7 +1892,7 @@ Probes:
       subprogram: {subprogram: 62}
       events:
         - Kind: Entry
-          Type: 1398 EventRootType Probe[main.testMapStringToInt]
+          Type: 1414 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0xce74e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1870,7 +1913,7 @@ Probes:
       subprogram: {subprogram: 63}
       events:
         - Kind: Entry
-          Type: 1399 EventRootType Probe[main.testMapStringToSlice]
+          Type: 1415 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0xce7500", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1891,7 +1934,7 @@ Probes:
       subprogram: {subprogram: 61}
       events:
         - Kind: Entry
-          Type: 1397 EventRootType Probe[main.testMapStringToStruct]
+          Type: 1413 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0xce74c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1912,7 +1955,7 @@ Probes:
       subprogram: {subprogram: 71}
       events:
         - Kind: Entry
-          Type: 1408 EventRootType Probe[main.testMapWithLinkedList]
+          Type: 1424 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0xce7600", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1933,7 +1976,7 @@ Probes:
       subprogram: {subprogram: 74}
       events:
         - Kind: Entry
-          Type: 1411 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          Type: 1427 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0xce7660", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1954,7 +1997,7 @@ Probes:
       subprogram: {subprogram: 75}
       events:
         - Kind: Entry
-          Type: 1412 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          Type: 1428 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0xce7680", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1975,7 +2018,7 @@ Probes:
       subprogram: {subprogram: 72}
       events:
         - Kind: Entry
-          Type: 1409 EventRootType Probe[main.testMapWithSmallValue]
+          Type: 1425 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0xce7620", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1998,7 +2041,7 @@ Probes:
       subprogram: {subprogram: 73}
       events:
         - Kind: Entry
-          Type: 1410 EventRootType Probe[main.testMapWithSmallValueMassive]
+          Type: 1426 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0xce7640", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2019,7 +2062,7 @@ Probes:
       subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1535 EventRootType Probe[main.testMassiveString]
+          Type: 1551 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xcec5c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2041,7 +2084,7 @@ Probes:
       subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1536 EventRootType Probe[main.testMassiveString]
+          Type: 1552 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xcec5c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2087,11 +2130,11 @@ Probes:
       subprogram: {subprogram: 125}
       events:
         - Kind: Entry
-          Type: 1503 EventRootType Probe[main.testMixedArgsStackReturn]
+          Type: 1519 EventRootType Probe[main.testMixedArgsStackReturn]
           InjectionPoints: [{PC: "0xceb4d3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1504 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          Type: 1520 EventRootType Probe[main.testMixedArgsStackReturn]Return
           InjectionPoints: [{PC: "0xceb702", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2156,11 +2199,11 @@ Probes:
       subprogram: {subprogram: 127}
       events:
         - Kind: Entry
-          Type: 1507 EventRootType Probe[main.testMultipleArrayArgs]
+          Type: 1523 EventRootType Probe[main.testMultipleArrayArgs]
           InjectionPoints: [{PC: "0xceb84e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1508 EventRootType Probe[main.testMultipleArrayArgs]Return
+          Type: 1524 EventRootType Probe[main.testMultipleArrayArgs]Return
           InjectionPoints: [{PC: "0xceb91d", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2190,11 +2233,11 @@ Probes:
       subprogram: {subprogram: 123}
       events:
         - Kind: Entry
-          Type: 1499 EventRootType Probe[main.testMultipleLargeArgs]
+          Type: 1515 EventRootType Probe[main.testMultipleLargeArgs]
           InjectionPoints: [{PC: "0xceafce", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1500 EventRootType Probe[main.testMultipleLargeArgs]Return
+          Type: 1516 EventRootType Probe[main.testMultipleLargeArgs]Return
           InjectionPoints: [{PC: "0xceb1eb", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2219,11 +2262,11 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1453 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1469 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xcea36e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1454 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1470 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcea40f", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2258,7 +2301,7 @@ Probes:
       subprogram: {subprogram: 85}
       events:
         - Kind: Entry
-          Type: 1423 EventRootType Probe[main.testMultipleSimpleParams]
+          Type: 1439 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0xce9160", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2298,11 +2341,11 @@ Probes:
       subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1449 EventRootType Probe[main.testNamedReturn]
+          Type: 1465 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0xcea2ca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1450 EventRootType Probe[main.testNamedReturn]Return
+          Type: 1466 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0xcea33b", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2328,11 +2371,11 @@ Probes:
       subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1451 EventRootType Probe[main.testNamedReturn]
+          Type: 1467 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0xcea2ca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1452 EventRootType Probe[main.testNamedReturn]Return
+          Type: 1468 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0xcea33b", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2359,7 +2402,7 @@ Probes:
       subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1544 EventRootType Probe[main.testNestedPointer]
+          Type: 1560 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0xcec9c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2383,7 +2426,7 @@ Probes:
       subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1545 EventRootType Probe[main.testNestedPointer]
+          Type: 1561 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0xcec9c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2413,7 +2456,7 @@ Probes:
       subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1546 EventRootType Probe[main.testNestedPointer]
+          Type: 1562 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0xcec9c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2437,7 +2480,7 @@ Probes:
       subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1547 EventRootType Probe[main.testNestedPointer]
+          Type: 1563 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0xcec9c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2463,7 +2506,7 @@ Probes:
       subprogram: {subprogram: 94}
       events:
         - Kind: Entry
-          Type: 1433 EventRootType Probe[main.testNilPointer]
+          Type: 1449 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0xce9720", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2489,7 +2532,7 @@ Probes:
       subprogram: {subprogram: 138}
       events:
         - Kind: Entry
-          Type: 1521 EventRootType Probe[main.testNilSlice]
+          Type: 1537 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0xcec100", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2515,7 +2558,7 @@ Probes:
       subprogram: {subprogram: 135}
       events:
         - Kind: Entry
-          Type: 1518 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 1534 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0xcec0a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2549,7 +2592,7 @@ Probes:
       subprogram: {subprogram: 137}
       events:
         - Kind: Entry
-          Type: 1520 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 1536 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0xcec0e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2580,7 +2623,7 @@ Probes:
       subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1534 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 1550 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0xcec5a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2601,7 +2644,7 @@ Probes:
       subprogram: {subprogram: 90}
       events:
         - Kind: Entry
-          Type: 1429 EventRootType Probe[main.testPointerLoop]
+          Type: 1445 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0xce95a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2622,7 +2665,7 @@ Probes:
       subprogram: {subprogram: 67}
       events:
         - Kind: Entry
-          Type: 1403 EventRootType Probe[main.testPointerToMap]
+          Type: 1419 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0xce7580", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2643,7 +2686,7 @@ Probes:
       subprogram: {subprogram: 88}
       events:
         - Kind: Entry
-          Type: 1427 EventRootType Probe[main.testPointerToSimpleStruct]
+          Type: 1443 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0xce9560", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2664,11 +2707,11 @@ Probes:
       subprogram: {subprogram: 101}
       events:
         - Kind: Entry
-          Type: 1445 EventRootType Probe[main.testReturnsAny]
+          Type: 1461 EventRootType Probe[main.testReturnsAny]
           InjectionPoints: [{PC: "0xce9f6e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1446 EventRootType Probe[main.testReturnsAny]Return
+          Type: 1462 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints:
             - PC: "0xcea015"
               Frameless: false
@@ -2702,11 +2745,11 @@ Probes:
       subprogram: {subprogram: 100}
       events:
         - Kind: Entry
-          Type: 1443 EventRootType Probe[main.testReturnsAnyAndError]
+          Type: 1459 EventRootType Probe[main.testReturnsAnyAndError]
           InjectionPoints: [{PC: "0xce9e0e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1444 EventRootType Probe[main.testReturnsAnyAndError]Return
+          Type: 1460 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
             - PC: "0xce9e64"
               Frameless: false
@@ -2739,11 +2782,11 @@ Probes:
       subprogram: {subprogram: 110}
       events:
         - Kind: Entry
-          Type: 1473 EventRootType Probe[main.testReturnsArray]
+          Type: 1489 EventRootType Probe[main.testReturnsArray]
           InjectionPoints: [{PC: "0xcea7ea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1474 EventRootType Probe[main.testReturnsArray]Return
+          Type: 1490 EventRootType Probe[main.testReturnsArray]Return
           InjectionPoints: [{PC: "0xcea84f", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2759,11 +2802,11 @@ Probes:
       subprogram: {subprogram: 111}
       events:
         - Kind: Entry
-          Type: 1475 EventRootType Probe[main.testReturnsArrayOne]
+          Type: 1491 EventRootType Probe[main.testReturnsArrayOne]
           InjectionPoints: [{PC: "0xcea86a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1476 EventRootType Probe[main.testReturnsArrayOne]Return
+          Type: 1492 EventRootType Probe[main.testReturnsArrayOne]Return
           InjectionPoints: [{PC: "0xcea8ab", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2779,11 +2822,11 @@ Probes:
       subprogram: {subprogram: 112}
       events:
         - Kind: Entry
-          Type: 1477 EventRootType Probe[main.testReturnsArrayZero]
+          Type: 1493 EventRootType Probe[main.testReturnsArrayZero]
           InjectionPoints: [{PC: "0xcea8ca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1478 EventRootType Probe[main.testReturnsArrayZero]Return
+          Type: 1494 EventRootType Probe[main.testReturnsArrayZero]Return
           InjectionPoints: [{PC: "0xcea906", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2799,11 +2842,11 @@ Probes:
       subprogram: {subprogram: 114}
       events:
         - Kind: Entry
-          Type: 1481 EventRootType Probe[main.testReturnsBacktrackInt]
+          Type: 1497 EventRootType Probe[main.testReturnsBacktrackInt]
           InjectionPoints: [{PC: "0xcea9ae", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1482 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          Type: 1498 EventRootType Probe[main.testReturnsBacktrackInt]Return
           InjectionPoints: [{PC: "0xceaa2a", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2819,11 +2862,11 @@ Probes:
       subprogram: {subprogram: 120}
       events:
         - Kind: Entry
-          Type: 1493 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          Type: 1509 EventRootType Probe[main.testReturnsBoolAndUintptr]
           InjectionPoints: [{PC: "0xcead0a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1494 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          Type: 1510 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
           InjectionPoints: [{PC: "0xcead50", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2839,11 +2882,11 @@ Probes:
       subprogram: {subprogram: 108}
       events:
         - Kind: Entry
-          Type: 1469 EventRootType Probe[main.testReturnsComplex]
+          Type: 1485 EventRootType Probe[main.testReturnsComplex]
           InjectionPoints: [{PC: "0xcea6aa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1470 EventRootType Probe[main.testReturnsComplex]Return
+          Type: 1486 EventRootType Probe[main.testReturnsComplex]Return
           InjectionPoints: [{PC: "0xcea706", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2860,11 +2903,11 @@ Probes:
       subprogram: {subprogram: 99}
       events:
         - Kind: Entry
-          Type: 1441 EventRootType Probe[main.testReturnsError]
+          Type: 1457 EventRootType Probe[main.testReturnsError]
           InjectionPoints: [{PC: "0xce9d8a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1442 EventRootType Probe[main.testReturnsError]Return
+          Type: 1458 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
             - PC: "0xce9dc4"
               Frameless: false
@@ -2888,11 +2931,11 @@ Probes:
       subprogram: {subprogram: 96}
       events:
         - Kind: Entry
-          Type: 1435 EventRootType Probe[main.testReturnsInt]
+          Type: 1451 EventRootType Probe[main.testReturnsInt]
           InjectionPoints: [{PC: "0xce9b8a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1436 EventRootType Probe[main.testReturnsInt]Return
+          Type: 1452 EventRootType Probe[main.testReturnsInt]Return
           InjectionPoints: [{PC: "0xce9bdb", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2912,11 +2955,11 @@ Probes:
       subprogram: {subprogram: 98}
       events:
         - Kind: Entry
-          Type: 1439 EventRootType Probe[main.testReturnsIntAndFloat]
+          Type: 1455 EventRootType Probe[main.testReturnsIntAndFloat]
           InjectionPoints: [{PC: "0xce9cae", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1440 EventRootType Probe[main.testReturnsIntAndFloat]Return
+          Type: 1456 EventRootType Probe[main.testReturnsIntAndFloat]Return
           InjectionPoints: [{PC: "0xce9d65", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2936,11 +2979,11 @@ Probes:
       subprogram: {subprogram: 97}
       events:
         - Kind: Entry
-          Type: 1437 EventRootType Probe[main.testReturnsIntPointer]
+          Type: 1453 EventRootType Probe[main.testReturnsIntPointer]
           InjectionPoints: [{PC: "0xce9c0a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1438 EventRootType Probe[main.testReturnsIntPointer]Return
+          Type: 1454 EventRootType Probe[main.testReturnsIntPointer]Return
           InjectionPoints: [{PC: "0xce9c74", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2961,11 +3004,11 @@ Probes:
       subprogram: {subprogram: 102}
       events:
         - Kind: Entry
-          Type: 1447 EventRootType Probe[main.testReturnsInterface]
+          Type: 1463 EventRootType Probe[main.testReturnsInterface]
           InjectionPoints: [{PC: "0xcea16e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1448 EventRootType Probe[main.testReturnsInterface]Return
+          Type: 1464 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
             - PC: "0xcea23d"
               Frameless: false
@@ -2989,11 +3032,11 @@ Probes:
       subprogram: {subprogram: 109}
       events:
         - Kind: Entry
-          Type: 1471 EventRootType Probe[main.testReturnsLargeStruct]
+          Type: 1487 EventRootType Probe[main.testReturnsLargeStruct]
           InjectionPoints: [{PC: "0xcea72e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1472 EventRootType Probe[main.testReturnsLargeStruct]Return
+          Type: 1488 EventRootType Probe[main.testReturnsLargeStruct]Return
           InjectionPoints: [{PC: "0xcea7c3", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3009,11 +3052,11 @@ Probes:
       subprogram: {subprogram: 107}
       events:
         - Kind: Entry
-          Type: 1467 EventRootType Probe[main.testReturnsManyFloats]
+          Type: 1483 EventRootType Probe[main.testReturnsManyFloats]
           InjectionPoints: [{PC: "0xcea5ae", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1468 EventRootType Probe[main.testReturnsManyFloats]Return
+          Type: 1484 EventRootType Probe[main.testReturnsManyFloats]Return
           InjectionPoints: [{PC: "0xcea687", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3029,11 +3072,11 @@ Probes:
       subprogram: {subprogram: 116}
       events:
         - Kind: Entry
-          Type: 1485 EventRootType Probe[main.testReturnsMixed]
+          Type: 1501 EventRootType Probe[main.testReturnsMixed]
           InjectionPoints: [{PC: "0xceab2a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1486 EventRootType Probe[main.testReturnsMixed]Return
+          Type: 1502 EventRootType Probe[main.testReturnsMixed]Return
           InjectionPoints: [{PC: "0xceab8c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3049,11 +3092,11 @@ Probes:
       subprogram: {subprogram: 113}
       events:
         - Kind: Entry
-          Type: 1479 EventRootType Probe[main.testReturnsMixedStruct]
+          Type: 1495 EventRootType Probe[main.testReturnsMixedStruct]
           InjectionPoints: [{PC: "0xcea92a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1480 EventRootType Probe[main.testReturnsMixedStruct]Return
+          Type: 1496 EventRootType Probe[main.testReturnsMixedStruct]Return
           InjectionPoints: [{PC: "0xcea978", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3069,11 +3112,11 @@ Probes:
       subprogram: {subprogram: 119}
       events:
         - Kind: Entry
-          Type: 1491 EventRootType Probe[main.testReturnsMultipleFloats]
+          Type: 1507 EventRootType Probe[main.testReturnsMultipleFloats]
           InjectionPoints: [{PC: "0xceac8a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1492 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          Type: 1508 EventRootType Probe[main.testReturnsMultipleFloats]Return
           InjectionPoints: [{PC: "0xceacd6", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3089,11 +3132,11 @@ Probes:
       subprogram: {subprogram: 118}
       events:
         - Kind: Entry
-          Type: 1489 EventRootType Probe[main.testReturnsOnlyFloat]
+          Type: 1505 EventRootType Probe[main.testReturnsOnlyFloat]
           InjectionPoints: [{PC: "0xceac2a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1490 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          Type: 1506 EventRootType Probe[main.testReturnsOnlyFloat]Return
           InjectionPoints: [{PC: "0xceac6e", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3109,11 +3152,11 @@ Probes:
       subprogram: {subprogram: 106}
       events:
         - Kind: Entry
-          Type: 1465 EventRootType Probe[main.testReturnsPrimitives]
+          Type: 1481 EventRootType Probe[main.testReturnsPrimitives]
           InjectionPoints: [{PC: "0xcea52a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1466 EventRootType Probe[main.testReturnsPrimitives]Return
+          Type: 1482 EventRootType Probe[main.testReturnsPrimitives]Return
           InjectionPoints: [{PC: "0xcea591", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3129,11 +3172,11 @@ Probes:
       subprogram: {subprogram: 117}
       events:
         - Kind: Entry
-          Type: 1487 EventRootType Probe[main.testReturnsStructWithArray]
+          Type: 1503 EventRootType Probe[main.testReturnsStructWithArray]
           InjectionPoints: [{PC: "0xceabaa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1488 EventRootType Probe[main.testReturnsStructWithArray]Return
+          Type: 1504 EventRootType Probe[main.testReturnsStructWithArray]Return
           InjectionPoints: [{PC: "0xceac0f", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3149,11 +3192,11 @@ Probes:
       subprogram: {subprogram: 115}
       events:
         - Kind: Entry
-          Type: 1483 EventRootType Probe[main.testReturnsWideStruct]
+          Type: 1499 EventRootType Probe[main.testReturnsWideStruct]
           InjectionPoints: [{PC: "0xceaa4e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1484 EventRootType Probe[main.testReturnsWideStruct]Return
+          Type: 1500 EventRootType Probe[main.testReturnsWideStruct]Return
           InjectionPoints: [{PC: "0xceaaf2", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3170,7 +3213,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - Kind: Entry
-          Type: 1325 EventRootType Probe[main.testRuneArray]
+          Type: 1341 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0xce4dc0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3204,11 +3247,11 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1455 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1471 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xcea36e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1456 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1472 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcea40f", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3253,7 +3296,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 1346 EventRootType Probe[main.testSingleBool]
+          Type: 1362 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0xce5420", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3274,7 +3317,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - Kind: Entry
-          Type: 1344 EventRootType Probe[main.testSingleByte]
+          Type: 1360 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0xce53e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3295,7 +3338,7 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 1357 EventRootType Probe[main.testSingleFloat32]
+          Type: 1373 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0xce5580", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3316,7 +3359,7 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - Kind: Entry
-          Type: 1358 EventRootType Probe[main.testSingleFloat64]
+          Type: 1374 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0xce55a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3337,7 +3380,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 1347 EventRootType Probe[main.testSingleInt]
+          Type: 1363 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0xce5440", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3358,7 +3401,7 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - Kind: Entry
-          Type: 1349 EventRootType Probe[main.testSingleInt16]
+          Type: 1365 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0xce5480", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3380,7 +3423,7 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - Kind: Entry
-          Type: 1350 EventRootType Probe[main.testSingleInt32]
+          Type: 1366 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0xce54a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3401,7 +3444,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - Kind: Entry
-          Type: 1351 EventRootType Probe[main.testSingleInt64]
+          Type: 1367 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0xce54c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3429,7 +3472,7 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - Kind: Entry
-          Type: 1348 EventRootType Probe[main.testSingleInt8]
+          Type: 1364 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0xce5460", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3459,7 +3502,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 1345 EventRootType Probe[main.testSingleRune]
+          Type: 1361 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0xce5400", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3480,7 +3523,7 @@ Probes:
       subprogram: {subprogram: 143}
       events:
         - Kind: Entry
-          Type: 1528 EventRootType Probe[main.testSingleString]
+          Type: 1544 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0xcec520", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3501,7 +3544,7 @@ Probes:
       subprogram: {subprogram: 29}
       events:
         - Kind: Entry
-          Type: 1352 EventRootType Probe[main.testSingleUint]
+          Type: 1368 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0xce54e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3522,7 +3565,7 @@ Probes:
       subprogram: {subprogram: 31}
       events:
         - Kind: Entry
-          Type: 1354 EventRootType Probe[main.testSingleUint16]
+          Type: 1370 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0xce5520", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3543,7 +3586,7 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - Kind: Entry
-          Type: 1355 EventRootType Probe[main.testSingleUint32]
+          Type: 1371 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0xce5540", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3564,7 +3607,7 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 1356 EventRootType Probe[main.testSingleUint64]
+          Type: 1372 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0xce5560", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3585,7 +3628,7 @@ Probes:
       subprogram: {subprogram: 30}
       events:
         - Kind: Entry
-          Type: 1353 EventRootType Probe[main.testSingleUint8]
+          Type: 1369 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0xce5500", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3606,7 +3649,7 @@ Probes:
       subprogram: {subprogram: 140}
       events:
         - Kind: Entry
-          Type: 1524 EventRootType Probe[main.testSliceEmptyStructs]
+          Type: 1540 EventRootType Probe[main.testSliceEmptyStructs]
           InjectionPoints: [{PC: "0xcec140", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3627,7 +3670,7 @@ Probes:
       subprogram: {subprogram: 132}
       events:
         - Kind: Entry
-          Type: 1515 EventRootType Probe[main.testSliceOfSlices]
+          Type: 1531 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0xcec040", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3648,7 +3691,7 @@ Probes:
       subprogram: {subprogram: 65}
       events:
         - Kind: Entry
-          Type: 1401 EventRootType Probe[main.testSmallMap]
+          Type: 1417 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0xce7540", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3668,11 +3711,11 @@ Probes:
       subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1463 EventRootType Probe[main.testSomeNamedReturn]
+          Type: 1479 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0xcea44e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1464 EventRootType Probe[main.testSomeNamedReturn]Return
+          Type: 1480 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0xcea4ed", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3692,11 +3735,11 @@ Probes:
       subprogram: {subprogram: 126}
       events:
         - Kind: Entry
-          Type: 1505 EventRootType Probe[main.testStackArgRegReturns]
+          Type: 1521 EventRootType Probe[main.testStackArgRegReturns]
           InjectionPoints: [{PC: "0xceb7aa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1506 EventRootType Probe[main.testStackArgRegReturns]Return
+          Type: 1522 EventRootType Probe[main.testStackArgRegReturns]Return
           InjectionPoints: [{PC: "0xceb81e", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3717,7 +3760,7 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - Kind: Entry
-          Type: 1326 EventRootType Probe[main.testStringArray]
+          Type: 1342 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0xce4de0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3738,7 +3781,7 @@ Probes:
       subprogram: {subprogram: 93}
       events:
         - Kind: Entry
-          Type: 1432 EventRootType Probe[main.testStringPointer]
+          Type: 1448 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0xce96e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3759,7 +3802,7 @@ Probes:
       subprogram: {subprogram: 136}
       events:
         - Kind: Entry
-          Type: 1519 EventRootType Probe[main.testStringSlice]
+          Type: 1535 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0xcec0c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3780,7 +3823,7 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - Kind: Entry
-          Type: 1367 EventRootType Probe[main.testStringType1]
+          Type: 1383 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0xce5b20", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3801,7 +3844,7 @@ Probes:
       subprogram: {subprogram: 45}
       events:
         - Kind: Entry
-          Type: 1368 EventRootType Probe[main.testStringType2]
+          Type: 1384 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0xce5b40", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3822,7 +3865,7 @@ Probes:
       subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1543 EventRootType Probe[main.testStruct]
+          Type: 1559 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0xcec900", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3848,7 +3891,7 @@ Probes:
       subprogram: {subprogram: 133}
       events:
         - Kind: Entry
-          Type: 1516 EventRootType Probe[main.testStructSlice]
+          Type: 1532 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0xcec060", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3874,7 +3917,7 @@ Probes:
       subprogram: {subprogram: 59}
       events:
         - Kind: Entry
-          Type: 1395 EventRootType Probe[main.testStructWithAny]
+          Type: 1411 EventRootType Probe[main.testStructWithAny]
           InjectionPoints: [{PC: "0xce6e40", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3894,11 +3937,11 @@ Probes:
       subprogram: {subprogram: 128}
       events:
         - Kind: Entry
-          Type: 1509 EventRootType Probe[main.testStructWithArrayArg]
+          Type: 1525 EventRootType Probe[main.testStructWithArrayArg]
           InjectionPoints: [{PC: "0xceb94e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1510 EventRootType Probe[main.testStructWithArrayArg]Return
+          Type: 1526 EventRootType Probe[main.testStructWithArrayArg]Return
           InjectionPoints: [{PC: "0xceba04", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3919,7 +3962,7 @@ Probes:
       subprogram: {subprogram: 153}
       events:
         - Kind: Entry
-          Type: 1541 EventRootType Probe[main.testStructWithCyclicMaps]
+          Type: 1557 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0xcec7c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3939,7 +3982,7 @@ Probes:
       subprogram: {subprogram: 152}
       events:
         - Kind: Entry
-          Type: 1540 EventRootType Probe[main.testStructWithCyclicSlices]
+          Type: 1556 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0xcec7a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3965,7 +4008,7 @@ Probes:
       subprogram: {subprogram: 60}
       events:
         - Kind: Entry
-          Type: 1396 EventRootType Probe[main.testStructWithMap]
+          Type: 1412 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0xce74a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3996,7 +4039,7 @@ Probes:
       subprogram: {subprogram: 141}
       events:
         - Kind: Entry
-          Type: 1525 EventRootType Probe[main.testSubslices]
+          Type: 1541 EventRootType Probe[main.testSubslices]
           InjectionPoints: [{PC: "0xcec160", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4035,7 +4078,7 @@ Probes:
       subprogram: {subprogram: 151}
       events:
         - Kind: Entry
-          Type: 1539 EventRootType Probe[main.testSubstrings]
+          Type: 1555 EventRootType Probe[main.testSubstrings]
           InjectionPoints: [{PC: "0xcec620", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4067,11 +4110,11 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1457 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1473 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xcea36e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1458 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1474 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcea40f", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -4091,11 +4134,11 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1459 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1475 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xcea36e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1460 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1476 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcea40f", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -4117,11 +4160,11 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1461 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1477 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xcea36e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1462 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1478 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcea40f", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -4149,7 +4192,7 @@ Probes:
       subprogram: {subprogram: 144}
       events:
         - Kind: Entry
-          Type: 1529 EventRootType Probe[main.testThreeStrings]
+          Type: 1545 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0xcec540", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4180,7 +4223,7 @@ Probes:
       subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1530 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1546 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0xcec560", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4209,7 +4252,7 @@ Probes:
       subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1531 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1547 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0xcec560", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4240,7 +4283,7 @@ Probes:
       subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1532 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1548 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0xcec580", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4269,7 +4312,7 @@ Probes:
       subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1533 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1549 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0xcec580", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4300,7 +4343,7 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 1359 EventRootType Probe[main.testTypeAlias]
+          Type: 1375 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0xce55c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4321,7 +4364,7 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - Kind: Entry
-          Type: 1335 EventRootType Probe[main.testUint16Array]
+          Type: 1351 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0xce4f00", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4342,7 +4385,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - Kind: Entry
-          Type: 1336 EventRootType Probe[main.testUint32Array]
+          Type: 1352 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0xce4f20", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4363,7 +4406,7 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - Kind: Entry
-          Type: 1337 EventRootType Probe[main.testUint64Array]
+          Type: 1353 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0xce4f40", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4384,7 +4427,7 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - Kind: Entry
-          Type: 1334 EventRootType Probe[main.testUint8Array]
+          Type: 1350 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0xce4ee0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4405,7 +4448,7 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - Kind: Entry
-          Type: 1333 EventRootType Probe[main.testUintArray]
+          Type: 1349 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0xce4ec0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4426,7 +4469,7 @@ Probes:
       subprogram: {subprogram: 92}
       events:
         - Kind: Entry
-          Type: 1431 EventRootType Probe[main.testUintPointer]
+          Type: 1447 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0xce9600", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4447,7 +4490,7 @@ Probes:
       subprogram: {subprogram: 130}
       events:
         - Kind: Entry
-          Type: 1513 EventRootType Probe[main.testUintSlice]
+          Type: 1529 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0xcec000", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4468,7 +4511,7 @@ Probes:
       subprogram: {subprogram: 149}
       events:
         - Kind: Entry
-          Type: 1537 EventRootType Probe[main.testUnitializedString]
+          Type: 1553 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0xcec5e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4489,7 +4532,7 @@ Probes:
       subprogram: {subprogram: 91}
       events:
         - Kind: Entry
-          Type: 1430 EventRootType Probe[main.testUnsafePointer]
+          Type: 1446 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0xce95c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4510,7 +4553,7 @@ Probes:
       subprogram: {subprogram: 20}
       events:
         - Kind: Entry
-          Type: 1343 EventRootType Probe[main.testVeryLargeArray]
+          Type: 1359 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0xce5020", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4531,7 +4574,7 @@ Probes:
       subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1522 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1538 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xcec120", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4552,7 +4595,7 @@ Probes:
       subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1523 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1539 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xcec120", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4569,10 +4612,10 @@ Probes:
       template: testWhollyInlinedSubroutine
       segments: [testWhollyInlinedSubroutine]
       captureSnapshot: true
-      subprogram: {subprogram: 164}
+      subprogram: {subprogram: 165}
       events:
         - Kind: Entry
-          Type: 1563 EventRootType Probe[main.firstBehavior.DoSomething]
+          Type: 1580 EventRootType Probe[main.firstBehavior.DoSomething]
           InjectionPoints:
             - PC: "0xce6c4a"
               Frameless: false
@@ -4580,7 +4623,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1564 EventRootType Probe[main.firstBehavior.DoSomething]Return
+          Type: 1581 EventRootType Probe[main.firstBehavior.DoSomething]Return
           InjectionPoints: [{PC: "0xce6c85", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -4601,11 +4644,11 @@ Probes:
       subprogram: {subprogram: 129}
       events:
         - Kind: Entry
-          Type: 1511 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          Type: 1527 EventRootType Probe[main.testZeroSizeArgAndReturn]
           InjectionPoints: [{PC: "0xceba2e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1512 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          Type: 1528 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
           InjectionPoints: [{PC: "0xcebaac", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -7891,6 +7934,69 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 158
+      Name: main.executeStructFuncs
+      OutOfLinePCRanges: [0xcecaa0..0xcedb38]
+      InlinePCRanges: []
+      Variables:
+        - Name: n
+          Type: 327 StructureType main.nStruct
+          Locations: [{Range: 0xcecaa0..0xcedb38, Pieces: []}]
+          Role: Local
+        - Name: ns
+          Type: 268 StructureType main.structWithNoStrings
+          Locations: [{Range: 0xcecaa0..0xcedb38, Pieces: []}]
+          Role: Local
+        - Name: cs
+          Type: 328 StructureType main.cStruct
+          Locations: [{Range: 0xcecaa0..0xcedb38, Pieces: []}]
+          Role: Local
+        - Name: rcvr
+          Type: 329 StructureType main.receiver
+          Locations: [{Range: 0xcecaa0..0xcedb38, Pieces: []}]
+          Role: Local
+        - Name: ts
+          Type: 330 StructureType main.threestrings
+          Locations:
+            - Range: 0xcecac4..0xcedb38
+              Pieces: [{Size: 48, Op: {CfaOffset: -2080}}]
+          Role: Local
+        - Name: s
+          Type: 322 StructureType main.aStruct
+          Locations:
+            - Range: 0xcecb4d..0xcedb38
+              Pieces: [{Size: 56, Op: {CfaOffset: -1920}}]
+          Role: Local
+        - Name: b
+          Type: 331 StructureType main.bStruct
+          Locations:
+            - Range: 0xcecbed..0xcedb38
+              Pieces: [{Size: 72, Op: {CfaOffset: -2080}}]
+          Role: Local
+        - Name: tenStr
+          Type: 332 StructureType main.tenStrings
+          Locations:
+            - Range: 0xceceb8..0xcedb38
+              Pieces: [{Size: 160, Op: {CfaOffset: -2080}}]
+          Role: Local
+        - Name: deep
+          Type: 333 StructureType main.deepStruct1
+          Locations:
+            - Range: 0xcecfb1..0xcedb38
+              Pieces: [{Size: 48, Op: {CfaOffset: -2168}}]
+          Role: Local
+        - Name: fields
+          Type: 339 StructureType main.lotsOfFields
+          Locations:
+            - Range: 0xced03c..0xcedb38
+              Pieces: [{Size: 26, Op: {CfaOffset: -2168}}]
+          Role: Local
+        - Name: sta
+          Type: 340 StructureType main.structWithTwoArrays
+          Locations:
+            - Range: 0xced0a4..0xcedb38
+              Pieces: [{Size: 72, Op: {CfaOffset: -2168}}]
+          Role: Local
+    - ID: 159
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0xce6560..0xce65c2]
       InlinePCRanges:
@@ -7919,28 +8025,28 @@ Subprograms:
             - Range: 0xce6880..0xce689a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 159
+    - ID: 160
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xce6806..0xce683e]
           RootRanges: [0xce67a0..0xce6865]
       Variables: []
-    - ID: 160
+    - ID: 161
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xce6913..0xce6951]
           RootRanges: [0xce6900..0xce6a05]
       Variables: []
-    - ID: 161
+    - ID: 162
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xce69bb..0xce69f3]
           RootRanges: [0xce6900..0xce6a05]
       Variables: []
-    - ID: 162
+    - ID: 163
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -7953,7 +8059,7 @@ Subprograms:
             - Range: 0xce6a20..0xce6a25
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 163
+    - ID: 164
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -7970,7 +8076,7 @@ Subprograms:
             - Range: 0xce6ae7..0xce6c25
               Pieces: [{Size: 40, Op: {CfaOffset: -128}}]
           Role: Parameter
-    - ID: 164
+    - ID: 165
       Name: main.firstBehavior.DoSomething
       OutOfLinePCRanges: [0xce6c40..0xce6ca6]
       InlinePCRanges:
@@ -7978,7 +8084,7 @@ Subprograms:
           RootRanges: [0xcedca0..0xcedd05]
       Variables:
         - Name: b
-          Type: 327 StructureType main.firstBehavior
+          Type: 343 StructureType main.firstBehavior
           Locations:
             - Range: 0xce6c40..0xce6c5e
               Pieces:
@@ -8001,7 +8107,7 @@ Subprograms:
             - Range: 0xce6c86..0xce6ca6
               Pieces: []
           Role: Return
-    - ID: 165
+    - ID: 166
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -8017,20 +8123,20 @@ Types:
       ByteSize: 8
       Pointee: 146 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 1239
+      ID: 1255
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 1240 PointerType *main.deepSlice3
+      Pointee: 1256 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 1264
+      ID: 1280
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 1265 PointerType *main.deepSlice8
+      Pointee: 1281 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 1270
+      ID: 1286
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 1271 PointerType *main.deepSlice9
+      Pointee: 1287 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 159
       Name: '**main.stringType2'
@@ -8038,7 +8144,7 @@ Types:
       GoKind: 22
       Pointee: 160 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 1235
+      ID: 1251
       Name: '**main.t'
       ByteSize: 8
       Pointee: 254 PointerType *main.t
@@ -8081,30 +8187,30 @@ Types:
       ByteSize: 8
       Pointee: 154 PointerType *table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1247
+      ID: 1263
       Name: '**table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1248 PointerType *table<int,*main.deepMap3>
+      Pointee: 1264 PointerType *table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1281
+      ID: 1297
       Name: '**table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1282 PointerType *table<int,*main.deepMap8>
+      Pointee: 1298 PointerType *table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1296
+      ID: 1312
       Name: '**table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1297 PointerType *table<int,*main.deepMap9>
+      Pointee: 1313 PointerType *table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 175
       Name: '**table<int,int>'
       ByteSize: 8
       Pointee: 176 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 1311
+      ID: 1327
       Name: '**table<int,interface {}>'
       ByteSize: 8
-      Pointee: 1312 PointerType *table<int,interface {}>
+      Pointee: 1328 PointerType *table<int,interface {}>
     - __kind: PointerType
       ID: 242
       Name: '**table<int,struct {}>'
@@ -8126,10 +8232,10 @@ Types:
       ByteSize: 8
       Pointee: 191 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 983
+      ID: 999
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 984 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 1000 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 185
       Name: '**table<string,int>'
@@ -8191,120 +8297,120 @@ Types:
       ByteSize: 8
       Pointee: 218 PointerType *table<uint8,uint8>
     - __kind: PointerType
-      ID: 341
+      ID: 357
       Name: '*[]*main.deepSlice2.array'
       ByteSize: 8
-      Pointee: 340 GoSliceDataType []*main.deepSlice2.array
+      Pointee: 356 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 1243
+      ID: 1259
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 1242 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 1258 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 1268
+      ID: 1284
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 1267 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 1283 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 1274
+      ID: 1290
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 1273 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 1289 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
-      ID: 336
+      ID: 352
       Name: '*[]*runtime.p.array'
       ByteSize: 8
-      Pointee: 335 GoSliceDataType []*runtime.p.array
+      Pointee: 351 GoSliceDataType []*runtime.p.array
     - __kind: PointerType
-      ID: 338
+      ID: 354
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 337 GoSliceDataType []*string.array
+      Pointee: 353 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 501
+      ID: 517
       Name: '*[][][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 500 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Pointee: 516 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 290
       Name: '*[][][][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 287 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 499
+      ID: 515
       Name: '*[][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 498 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Pointee: 514 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 288
       Name: '*[][][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 285 GoSliceHeaderType [][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 497
+      ID: 513
       Name: '*[][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 496 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Pointee: 512 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 286
       Name: '*[][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 283 GoSliceHeaderType [][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 495
+      ID: 511
       Name: '*[][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 494 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Pointee: 510 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 284
       Name: '*[][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 281 GoSliceHeaderType [][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 493
+      ID: 509
       Name: '*[][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 492 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Pointee: 508 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 479
+      ID: 495
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 478 GoSliceDataType [][]uint.array
+      Pointee: 494 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 485
+      ID: 501
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 484 GoSliceDataType []bool.array
+      Pointee: 500 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 1020
+      ID: 1036
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 1019 GoSliceDataType []float64.array
+      Pointee: 1035 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 1277
+      ID: 1293
       Name: '*[]interface {}.array'
       ByteSize: 8
-      Pointee: 1276 GoSliceDataType []interface {}.array
+      Pointee: 1292 GoSliceDataType []interface {}.array
     - __kind: PointerType
       ID: 282
       Name: '*[]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 279 GoSliceHeaderType []main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 491
+      ID: 507
       Name: '*[]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 490 GoSliceDataType []main.structWithCyclicSlices.array
+      Pointee: 506 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 551
+      ID: 567
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 550 GoSliceDataType []main.structWithMap.array
+      Pointee: 566 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 481
+      ID: 497
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 480 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 496 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
       ID: 40
       Name: '*[]runtime.ancestorInfo'
@@ -8313,101 +8419,101 @@ Types:
       GoKind: 22
       Pointee: 41 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 483
+      ID: 499
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 482 GoSliceDataType []string.array
+      Pointee: 498 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 489
+      ID: 505
       Name: '*[]struct {}.array'
       ByteSize: 8
-      Pointee: 488 GoSliceDataType []struct {}.array
+      Pointee: 504 GoSliceDataType []struct {}.array
     - __kind: PointerType
       ID: 265
       Name: '*[]uint'
       ByteSize: 8
       Pointee: 263 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 477
+      ID: 493
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 476 GoSliceDataType []uint.array
+      Pointee: 492 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 487
+      ID: 503
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 486 GoSliceDataType []uint16.array
+      Pointee: 502 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 331
+      ID: 347
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 330 GoSliceDataType []uint8.array
+      Pointee: 346 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 333
+      ID: 349
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 332 GoSliceDataType []uintptr.array
+      Pointee: 348 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 1151
+      ID: 1167
       Name: '*archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 2.009088e+06
       GoKind: 22
-      Pointee: 1152 UnresolvedPointeeType archive/tar.Writer
+      Pointee: 1168 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
-      ID: 785
+      ID: 801
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 941344
       GoKind: 22
-      Pointee: 786 GoSliceHeaderType archive/tar.headerError
+      Pointee: 802 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 788
+      ID: 804
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 787 GoSliceDataType archive/tar.headerError.array
+      Pointee: 803 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 1085
+      ID: 1101
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.448352e+06
       GoKind: 22
-      Pointee: 1086 UnresolvedPointeeType archive/tar.regFileWriter
+      Pointee: 1102 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
-      ID: 1033
+      ID: 1049
       Name: '*archive/zip.countWriter'
       ByteSize: 8
       GoRuntimeType: 941536
       GoKind: 22
-      Pointee: 1034 UnresolvedPointeeType archive/zip.countWriter
+      Pointee: 1050 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
-      ID: 1035
+      ID: 1051
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
       GoRuntimeType: 941632
       GoKind: 22
-      Pointee: 1036 StructureType archive/zip.dirWriter
+      Pointee: 1052 StructureType archive/zip.dirWriter
     - __kind: PointerType
-      ID: 1128
+      ID: 1144
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.92512e+06
       GoKind: 22
-      Pointee: 1129 UnresolvedPointeeType archive/zip.fileWriter
+      Pointee: 1145 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
-      ID: 1061
+      ID: 1077
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1.067264e+06
       GoKind: 22
-      Pointee: 1062 StructureType archive/zip.nopCloser
+      Pointee: 1078 StructureType archive/zip.nopCloser
     - __kind: PointerType
-      ID: 1063
+      ID: 1079
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
       GoRuntimeType: 1.06752e+06
       GoKind: 22
-      Pointee: 1064 UnresolvedPointeeType archive/zip.pooledFlateWriter
+      Pointee: 1080 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -8416,26 +8522,26 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 1109
+      ID: 1125
       Name: '*bufio.Reader'
       ByteSize: 8
       GoRuntimeType: 2.198464e+06
       GoKind: 22
-      Pointee: 1110 UnresolvedPointeeType bufio.Reader
+      Pointee: 1126 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
-      ID: 1138
+      ID: 1154
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1.971136e+06
       GoKind: 22
-      Pointee: 1139 UnresolvedPointeeType bufio.Writer
+      Pointee: 1155 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
-      ID: 1187
+      ID: 1203
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.300448e+06
       GoKind: 22
-      Pointee: 1188 UnresolvedPointeeType bytes.Buffer
+      Pointee: 1204 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
       ID: 114
       Name: '*complex128'
@@ -8444,388 +8550,388 @@ Types:
       GoKind: 22
       Pointee: 18 BaseType complex128
     - __kind: PointerType
-      ID: 700
+      ID: 716
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 923488
       GoKind: 22
-      Pointee: 589 BaseType compress/flate.CorruptInputError
+      Pointee: 605 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 701
+      ID: 717
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 923584
       GoKind: 22
-      Pointee: 590 GoStringHeaderType compress/flate.InternalError
+      Pointee: 606 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 592
+      ID: 608
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 591 GoStringDataType compress/flate.InternalError.str
+      Pointee: 607 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 1083
+      ID: 1099
       Name: '*compress/flate.Writer'
       ByteSize: 8
       GoRuntimeType: 1.437152e+06
       GoKind: 22
-      Pointee: 1084 UnresolvedPointeeType compress/flate.Writer
+      Pointee: 1100 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
-      ID: 1029
+      ID: 1045
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
       GoRuntimeType: 923680
       GoKind: 22
-      Pointee: 1030 UnresolvedPointeeType compress/flate.dictWriter
+      Pointee: 1046 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
-      ID: 1105
+      ID: 1121
       Name: '*compress/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.744256e+06
       GoKind: 22
-      Pointee: 1106 UnresolvedPointeeType compress/gzip.Writer
+      Pointee: 1122 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
-      ID: 933
+      ID: 949
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.212928e+06
       GoKind: 22
-      Pointee: 934 StructureType context.deadlineExceededError
+      Pointee: 950 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 777
+      ID: 793
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 935968
       GoKind: 22
-      Pointee: 600 BaseType crypto/aes.KeySizeError
+      Pointee: 616 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 778
+      ID: 794
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 936160
       GoKind: 22
-      Pointee: 601 BaseType crypto/des.KeySizeError
+      Pointee: 617 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 779
+      ID: 795
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 936448
       GoKind: 22
-      Pointee: 602 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 618 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 1100
+      ID: 1116
       Name: '*crypto/internal/fips140/hmac.HMAC'
       ByteSize: 8
       GoRuntimeType: 1.6848e+06
       GoKind: 22
-      Pointee: 1101 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
+      Pointee: 1117 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
     - __kind: PointerType
-      ID: 882
+      ID: 898
       Name: '*crypto/internal/fips140/hmac.errCloneUnsupported'
       ByteSize: 8
       GoRuntimeType: 1.075072e+06
       GoKind: 22
-      Pointee: 883 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
+      Pointee: 899 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
     - __kind: PointerType
-      ID: 1130
+      ID: 1146
       Name: '*crypto/internal/fips140/sha256.Digest'
       ByteSize: 8
       GoRuntimeType: 1.925632e+06
       GoKind: 22
-      Pointee: 1131 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
+      Pointee: 1147 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
     - __kind: PointerType
-      ID: 1162
+      ID: 1178
       Name: '*crypto/internal/fips140/sha3.Digest'
       ByteSize: 8
       GoRuntimeType: 2.142464e+06
       GoKind: 22
-      Pointee: 1163 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
+      Pointee: 1179 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
     - __kind: PointerType
-      ID: 1136
+      ID: 1152
       Name: '*crypto/internal/fips140/sha3.SHAKE'
       ByteSize: 8
       GoRuntimeType: 1.9264e+06
       GoKind: 22
-      Pointee: 1137 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
+      Pointee: 1153 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
     - __kind: PointerType
-      ID: 1132
+      ID: 1148
       Name: '*crypto/internal/fips140/sha512.Digest'
       ByteSize: 8
       GoRuntimeType: 1.925888e+06
       GoKind: 22
-      Pointee: 1133 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
+      Pointee: 1149 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
     - __kind: PointerType
-      ID: 1126
+      ID: 1142
       Name: '*crypto/md5.digest'
       ByteSize: 8
       GoRuntimeType: 1.923072e+06
       GoKind: 22
-      Pointee: 1127 UnresolvedPointeeType crypto/md5.digest
+      Pointee: 1143 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
-      ID: 780
+      ID: 796
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 936736
       GoKind: 22
-      Pointee: 603 BaseType crypto/rc4.KeySizeError
+      Pointee: 619 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 1149
+      ID: 1165
       Name: '*crypto/sha1.digest'
       ByteSize: 8
       GoRuntimeType: 2.006784e+06
       GoKind: 22
-      Pointee: 1150 UnresolvedPointeeType crypto/sha1.digest
+      Pointee: 1166 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
-      ID: 1134
+      ID: 1150
       Name: '*crypto/sha3.SHA3'
       ByteSize: 8
       GoRuntimeType: 1.926144e+06
       GoKind: 22
-      Pointee: 1135 UnresolvedPointeeType crypto/sha3.SHA3
+      Pointee: 1151 UnresolvedPointeeType crypto/sha3.SHA3
     - __kind: PointerType
-      ID: 1118
+      ID: 1134
       Name: '*crypto/sha3.SHAKE'
       ByteSize: 8
       GoRuntimeType: 1.827808e+06
       GoKind: 22
-      Pointee: 1119 UnresolvedPointeeType crypto/sha3.SHAKE
+      Pointee: 1135 UnresolvedPointeeType crypto/sha3.SHAKE
     - __kind: PointerType
-      ID: 704
+      ID: 720
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 925024
       GoKind: 22
-      Pointee: 593 BaseType crypto/tls.AlertError
+      Pointee: 609 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 871
+      ID: 887
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1.056512e+06
       GoKind: 22
-      Pointee: 872 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 888 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 1213
+      ID: 1229
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2.403168e+06
       GoKind: 22
-      Pointee: 1214 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 1230 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 705
+      ID: 721
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 925120
       GoKind: 22
-      Pointee: 706 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 722 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 702
+      ID: 718
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 924928
       GoKind: 22
-      Pointee: 703 StructureType crypto/tls.RecordHeaderError
+      Pointee: 719 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 870
+      ID: 886
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1.054848e+06
       GoKind: 22
-      Pointee: 825 BaseType crypto/tls.alert
+      Pointee: 841 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 1093
+      ID: 1109
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
       GoRuntimeType: 1.575104e+06
       GoKind: 22
-      Pointee: 1094 UnresolvedPointeeType crypto/tls.cthWrapper
+      Pointee: 1110 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
-      ID: 707
+      ID: 723
       Name: '*crypto/tls.echConfigErr'
       ByteSize: 8
       GoRuntimeType: 925216
       GoKind: 22
-      Pointee: 708 UnresolvedPointeeType crypto/tls.echConfigErr
+      Pointee: 724 UnresolvedPointeeType crypto/tls.echConfigErr
     - __kind: PointerType
-      ID: 1098
+      ID: 1114
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
       GoRuntimeType: 1.65888e+06
       GoKind: 22
-      Pointee: 1099 UnresolvedPointeeType crypto/tls.finishedHash
+      Pointee: 1115 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
-      ID: 968
+      ID: 984
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1.437632e+06
       GoKind: 22
-      Pointee: 969 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 985 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 985
+      ID: 1001
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.035424e+06
       GoKind: 22
-      Pointee: 986 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 1002 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 773
+      ID: 789
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 934816
       GoKind: 22
-      Pointee: 774 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 790 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 767
+      ID: 783
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 933856
       GoKind: 22
-      Pointee: 768 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 784 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 769
+      ID: 785
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 934336
       GoKind: 22
-      Pointee: 770 StructureType crypto/x509.HostnameError
+      Pointee: 786 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 766
+      ID: 782
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 933760
       GoKind: 22
-      Pointee: 599 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 615 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 876
+      ID: 892
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1.06176e+06
       GoKind: 22
-      Pointee: 877 StructureType crypto/x509.SystemRootsError
+      Pointee: 893 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 775
+      ID: 791
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 934912
       GoKind: 22
-      Pointee: 776 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 792 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 771
+      ID: 787
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 934720
       GoKind: 22
-      Pointee: 772 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 788 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 789
+      ID: 805
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 941824
       GoKind: 22
-      Pointee: 790 StructureType encoding/asn1.StructuralError
+      Pointee: 806 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 793
+      ID: 809
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 942016
       GoKind: 22
-      Pointee: 794 StructureType encoding/asn1.SyntaxError
+      Pointee: 810 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 791
+      ID: 807
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 941920
       GoKind: 22
-      Pointee: 792 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 808 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 689
+      ID: 705
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 921472
       GoKind: 22
-      Pointee: 584 BaseType encoding/base64.CorruptInputError
+      Pointee: 600 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 1051
+      ID: 1067
       Name: '*encoding/base64.encoder'
       ByteSize: 8
       GoRuntimeType: 1.051904e+06
       GoKind: 22
-      Pointee: 1052 UnresolvedPointeeType encoding/base64.encoder
+      Pointee: 1068 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
-      ID: 692
+      ID: 708
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 922336
       GoKind: 22
-      Pointee: 585 BaseType encoding/hex.InvalidByteError
+      Pointee: 601 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 660
+      ID: 676
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 916288
       GoKind: 22
-      Pointee: 661 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 677 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 860
+      ID: 876
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1.048064e+06
       GoKind: 22
-      Pointee: 861 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 877 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 652
+      ID: 668
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 915904
       GoKind: 22
-      Pointee: 653 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 669 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 658
+      ID: 674
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 916192
       GoKind: 22
-      Pointee: 659 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 675 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 656
+      ID: 672
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 916096
       GoKind: 22
-      Pointee: 657 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 673 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 654
+      ID: 670
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 916000
       GoKind: 22
-      Pointee: 655 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 671 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 1193
+      ID: 1209
       Name: '*encoding/json.encodeState'
       ByteSize: 8
       GoRuntimeType: 2.321568e+06
       GoKind: 22
-      Pointee: 1194 UnresolvedPointeeType encoding/json.encodeState
+      Pointee: 1210 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 662
+      ID: 678
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 916672
       GoKind: 22
-      Pointee: 663 StructureType encoding/json.jsonError
+      Pointee: 679 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 1059
+      ID: 1075
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
       GoRuntimeType: 1.064064e+06
       GoKind: 22
-      Pointee: 1060 UnresolvedPointeeType encoding/pem.lineBreaker
+      Pointee: 1076 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
-      ID: 764
+      ID: 780
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 932992
       GoKind: 22
-      Pointee: 765 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 781 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
       ID: 111
       Name: '*error'
@@ -8834,19 +8940,19 @@ Types:
       GoKind: 22
       Pointee: 15 GoInterfaceType error
     - __kind: PointerType
-      ID: 625
+      ID: 641
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 905920
       GoKind: 22
-      Pointee: 626 UnresolvedPointeeType errors.errorString
+      Pointee: 642 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 827
+      ID: 843
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1.032704e+06
       GoKind: 22
-      Pointee: 828 UnresolvedPointeeType errors.joinError
+      Pointee: 844 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 113
       Name: '*float32'
@@ -8862,813 +8968,813 @@ Types:
       GoKind: 22
       Pointee: 13 BaseType float64
     - __kind: PointerType
-      ID: 1181
+      ID: 1197
       Name: '*fmt.pp'
       ByteSize: 8
       GoRuntimeType: 2.283008e+06
       GoKind: 22
-      Pointee: 1182 UnresolvedPointeeType fmt.pp
+      Pointee: 1198 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
-      ID: 829
+      ID: 845
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.032832e+06
       GoKind: 22
-      Pointee: 830 UnresolvedPointeeType fmt.wrapError
+      Pointee: 846 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 831
+      ID: 847
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1.03296e+06
       GoKind: 22
-      Pointee: 832 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 848 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 690
+      ID: 706
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 921856
       GoKind: 22
-      Pointee: 691 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 707 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 671
+      ID: 687
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 919072
       GoKind: 22
-      Pointee: 672 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 688 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 673
+      ID: 689
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 919168
       GoKind: 22
-      Pointee: 674 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 690 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 997
+      ID: 1013
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 918880
       GoKind: 22
-      Pointee: 998 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 1014 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 677
+      ID: 693
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 919456
       GoKind: 22
-      Pointee: 678 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 694 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 999
+      ID: 1015
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 918976
       GoKind: 22
-      Pointee: 1000 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 1016 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 675
+      ID: 691
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 919264
       GoKind: 22
-      Pointee: 578 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 594 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 580
+      ID: 596
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 579 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 595 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 670
+      ID: 686
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 918784
       GoKind: 22
-      Pointee: 575 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 591 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 577
+      ID: 593
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 576 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 592 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 676
+      ID: 692
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 919360
       GoKind: 22
-      Pointee: 581 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 597 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 583
+      ID: 599
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 582 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 598 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 1071
+      ID: 1087
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
       GoRuntimeType: 1.218432e+06
       GoKind: 22
-      Pointee: 1072 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      Pointee: 1088 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
-      ID: 1159
+      ID: 1175
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
       GoRuntimeType: 2.080576e+06
       GoKind: 22
-      Pointee: 1160 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      Pointee: 1176 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
-      ID: 783
+      ID: 799
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 940288
       GoKind: 22
-      Pointee: 784 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 800 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 942
+      ID: 958
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1.221888e+06
       GoKind: 22
-      Pointee: 943 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 959 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 1189
+      ID: 1205
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
       GoRuntimeType: 2.300992e+06
       GoKind: 22
-      Pointee: 1190 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      Pointee: 1206 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
-      ID: 715
+      ID: 731
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 928672
       GoKind: 22
-      Pointee: 716 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 732 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 722
+      ID: 738
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 929728
       GoKind: 22
-      Pointee: 723 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 739 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 717
+      ID: 733
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 929440
       GoKind: 22
-      Pointee: 598 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 614 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 720
+      ID: 736
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 929632
       GoKind: 22
-      Pointee: 721 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 737 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 718
+      ID: 734
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 929536
       GoKind: 22
-      Pointee: 719 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 735 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 738
+      ID: 754
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 931648
       GoKind: 22
-      Pointee: 739 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 755 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 742
+      ID: 758
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 931840
       GoKind: 22
-      Pointee: 743 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 759 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 740
+      ID: 756
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 931744
       GoKind: 22
-      Pointee: 741 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 757 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 736
+      ID: 752
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 931552
       GoKind: 22
-      Pointee: 737 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 753 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 1022
+      ID: 1038
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 1021 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 1037 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 750
+      ID: 766
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 932224
       GoKind: 22
-      Pointee: 751 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 767 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 744
+      ID: 760
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 931936
       GoKind: 22
-      Pointee: 745 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 761 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 748
+      ID: 764
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 932128
       GoKind: 22
-      Pointee: 749 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 765 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 746
+      ID: 762
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 932032
       GoKind: 22
-      Pointee: 747 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 763 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 752
+      ID: 768
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 932320
       GoKind: 22
-      Pointee: 753 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 769 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 758
+      ID: 774
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 932608
       GoKind: 22
-      Pointee: 759 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 775 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 760
+      ID: 776
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 932704
       GoKind: 22
-      Pointee: 761 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 777 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 756
+      ID: 772
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 932512
       GoKind: 22
-      Pointee: 757 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 773 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 754
+      ID: 770
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 932416
       GoKind: 22
-      Pointee: 755 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 771 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 762
+      ID: 778
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 932896
       GoKind: 22
-      Pointee: 763 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 779 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 679
+      ID: 695
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 920608
       GoKind: 22
-      Pointee: 680 StructureType github.com/cihub/seelog.baseError
+      Pointee: 696 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 1112
+      ID: 1128
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1.822432e+06
       GoKind: 22
-      Pointee: 1113 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 1129 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 681
+      ID: 697
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 920704
       GoKind: 22
-      Pointee: 682 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 698 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 1091
+      ID: 1107
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
       GoRuntimeType: 1.573824e+06
       GoKind: 22
-      Pointee: 1092 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+      Pointee: 1108 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
-      ID: 1047
+      ID: 1063
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
       GoRuntimeType: 1.050752e+06
       GoKind: 22
-      Pointee: 1048 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+      Pointee: 1064 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
-      ID: 1081
+      ID: 1097
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.435232e+06
       GoKind: 22
-      Pointee: 1082 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+      Pointee: 1098 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
-      ID: 685
+      ID: 701
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 920896
       GoKind: 22
-      Pointee: 686 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 702 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 1147
+      ID: 1163
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.99872e+06
       GoKind: 22
-      Pointee: 1148 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+      Pointee: 1164 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
-      ID: 1166
+      ID: 1182
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
       GoRuntimeType: 2.156256e+06
       GoKind: 22
-      Pointee: 1161 StructureType github.com/cihub/seelog.rollingFileWriterSize
+      Pointee: 1177 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
-      ID: 1165
+      ID: 1181
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
       GoRuntimeType: 2.155872e+06
       GoKind: 22
-      Pointee: 1164 StructureType github.com/cihub/seelog.rollingFileWriterTime
+      Pointee: 1180 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
-      ID: 1049
+      ID: 1065
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
       GoRuntimeType: 1.05088e+06
       GoKind: 22
-      Pointee: 1050 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+      Pointee: 1066 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
-      ID: 683
+      ID: 699
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 920800
       GoKind: 22
-      Pointee: 684 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 700 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 687
+      ID: 703
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 920992
       GoKind: 22
-      Pointee: 688 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 704 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 1114
+      ID: 1130
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.824224e+06
       GoKind: 22
-      Pointee: 1115 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+      Pointee: 1131 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
-      ID: 1155
+      ID: 1171
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 2.035136e+06
       GoKind: 22
-      Pointee: 1156 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+      Pointee: 1172 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
-      ID: 1157
+      ID: 1173
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
       GoRuntimeType: 2.066208e+06
       GoKind: 22
-      Pointee: 1158 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+      Pointee: 1174 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
-      ID: 973
+      ID: 989
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1.450752e+06
       GoKind: 22
-      Pointee: 974 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 990 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 886
+      ID: 902
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.07584e+06
       GoKind: 22
-      Pointee: 887 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 903 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 884
+      ID: 900
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1.075712e+06
       GoKind: 22
-      Pointee: 885 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 901 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 888
+      ID: 904
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.079808e+06
       GoKind: 22
-      Pointee: 889 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 905 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 890
+      ID: 906
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1.079936e+06
       GoKind: 22
-      Pointee: 891 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 907 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 1102
+      ID: 1118
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
       GoRuntimeType: 1.68768e+06
       GoKind: 22
-      Pointee: 1103 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+      Pointee: 1119 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
-      ID: 878
+      ID: 894
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.062272e+06
       GoKind: 22
-      Pointee: 879 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 895 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 693
+      ID: 709
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 922528
       GoKind: 22
-      Pointee: 694 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 710 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 1205
+      ID: 1221
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
       GoRuntimeType: 2.376896e+06
       GoKind: 22
-      Pointee: 1206 UnresolvedPointeeType github.com/json-iterator/go.Stream
+      Pointee: 1222 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
-      ID: 944
+      ID: 960
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1.230976e+06
       GoKind: 22
-      Pointee: 945 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 961 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 917
+      ID: 933
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1.209472e+06
       GoKind: 22
-      Pointee: 918 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 934 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 911
+      ID: 927
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1.209088e+06
       GoKind: 22
-      Pointee: 912 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 928 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 846
+      ID: 862
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1.04192e+06
       GoKind: 22
-      Pointee: 847 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 863 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 923
+      ID: 939
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1.209856e+06
       GoKind: 22
-      Pointee: 924 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 940 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 845
+      ID: 861
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1.041792e+06
       GoKind: 22
-      Pointee: 824 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 840 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 915
+      ID: 931
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1.209344e+06
       GoKind: 22
-      Pointee: 916 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 932 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 913
+      ID: 929
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1.209216e+06
       GoKind: 22
-      Pointee: 914 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 930 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 921
+      ID: 937
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1.209728e+06
       GoKind: 22
-      Pointee: 922 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 938 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 919
+      ID: 935
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1.2096e+06
       GoKind: 22
-      Pointee: 920 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 936 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 1209
+      ID: 1225
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
       GoRuntimeType: 2.391136e+06
       GoKind: 22
-      Pointee: 1210 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+      Pointee: 1226 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
-      ID: 927
+      ID: 943
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1.21024e+06
       GoKind: 22
-      Pointee: 928 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 944 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 850
+      ID: 866
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1.042176e+06
       GoKind: 22
-      Pointee: 851 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 867 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 848
+      ID: 864
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1.042048e+06
       GoKind: 22
-      Pointee: 849 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 865 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 925
+      ID: 941
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1.210112e+06
       GoKind: 22
-      Pointee: 926 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 942 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 805
+      ID: 821
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 955072
       GoKind: 22
-      Pointee: 608 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 624 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 610
+      ID: 626
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 609 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 625 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 988
+      ID: 1004
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1.686144e+06
       GoKind: 22
-      Pointee: 989 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 1005 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 894
+      ID: 910
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1.094656e+06
       GoKind: 22
-      Pointee: 895 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 911 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 1077
+      ID: 1093
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
       GoRuntimeType: 1.271808e+06
       GoKind: 22
-      Pointee: 1078 StructureType go.uber.org/zap.nopCloserSink
+      Pointee: 1094 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
-      ID: 1171
+      ID: 1187
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.171232e+06
       GoKind: 22
-      Pointee: 1172 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+      Pointee: 1188 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
-      ID: 1065
+      ID: 1081
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
       GoRuntimeType: 1.09696e+06
       GoKind: 22
-      Pointee: 1066 StructureType go.uber.org/zap/zapcore.writerWrapper
+      Pointee: 1082 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
-      ID: 806
+      ID: 822
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 956320
       GoKind: 22
-      Pointee: 611 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 627 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 952
+      ID: 968
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1.273472e+06
       GoKind: 22
-      Pointee: 953 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 969 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 809
+      ID: 825
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 956608
       GoKind: 22
-      Pointee: 810 StructureType golang.org/x/net/http2.connError
+      Pointee: 826 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 808
+      ID: 824
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 956512
       GoKind: 22
-      Pointee: 615 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 631 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 617
+      ID: 633
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 616 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 632 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 812
+      ID: 828
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 956800
       GoKind: 22
-      Pointee: 621 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 637 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 623
+      ID: 639
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 622 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 638 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 811
+      ID: 827
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 956704
       GoKind: 22
-      Pointee: 618 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 634 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 620
+      ID: 636
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 619 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 635 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 807
+      ID: 823
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 956416
       GoKind: 22
-      Pointee: 612 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 628 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 614
+      ID: 630
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 613 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 629 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1169
+      ID: 1185
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.169312e+06
       GoKind: 22
-      Pointee: 1170 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1186 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 813
+      ID: 829
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 956896
       GoKind: 22
-      Pointee: 814 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 830 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 815
+      ID: 831
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 956992
       GoKind: 22
-      Pointee: 624 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 640 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 801
+      ID: 817
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 950272
       GoKind: 22
-      Pointee: 802 StructureType google.golang.org/grpc.dropError
+      Pointee: 818 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 950
+      ID: 966
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1.270528e+06
       GoKind: 22
-      Pointee: 951 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 967 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 975
+      ID: 991
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1.458112e+06
       GoKind: 22
-      Pointee: 976 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 992 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 803
+      ID: 819
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 953344
       GoKind: 22
-      Pointee: 804 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 820 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 1120
+      ID: 1136
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1.830048e+06
       GoKind: 22
-      Pointee: 1121 StructureType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 1137 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 1075
+      ID: 1091
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
       GoRuntimeType: 1.267072e+06
       GoKind: 22
-      Pointee: 1076 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+      Pointee: 1092 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
-      ID: 892
+      ID: 908
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1.088896e+06
       GoKind: 22
-      Pointee: 893 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 909 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 1037
+      ID: 1053
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
       GoRuntimeType: 953440
       GoKind: 22
-      Pointee: 1038 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+      Pointee: 1054 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
-      ID: 781
+      ID: 797
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 938176
       GoKind: 22
-      Pointee: 782 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 798 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 880
+      ID: 896
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1.0656e+06
       GoKind: 22
-      Pointee: 881 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 897 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 948
+      ID: 964
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.23776e+06
       GoKind: 22
-      Pointee: 949 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 965 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 946
+      ID: 962
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1.237504e+06
       GoKind: 22
-      Pointee: 947 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 963 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 795
+      ID: 811
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 942880
       GoKind: 22
-      Pointee: 796 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 812 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 797
+      ID: 813
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 942976
       GoKind: 22
-      Pointee: 798 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 814 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 730
+      ID: 746
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 930112
       GoKind: 22
-      Pointee: 731 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 747 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 1124
+      ID: 1140
       Name: '*hash/crc32.digest'
       ByteSize: 8
       GoRuntimeType: 1.921024e+06
       GoKind: 22
-      Pointee: 1125 UnresolvedPointeeType hash/crc32.digest
+      Pointee: 1141 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
-      ID: 816
+      ID: 832
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 957760
       GoKind: 22
-      Pointee: 817 UnresolvedPointeeType html/template.Error
+      Pointee: 833 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 104
       Name: '*int'
@@ -9712,61 +9818,61 @@ Types:
       GoKind: 22
       Pointee: 163 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 977
+      ID: 993
       Name: '*internal/abi.Type'
       ByteSize: 8
       GoRuntimeType: 2.221728e+06
       GoKind: 22
-      Pointee: 978 UnresolvedPointeeType internal/abi.Type
+      Pointee: 994 UnresolvedPointeeType internal/abi.Type
     - __kind: PointerType
-      ID: 698
+      ID: 714
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 923200
       GoKind: 22
-      Pointee: 699 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 715 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 696
+      ID: 712
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 923104
       GoKind: 22
-      Pointee: 697 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 713 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 1023
+      ID: 1039
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
       GoRuntimeType: 910912
       GoKind: 22
-      Pointee: 1024 UnresolvedPointeeType internal/godebug.runtimeStderr
+      Pointee: 1040 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
-      ID: 909
+      ID: 925
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.20832e+06
       GoKind: 22
-      Pointee: 910 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 926 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 1211
+      ID: 1227
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2.3968e+06
       GoKind: 22
-      Pointee: 1212 UnresolvedPointeeType internal/poll.FD
+      Pointee: 1228 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 907
+      ID: 923
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1.208192e+06
       GoKind: 22
-      Pointee: 908 StructureType internal/poll.errNetClosing
+      Pointee: 924 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 629
+      ID: 645
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 910144
       GoKind: 22
-      Pointee: 630 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 646 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
       ID: 99
       Name: '*internal/runtime/atomic.Pointer[runtime.m]'
@@ -9775,66 +9881,66 @@ Types:
       GoKind: 22
       Pointee: 100 UnresolvedPointeeType internal/runtime/atomic.Pointer[runtime.m]
     - __kind: PointerType
-      ID: 695
+      ID: 711
       Name: '*internal/runtime/cgroup.stringError'
       ByteSize: 8
       GoRuntimeType: 922912
       GoKind: 22
-      Pointee: 586 GoStringHeaderType internal/runtime/cgroup.stringError
+      Pointee: 602 GoStringHeaderType internal/runtime/cgroup.stringError
     - __kind: PointerType
-      ID: 588
+      ID: 604
       Name: '*internal/runtime/cgroup.stringError.str'
       ByteSize: 8
-      Pointee: 587 GoStringDataType internal/runtime/cgroup.stringError.str
+      Pointee: 603 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: PointerType
-      ID: 864
+      ID: 880
       Name: '*internal/runtime/maps.unhashableTypeError'
       ByteSize: 8
       GoRuntimeType: 1.053184e+06
       GoKind: 22
-      Pointee: 865 StructureType internal/runtime/maps.unhashableTypeError
+      Pointee: 881 StructureType internal/runtime/maps.unhashableTypeError
     - __kind: PointerType
-      ID: 638
+      ID: 654
       Name: '*internal/strconv.Error'
       ByteSize: 8
       GoRuntimeType: 912064
       GoKind: 22
-      Pointee: 555 BaseType internal/strconv.Error
+      Pointee: 571 BaseType internal/strconv.Error
     - __kind: PointerType
-      ID: 1069
+      ID: 1085
       Name: '*io.PipeWriter'
       ByteSize: 8
       GoRuntimeType: 1.199488e+06
       GoKind: 22
-      Pointee: 1070 UnresolvedPointeeType io.PipeWriter
+      Pointee: 1086 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
-      ID: 1067
+      ID: 1083
       Name: '*io.discard'
       ByteSize: 8
       GoRuntimeType: 1.199104e+06
       GoKind: 22
-      Pointee: 1068 StructureType io.discard
+      Pointee: 1084 StructureType io.discard
     - __kind: PointerType
-      ID: 1041
+      ID: 1057
       Name: '*io.multiWriter'
       ByteSize: 8
       GoRuntimeType: 1.033728e+06
       GoKind: 22
-      Pointee: 1042 UnresolvedPointeeType io.multiWriter
+      Pointee: 1058 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
-      ID: 905
+      ID: 921
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1.20768e+06
       GoKind: 22
-      Pointee: 906 UnresolvedPointeeType io/fs.PathError
+      Pointee: 922 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 1116
+      ID: 1132
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 1.824448e+06
       GoKind: 22
-      Pointee: 1117 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+      Pointee: 1133 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
       ID: 323
       Name: '*main.anotherStruct'
@@ -9842,19 +9948,19 @@ Types:
       GoKind: 22
       Pointee: 324 StructureType main.anotherStruct
     - __kind: PointerType
-      ID: 348
+      ID: 364
       Name: '*main.deepMap2'
       ByteSize: 8
       GoRuntimeType: 391584
       GoKind: 22
-      Pointee: 349 StructureType main.deepMap2
+      Pointee: 365 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 1255
+      ID: 1271
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 391520
       GoKind: 22
-      Pointee: 1256 UnresolvedPointeeType main.deepMap3
+      Pointee: 1272 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 155
       Name: '*main.deepMap7'
@@ -9863,19 +9969,19 @@ Types:
       GoKind: 22
       Pointee: 156 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 1289
+      ID: 1305
       Name: '*main.deepMap8'
       ByteSize: 8
       GoRuntimeType: 391200
       GoKind: 22
-      Pointee: 1290 StructureType main.deepMap8
+      Pointee: 1306 StructureType main.deepMap8
     - __kind: PointerType
-      ID: 1304
+      ID: 1320
       Name: '*main.deepMap9'
       ByteSize: 8
       GoRuntimeType: 391136
       GoKind: 22
-      Pointee: 1305 StructureType main.deepMap9
+      Pointee: 1321 StructureType main.deepMap9
     - __kind: PointerType
       ID: 139
       Name: '*main.deepPtr2'
@@ -9884,12 +9990,12 @@ Types:
       GoKind: 22
       Pointee: 140 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 1215
+      ID: 1231
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 392096
       GoKind: 22
-      Pointee: 1216 UnresolvedPointeeType main.deepPtr3
+      Pointee: 1232 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 141
       Name: '*main.deepPtr7'
@@ -9898,33 +10004,33 @@ Types:
       GoKind: 22
       Pointee: 142 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 1259
+      ID: 1275
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 391776
       GoKind: 22
-      Pointee: 1260 StructureType main.deepPtr8
+      Pointee: 1276 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 1261
+      ID: 1277
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 391712
       GoKind: 22
-      Pointee: 1262 StructureType main.deepPtr9
+      Pointee: 1278 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 146
       Name: '*main.deepSlice2'
       ByteSize: 8
       GoRuntimeType: 392736
       GoKind: 22
-      Pointee: 339 StructureType main.deepSlice2
+      Pointee: 355 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 1240
+      ID: 1256
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 392672
       GoKind: 22
-      Pointee: 1241 UnresolvedPointeeType main.deepSlice3
+      Pointee: 1257 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 147
       Name: '*main.deepSlice7'
@@ -9933,19 +10039,19 @@ Types:
       GoKind: 22
       Pointee: 148 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 1265
+      ID: 1281
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 392352
       GoKind: 22
-      Pointee: 1266 StructureType main.deepSlice8
+      Pointee: 1282 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 1271
+      ID: 1287
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 392288
       GoKind: 22
-      Pointee: 1272 StructureType main.deepSlice9
+      Pointee: 1288 StructureType main.deepSlice9
     - __kind: PointerType
       ID: 326
       Name: '*main.emptyStruct'
@@ -9960,14 +10066,14 @@ Types:
       GoKind: 22
       Pointee: 166 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 1232
+      ID: 1248
       Name: '*main.firstBehavior'
       ByteSize: 8
       GoRuntimeType: 905632
       GoKind: 22
-      Pointee: 327 StructureType main.firstBehavior
+      Pointee: 343 StructureType main.firstBehavior
     - __kind: PointerType
-      ID: 1321
+      ID: 1337
       Name: '*main.nestedStruct'
       ByteSize: 8
       GoRuntimeType: 392992
@@ -9987,19 +10093,19 @@ Types:
       GoKind: 22
       Pointee: 277 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 1233
+      ID: 1249
       Name: '*main.secondBehavior'
       ByteSize: 8
       GoRuntimeType: 905728
       GoKind: 22
-      Pointee: 1234 StructureType main.secondBehavior
+      Pointee: 1250 StructureType main.secondBehavior
     - __kind: PointerType
-      ID: 1220
+      ID: 1236
       Name: '*main.somethingImpl'
       ByteSize: 8
       GoRuntimeType: 905824
       GoKind: 22
-      Pointee: 1221 UnresolvedPointeeType main.somethingImpl
+      Pointee: 1237 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
       ID: 157
       Name: '*main.stringType1'
@@ -10007,28 +10113,28 @@ Types:
       GoKind: 22
       Pointee: 158 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 1218
+      ID: 1234
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 1217 GoStringDataType main.stringType1.str
+      Pointee: 1233 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 160
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 1219 GoStringHeaderType main.stringType2
+      Pointee: 1235 GoStringHeaderType main.stringType2
     - __kind: PointerType
-      ID: 1323
+      ID: 1339
       Name: '*main.stringType2.str'
       ByteSize: 8
-      Pointee: 1322 GoStringDataType main.stringType2.str
+      Pointee: 1338 GoStringDataType main.stringType2.str
     - __kind: PointerType
       ID: 280
       Name: '*main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 278 StructureType main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 400
+      ID: 416
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 391072
@@ -10052,10 +10158,10 @@ Types:
       GoKind: 22
       Pointee: 255 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 1237
+      ID: 1253
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 1236 GoSliceDataType main.t.array
+      Pointee: 1252 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 275
       Name: '*main.threeStringStruct'
@@ -10088,30 +10194,30 @@ Types:
       ByteSize: 8
       Pointee: 152 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1245
+      ID: 1261
       Name: '*map<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1246 GoSwissMapHeaderType map<int,*main.deepMap3>
+      Pointee: 1262 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1279
+      ID: 1295
       Name: '*map<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1280 GoSwissMapHeaderType map<int,*main.deepMap8>
+      Pointee: 1296 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1294
+      ID: 1310
       Name: '*map<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1295 GoSwissMapHeaderType map<int,*main.deepMap9>
+      Pointee: 1311 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: PointerType
       ID: 173
       Name: '*map<int,int>'
       ByteSize: 8
       Pointee: 174 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 1309
+      ID: 1325
       Name: '*map<int,interface {}>'
       ByteSize: 8
-      Pointee: 1310 GoSwissMapHeaderType map<int,interface {}>
+      Pointee: 1326 GoSwissMapHeaderType map<int,interface {}>
     - __kind: PointerType
       ID: 240
       Name: '*map<int,struct {}>'
@@ -10133,10 +10239,10 @@ Types:
       ByteSize: 8
       Pointee: 189 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 981
+      ID: 997
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 982 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 998 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 183
       Name: '*map<string,int>'
@@ -10204,696 +10310,696 @@ Types:
       GoKind: 22
       Pointee: 182 GoMapType map[string]int
     - __kind: PointerType
-      ID: 734
+      ID: 750
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 930976
       GoKind: 22
-      Pointee: 735 StructureType math/big.ErrNaN
+      Pointee: 751 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 1031
+      ID: 1047
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
       GoRuntimeType: 925792
       GoKind: 22
-      Pointee: 1032 StructureType mime/multipart.writerOnly·1
+      Pointee: 1048 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
-      ID: 936
+      ID: 952
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1.216256e+06
       GoKind: 22
-      Pointee: 937 UnresolvedPointeeType net.AddrError
+      Pointee: 953 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 962
+      ID: 978
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1.433472e+06
       GoKind: 22
-      Pointee: 963 UnresolvedPointeeType net.DNSError
+      Pointee: 979 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 1175
+      ID: 1191
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2.25712e+06
       GoKind: 22
-      Pointee: 1176 UnresolvedPointeeType net.IPConn
+      Pointee: 1192 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 960
+      ID: 976
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1.433152e+06
       GoKind: 22
-      Pointee: 961 UnresolvedPointeeType net.OpError
+      Pointee: 977 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 938
+      ID: 954
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.216384e+06
       GoKind: 22
-      Pointee: 939 UnresolvedPointeeType net.ParseError
+      Pointee: 955 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 1185
+      ID: 1201
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2.284032e+06
       GoKind: 22
-      Pointee: 1186 UnresolvedPointeeType net.TCPConn
+      Pointee: 1202 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 1195
+      ID: 1211
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2.329152e+06
       GoKind: 22
-      Pointee: 1196 UnresolvedPointeeType net.UDPConn
+      Pointee: 1212 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 1183
+      ID: 1199
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2.28352e+06
       GoKind: 22
-      Pointee: 1184 UnresolvedPointeeType net.UnixConn
+      Pointee: 1200 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 935
+      ID: 951
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1.215488e+06
       GoKind: 22
-      Pointee: 898 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 914 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 900
+      ID: 916
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 899 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 915 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 862
+      ID: 878
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1.04896e+06
       GoKind: 22
-      Pointee: 863 StructureType net.canceledError
+      Pointee: 879 StructureType net.canceledError
     - __kind: PointerType
-      ID: 1153
+      ID: 1169
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 2.032256e+06
       GoKind: 22
-      Pointee: 1154 UnresolvedPointeeType net.conn
+      Pointee: 1170 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 1006
+      ID: 1022
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1.86768e+06
       GoKind: 22
-      Pointee: 1007 StructureType net.dialResult·1
+      Pointee: 1023 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 1197
+      ID: 1213
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2.333408e+06
       GoKind: 22
-      Pointee: 1198 UnresolvedPointeeType net.netFD
+      Pointee: 1214 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 664
+      ID: 680
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 917632
       GoKind: 22
-      Pointee: 665 UnresolvedPointeeType net.notFoundError
+      Pointee: 681 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 666
+      ID: 682
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 918304
       GoKind: 22
-      Pointee: 667 StructureType net.result·2
+      Pointee: 683 StructureType net.result·2
     - __kind: PointerType
-      ID: 1179
+      ID: 1195
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.270048e+06
       GoKind: 22
-      Pointee: 1180 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 1196 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 1177
+      ID: 1193
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.269568e+06
       GoKind: 22
-      Pointee: 1178 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 1194 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 940
+      ID: 956
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1.217024e+06
       GoKind: 22
-      Pointee: 941 UnresolvedPointeeType net.temporaryError
+      Pointee: 957 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 964
+      ID: 980
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.433632e+06
       GoKind: 22
-      Pointee: 965 UnresolvedPointeeType net.timeoutError
+      Pointee: 981 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 852
+      ID: 868
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1.044736e+06
       GoKind: 22
-      Pointee: 853 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 869 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
-      ID: 1025
+      ID: 1041
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
       GoRuntimeType: 913408
       GoKind: 22
-      Pointee: 1026 StructureType net/http.bufioFlushWriter
+      Pointee: 1042 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
-      ID: 641
+      ID: 657
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 914080
       GoKind: 22
-      Pointee: 556 BaseType net/http.http2ConnectionError
+      Pointee: 572 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 642
+      ID: 658
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 914176
       GoKind: 22
-      Pointee: 643 StructureType net/http.http2GoAwayError
+      Pointee: 659 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 956
+      ID: 972
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1.429152e+06
       GoKind: 22
-      Pointee: 957 StructureType net/http.http2StreamError
+      Pointee: 973 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 646
+      ID: 662
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 914752
       GoKind: 22
-      Pointee: 647 StructureType net/http.http2connError
+      Pointee: 663 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 1087
+      ID: 1103
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
       GoRuntimeType: 1.569984e+06
       GoKind: 22
-      Pointee: 1088 UnresolvedPointeeType net/http.http2dataBuffer
+      Pointee: 1104 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 645
+      ID: 661
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 914656
       GoKind: 22
-      Pointee: 560 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 576 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 562
+      ID: 578
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 561 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 577 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 649
+      ID: 665
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 914944
       GoKind: 22
-      Pointee: 566 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 582 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 568
+      ID: 584
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 567 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 583 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 648
+      ID: 664
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 914848
       GoKind: 22
-      Pointee: 563 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 579 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 565
+      ID: 581
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 564 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 580 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 931
+      ID: 947
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1.21216e+06
       GoKind: 22
-      Pointee: 932 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 948 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 858
+      ID: 874
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1.045248e+06
       GoKind: 22
-      Pointee: 859 StructureType net/http.http2noCachedConnError
+      Pointee: 875 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 1142
+      ID: 1158
       Name: '*net/http.http2pipe'
       ByteSize: 8
       GoRuntimeType: 1.97344e+06
       GoKind: 22
-      Pointee: 1143 UnresolvedPointeeType net/http.http2pipe
+      Pointee: 1159 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 644
+      ID: 660
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 914560
       GoKind: 22
-      Pointee: 557 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 573 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 559
+      ID: 575
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 558 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 574 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1027
+      ID: 1043
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
       GoRuntimeType: 915040
       GoKind: 22
-      Pointee: 1028 StructureType net/http.http2stickyErrWriter
+      Pointee: 1044 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
-      ID: 854
+      ID: 870
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1.044992e+06
       GoKind: 22
-      Pointee: 855 StructureType net/http.nothingWrittenError
+      Pointee: 871 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 1089
+      ID: 1105
       Name: '*net/http.persistConn'
       ByteSize: 8
       GoRuntimeType: 2.217984e+06
       GoKind: 22
-      Pointee: 1090 UnresolvedPointeeType net/http.persistConn
+      Pointee: 1106 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
-      ID: 1045
+      ID: 1061
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
       GoRuntimeType: 1.044864e+06
       GoKind: 22
-      Pointee: 1046 StructureType net/http.persistConnWriter
+      Pointee: 1062 StructureType net/http.persistConnWriter
     - __kind: PointerType
-      ID: 1079
+      ID: 1095
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1.429312e+06
       GoKind: 22
-      Pointee: 1080 StructureType net/http.readWriteCloserBody
+      Pointee: 1096 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 650
+      ID: 666
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 915136
       GoKind: 22
-      Pointee: 651 StructureType net/http.requestBodyReadError
+      Pointee: 667 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 958
+      ID: 974
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.430432e+06
       GoKind: 22
-      Pointee: 959 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 975 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 929
+      ID: 945
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1.212032e+06
       GoKind: 22
-      Pointee: 930 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 946 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 856
+      ID: 872
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1.04512e+06
       GoKind: 22
-      Pointee: 857 StructureType net/http.transportReadFromServerError
+      Pointee: 873 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 1122
+      ID: 1138
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
       GoRuntimeType: 1.863872e+06
       GoKind: 22
-      Pointee: 1123 StructureType net/http.unencryptedNetConnInTLSConn
+      Pointee: 1139 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 639
+      ID: 655
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 913312
       GoKind: 22
-      Pointee: 640 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 656 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 1144
+      ID: 1160
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
       GoRuntimeType: 1.975232e+06
       GoKind: 22
-      Pointee: 1145 StructureType net/http/internal.FlushAfterChunkWriter
+      Pointee: 1161 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
-      ID: 1055
+      ID: 1071
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
       GoRuntimeType: 1.057536e+06
       GoKind: 22
-      Pointee: 1056 UnresolvedPointeeType net/http/internal.chunkedWriter
+      Pointee: 1072 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
-      ID: 726
+      ID: 742
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 929920
       GoKind: 22
-      Pointee: 727 StructureType net/netip.parseAddrError
+      Pointee: 743 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 724
+      ID: 740
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 929824
       GoKind: 22
-      Pointee: 725 StructureType net/netip.parsePrefixError
+      Pointee: 741 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 1095
+      ID: 1111
       Name: '*net/smtp.Client'
       ByteSize: 8
       GoRuntimeType: 2.141056e+06
       GoKind: 22
-      Pointee: 1096 UnresolvedPointeeType net/smtp.Client
+      Pointee: 1112 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
-      ID: 1057
+      ID: 1073
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
       GoRuntimeType: 1.061888e+06
       GoKind: 22
-      Pointee: 1058 StructureType net/smtp.dataCloser
+      Pointee: 1074 StructureType net/smtp.dataCloser
     - __kind: PointerType
-      ID: 710
+      ID: 726
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 925984
       GoKind: 22
-      Pointee: 711 UnresolvedPointeeType net/textproto.Error
+      Pointee: 727 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 709
+      ID: 725
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 925888
       GoKind: 22
-      Pointee: 594 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 610 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 596
+      ID: 612
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 595 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 611 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 1053
+      ID: 1069
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
       GoRuntimeType: 1.057024e+06
       GoKind: 22
-      Pointee: 1054 UnresolvedPointeeType net/textproto.dotWriter
+      Pointee: 1070 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
-      ID: 966
+      ID: 982
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1.433952e+06
       GoKind: 22
-      Pointee: 967 UnresolvedPointeeType net/url.Error
+      Pointee: 983 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 668
+      ID: 684
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 918400
       GoKind: 22
-      Pointee: 569 GoStringHeaderType net/url.EscapeError
+      Pointee: 585 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 571
+      ID: 587
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 570 GoStringDataType net/url.EscapeError.str
+      Pointee: 586 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 669
+      ID: 685
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 918496
       GoKind: 22
-      Pointee: 572 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 588 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 574
+      ID: 590
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 573 GoStringDataType net/url.InvalidHostError.str
-    - __kind: PointerType
-      ID: 446
-      Name: '*noalg.map.group[[4]int][4]int'
-      ByteSize: 8
-      Pointee: 447 StructureType noalg.map.group[[4]int][4]int
-    - __kind: PointerType
-      ID: 438
-      Name: '*noalg.map.group[[4]int]uint8'
-      ByteSize: 8
-      Pointee: 439 StructureType noalg.map.group[[4]int]uint8
-    - __kind: PointerType
-      ID: 386
-      Name: '*noalg.map.group[[4]string][2]int'
-      ByteSize: 8
-      Pointee: 387 StructureType noalg.map.group[[4]string][2]int
-    - __kind: PointerType
-      ID: 405
-      Name: '*noalg.map.group[bool]main.node'
-      ByteSize: 8
-      Pointee: 406 StructureType noalg.map.group[bool]main.node
-    - __kind: PointerType
-      ID: 344
-      Name: '*noalg.map.group[int]*main.deepMap2'
-      ByteSize: 8
-      Pointee: 345 StructureType noalg.map.group[int]*main.deepMap2
-    - __kind: PointerType
-      ID: 1251
-      Name: '*noalg.map.group[int]*main.deepMap3'
-      ByteSize: 8
-      Pointee: 1252 StructureType noalg.map.group[int]*main.deepMap3
-    - __kind: PointerType
-      ID: 1285
-      Name: '*noalg.map.group[int]*main.deepMap8'
-      ByteSize: 8
-      Pointee: 1286 StructureType noalg.map.group[int]*main.deepMap8
-    - __kind: PointerType
-      ID: 1300
-      Name: '*noalg.map.group[int]*main.deepMap9'
-      ByteSize: 8
-      Pointee: 1301 StructureType noalg.map.group[int]*main.deepMap9
-    - __kind: PointerType
-      ID: 354
-      Name: '*noalg.map.group[int]int'
-      ByteSize: 8
-      Pointee: 355 StructureType noalg.map.group[int]int
-    - __kind: PointerType
-      ID: 1315
-      Name: '*noalg.map.group[int]interface {}'
-      ByteSize: 8
-      Pointee: 1316 StructureType noalg.map.group[int]interface {}
+      Pointee: 589 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
       ID: 462
-      Name: '*noalg.map.group[int]struct {}'
+      Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 463 StructureType noalg.map.group[int]struct {}
-    - __kind: PointerType
-      ID: 413
-      Name: '*noalg.map.group[int]uint8'
-      ByteSize: 8
-      Pointee: 414 StructureType noalg.map.group[int]uint8
-    - __kind: PointerType
-      ID: 395
-      Name: '*noalg.map.group[string][]main.structWithMap'
-      ByteSize: 8
-      Pointee: 396 StructureType noalg.map.group[string][]main.structWithMap
-    - __kind: PointerType
-      ID: 378
-      Name: '*noalg.map.group[string][]string'
-      ByteSize: 8
-      Pointee: 379 StructureType noalg.map.group[string][]string
-    - __kind: PointerType
-      ID: 1013
-      Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
-      ByteSize: 8
-      Pointee: 1014 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-    - __kind: PointerType
-      ID: 370
-      Name: '*noalg.map.group[string]int'
-      ByteSize: 8
-      Pointee: 371 StructureType noalg.map.group[string]int
-    - __kind: PointerType
-      ID: 362
-      Name: '*noalg.map.group[string]main.nestedStruct'
-      ByteSize: 8
-      Pointee: 363 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 463 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
       ID: 454
-      Name: '*noalg.map.group[struct {}]int'
+      Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 455 StructureType noalg.map.group[struct {}]int
+      Pointee: 455 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 504
-      Name: '*noalg.map.group[struct {}]main.structWithCyclicMaps'
+      ID: 402
+      Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 505 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
-    - __kind: PointerType
-      ID: 512
-      Name: '*noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps'
-      ByteSize: 8
-      Pointee: 513 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
-    - __kind: PointerType
-      ID: 520
-      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
-      ByteSize: 8
-      Pointee: 521 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-    - __kind: PointerType
-      ID: 528
-      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
-      ByteSize: 8
-      Pointee: 529 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-    - __kind: PointerType
-      ID: 536
-      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
-      ByteSize: 8
-      Pointee: 537 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-    - __kind: PointerType
-      ID: 544
-      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
-      ByteSize: 8
-      Pointee: 545 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-    - __kind: PointerType
-      ID: 470
-      Name: '*noalg.map.group[struct {}]struct {}'
-      ByteSize: 8
-      Pointee: 471 StructureType noalg.map.group[struct {}]struct {}
-    - __kind: PointerType
-      ID: 429
-      Name: '*noalg.map.group[uint8][4]int'
-      ByteSize: 8
-      Pointee: 430 StructureType noalg.map.group[uint8][4]int
+      Pointee: 403 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
       ID: 421
+      Name: '*noalg.map.group[bool]main.node'
+      ByteSize: 8
+      Pointee: 422 StructureType noalg.map.group[bool]main.node
+    - __kind: PointerType
+      ID: 360
+      Name: '*noalg.map.group[int]*main.deepMap2'
+      ByteSize: 8
+      Pointee: 361 StructureType noalg.map.group[int]*main.deepMap2
+    - __kind: PointerType
+      ID: 1267
+      Name: '*noalg.map.group[int]*main.deepMap3'
+      ByteSize: 8
+      Pointee: 1268 StructureType noalg.map.group[int]*main.deepMap3
+    - __kind: PointerType
+      ID: 1301
+      Name: '*noalg.map.group[int]*main.deepMap8'
+      ByteSize: 8
+      Pointee: 1302 StructureType noalg.map.group[int]*main.deepMap8
+    - __kind: PointerType
+      ID: 1316
+      Name: '*noalg.map.group[int]*main.deepMap9'
+      ByteSize: 8
+      Pointee: 1317 StructureType noalg.map.group[int]*main.deepMap9
+    - __kind: PointerType
+      ID: 370
+      Name: '*noalg.map.group[int]int'
+      ByteSize: 8
+      Pointee: 371 StructureType noalg.map.group[int]int
+    - __kind: PointerType
+      ID: 1331
+      Name: '*noalg.map.group[int]interface {}'
+      ByteSize: 8
+      Pointee: 1332 StructureType noalg.map.group[int]interface {}
+    - __kind: PointerType
+      ID: 478
+      Name: '*noalg.map.group[int]struct {}'
+      ByteSize: 8
+      Pointee: 479 StructureType noalg.map.group[int]struct {}
+    - __kind: PointerType
+      ID: 429
+      Name: '*noalg.map.group[int]uint8'
+      ByteSize: 8
+      Pointee: 430 StructureType noalg.map.group[int]uint8
+    - __kind: PointerType
+      ID: 411
+      Name: '*noalg.map.group[string][]main.structWithMap'
+      ByteSize: 8
+      Pointee: 412 StructureType noalg.map.group[string][]main.structWithMap
+    - __kind: PointerType
+      ID: 394
+      Name: '*noalg.map.group[string][]string'
+      ByteSize: 8
+      Pointee: 395 StructureType noalg.map.group[string][]string
+    - __kind: PointerType
+      ID: 1029
+      Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
+      ByteSize: 8
+      Pointee: 1030 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+    - __kind: PointerType
+      ID: 386
+      Name: '*noalg.map.group[string]int'
+      ByteSize: 8
+      Pointee: 387 StructureType noalg.map.group[string]int
+    - __kind: PointerType
+      ID: 378
+      Name: '*noalg.map.group[string]main.nestedStruct'
+      ByteSize: 8
+      Pointee: 379 StructureType noalg.map.group[string]main.nestedStruct
+    - __kind: PointerType
+      ID: 470
+      Name: '*noalg.map.group[struct {}]int'
+      ByteSize: 8
+      Pointee: 471 StructureType noalg.map.group[struct {}]int
+    - __kind: PointerType
+      ID: 520
+      Name: '*noalg.map.group[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 521 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 528
+      Name: '*noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 529 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 536
+      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 537 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 544
+      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 545 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 552
+      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 553 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 560
+      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 561 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 486
+      Name: '*noalg.map.group[struct {}]struct {}'
+      ByteSize: 8
+      Pointee: 487 StructureType noalg.map.group[struct {}]struct {}
+    - __kind: PointerType
+      ID: 445
+      Name: '*noalg.map.group[uint8][4]int'
+      ByteSize: 8
+      Pointee: 446 StructureType noalg.map.group[uint8][4]int
+    - __kind: PointerType
+      ID: 437
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 422 StructureType noalg.map.group[uint8]uint8
+      Pointee: 438 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
-      ID: 1203
+      ID: 1219
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2.37152e+06
       GoKind: 22
-      Pointee: 1204 UnresolvedPointeeType os.File
+      Pointee: 1220 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 833
+      ID: 849
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1.035776e+06
       GoKind: 22
-      Pointee: 834 UnresolvedPointeeType os.LinkError
+      Pointee: 850 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 901
+      ID: 917
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1.20064e+06
       GoKind: 22
-      Pointee: 902 UnresolvedPointeeType os.SyscallError
+      Pointee: 918 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 1201
+      ID: 1217
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.370784e+06
       GoKind: 22
-      Pointee: 1202 StructureType os.fileWithoutReadFrom
+      Pointee: 1218 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 1199
+      ID: 1215
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.370048e+06
       GoKind: 22
-      Pointee: 1200 StructureType os.fileWithoutWriteTo
+      Pointee: 1216 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 866
+      ID: 882
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1.053568e+06
       GoKind: 22
-      Pointee: 867 UnresolvedPointeeType os/exec.Error
+      Pointee: 883 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 1009
+      ID: 1025
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2.112672e+06
       GoKind: 22
-      Pointee: 1010 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 1026 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 1073
+      ID: 1089
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
       GoRuntimeType: 1.223296e+06
       GoKind: 22
-      Pointee: 1074 UnresolvedPointeeType os/exec.prefixSuffixSaver
+      Pointee: 1090 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
-      ID: 868
+      ID: 884
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1.053696e+06
       GoKind: 22
-      Pointee: 869 StructureType os/exec.wrappedError
+      Pointee: 885 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 800
+      ID: 816
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 948352
       GoKind: 22
-      Pointee: 605 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 621 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 607
+      ID: 623
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 606 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 622 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 799
+      ID: 815
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 948256
       GoKind: 22
-      Pointee: 604 BaseType os/user.UnknownUserIdError
+      Pointee: 620 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 631
+      ID: 647
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 910816
       GoKind: 22
-      Pointee: 632 UnresolvedPointeeType reflect.ValueError
+      Pointee: 648 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 732
+      ID: 748
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 930592
       GoKind: 22
-      Pointee: 733 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 749 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 837
+      ID: 853
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1.038592e+06
       GoKind: 22
-      Pointee: 838 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 854 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 841
+      ID: 857
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1.039232e+06
       GoKind: 22
-      Pointee: 842 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 858 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 27
       Name: '*runtime._defer'
@@ -10909,12 +11015,12 @@ Types:
       GoKind: 22
       Pointee: 26 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 839
+      ID: 855
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1.03872e+06
       GoKind: 22
-      Pointee: 840 StructureType runtime.boundsError
+      Pointee: 856 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 69
       Name: '*runtime.cgoCallers'
@@ -10930,24 +11036,24 @@ Types:
       GoKind: 22
       Pointee: 49 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 903
+      ID: 919
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1.206528e+06
       GoKind: 22
-      Pointee: 904 StructureType runtime.errorAddressString
+      Pointee: 920 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 835
+      ID: 851
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1.036928e+06
       GoKind: 22
-      Pointee: 818 GoStringHeaderType runtime.errorString
+      Pointee: 834 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 820
+      ID: 836
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 819 GoStringDataType runtime.errorString.str
+      Pointee: 835 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 59
       Name: '*runtime.g'
@@ -10968,19 +11074,19 @@ Types:
       ByteSize: 8
       GoRuntimeType: 1.038336e+06
       GoKind: 22
-      Pointee: 334 UnresolvedPointeeType runtime.p
+      Pointee: 350 UnresolvedPointeeType runtime.p
     - __kind: PointerType
-      ID: 836
+      ID: 852
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1.037056e+06
       GoKind: 22
-      Pointee: 821 GoStringHeaderType runtime.plainError
+      Pointee: 837 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 823
+      ID: 839
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 822 GoStringDataType runtime.plainError.str
+      Pointee: 838 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 42
       Name: '*runtime.sudog'
@@ -10996,12 +11102,12 @@ Types:
       GoKind: 22
       Pointee: 51 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
-      ID: 627
+      ID: 643
       Name: '*runtime.synctestDeadlockError'
       ByteSize: 8
       GoRuntimeType: 909472
       GoKind: 22
-      Pointee: 628 StructureType runtime.synctestDeadlockError
+      Pointee: 644 StructureType runtime.synctestDeadlockError
     - __kind: PointerType
       ID: 45
       Name: '*runtime.timer'
@@ -11024,12 +11130,12 @@ Types:
       GoKind: 22
       Pointee: 54 UnresolvedPointeeType runtime.xRegState
     - __kind: PointerType
-      ID: 843
+      ID: 859
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1.039488e+06
       GoKind: 22
-      Pointee: 844 UnresolvedPointeeType strconv.NumError
+      Pointee: 860 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 101
       Name: '*string'
@@ -11038,31 +11144,31 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 329
+      ID: 345
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 328 GoStringDataType string.str
+      Pointee: 344 GoStringDataType string.str
     - __kind: PointerType
-      ID: 1140
+      ID: 1156
       Name: '*strings.Builder'
       ByteSize: 8
       GoRuntimeType: 1.97216e+06
       GoKind: 22
-      Pointee: 1141 UnresolvedPointeeType strings.Builder
+      Pointee: 1157 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
-      ID: 1043
+      ID: 1059
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
       GoRuntimeType: 1.039616e+06
       GoKind: 22
-      Pointee: 1044 UnresolvedPointeeType strings.appendSliceWriter
+      Pointee: 1060 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
-      ID: 1039
+      ID: 1055
       Name: '*struct { io.Writer }'
       ByteSize: 8
       GoRuntimeType: 981824
       GoKind: 22
-      Pointee: 1040 StructureType struct { io.Writer }
+      Pointee: 1056 StructureType struct { io.Writer }
     - __kind: PointerType
       ID: 273
       Name: '*struct {}'
@@ -11071,194 +11177,194 @@ Types:
       GoKind: 22
       Pointee: 131 StructureType struct {}
     - __kind: PointerType
-      ID: 955
+      ID: 971
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1.428672e+06
       GoKind: 22
-      Pointee: 954 BaseType syscall.Errno
+      Pointee: 970 BaseType syscall.Errno
     - __kind: PointerType
       ID: 233
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 444 StructureType table<[4]int,[4]int>
+      Pointee: 460 StructureType table<[4]int,[4]int>
     - __kind: PointerType
       ID: 228
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 436 StructureType table<[4]int,uint8>
+      Pointee: 452 StructureType table<[4]int,uint8>
     - __kind: PointerType
       ID: 196
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 384 StructureType table<[4]string,[2]int>
+      Pointee: 400 StructureType table<[4]string,[2]int>
     - __kind: PointerType
       ID: 208
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 403 StructureType table<bool,main.node>
+      Pointee: 419 StructureType table<bool,main.node>
     - __kind: PointerType
       ID: 154
       Name: '*table<int,*main.deepMap2>'
       ByteSize: 8
-      Pointee: 342 StructureType table<int,*main.deepMap2>
+      Pointee: 358 StructureType table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1248
+      ID: 1264
       Name: '*table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1249 StructureType table<int,*main.deepMap3>
+      Pointee: 1265 StructureType table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1282
+      ID: 1298
       Name: '*table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1283 StructureType table<int,*main.deepMap8>
+      Pointee: 1299 StructureType table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1297
+      ID: 1313
       Name: '*table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1298 StructureType table<int,*main.deepMap9>
+      Pointee: 1314 StructureType table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 176
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 352 StructureType table<int,int>
+      Pointee: 368 StructureType table<int,int>
     - __kind: PointerType
-      ID: 1312
+      ID: 1328
       Name: '*table<int,interface {}>'
       ByteSize: 8
-      Pointee: 1313 StructureType table<int,interface {}>
+      Pointee: 1329 StructureType table<int,interface {}>
     - __kind: PointerType
       ID: 243
       Name: '*table<int,struct {}>'
       ByteSize: 8
-      Pointee: 460 StructureType table<int,struct {}>
+      Pointee: 476 StructureType table<int,struct {}>
     - __kind: PointerType
       ID: 213
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 411 StructureType table<int,uint8>
+      Pointee: 427 StructureType table<int,uint8>
     - __kind: PointerType
       ID: 203
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 393 StructureType table<string,[]main.structWithMap>
+      Pointee: 409 StructureType table<string,[]main.structWithMap>
     - __kind: PointerType
       ID: 191
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 376 StructureType table<string,[]string>
+      Pointee: 392 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 984
+      ID: 1000
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 1011 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 1027 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 186
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 368 StructureType table<string,int>
+      Pointee: 384 StructureType table<string,int>
     - __kind: PointerType
       ID: 181
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 360 StructureType table<string,main.nestedStruct>
+      Pointee: 376 StructureType table<string,main.nestedStruct>
     - __kind: PointerType
       ID: 238
       Name: '*table<struct {},int>'
       ByteSize: 8
-      Pointee: 452 StructureType table<struct {},int>
+      Pointee: 468 StructureType table<struct {},int>
     - __kind: PointerType
       ID: 296
       Name: '*table<struct {},main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 502 StructureType table<struct {},main.structWithCyclicMaps>
+      Pointee: 518 StructureType table<struct {},main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 301
       Name: '*table<struct {},map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 510 StructureType table<struct {},map[struct {}]main.structWithCyclicMaps>
+      Pointee: 526 StructureType table<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 306
       Name: '*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 518 StructureType table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 534 StructureType table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 311
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 526 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 542 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 316
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 534 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 550 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 321
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 542 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 558 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 248
       Name: '*table<struct {},struct {}>'
       ByteSize: 8
-      Pointee: 468 StructureType table<struct {},struct {}>
+      Pointee: 484 StructureType table<struct {},struct {}>
     - __kind: PointerType
       ID: 223
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 427 StructureType table<uint8,[4]int>
+      Pointee: 443 StructureType table<uint8,[4]int>
     - __kind: PointerType
       ID: 218
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 419 StructureType table<uint8,uint8>
+      Pointee: 435 StructureType table<uint8,uint8>
     - __kind: PointerType
-      ID: 1173
+      ID: 1189
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
       GoRuntimeType: 2.183456e+06
       GoKind: 22
-      Pointee: 1174 UnresolvedPointeeType text/tabwriter.Writer
+      Pointee: 1190 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
-      ID: 896
+      ID: 912
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1.098496e+06
       GoKind: 22
-      Pointee: 897 StructureType text/template.ExecError
+      Pointee: 913 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 971
+      ID: 987
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.640256e+06
       GoKind: 22
-      Pointee: 972 UnresolvedPointeeType time.Location
+      Pointee: 988 UnresolvedPointeeType time.Location
     - __kind: PointerType
-      ID: 636
+      ID: 652
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 911776
       GoKind: 22
-      Pointee: 637 UnresolvedPointeeType time.ParseError
+      Pointee: 653 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 633
+      ID: 649
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 911584
       GoKind: 22
-      Pointee: 552 GoStringHeaderType time.fileSizeError
+      Pointee: 568 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 554
+      ID: 570
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 553 GoStringDataType time.fileSizeError.str
+      Pointee: 569 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 634
+      ID: 650
       Name: '*time.parseDurationError'
       ByteSize: 8
       GoRuntimeType: 911680
       GoKind: 22
-      Pointee: 635 UnresolvedPointeeType time.parseDurationError
+      Pointee: 651 UnresolvedPointeeType time.parseDurationError
     - __kind: PointerType
       ID: 112
       Name: '*uint'
@@ -11302,52 +11408,88 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: PointerType
-      ID: 728
+      ID: 744
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 930016
       GoKind: 22
-      Pointee: 729 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 745 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 1167
+      ID: 1183
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.158944e+06
       GoKind: 22
-      Pointee: 1168 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1184 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 712
+      ID: 728
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 926176
       GoKind: 22
-      Pointee: 713 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 729 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 714
+      ID: 730
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 926272
       GoKind: 22
-      Pointee: 597 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 613 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 873
+      ID: 889
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1.05728e+06
       GoKind: 22
-      Pointee: 874 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 890 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 875
+      ID: 891
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1.057408e+06
       GoKind: 22
-      Pointee: 826 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 842 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1565
+      ID: 1582
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
     - __kind: EventRootType
-      ID: 1563
+      ID: 1566
+      Name: Probe[main.executeStructFuncs]Line
+      ByteSize: 66
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: sta.a
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 341 ArrayType [3]uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 10, name: sta}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: sta.b
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 10, name: sta}
+                  Offset: 24
+                  ByteSize: 1
+        - Name: sta.c
+          Offset: 26
+          Kind: template_segment
+          Expression:
+            Type: 342 ArrayType [5]int64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 10, name: sta}
+                  Offset: 32
+                  ByteSize: 40
+    - __kind: EventRootType
+      ID: 1580
       Name: Probe[main.firstBehavior.DoSomething]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11356,14 +11498,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 327 StructureType main.firstBehavior
+            Type: 343 StructureType main.firstBehavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 0, name: b}
+                  Variable: {subprogram: 165, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1564
+      ID: 1581
       Name: Probe[main.firstBehavior.DoSomething]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11375,14 +11517,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 1, name: ~r0}
+                  Variable: {subprogram: 165, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1526
+      ID: 1542
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1527
+      ID: 1543
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11398,7 +11540,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1393
+      ID: 1409
       Name: Probe[main.testAnyPtr]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11424,7 +11566,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1394
+      ID: 1410
       Name: Probe[main.testAnyPtr]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11440,7 +11582,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1390
+      ID: 1406
       Name: Probe[main.testAny]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11466,7 +11608,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1391
+      ID: 1407
       Name: Probe[main.testAny]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11482,7 +11624,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1497
+      ID: 1513
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11508,7 +11650,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1498
+      ID: 1514
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11524,7 +11666,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1342
+      ID: 1358
       Name: Probe[main.testArrayEmptyStructs]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11550,7 +11692,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1340
+      ID: 1356
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 129
       PresenceBitsetSize: 1
@@ -11576,7 +11718,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1338
+      ID: 1354
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -11602,7 +11744,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1402
+      ID: 1418
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11628,7 +11770,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1339
+      ID: 1355
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -11654,7 +11796,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1341
+      ID: 1357
       Name: Probe[main.testArrayOfStructs]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -11680,7 +11822,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1424
+      ID: 1440
       Name: Probe[main.testAtomicAdd]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11706,7 +11848,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1425
+      ID: 1441
       Name: Probe[main.testAtomicAdd]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11722,7 +11864,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1360
+      ID: 1376
       Name: Probe[main.testBigStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -11748,7 +11890,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1327
+      ID: 1343
       Name: Probe[main.testBoolArray]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -11774,7 +11916,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1324
+      ID: 1340
       Name: Probe[main.testByteArray]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -11800,7 +11942,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1426
+      ID: 1442
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11826,7 +11968,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1420
+      ID: 1436
       Name: Probe[main.testCombinedByte]
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -11892,7 +12034,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1421
+      ID: 1437
       Name: Probe[main.testCombinedString]
       ByteSize: 18
       PresenceBitsetSize: 1
@@ -11918,7 +12060,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1422
+      ID: 1438
       Name: Probe[main.testCombinedString]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -11954,7 +12096,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1434
+      ID: 1450
       Name: Probe[main.testCycle]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11980,7 +12122,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1365
+      ID: 1381
       Name: Probe[main.testDeepMap1]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12006,7 +12148,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1366
+      ID: 1382
       Name: Probe[main.testDeepMap7]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12032,7 +12174,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1361
+      ID: 1377
       Name: Probe[main.testDeepPtr1]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12058,7 +12200,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1362
+      ID: 1378
       Name: Probe[main.testDeepPtr7]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12084,7 +12226,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1363
+      ID: 1379
       Name: Probe[main.testDeepSlice1]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12110,7 +12252,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1364
+      ID: 1380
       Name: Probe[main.testDeepSlice7]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12136,7 +12278,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1517
+      ID: 1533
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -12182,7 +12324,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1514
+      ID: 1530
       Name: Probe[main.testEmptySlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12208,7 +12350,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1538
+      ID: 1554
       Name: Probe[main.testEmptyString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12234,7 +12376,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1549
+      ID: 1565
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12260,7 +12402,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1548
+      ID: 1564
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -12286,7 +12428,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1392
+      ID: 1408
       Name: Probe[main.testError]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12312,7 +12454,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1374
+      ID: 1390
       Name: Probe[main.testEsotericHeap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12338,10 +12480,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1375
+      ID: 1391
       Name: Probe[main.testEsotericHeap]Return
     - __kind: EventRootType
-      ID: 1372
+      ID: 1388
       Name: Probe[main.testEsotericStack]
       ByteSize: 129
       PresenceBitsetSize: 1
@@ -12367,10 +12509,10 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1373
+      ID: 1389
       Name: Probe[main.testEsotericStack]Return
     - __kind: EventRootType
-      ID: 1386
+      ID: 1402
       Name: Probe[main.testFramelessArray]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12396,7 +12538,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1388
+      ID: 1404
       Name: Probe[main.testFramelessArray]Line
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -12432,7 +12574,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1387
+      ID: 1403
       Name: Probe[main.testFramelessArray]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12448,7 +12590,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1384
+      ID: 1400
       Name: Probe[main.testFrameless]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12474,7 +12616,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1385
+      ID: 1401
       Name: Probe[main.testFrameless]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12490,7 +12632,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1376
+      ID: 1392
       Name: Probe[main.testInlinedBA]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12516,10 +12658,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1377
+      ID: 1393
       Name: Probe[main.testInlinedBA]Return
     - __kind: EventRootType
-      ID: 1380
+      ID: 1396
       Name: Probe[main.testInlinedBBA]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12545,13 +12687,13 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1381
+      ID: 1397
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1555
+      ID: 1572
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 1378
+      ID: 1394
       Name: Probe[main.testInlinedBB]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12597,28 +12739,28 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1379
+      ID: 1395
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1556
+      ID: 1573
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1557
+      ID: 1574
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1558
+      ID: 1575
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1559
+      ID: 1576
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
-      ID: 1382
+      ID: 1398
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 1383
+      ID: 1399
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1552
+      ID: 1569
       Name: Probe[main.testInlinedPrint]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12630,7 +12772,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12640,11 +12782,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1550
+      ID: 1567
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12656,11 +12798,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1551
+      ID: 1568
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12672,7 +12814,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x_val
@@ -12682,11 +12824,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1554
+      ID: 1571
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12698,7 +12840,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12708,14 +12850,14 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1553
+      ID: 1570
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1560
+      ID: 1577
       Name: Probe[main.testInlinedSq]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12727,7 +12869,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12737,11 +12879,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1561
+      ID: 1578
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12753,7 +12895,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12763,11 +12905,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1562
+      ID: 1579
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12779,7 +12921,7 @@ Types:
             Type: 167 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: a}
+                  Variable: {subprogram: 164, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: a
@@ -12789,11 +12931,11 @@ Types:
             Type: 167 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: a}
+                  Variable: {subprogram: 164, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1330
+      ID: 1346
       Name: Probe[main.testInt16Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12819,7 +12961,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1331
+      ID: 1347
       Name: Probe[main.testInt32Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12845,7 +12987,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1332
+      ID: 1348
       Name: Probe[main.testInt64Array]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12871,7 +13013,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1329
+      ID: 1345
       Name: Probe[main.testInt8Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -12897,7 +13039,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1328
+      ID: 1344
       Name: Probe[main.testIntArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12923,7 +13065,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1389
+      ID: 1405
       Name: Probe[main.testInterface]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12949,7 +13091,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1495
+      ID: 1511
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 161
       PresenceBitsetSize: 1
@@ -12975,7 +13117,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1496
+      ID: 1512
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12991,7 +13133,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1428
+      ID: 1444
       Name: Probe[main.testLinkedList]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13017,46 +13159,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1369
+      ID: 1385
       Name: Probe[main.testLongFunctionWithChangingState]Line
     - __kind: EventRootType
-      ID: 1370
-      Name: Probe[main.testLongFunctionWithChangingState]Line
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: aPerArch
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 1, name: aPerArch}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: b
-          Offset: 17
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 2, name: b}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1371
+      ID: 1386
       Name: Probe[main.testLongFunctionWithChangingState]Line
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13092,7 +13198,43 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1501
+      ID: 1387
+      Name: Probe[main.testLongFunctionWithChangingState]Line
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: aPerArch
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 1, name: aPerArch}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 17
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1517
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 147
       PresenceBitsetSize: 3
@@ -13278,7 +13420,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1502
+      ID: 1518
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13294,7 +13436,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1400
+      ID: 1416
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13320,7 +13462,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1407
+      ID: 1423
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13346,7 +13488,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1419
+      ID: 1435
       Name: Probe[main.testMapEmptyKeyAndValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13372,7 +13514,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1417
+      ID: 1433
       Name: Probe[main.testMapEmptyKey]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13398,7 +13540,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1418
+      ID: 1434
       Name: Probe[main.testMapEmptyValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13424,7 +13566,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1404
+      ID: 1420
       Name: Probe[main.testMapIntToInt]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13450,7 +13592,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1416
+      ID: 1432
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13476,7 +13618,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1415
+      ID: 1431
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13502,7 +13644,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1405
+      ID: 1421
       Name: Probe[main.testMapMassive]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13528,7 +13670,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1406
+      ID: 1422
       Name: Probe[main.testMapMassive]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13554,7 +13696,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1414
+      ID: 1430
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13580,7 +13722,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1413
+      ID: 1429
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13606,7 +13748,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1398
+      ID: 1414
       Name: Probe[main.testMapStringToInt]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13632,7 +13774,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1399
+      ID: 1415
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13658,7 +13800,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1397
+      ID: 1413
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13684,7 +13826,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1408
+      ID: 1424
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13710,7 +13852,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1412
+      ID: 1428
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13736,7 +13878,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1411
+      ID: 1427
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13762,7 +13904,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1410
+      ID: 1426
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13788,7 +13930,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1409
+      ID: 1425
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13814,7 +13956,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1535
+      ID: 1551
       Name: Probe[main.testMassiveString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13840,7 +13982,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1536
+      ID: 1552
       Name: Probe[main.testMassiveString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13866,7 +14008,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1503
+      ID: 1519
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 163
       PresenceBitsetSize: 3
@@ -14052,7 +14194,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1504
+      ID: 1520
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -14068,7 +14210,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1507
+      ID: 1523
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -14114,7 +14256,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1508
+      ID: 1524
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -14140,7 +14282,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1499
+      ID: 1515
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 321
       PresenceBitsetSize: 1
@@ -14186,7 +14328,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1500
+      ID: 1516
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -14202,7 +14344,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1453
+      ID: 1469
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14228,7 +14370,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1455
+      ID: 1471
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14274,7 +14416,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1457
+      ID: 1473
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14290,7 +14432,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1459
+      ID: 1475
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14306,7 +14448,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1461
+      ID: 1477
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14322,7 +14464,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1454
+      ID: 1470
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14348,7 +14490,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1456
+      ID: 1472
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -14414,7 +14556,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1458
+      ID: 1474
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14440,7 +14582,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1460
+      ID: 1476
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14466,7 +14608,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1462
+      ID: 1478
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14492,7 +14634,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1423
+      ID: 1439
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 62
       PresenceBitsetSize: 2
@@ -14598,7 +14740,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1449
+      ID: 1465
       Name: Probe[main.testNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14624,7 +14766,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1451
+      ID: 1467
       Name: Probe[main.testNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14650,7 +14792,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1450
+      ID: 1466
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14666,7 +14808,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1452
+      ID: 1468
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14692,7 +14834,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1544
+      ID: 1560
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14718,7 +14860,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1545
+      ID: 1561
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14740,10 +14882,10 @@ Types:
                   Bias: 8
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1546
+      ID: 1562
       Name: Probe[main.testNestedPointer]
     - __kind: EventRootType
-      ID: 1547
+      ID: 1563
       Name: Probe[main.testNestedPointer]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -14765,7 +14907,7 @@ Types:
                   Bias: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1433
+      ID: 1449
       Name: Probe[main.testNilPointer]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14811,7 +14953,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1518
+      ID: 1534
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -14857,7 +14999,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1520
+      ID: 1536
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 67
       PresenceBitsetSize: 1
@@ -14923,7 +15065,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1521
+      ID: 1537
       Name: Probe[main.testNilSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -14949,7 +15091,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1534
+      ID: 1550
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14975,7 +15117,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1429
+      ID: 1445
       Name: Probe[main.testPointerLoop]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15001,7 +15143,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1403
+      ID: 1419
       Name: Probe[main.testPointerToMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15027,7 +15169,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1427
+      ID: 1443
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15053,7 +15195,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1443
+      ID: 1459
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 35
       PresenceBitsetSize: 1
@@ -15099,7 +15241,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1444
+      ID: 1460
       Name: Probe[main.testReturnsAnyAndError]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15125,7 +15267,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1445
+      ID: 1461
       Name: Probe[main.testReturnsAny]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15151,7 +15293,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1446
+      ID: 1462
       Name: Probe[main.testReturnsAny]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15167,10 +15309,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1475
+      ID: 1491
       Name: Probe[main.testReturnsArrayOne]
     - __kind: EventRootType
-      ID: 1476
+      ID: 1492
       Name: Probe[main.testReturnsArrayOne]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15186,10 +15328,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1477
+      ID: 1493
       Name: Probe[main.testReturnsArrayZero]
     - __kind: EventRootType
-      ID: 1478
+      ID: 1494
       Name: Probe[main.testReturnsArrayZero]Return
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -15205,10 +15347,10 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1473
+      ID: 1489
       Name: Probe[main.testReturnsArray]
     - __kind: EventRootType
-      ID: 1474
+      ID: 1490
       Name: Probe[main.testReturnsArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15224,10 +15366,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1481
+      ID: 1497
       Name: Probe[main.testReturnsBacktrackInt]
     - __kind: EventRootType
-      ID: 1482
+      ID: 1498
       Name: Probe[main.testReturnsBacktrackInt]Return
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -15323,10 +15465,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1493
+      ID: 1509
       Name: Probe[main.testReturnsBoolAndUintptr]
     - __kind: EventRootType
-      ID: 1494
+      ID: 1510
       Name: Probe[main.testReturnsBoolAndUintptr]Return
       ByteSize: 10
       PresenceBitsetSize: 1
@@ -15352,10 +15494,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1469
+      ID: 1485
       Name: Probe[main.testReturnsComplex]
     - __kind: EventRootType
-      ID: 1470
+      ID: 1486
       Name: Probe[main.testReturnsComplex]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15381,7 +15523,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1441
+      ID: 1457
       Name: Probe[main.testReturnsError]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -15407,7 +15549,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1442
+      ID: 1458
       Name: Probe[main.testReturnsError]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15423,7 +15565,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1439
+      ID: 1455
       Name: Probe[main.testReturnsIntAndFloat]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15449,7 +15591,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1440
+      ID: 1456
       Name: Probe[main.testReturnsIntAndFloat]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15475,7 +15617,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1437
+      ID: 1453
       Name: Probe[main.testReturnsIntPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15501,7 +15643,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1438
+      ID: 1454
       Name: Probe[main.testReturnsIntPointer]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15517,7 +15659,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1435
+      ID: 1451
       Name: Probe[main.testReturnsInt]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15543,7 +15685,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1436
+      ID: 1452
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15559,7 +15701,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1447
+      ID: 1463
       Name: Probe[main.testReturnsInterface]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15585,7 +15727,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1448
+      ID: 1464
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15601,10 +15743,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1471
+      ID: 1487
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1472
+      ID: 1488
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -15620,10 +15762,10 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1467
+      ID: 1483
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1468
+      ID: 1484
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 139
       PresenceBitsetSize: 3
@@ -15799,10 +15941,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1479
+      ID: 1495
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1480
+      ID: 1496
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15818,10 +15960,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1485
+      ID: 1501
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1486
+      ID: 1502
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -15877,10 +16019,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1491
+      ID: 1507
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1492
+      ID: 1508
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -15906,10 +16048,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1489
+      ID: 1505
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1490
+      ID: 1506
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15925,10 +16067,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1465
+      ID: 1481
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1466
+      ID: 1482
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -16014,10 +16156,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1487
+      ID: 1503
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1488
+      ID: 1504
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16033,10 +16175,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1483
+      ID: 1499
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1484
+      ID: 1500
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -16052,7 +16194,7 @@ Types:
                   Offset: 0
                   ByteSize: 88
     - __kind: EventRootType
-      ID: 1325
+      ID: 1341
       Name: Probe[main.testRuneArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16078,7 +16220,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1346
+      ID: 1362
       Name: Probe[main.testSingleBool]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -16104,7 +16246,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1344
+      ID: 1360
       Name: Probe[main.testSingleByte]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -16130,7 +16272,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1357
+      ID: 1373
       Name: Probe[main.testSingleFloat32]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -16156,7 +16298,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1358
+      ID: 1374
       Name: Probe[main.testSingleFloat64]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16182,7 +16324,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1349
+      ID: 1365
       Name: Probe[main.testSingleInt16]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -16208,7 +16350,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1350
+      ID: 1366
       Name: Probe[main.testSingleInt32]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -16234,7 +16376,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1351
+      ID: 1367
       Name: Probe[main.testSingleInt64]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16260,7 +16402,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1348
+      ID: 1364
       Name: Probe[main.testSingleInt8]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -16306,7 +16448,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1347
+      ID: 1363
       Name: Probe[main.testSingleInt]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16332,7 +16474,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1345
+      ID: 1361
       Name: Probe[main.testSingleRune]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -16358,7 +16500,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1528
+      ID: 1544
       Name: Probe[main.testSingleString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16384,7 +16526,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1354
+      ID: 1370
       Name: Probe[main.testSingleUint16]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -16410,7 +16552,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1355
+      ID: 1371
       Name: Probe[main.testSingleUint32]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -16436,7 +16578,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1356
+      ID: 1372
       Name: Probe[main.testSingleUint64]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16462,7 +16604,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1353
+      ID: 1369
       Name: Probe[main.testSingleUint8]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -16488,7 +16630,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1352
+      ID: 1368
       Name: Probe[main.testSingleUint]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16514,7 +16656,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1524
+      ID: 1540
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16540,7 +16682,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1515
+      ID: 1531
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16566,7 +16708,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1401
+      ID: 1417
       Name: Probe[main.testSmallMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16592,7 +16734,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1463
+      ID: 1479
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16618,7 +16760,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1464
+      ID: 1480
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16654,7 +16796,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1505
+      ID: 1521
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -16680,7 +16822,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1506
+      ID: 1522
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16716,7 +16858,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1326
+      ID: 1342
       Name: Probe[main.testStringArray]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -16742,7 +16884,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1432
+      ID: 1448
       Name: Probe[main.testStringPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16768,7 +16910,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1519
+      ID: 1535
       Name: Probe[main.testStringSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16794,7 +16936,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1367
+      ID: 1383
       Name: Probe[main.testStringType1]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16820,7 +16962,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1368
+      ID: 1384
       Name: Probe[main.testStringType2]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16846,7 +16988,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1516
+      ID: 1532
       Name: Probe[main.testStructSlice]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -16892,7 +17034,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1395
+      ID: 1411
       Name: Probe[main.testStructWithAny]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16918,7 +17060,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1509
+      ID: 1525
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16944,7 +17086,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1510
+      ID: 1526
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16970,7 +17112,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1541
+      ID: 1557
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16996,7 +17138,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1540
+      ID: 1556
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 289
       PresenceBitsetSize: 1
@@ -17022,7 +17164,7 @@ Types:
                   Offset: 0
                   ByteSize: 144
     - __kind: EventRootType
-      ID: 1396
+      ID: 1412
       Name: Probe[main.testStructWithMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17048,7 +17190,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1542
+      ID: 1558
       Name: Probe[main.testStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17064,7 +17206,7 @@ Types:
                   Offset: 8
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1543
+      ID: 1559
       Name: Probe[main.testStruct]
       ByteSize: 113
       PresenceBitsetSize: 1
@@ -17090,7 +17232,7 @@ Types:
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1525
+      ID: 1541
       Name: Probe[main.testSubslices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -17156,7 +17298,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1539
+      ID: 1555
       Name: Probe[main.testSubstrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17222,7 +17364,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1532
+      ID: 1548
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17248,7 +17390,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1533
+      ID: 1549
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17293,7 +17435,7 @@ Types:
                   Bias: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1530
+      ID: 1546
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17319,7 +17461,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1531
+      ID: 1547
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17355,7 +17497,7 @@ Types:
                   Offset: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1529
+      ID: 1545
       Name: Probe[main.testThreeStrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17421,7 +17563,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1359
+      ID: 1375
       Name: Probe[main.testTypeAlias]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -17447,7 +17589,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1335
+      ID: 1351
       Name: Probe[main.testUint16Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -17473,7 +17615,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1336
+      ID: 1352
       Name: Probe[main.testUint32Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17499,7 +17641,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1337
+      ID: 1353
       Name: Probe[main.testUint64Array]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17525,7 +17667,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1334
+      ID: 1350
       Name: Probe[main.testUint8Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -17551,7 +17693,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1333
+      ID: 1349
       Name: Probe[main.testUintArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17577,7 +17719,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1431
+      ID: 1447
       Name: Probe[main.testUintPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17603,7 +17745,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1513
+      ID: 1529
       Name: Probe[main.testUintSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17629,7 +17771,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1537
+      ID: 1553
       Name: Probe[main.testUnitializedString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17655,7 +17797,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1430
+      ID: 1446
       Name: Probe[main.testUnsafePointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17681,7 +17823,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1343
+      ID: 1359
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 1601
       PresenceBitsetSize: 1
@@ -17707,7 +17849,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1522
+      ID: 1538
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17733,7 +17875,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1523
+      ID: 1539
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17759,7 +17901,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1511
+      ID: 1527
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17805,7 +17947,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1512
+      ID: 1528
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -18066,7 +18208,15 @@ Types:
       HasCount: true
       Element: 33 StructureType internal/runtime/atomic.Uint32
     - __kind: ArrayType
-      ID: 433
+      ID: 341
+      Name: '[3]uint64'
+      ByteSize: 24
+      GoKind: 17
+      Count: 3
+      HasCount: true
+      Element: 8 BaseType uint64
+    - __kind: ArrayType
+      ID: 449
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 689888
@@ -18075,7 +18225,7 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 390
+      ID: 406
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 690176
@@ -18101,7 +18251,15 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 1001
+      ID: 342
+      Name: '[5]int64'
+      ByteSize: 40
+      GoKind: 17
+      Count: 5
+      HasCount: true
+      Element: 12 BaseType int64
+    - __kind: ArrayType
+      ID: 1017
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 691712
@@ -18143,15 +18301,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 340 GoSliceDataType []*main.deepSlice2.array
+      Data: 356 GoSliceDataType []*main.deepSlice2.array
     - __kind: GoSliceDataType
-      ID: 340
+      ID: 356
       Name: '[]*main.deepSlice2.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 146 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 1238
+      ID: 1254
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 483936
@@ -18159,22 +18317,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1239 PointerType **main.deepSlice3
+          Type: 1255 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1242 GoSliceDataType []*main.deepSlice3.array
+      Data: 1258 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 1242
+      ID: 1258
       Name: '[]*main.deepSlice3.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1240 PointerType *main.deepSlice3
+      Element: 1256 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 1263
+      ID: 1279
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 483616
@@ -18182,22 +18340,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1264 PointerType **main.deepSlice8
+          Type: 1280 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1267 GoSliceDataType []*main.deepSlice8.array
+      Data: 1283 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 1267
+      ID: 1283
       Name: '[]*main.deepSlice8.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1265 PointerType *main.deepSlice8
+      Element: 1281 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 1269
+      ID: 1285
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 483552
@@ -18205,20 +18363,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1270 PointerType **main.deepSlice9
+          Type: 1286 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1273 GoSliceDataType []*main.deepSlice9.array
+      Data: 1289 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 1273
+      ID: 1289
       Name: '[]*main.deepSlice9.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1271 PointerType *main.deepSlice9
+      Element: 1287 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 66
       Name: '[]*runtime.p'
@@ -18235,9 +18393,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 335 GoSliceDataType []*runtime.p.array
+      Data: 351 GoSliceDataType []*runtime.p.array
     - __kind: GoSliceDataType
-      ID: 335
+      ID: 351
       Name: '[]*runtime.p.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -18258,171 +18416,171 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 337 GoSliceDataType []*string.array
+      Data: 353 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 337
+      ID: 353
       Name: '[]*string.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 101 PointerType *string
     - __kind: GoSliceDataType
-      ID: 450
+      ID: 466
       Name: '[]*table<[4]int,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 233 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 442
+      ID: 458
       Name: '[]*table<[4]int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 228 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 391
+      ID: 407
       Name: '[]*table<[4]string,[2]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 196 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 409
+      ID: 425
       Name: '[]*table<bool,main.node>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 208 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 350
+      ID: 366
       Name: '[]*table<int,*main.deepMap2>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 154 PointerType *table<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 1257
+      ID: 1273
       Name: '[]*table<int,*main.deepMap3>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1248 PointerType *table<int,*main.deepMap3>
+      Element: 1264 PointerType *table<int,*main.deepMap3>
     - __kind: GoSliceDataType
-      ID: 1291
+      ID: 1307
       Name: '[]*table<int,*main.deepMap8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1282 PointerType *table<int,*main.deepMap8>
+      Element: 1298 PointerType *table<int,*main.deepMap8>
     - __kind: GoSliceDataType
-      ID: 1306
+      ID: 1322
       Name: '[]*table<int,*main.deepMap9>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1297 PointerType *table<int,*main.deepMap9>
+      Element: 1313 PointerType *table<int,*main.deepMap9>
     - __kind: GoSliceDataType
-      ID: 358
+      ID: 374
       Name: '[]*table<int,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 176 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 1319
+      ID: 1335
       Name: '[]*table<int,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1312 PointerType *table<int,interface {}>
+      Element: 1328 PointerType *table<int,interface {}>
     - __kind: GoSliceDataType
-      ID: 466
+      ID: 482
       Name: '[]*table<int,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 243 PointerType *table<int,struct {}>
     - __kind: GoSliceDataType
-      ID: 417
+      ID: 433
       Name: '[]*table<int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 213 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 401
+      ID: 417
       Name: '[]*table<string,[]main.structWithMap>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 203 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 382
+      ID: 398
       Name: '[]*table<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 191 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 1017
+      ID: 1033
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 984 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 1000 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 374
+      ID: 390
       Name: '[]*table<string,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 186 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 366
+      ID: 382
       Name: '[]*table<string,main.nestedStruct>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 181 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 458
+      ID: 474
       Name: '[]*table<struct {},int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 238 PointerType *table<struct {},int>
     - __kind: GoSliceDataType
-      ID: 508
+      ID: 524
       Name: '[]*table<struct {},main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 296 PointerType *table<struct {},main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 516
+      ID: 532
       Name: '[]*table<struct {},map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 301 PointerType *table<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 524
+      ID: 540
       Name: '[]*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 306 PointerType *table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 532
+      ID: 548
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 311 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 540
+      ID: 556
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 316 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 548
+      ID: 564
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 321 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 474
+      ID: 490
       Name: '[]*table<struct {},struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 248 PointerType *table<struct {},struct {}>
     - __kind: GoSliceDataType
-      ID: 434
+      ID: 450
       Name: '[]*table<uint8,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 223 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 425
+      ID: 441
       Name: '[]*table<uint8,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
@@ -18442,9 +18600,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 500 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Data: 516 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 500
+      ID: 516
       Name: '[][][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -18464,9 +18622,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 498 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Data: 514 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 498
+      ID: 514
       Name: '[][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -18486,9 +18644,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 496 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Data: 512 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 496
+      ID: 512
       Name: '[][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -18508,9 +18666,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 494 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Data: 510 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 494
+      ID: 510
       Name: '[][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -18530,9 +18688,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 492 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Data: 508 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 492
+      ID: 508
       Name: '[][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -18552,9 +18710,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 478 GoSliceDataType [][]uint.array
+      Data: 494 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 478
+      ID: 494
       Name: '[][]uint.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -18575,15 +18733,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 484 GoSliceDataType []bool.array
+      Data: 500 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 484
+      ID: 500
       Name: '[]bool.array'
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 996
+      ID: 1012
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 493536
@@ -18598,15 +18756,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1019 GoSliceDataType []float64.array
+      Data: 1035 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 1019
+      ID: 1035
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 13 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 1275
+      ID: 1291
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 493984
@@ -18621,9 +18779,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1276 GoSliceDataType []interface {}.array
+      Data: 1292 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 1276
+      ID: 1292
       Name: '[]interface {}.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -18643,15 +18801,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 490 GoSliceDataType []main.structWithCyclicSlices.array
+      Data: 506 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 490
+      ID: 506
       Name: '[]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 144
       Element: 278 StructureType main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 399
+      ID: 415
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 484256
@@ -18659,16 +18817,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 400 PointerType *main.structWithMap
+          Type: 416 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 550 GoSliceDataType []main.structWithMap.array
+      Data: 566 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 550
+      ID: 566
       Name: '[]main.structWithMap.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -18688,175 +18846,175 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 480 GoSliceDataType []main.structWithNoStrings.array
+      Data: 496 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 480
+      ID: 496
       Name: '[]main.structWithNoStrings.array'
       DynamicSizeClass: slice
       ByteSize: 2
       Element: 268 StructureType main.structWithNoStrings
     - __kind: GoSliceDataType
-      ID: 451
+      ID: 467
       Name: '[]noalg.map.group[[4]int][4]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 520
-      Element: 447 StructureType noalg.map.group[[4]int][4]int
+      Element: 463 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 443
+      ID: 459
       Name: '[]noalg.map.group[[4]int]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 439 StructureType noalg.map.group[[4]int]uint8
+      Element: 455 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 392
+      ID: 408
       Name: '[]noalg.map.group[[4]string][2]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 648
-      Element: 387 StructureType noalg.map.group[[4]string][2]int
+      Element: 403 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 410
+      ID: 426
       Name: '[]noalg.map.group[bool]main.node.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 406 StructureType noalg.map.group[bool]main.node
+      Element: 422 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
-      ID: 351
+      ID: 367
       Name: '[]noalg.map.group[int]*main.deepMap2.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 345 StructureType noalg.map.group[int]*main.deepMap2
+      Element: 361 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSliceDataType
-      ID: 1258
+      ID: 1274
       Name: '[]noalg.map.group[int]*main.deepMap3.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1252 StructureType noalg.map.group[int]*main.deepMap3
+      Element: 1268 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSliceDataType
-      ID: 1292
+      ID: 1308
       Name: '[]noalg.map.group[int]*main.deepMap8.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1286 StructureType noalg.map.group[int]*main.deepMap8
+      Element: 1302 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSliceDataType
-      ID: 1307
+      ID: 1323
       Name: '[]noalg.map.group[int]*main.deepMap9.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1301 StructureType noalg.map.group[int]*main.deepMap9
+      Element: 1317 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSliceDataType
-      ID: 359
+      ID: 375
       Name: '[]noalg.map.group[int]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 355 StructureType noalg.map.group[int]int
+      Element: 371 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 1320
+      ID: 1336
       Name: '[]noalg.map.group[int]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 1316 StructureType noalg.map.group[int]interface {}
+      Element: 1332 StructureType noalg.map.group[int]interface {}
     - __kind: GoSliceDataType
-      ID: 467
+      ID: 483
       Name: '[]noalg.map.group[int]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 463 StructureType noalg.map.group[int]struct {}
+      Element: 479 StructureType noalg.map.group[int]struct {}
     - __kind: GoSliceDataType
-      ID: 418
+      ID: 434
       Name: '[]noalg.map.group[int]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 414 StructureType noalg.map.group[int]uint8
+      Element: 430 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
-      ID: 402
+      ID: 418
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 396 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 412 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
-      ID: 383
+      ID: 399
       Name: '[]noalg.map.group[string][]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 379 StructureType noalg.map.group[string][]string
+      Element: 395 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 1018
+      ID: 1034
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 1014 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 1030 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
-      ID: 375
+      ID: 391
       Name: '[]noalg.map.group[string]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 371 StructureType noalg.map.group[string]int
+      Element: 387 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 367
+      ID: 383
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 363 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 379 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 459
+      ID: 475
       Name: '[]noalg.map.group[struct {}]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 455 StructureType noalg.map.group[struct {}]int
+      Element: 471 StructureType noalg.map.group[struct {}]int
     - __kind: GoSliceDataType
-      ID: 509
+      ID: 525
       Name: '[]noalg.map.group[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 392
-      Element: 505 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      Element: 521 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 517
+      ID: 533
       Name: '[]noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 513 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 529 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 525
+      ID: 541
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 521 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 537 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 533
+      ID: 549
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 529 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 545 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 541
+      ID: 557
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 537 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 553 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 549
+      ID: 565
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 545 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 561 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 475
+      ID: 491
       Name: '[]noalg.map.group[struct {}]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 16
-      Element: 471 StructureType noalg.map.group[struct {}]struct {}
+      Element: 487 StructureType noalg.map.group[struct {}]struct {}
     - __kind: GoSliceDataType
-      ID: 435
+      ID: 451
       Name: '[]noalg.map.group[uint8][4]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 430 StructureType noalg.map.group[uint8][4]int
+      Element: 446 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 426
+      ID: 442
       Name: '[]noalg.map.group[uint8]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 24
-      Element: 422 StructureType noalg.map.group[uint8]uint8
+      Element: 438 StructureType noalg.map.group[uint8]uint8
     - __kind: UnresolvedPointeeType
       ID: 41
       Name: '[]runtime.ancestorInfo'
@@ -18877,9 +19035,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 482 GoSliceDataType []string.array
+      Data: 498 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 482
+      ID: 498
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -18899,9 +19057,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 488 GoSliceDataType []struct {}.array
+      Data: 504 GoSliceDataType []struct {}.array
     - __kind: GoSliceDataType
-      ID: 488
+      ID: 504
       Name: '[]struct {}.array'
       DynamicSizeClass: slice
       Element: 131 StructureType struct {}
@@ -18921,9 +19079,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 476 GoSliceDataType []uint.array
+      Data: 492 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 476
+      ID: 492
       Name: '[]uint.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -18944,9 +19102,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 486 GoSliceDataType []uint16.array
+      Data: 502 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 486
+      ID: 502
       Name: '[]uint16.array'
       DynamicSizeClass: slice
       ByteSize: 2
@@ -18967,9 +19125,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 330 GoSliceDataType []uint8.array
+      Data: 346 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 330
+      ID: 346
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -18990,19 +19148,19 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 332 GoSliceDataType []uintptr.array
+      Data: 348 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 332
+      ID: 348
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 1 BaseType uintptr
     - __kind: UnresolvedPointeeType
-      ID: 1152
+      ID: 1168
       Name: archive/tar.Writer
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 786
+      ID: 802
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 941440
@@ -19017,33 +19175,33 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 787 GoSliceDataType archive/tar.headerError.array
+      Data: 803 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 787
+      ID: 803
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1086
+      ID: 1102
       Name: archive/tar.regFileWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1034
+      ID: 1050
       Name: archive/zip.countWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1036
+      ID: 1052
       Name: archive/zip.dirWriter
       GoRuntimeType: 1.129728e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1129
+      ID: 1145
       Name: archive/zip.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1062
+      ID: 1078
       Name: archive/zip.nopCloser
       ByteSize: 16
       GoRuntimeType: 1.581184e+06
@@ -19053,7 +19211,7 @@ Types:
           Offset: 0
           Type: 137 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1064
+      ID: 1080
       Name: archive/zip.pooledFlateWriter
       ByteSize: 8
     - __kind: BaseType
@@ -19063,15 +19221,15 @@ Types:
       GoRuntimeType: 591616
       GoKind: 1
     - __kind: UnresolvedPointeeType
-      ID: 1110
+      ID: 1126
       Name: bufio.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1139
+      ID: 1155
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1188
+      ID: 1204
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
@@ -19097,13 +19255,13 @@ Types:
       GoRuntimeType: 591360
       GoKind: 15
     - __kind: BaseType
-      ID: 589
+      ID: 605
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 842592
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 590
+      ID: 606
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 842688
@@ -19111,120 +19269,120 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 592 PointerType *compress/flate.InternalError.str
+          Type: 608 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 591 GoStringDataType compress/flate.InternalError.str
+      Data: 607 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 591
+      ID: 607
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1084
+      ID: 1100
       Name: compress/flate.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1030
+      ID: 1046
       Name: compress/flate.dictWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1106
+      ID: 1122
       Name: compress/gzip.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 934
+      ID: 950
       Name: context.deadlineExceededError
       GoRuntimeType: 1.493504e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 600
+      ID: 616
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 845184
       GoKind: 2
     - __kind: BaseType
-      ID: 601
+      ID: 617
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 845280
       GoKind: 2
     - __kind: BaseType
-      ID: 602
+      ID: 618
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 845376
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1101
+      ID: 1117
       Name: crypto/internal/fips140/hmac.HMAC
       ByteSize: 8
     - __kind: StructureType
-      ID: 883
+      ID: 899
       Name: crypto/internal/fips140/hmac.errCloneUnsupported
       GoRuntimeType: 1.301184e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1131
+      ID: 1147
       Name: crypto/internal/fips140/sha256.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1163
+      ID: 1179
       Name: crypto/internal/fips140/sha3.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1137
+      ID: 1153
       Name: crypto/internal/fips140/sha3.SHAKE
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1133
+      ID: 1149
       Name: crypto/internal/fips140/sha512.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1127
+      ID: 1143
       Name: crypto/md5.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 603
+      ID: 619
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 845472
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1150
+      ID: 1166
       Name: crypto/sha1.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1135
+      ID: 1151
       Name: crypto/sha3.SHA3
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1119
+      ID: 1135
       Name: crypto/sha3.SHAKE
       ByteSize: 8
     - __kind: BaseType
-      ID: 593
+      ID: 609
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 843168
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 872
+      ID: 888
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1214
+      ID: 1230
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 706
+      ID: 722
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 703
+      ID: 719
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1.749632e+06
@@ -19235,38 +19393,38 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 1001 ArrayType [5]uint8
+          Type: 1017 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 1002 GoInterfaceType net.Conn
+          Type: 1018 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 825
+      ID: 841
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 1.00352e+06
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1094
+      ID: 1110
       Name: crypto/tls.cthWrapper
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 708
+      ID: 724
       Name: crypto/tls.echConfigErr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1099
+      ID: 1115
       Name: crypto/tls.finishedHash
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 969
+      ID: 985
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 986
+      ID: 1002
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 774
+      ID: 790
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1.752512e+06
@@ -19274,21 +19432,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 985 PointerType *crypto/x509.Certificate
+          Type: 1001 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 1004 BaseType crypto/x509.InvalidReason
+          Type: 1020 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 768
+      ID: 784
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1.127168e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 770
+      ID: 786
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1.616416e+06
@@ -19296,24 +19454,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 985 PointerType *crypto/x509.Certificate
+          Type: 1001 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 599
+      ID: 615
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 844704
       GoKind: 2
     - __kind: BaseType
-      ID: 1004
+      ID: 1020
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 596672
       GoKind: 2
     - __kind: StructureType
-      ID: 877
+      ID: 893
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1.577024e+06
@@ -19323,13 +19481,13 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 776
+      ID: 792
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1.127424e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 772
+      ID: 788
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1.75232e+06
@@ -19337,15 +19495,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 985 PointerType *crypto/x509.Certificate
+          Type: 1001 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 15 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 985 PointerType *crypto/x509.Certificate
+          Type: 1001 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 790
+      ID: 806
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1.448992e+06
@@ -19355,7 +19513,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 794
+      ID: 810
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1.449152e+06
@@ -19365,55 +19523,55 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 792
+      ID: 808
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 584
+      ID: 600
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 842112
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 1052
+      ID: 1068
       Name: encoding/base64.encoder
       ByteSize: 8
     - __kind: BaseType
-      ID: 585
+      ID: 601
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 842304
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 661
+      ID: 677
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 861
+      ID: 877
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 653
+      ID: 669
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 659
+      ID: 675
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 657
+      ID: 673
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 655
+      ID: 671
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1194
+      ID: 1210
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 663
+      ID: 679
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1.432192e+06
@@ -19423,11 +19581,11 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1060
+      ID: 1076
       Name: encoding/pem.lineBreaker
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 765
+      ID: 781
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -19444,11 +19602,11 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 626
+      ID: 642
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 828
+      ID: 844
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -19464,15 +19622,15 @@ Types:
       GoRuntimeType: 591552
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 1182
+      ID: 1198
       Name: fmt.pp
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 830
+      ID: 846
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 832
+      ID: 848
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -19488,11 +19646,11 @@ Types:
       GoRuntimeType: 855744
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 691
+      ID: 707
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 672
+      ID: 688
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1.74848e+06
@@ -19500,7 +19658,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 994 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 1010 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 7 BaseType int
@@ -19508,25 +19666,25 @@ Types:
           Offset: 200
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 674
+      ID: 690
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 998
+      ID: 1014
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 678
+      ID: 694
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1.123456e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1000
+      ID: 1016
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 578
+      ID: 594
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 841536
@@ -19534,18 +19692,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 580 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 596 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 579 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 595 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 579
+      ID: 595
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 994
+      ID: 1010
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2.243488e+06
@@ -19553,7 +19711,7 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 995 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 1011 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -19568,7 +19726,7 @@ Types:
           Type: 13 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 996 GoSliceHeaderType []float64
+          Type: 1012 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 12 BaseType int64
@@ -19577,10 +19735,10 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 997 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 1013 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 999 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 1015 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
           Type: 269 GoSliceHeaderType []string
@@ -19594,13 +19752,13 @@ Types:
           Offset: 184
           Type: 12 BaseType int64
     - __kind: BaseType
-      ID: 995
+      ID: 1011
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 593344
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 575
+      ID: 591
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 841440
@@ -19608,18 +19766,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 577 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 593 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 576 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 592 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 576
+      ID: 592
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 581
+      ID: 597
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 841632
@@ -19627,60 +19785,60 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 583 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 599 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 582 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 598 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 582
+      ID: 598
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1072
+      ID: 1088
       Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1160
+      ID: 1176
       Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 784
+      ID: 800
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 943
+      ID: 959
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1190
+      ID: 1206
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 716
+      ID: 732
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 723
+      ID: 739
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1.1264e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 598
+      ID: 614
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 843840
       GoKind: 2
     - __kind: StructureType
-      ID: 721
+      ID: 737
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1.126272e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 719
+      ID: 735
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1.614336e+06
@@ -19693,7 +19851,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 739
+      ID: 755
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1.615136e+06
@@ -19706,7 +19864,7 @@ Types:
           Offset: 16
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 743
+      ID: 759
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1.751744e+06
@@ -19722,7 +19880,7 @@ Types:
           Offset: 24
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 741
+      ID: 757
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1.441952e+06
@@ -19732,7 +19890,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 737
+      ID: 753
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1.441632e+06
@@ -19742,14 +19900,14 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 980
+      ID: 996
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1.514784e+06
       GoKind: 21
-      HeaderType: 982 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 998 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 1003
+      ID: 1019
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1.060864e+06
@@ -19764,15 +19922,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1021 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 1037 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 1021
+      ID: 1037
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 751
+      ID: 767
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1.615456e+06
@@ -19780,12 +19938,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 980 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 996 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 980 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 996 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 745
+      ID: 761
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1.442112e+06
@@ -19795,7 +19953,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 749
+      ID: 765
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1.751936e+06
@@ -19806,12 +19964,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 1003 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1019 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 1003 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1019 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 747
+      ID: 763
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1.615296e+06
@@ -19824,7 +19982,7 @@ Types:
           Offset: 8
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 753
+      ID: 769
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1.442272e+06
@@ -19832,9 +19990,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 970 StructureType time.Time
+          Type: 986 StructureType time.Time
     - __kind: StructureType
-      ID: 759
+      ID: 775
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1.615776e+06
@@ -19847,7 +20005,7 @@ Types:
           Offset: 8
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 761
+      ID: 777
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1.442592e+06
@@ -19857,7 +20015,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 757
+      ID: 773
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1.615616e+06
@@ -19870,7 +20028,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 755
+      ID: 771
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1.442432e+06
@@ -19880,7 +20038,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 763
+      ID: 779
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1.615936e+06
@@ -19893,7 +20051,7 @@ Types:
           Offset: 8
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 680
+      ID: 696
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1.434432e+06
@@ -19903,11 +20061,11 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1113
+      ID: 1129
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 682
+      ID: 698
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1.434592e+06
@@ -19915,21 +20073,21 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 680 StructureType github.com/cihub/seelog.baseError
+          Type: 696 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1092
+      ID: 1108
       Name: github.com/cihub/seelog.connWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1048
+      ID: 1064
       Name: github.com/cihub/seelog.consoleWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1082
+      ID: 1098
       Name: github.com/cihub/seelog.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 686
+      ID: 702
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1.434912e+06
@@ -19937,13 +20095,13 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 680 StructureType github.com/cihub/seelog.baseError
+          Type: 696 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1148
+      ID: 1164
       Name: github.com/cihub/seelog.rollingFileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1161
+      ID: 1177
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
       GoRuntimeType: 2.129824e+06
@@ -19951,12 +20109,12 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1147 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1163 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: maxFileSize
           Offset: 8
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 1164
+      ID: 1180
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
       GoRuntimeType: 2.155488e+06
@@ -19964,7 +20122,7 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1147 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1163 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: timePattern
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -19972,11 +20130,11 @@ Types:
           Offset: 24
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1050
+      ID: 1066
       Name: github.com/cihub/seelog.smtpWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 684
+      ID: 700
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1.434752e+06
@@ -19984,9 +20142,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 680 StructureType github.com/cihub/seelog.baseError
+          Type: 696 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 688
+      ID: 704
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1.435072e+06
@@ -19994,64 +20152,64 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 680 StructureType github.com/cihub/seelog.baseError
+          Type: 696 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1115
+      ID: 1131
       Name: github.com/cihub/seelog/archive/gzip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1156
+      ID: 1172
       Name: github.com/cihub/seelog/archive/tar.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1158
+      ID: 1174
       Name: github.com/cihub/seelog/archive/zip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 974
+      ID: 990
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 887
+      ID: 903
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 885
+      ID: 901
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 889
+      ID: 905
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 891
+      ID: 907
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1103
+      ID: 1119
       Name: github.com/gogo/protobuf/proto.textWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 879
+      ID: 895
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 694
+      ID: 710
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1.436032e+06
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 7 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 1206
+      ID: 1222
       Name: github.com/json-iterator/go.Stream
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 945
+      ID: 961
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 918
+      ID: 934
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1.86208e+06
@@ -20067,11 +20225,11 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 912
+      ID: 928
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 847
+      ID: 863
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1.721184e+06
@@ -20084,7 +20242,7 @@ Types:
           Offset: 1
           Type: 20 BaseType int8
     - __kind: StructureType
-      ID: 924
+      ID: 940
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1.862528e+06
@@ -20100,13 +20258,13 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 824
+      ID: 840
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 1.000832e+06
       GoKind: 8
     - __kind: StructureType
-      ID: 916
+      ID: 932
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1.861856e+06
@@ -20122,13 +20280,13 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 1005
+      ID: 1021
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 839712
       GoKind: 8
     - __kind: StructureType
-      ID: 914
+      ID: 930
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1.861632e+06
@@ -20136,15 +20294,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 1005 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 1021 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 1005 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 1021 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 922
+      ID: 938
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1.775872e+06
@@ -20157,7 +20315,7 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 920
+      ID: 936
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1.862304e+06
@@ -20173,11 +20331,11 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1210
+      ID: 1226
       Name: github.com/tinylib/msgp/msgp.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 928
+      ID: 944
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1.641216e+06
@@ -20187,19 +20345,19 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 851
+      ID: 867
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1.294656e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 849
+      ID: 865
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1.294528e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 926
+      ID: 942
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1.776064e+06
@@ -20212,7 +20370,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 608
+      ID: 624
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 847296
@@ -20220,22 +20378,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 610 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 626 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 609 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 625 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 609
+      ID: 625
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 989
+      ID: 1005
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 895
+      ID: 911
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1.460832e+06
@@ -20245,7 +20403,7 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 1078
+      ID: 1094
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
       GoRuntimeType: 1.696512e+06
@@ -20253,13 +20411,13 @@ Types:
       RawFields:
         - Name: WriteSyncer
           Offset: 0
-          Type: 1104 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+          Type: 1120 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
     - __kind: UnresolvedPointeeType
-      ID: 1172
+      ID: 1188
       Name: go.uber.org/zap/buffer.Buffer
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1104
+      ID: 1120
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
       GoRuntimeType: 1.13728e+06
@@ -20272,7 +20430,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1066
+      ID: 1082
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
       GoRuntimeType: 1.586304e+06
@@ -20282,19 +20440,19 @@ Types:
           Offset: 0
           Type: 137 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 611
+      ID: 627
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 847872
       GoKind: 10
     - __kind: BaseType
-      ID: 987
+      ID: 1003
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 1.01408e+06
       GoKind: 10
     - __kind: StructureType
-      ID: 953
+      ID: 969
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1.900608e+06
@@ -20305,12 +20463,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 987 BaseType golang.org/x/net/http2.ErrCode
+          Type: 1003 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 810
+      ID: 826
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1.623456e+06
@@ -20318,12 +20476,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 987 BaseType golang.org/x/net/http2.ErrCode
+          Type: 1003 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 615
+      ID: 631
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 848064
@@ -20331,18 +20489,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 617 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 633 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 616 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 632 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 616
+      ID: 632
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 621
+      ID: 637
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 848256
@@ -20350,18 +20508,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 623 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 639 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 622 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 638 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 622
+      ID: 638
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 618
+      ID: 634
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 848160
@@ -20369,18 +20527,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 620 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 636 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 619 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 635 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 619
+      ID: 635
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 612
+      ID: 628
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 847968
@@ -20388,22 +20546,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 614 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 630 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 613 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 629 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 613
+      ID: 629
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1170
+      ID: 1186
       Name: golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 814
+      ID: 830
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.461472e+06
@@ -20413,13 +20571,13 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: BaseType
-      ID: 624
+      ID: 640
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 848352
       GoKind: 2
     - __kind: StructureType
-      ID: 802
+      ID: 818
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1.456512e+06
@@ -20429,11 +20587,11 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 951
+      ID: 967
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 976
+      ID: 992
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1.929472e+06
@@ -20449,7 +20607,7 @@ Types:
           Offset: 24
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 804
+      ID: 820
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1.622976e+06
@@ -20462,7 +20620,7 @@ Types:
           Offset: 16
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 1121
+      ID: 1137
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
       GoRuntimeType: 1.9888e+06
@@ -20470,16 +20628,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 1002 GoInterfaceType net.Conn
+          Type: 1018 GoInterfaceType net.Conn
         - Name: r
           Offset: 16
-          Type: 1146 GoInterfaceType io.Reader
+          Type: 1162 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 1076
+      ID: 1092
       Name: google.golang.org/grpc/internal/transport.bufWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 893
+      ID: 909
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1.583904e+06
@@ -20489,29 +20647,29 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1038
+      ID: 1054
       Name: google.golang.org/grpc/mem.writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 782
+      ID: 798
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 881
+      ID: 897
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 949
+      ID: 965
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 947
+      ID: 963
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1.526304e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 796
+      ID: 812
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1.449792e+06
@@ -20521,7 +20679,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 798
+      ID: 814
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1.449952e+06
@@ -20531,393 +20689,393 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 731
+      ID: 747
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 445
+      ID: 461
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 446 PointerType *noalg.map.group[[4]int][4]int
+          Type: 462 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 447 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 451 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      GroupType: 463 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 467 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 437
+      ID: 453
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 438 PointerType *noalg.map.group[[4]int]uint8
+          Type: 454 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 439 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 443 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 455 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 459 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 385
+      ID: 401
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 386 PointerType *noalg.map.group[[4]string][2]int
+          Type: 402 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 387 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 392 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 403 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 408 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 404
+      ID: 420
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 405 PointerType *noalg.map.group[bool]main.node
+          Type: 421 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 406 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 410 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 422 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 426 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 343
+      ID: 359
       Name: groupReference<int,*main.deepMap2>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 344 PointerType *noalg.map.group[int]*main.deepMap2
+          Type: 360 PointerType *noalg.map.group[int]*main.deepMap2
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 345 StructureType noalg.map.group[int]*main.deepMap2
-      GroupSliceType: 351 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
+      GroupType: 361 StructureType noalg.map.group[int]*main.deepMap2
+      GroupSliceType: 367 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
     - __kind: GoSwissMapGroupsType
-      ID: 1250
+      ID: 1266
       Name: groupReference<int,*main.deepMap3>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1251 PointerType *noalg.map.group[int]*main.deepMap3
+          Type: 1267 PointerType *noalg.map.group[int]*main.deepMap3
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1252 StructureType noalg.map.group[int]*main.deepMap3
-      GroupSliceType: 1258 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+      GroupType: 1268 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 1274 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
     - __kind: GoSwissMapGroupsType
-      ID: 1284
+      ID: 1300
       Name: groupReference<int,*main.deepMap8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1285 PointerType *noalg.map.group[int]*main.deepMap8
+          Type: 1301 PointerType *noalg.map.group[int]*main.deepMap8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1286 StructureType noalg.map.group[int]*main.deepMap8
-      GroupSliceType: 1292 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
+      GroupType: 1302 StructureType noalg.map.group[int]*main.deepMap8
+      GroupSliceType: 1308 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
     - __kind: GoSwissMapGroupsType
-      ID: 1299
+      ID: 1315
       Name: groupReference<int,*main.deepMap9>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1300 PointerType *noalg.map.group[int]*main.deepMap9
+          Type: 1316 PointerType *noalg.map.group[int]*main.deepMap9
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1301 StructureType noalg.map.group[int]*main.deepMap9
-      GroupSliceType: 1307 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
+      GroupType: 1317 StructureType noalg.map.group[int]*main.deepMap9
+      GroupSliceType: 1323 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
     - __kind: GoSwissMapGroupsType
-      ID: 353
+      ID: 369
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 354 PointerType *noalg.map.group[int]int
+          Type: 370 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 355 StructureType noalg.map.group[int]int
-      GroupSliceType: 359 GoSliceDataType []noalg.map.group[int]int.array
+      GroupType: 371 StructureType noalg.map.group[int]int
+      GroupSliceType: 375 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 1314
+      ID: 1330
       Name: groupReference<int,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1315 PointerType *noalg.map.group[int]interface {}
+          Type: 1331 PointerType *noalg.map.group[int]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1316 StructureType noalg.map.group[int]interface {}
-      GroupSliceType: 1320 GoSliceDataType []noalg.map.group[int]interface {}.array
+      GroupType: 1332 StructureType noalg.map.group[int]interface {}
+      GroupSliceType: 1336 GoSliceDataType []noalg.map.group[int]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 461
+      ID: 477
       Name: groupReference<int,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 462 PointerType *noalg.map.group[int]struct {}
+          Type: 478 PointerType *noalg.map.group[int]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 463 StructureType noalg.map.group[int]struct {}
-      GroupSliceType: 467 GoSliceDataType []noalg.map.group[int]struct {}.array
+      GroupType: 479 StructureType noalg.map.group[int]struct {}
+      GroupSliceType: 483 GoSliceDataType []noalg.map.group[int]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 412
+      ID: 428
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 413 PointerType *noalg.map.group[int]uint8
+          Type: 429 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 414 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 418 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 430 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 434 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 394
+      ID: 410
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 395 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 411 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 396 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 402 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 412 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 418 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 377
+      ID: 393
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 378 PointerType *noalg.map.group[string][]string
+          Type: 394 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 379 StructureType noalg.map.group[string][]string
-      GroupSliceType: 383 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 395 StructureType noalg.map.group[string][]string
+      GroupSliceType: 399 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 1012
+      ID: 1028
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1013 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1029 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1014 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 1018 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 1030 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 1034 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
-      ID: 369
+      ID: 385
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 370 PointerType *noalg.map.group[string]int
+          Type: 386 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 371 StructureType noalg.map.group[string]int
-      GroupSliceType: 375 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 387 StructureType noalg.map.group[string]int
+      GroupSliceType: 391 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 361
+      ID: 377
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 362 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 378 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 363 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 367 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+      GroupType: 379 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 383 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 453
+      ID: 469
       Name: groupReference<struct {},int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 454 PointerType *noalg.map.group[struct {}]int
+          Type: 470 PointerType *noalg.map.group[struct {}]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 455 StructureType noalg.map.group[struct {}]int
-      GroupSliceType: 459 GoSliceDataType []noalg.map.group[struct {}]int.array
+      GroupType: 471 StructureType noalg.map.group[struct {}]int
+      GroupSliceType: 475 GoSliceDataType []noalg.map.group[struct {}]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 503
+      ID: 519
       Name: groupReference<struct {},main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 504 PointerType *noalg.map.group[struct {}]main.structWithCyclicMaps
+          Type: 520 PointerType *noalg.map.group[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 505 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 509 GoSliceDataType []noalg.map.group[struct {}]main.structWithCyclicMaps.array
+      GroupType: 521 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 525 GoSliceDataType []noalg.map.group[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 511
+      ID: 527
       Name: groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 512 PointerType *noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 528 PointerType *noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 513 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 517 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 529 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 533 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 519
+      ID: 535
       Name: groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 520 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 536 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 521 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 525 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 537 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 541 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 527
+      ID: 543
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 528 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 544 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 529 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 533 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 545 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 549 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 535
+      ID: 551
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 536 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 552 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 537 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 541 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 553 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 557 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 543
+      ID: 559
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 544 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 560 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 545 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 549 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 561 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 565 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 469
+      ID: 485
       Name: groupReference<struct {},struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 470 PointerType *noalg.map.group[struct {}]struct {}
+          Type: 486 PointerType *noalg.map.group[struct {}]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 471 StructureType noalg.map.group[struct {}]struct {}
-      GroupSliceType: 475 GoSliceDataType []noalg.map.group[struct {}]struct {}.array
+      GroupType: 487 StructureType noalg.map.group[struct {}]struct {}
+      GroupSliceType: 491 GoSliceDataType []noalg.map.group[struct {}]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 428
+      ID: 444
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 429 PointerType *noalg.map.group[uint8][4]int
+          Type: 445 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 430 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 435 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 446 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 451 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 420
+      ID: 436
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 421 PointerType *noalg.map.group[uint8]uint8
+          Type: 437 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 422 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 426 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 438 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 442 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: UnresolvedPointeeType
-      ID: 1125
+      ID: 1141
       Name: hash/crc32.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 817
+      ID: 833
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -20964,17 +21122,17 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: BaseType
-      ID: 1008
+      ID: 1024
       Name: internal/abi.BoundsErrorCode
       ByteSize: 1
       GoRuntimeType: 594240
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 978
+      ID: 994
       Name: internal/abi.Type
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 699
+      ID: 715
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -21000,29 +21158,29 @@ Types:
           Offset: 296
           Type: 2 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 697
+      ID: 713
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1024
+      ID: 1040
       Name: internal/godebug.runtimeStderr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 910
+      ID: 926
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1212
+      ID: 1228
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 908
+      ID: 924
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1.490304e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 630
+      ID: 646
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -21094,7 +21252,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 586
+      ID: 602
       Name: internal/runtime/cgroup.stringError
       ByteSize: 16
       GoRuntimeType: 842496
@@ -21102,18 +21260,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 588 PointerType *internal/runtime/cgroup.stringError.str
+          Type: 604 PointerType *internal/runtime/cgroup.stringError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 587 GoStringDataType internal/runtime/cgroup.stringError.str
+      Data: 603 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: GoStringDataType
-      ID: 587
+      ID: 603
       Name: internal/runtime/cgroup.stringError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 865
+      ID: 881
       Name: internal/runtime/maps.unhashableTypeError
       ByteSize: 8
       GoRuntimeType: 1.574784e+06
@@ -21121,15 +21279,15 @@ Types:
       RawFields:
         - Name: typ
           Offset: 0
-          Type: 977 PointerType *internal/abi.Type
+          Type: 993 PointerType *internal/abi.Type
     - __kind: BaseType
-      ID: 555
+      ID: 571
       Name: internal/strconv.Error
       ByteSize: 8
       GoRuntimeType: 839520
       GoKind: 2
     - __kind: StructureType
-      ID: 1224
+      ID: 1240
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.487744e+06
@@ -21142,11 +21300,11 @@ Types:
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 1070
+      ID: 1086
       Name: io.PipeWriter
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1111
+      ID: 1127
       Name: io.ReadWriteCloser
       ByteSize: 16
       GoRuntimeType: 1.199232e+06
@@ -21159,7 +21317,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1146
+      ID: 1162
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 1.033856e+06
@@ -21172,7 +21330,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1097
+      ID: 1113
       Name: io.WriteCloser
       ByteSize: 16
       GoRuntimeType: 1.119744e+06
@@ -21198,21 +21356,21 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1068
+      ID: 1084
       Name: io.discard
       GoRuntimeType: 1.476544e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1042
+      ID: 1058
       Name: io.multiWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 906
+      ID: 922
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1117
+      ID: 1133
       Name: log/slog/internal/buffer.Buffer
       ByteSize: 8
     - __kind: StructureType
@@ -21241,7 +21399,25 @@ Types:
       RawFields:
         - Name: nested
           Offset: 0
-          Type: 1321 PointerType *main.nestedStruct
+          Type: 1337 PointerType *main.nestedStruct
+    - __kind: StructureType
+      ID: 331
+      Name: main.bStruct
+      ByteSize: 72
+      GoKind: 25
+      RawFields:
+        - Name: aInt16
+          Offset: 0
+          Type: 109 BaseType int16
+        - Name: nested
+          Offset: 8
+          Type: 322 StructureType main.aStruct
+        - Name: aBool
+          Offset: 64
+          Type: 4 BaseType bool
+        - Name: aInt32
+          Offset: 68
+          Type: 10 BaseType int32
     - __kind: GoInterfaceType
       ID: 168
       Name: main.behavior
@@ -21271,6 +21447,21 @@ Types:
           Offset: 32
           Type: 137 GoInterfaceType io.Writer
     - __kind: StructureType
+      ID: 328
+      Name: main.cStruct
+      ByteSize: 24
+      GoKind: 25
+      RawFields:
+        - Name: aInt32
+          Offset: 0
+          Type: 10 BaseType int32
+        - Name: aUint
+          Offset: 8
+          Type: 14 BaseType uint
+        - Name: nested
+          Offset: 16
+          Type: 268 StructureType main.structWithNoStrings
+    - __kind: StructureType
       ID: 149
       Name: main.deepMap1
       ByteSize: 8
@@ -21281,7 +21472,7 @@ Types:
           Offset: 0
           Type: 150 GoMapType map[int]*main.deepMap2
     - __kind: StructureType
-      ID: 349
+      ID: 365
       Name: main.deepMap2
       ByteSize: 8
       GoRuntimeType: 1.19552e+06
@@ -21289,9 +21480,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1244 GoMapType map[int]*main.deepMap3
+          Type: 1260 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 1256
+      ID: 1272
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -21303,9 +21494,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1278 GoMapType map[int]*main.deepMap8
+          Type: 1294 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 1290
+      ID: 1306
       Name: main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.194752e+06
@@ -21313,9 +21504,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1293 GoMapType map[int]*main.deepMap9
+          Type: 1309 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 1305
+      ID: 1321
       Name: main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.194624e+06
@@ -21323,7 +21514,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1308 GoMapType map[int]interface {}
+          Type: 1324 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 138
       Name: main.deepPtr1
@@ -21343,9 +21534,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1215 PointerType *main.deepPtr3
+          Type: 1231 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 1216
+      ID: 1232
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -21357,9 +21548,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1259 PointerType *main.deepPtr8
+          Type: 1275 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 1260
+      ID: 1276
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1.195904e+06
@@ -21367,9 +21558,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1261 PointerType *main.deepPtr9
+          Type: 1277 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 1262
+      ID: 1278
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1.195776e+06
@@ -21389,7 +21580,7 @@ Types:
           Offset: 0
           Type: 144 GoSliceHeaderType []*main.deepSlice2
     - __kind: StructureType
-      ID: 339
+      ID: 355
       Name: main.deepSlice2
       ByteSize: 24
       GoRuntimeType: 1.197824e+06
@@ -21397,9 +21588,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1238 GoSliceHeaderType []*main.deepSlice3
+          Type: 1254 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 1241
+      ID: 1257
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -21411,9 +21602,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1263 GoSliceHeaderType []*main.deepSlice8
+          Type: 1279 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 1266
+      ID: 1282
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1.197056e+06
@@ -21421,9 +21612,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1269 GoSliceHeaderType []*main.deepSlice9
+          Type: 1285 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 1272
+      ID: 1288
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1.196928e+06
@@ -21431,7 +21622,73 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1275 GoSliceHeaderType []interface {}
+          Type: 1291 GoSliceHeaderType []interface {}
+    - __kind: StructureType
+      ID: 333
+      Name: main.deepStruct1
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: b
+          Offset: 8
+          Type: 334 StructureType main.deepStruct2
+    - __kind: StructureType
+      ID: 334
+      Name: main.deepStruct2
+      ByteSize: 40
+      GoKind: 25
+      RawFields:
+        - Name: c
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: d
+          Offset: 8
+          Type: 335 StructureType main.deepStruct3
+    - __kind: StructureType
+      ID: 335
+      Name: main.deepStruct3
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: e
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: f
+          Offset: 8
+          Type: 336 StructureType main.deepStruct4
+    - __kind: StructureType
+      ID: 336
+      Name: main.deepStruct4
+      ByteSize: 24
+      GoKind: 25
+      RawFields:
+        - Name: g
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: h
+          Offset: 8
+          Type: 337 StructureType main.deepStruct5
+    - __kind: StructureType
+      ID: 337
+      Name: main.deepStruct5
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: i
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: j
+          Offset: 8
+          Type: 338 StructureType main.deepStruct6
+    - __kind: StructureType
+      ID: 338
+      Name: main.deepStruct6
+      ByteSize: 8
+      GoKind: 25
+      RawFields: [{Name: k, Offset: 0, Type: 7 BaseType int}]
     - __kind: StructureType
       ID: 325
       Name: main.emptyStruct
@@ -21449,16 +21706,16 @@ Types:
           Type: 161 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 1222 StructureType sync.Mutex
+          Type: 1238 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 1225 StructureType sync.Once
+          Type: 1241 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 1228 StructureType sync.WaitGroup
+          Type: 1244 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 1231 StructureType sync/atomic.Int32
+          Type: 1247 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 161
       Name: main.esotericStack
@@ -21488,7 +21745,7 @@ Types:
           Offset: 56
           Type: 63 GoSubroutineType func()
     - __kind: StructureType
-      ID: 327
+      ID: 343
       Name: main.firstBehavior
       ByteSize: 16
       GoRuntimeType: 1.424992e+06
@@ -21534,6 +21791,90 @@ Types:
           Offset: 72
           Type: 7 BaseType int
     - __kind: StructureType
+      ID: 339
+      Name: main.lotsOfFields
+      ByteSize: 26
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 3 BaseType uint8
+        - Name: b
+          Offset: 1
+          Type: 3 BaseType uint8
+        - Name: c
+          Offset: 2
+          Type: 3 BaseType uint8
+        - Name: d
+          Offset: 3
+          Type: 3 BaseType uint8
+        - Name: e
+          Offset: 4
+          Type: 3 BaseType uint8
+        - Name: f
+          Offset: 5
+          Type: 3 BaseType uint8
+        - Name: g
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: h
+          Offset: 7
+          Type: 3 BaseType uint8
+        - Name: i
+          Offset: 8
+          Type: 3 BaseType uint8
+        - Name: j
+          Offset: 9
+          Type: 3 BaseType uint8
+        - Name: k
+          Offset: 10
+          Type: 3 BaseType uint8
+        - Name: l
+          Offset: 11
+          Type: 3 BaseType uint8
+        - Name: m
+          Offset: 12
+          Type: 3 BaseType uint8
+        - Name: n
+          Offset: 13
+          Type: 3 BaseType uint8
+        - Name: o
+          Offset: 14
+          Type: 3 BaseType uint8
+        - Name: p
+          Offset: 15
+          Type: 3 BaseType uint8
+        - Name: q
+          Offset: 16
+          Type: 3 BaseType uint8
+        - Name: r
+          Offset: 17
+          Type: 3 BaseType uint8
+        - Name: s
+          Offset: 18
+          Type: 3 BaseType uint8
+        - Name: t
+          Offset: 19
+          Type: 3 BaseType uint8
+        - Name: u
+          Offset: 20
+          Type: 3 BaseType uint8
+        - Name: v
+          Offset: 21
+          Type: 3 BaseType uint8
+        - Name: w
+          Offset: 22
+          Type: 3 BaseType uint8
+        - Name: x
+          Offset: 23
+          Type: 3 BaseType uint8
+        - Name: y
+          Offset: 24
+          Type: 3 BaseType uint8
+        - Name: z
+          Offset: 25
+          Type: 3 BaseType uint8
+    - __kind: StructureType
       ID: 260
       Name: main.mixedStruct
       ByteSize: 24
@@ -21548,6 +21889,21 @@ Types:
         - Name: c
           Offset: 16
           Type: 7 BaseType int
+    - __kind: StructureType
+      ID: 327
+      Name: main.nStruct
+      ByteSize: 24
+      GoKind: 25
+      RawFields:
+        - Name: aBool
+          Offset: 0
+          Type: 4 BaseType bool
+        - Name: aInt
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: aInt16
+          Offset: 16
+          Type: 109 BaseType int16
     - __kind: StructureType
       ID: 129
       Name: main.nestedStruct
@@ -21584,7 +21940,13 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1234
+      ID: 329
+      Name: main.receiver
+      ByteSize: 8
+      GoKind: 25
+      RawFields: [{Name: u, Offset: 0, Type: 14 BaseType uint}]
+    - __kind: StructureType
+      ID: 1250
       Name: main.secondBehavior
       ByteSize: 8
       GoRuntimeType: 1.425152e+06
@@ -21604,7 +21966,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1221
+      ID: 1237
       Name: main.somethingImpl
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -21615,31 +21977,31 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1218 PointerType *main.stringType1.str
+          Type: 1234 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 1217 GoStringDataType main.stringType1.str
+      Data: 1233 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 1217
+      ID: 1233
       Name: main.stringType1.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 1219
+      ID: 1235
       Name: main.stringType2
       ByteSize: 16
       GoKind: 24
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1323 PointerType *main.stringType2.str
+          Type: 1339 PointerType *main.stringType2.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 1322 GoStringDataType main.stringType2.str
+      Data: 1338 GoStringDataType main.stringType2.str
     - __kind: GoStringDataType
-      ID: 1322
+      ID: 1338
       Name: main.stringType2.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -21736,6 +22098,21 @@ Types:
           Offset: 1
           Type: 4 BaseType bool
     - __kind: StructureType
+      ID: 340
+      Name: main.structWithTwoArrays
+      ByteSize: 72
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 341 ArrayType [3]uint64
+        - Name: b
+          Offset: 24
+          Type: 3 BaseType uint8
+        - Name: c
+          Offset: 32
+          Type: 342 ArrayType [5]int64
+    - __kind: StructureType
       ID: 251
       Name: main.structWithTwoValues
       ByteSize: 16
@@ -21755,23 +22132,74 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1235 PointerType **main.t
+          Type: 1251 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1236 GoSliceDataType main.t.array
+      Data: 1252 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 1236
+      ID: 1252
       Name: main.t.array
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 254 PointerType *main.t
     - __kind: StructureType
+      ID: 332
+      Name: main.tenStrings
+      ByteSize: 160
+      GoKind: 25
+      RawFields:
+        - Name: first
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: second
+          Offset: 16
+          Type: 9 GoStringHeaderType string
+        - Name: third
+          Offset: 32
+          Type: 9 GoStringHeaderType string
+        - Name: fourth
+          Offset: 48
+          Type: 9 GoStringHeaderType string
+        - Name: fifth
+          Offset: 64
+          Type: 9 GoStringHeaderType string
+        - Name: sixth
+          Offset: 80
+          Type: 9 GoStringHeaderType string
+        - Name: seventh
+          Offset: 96
+          Type: 9 GoStringHeaderType string
+        - Name: eighth
+          Offset: 112
+          Type: 9 GoStringHeaderType string
+        - Name: ninth
+          Offset: 128
+          Type: 9 GoStringHeaderType string
+        - Name: tenth
+          Offset: 144
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
       ID: 274
       Name: main.threeStringStruct
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: b
+          Offset: 16
+          Type: 9 GoStringHeaderType string
+        - Name: c
+          Offset: 32
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 330
+      Name: main.threestrings
       ByteSize: 48
       GoKind: 25
       RawFields:
@@ -21861,8 +22289,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 450 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 447 StructureType noalg.map.group[[4]int][4]int
+      TablePtrSliceType: 466 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 463 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
       ID: 226
       Name: map<[4]int,uint8>
@@ -21896,8 +22324,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 442 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 439 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 458 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 455 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 194
       Name: map<[4]string,[2]int>
@@ -21931,8 +22359,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 391 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 387 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 407 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 403 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
       ID: 206
       Name: map<bool,main.node>
@@ -21966,8 +22394,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 409 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 406 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 425 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 422 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
       ID: 152
       Name: map<int,*main.deepMap2>
@@ -22001,10 +22429,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 350 GoSliceDataType []*table<int,*main.deepMap2>.array
-      GroupType: 345 StructureType noalg.map.group[int]*main.deepMap2
+      TablePtrSliceType: 366 GoSliceDataType []*table<int,*main.deepMap2>.array
+      GroupType: 361 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSwissMapHeaderType
-      ID: 1246
+      ID: 1262
       Name: map<int,*main.deepMap3>
       ByteSize: 48
       GoKind: 25
@@ -22017,7 +22445,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1247 PointerType **table<int,*main.deepMap3>
+          Type: 1263 PointerType **table<int,*main.deepMap3>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -22036,10 +22464,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1257 GoSliceDataType []*table<int,*main.deepMap3>.array
-      GroupType: 1252 StructureType noalg.map.group[int]*main.deepMap3
+      TablePtrSliceType: 1273 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 1268 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSwissMapHeaderType
-      ID: 1280
+      ID: 1296
       Name: map<int,*main.deepMap8>
       ByteSize: 48
       GoKind: 25
@@ -22052,7 +22480,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1281 PointerType **table<int,*main.deepMap8>
+          Type: 1297 PointerType **table<int,*main.deepMap8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -22071,10 +22499,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1291 GoSliceDataType []*table<int,*main.deepMap8>.array
-      GroupType: 1286 StructureType noalg.map.group[int]*main.deepMap8
+      TablePtrSliceType: 1307 GoSliceDataType []*table<int,*main.deepMap8>.array
+      GroupType: 1302 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSwissMapHeaderType
-      ID: 1295
+      ID: 1311
       Name: map<int,*main.deepMap9>
       ByteSize: 48
       GoKind: 25
@@ -22087,7 +22515,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1296 PointerType **table<int,*main.deepMap9>
+          Type: 1312 PointerType **table<int,*main.deepMap9>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -22106,8 +22534,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1306 GoSliceDataType []*table<int,*main.deepMap9>.array
-      GroupType: 1301 StructureType noalg.map.group[int]*main.deepMap9
+      TablePtrSliceType: 1322 GoSliceDataType []*table<int,*main.deepMap9>.array
+      GroupType: 1317 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSwissMapHeaderType
       ID: 174
       Name: map<int,int>
@@ -22141,10 +22569,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 358 GoSliceDataType []*table<int,int>.array
-      GroupType: 355 StructureType noalg.map.group[int]int
+      TablePtrSliceType: 374 GoSliceDataType []*table<int,int>.array
+      GroupType: 371 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
-      ID: 1310
+      ID: 1326
       Name: map<int,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -22157,7 +22585,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1311 PointerType **table<int,interface {}>
+          Type: 1327 PointerType **table<int,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -22176,8 +22604,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1319 GoSliceDataType []*table<int,interface {}>.array
-      GroupType: 1316 StructureType noalg.map.group[int]interface {}
+      TablePtrSliceType: 1335 GoSliceDataType []*table<int,interface {}>.array
+      GroupType: 1332 StructureType noalg.map.group[int]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 241
       Name: map<int,struct {}>
@@ -22211,8 +22639,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 466 GoSliceDataType []*table<int,struct {}>.array
-      GroupType: 463 StructureType noalg.map.group[int]struct {}
+      TablePtrSliceType: 482 GoSliceDataType []*table<int,struct {}>.array
+      GroupType: 479 StructureType noalg.map.group[int]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 211
       Name: map<int,uint8>
@@ -22246,8 +22674,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 417 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 414 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 433 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 430 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 201
       Name: map<string,[]main.structWithMap>
@@ -22281,8 +22709,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 401 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 396 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 417 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 412 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
       ID: 189
       Name: map<string,[]string>
@@ -22316,10 +22744,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 382 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 379 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 398 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 395 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 982
+      ID: 998
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -22332,7 +22760,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 983 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 999 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -22351,8 +22779,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1017 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 1014 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 1033 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 1030 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
       ID: 184
       Name: map<string,int>
@@ -22386,8 +22814,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 374 GoSliceDataType []*table<string,int>.array
-      GroupType: 371 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 390 GoSliceDataType []*table<string,int>.array
+      GroupType: 387 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
       ID: 179
       Name: map<string,main.nestedStruct>
@@ -22421,8 +22849,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 366 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 363 StructureType noalg.map.group[string]main.nestedStruct
+      TablePtrSliceType: 382 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 379 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSwissMapHeaderType
       ID: 236
       Name: map<struct {},int>
@@ -22456,8 +22884,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 458 GoSliceDataType []*table<struct {},int>.array
-      GroupType: 455 StructureType noalg.map.group[struct {}]int
+      TablePtrSliceType: 474 GoSliceDataType []*table<struct {},int>.array
+      GroupType: 471 StructureType noalg.map.group[struct {}]int
     - __kind: GoSwissMapHeaderType
       ID: 294
       Name: map<struct {},main.structWithCyclicMaps>
@@ -22491,8 +22919,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 508 GoSliceDataType []*table<struct {},main.structWithCyclicMaps>.array
-      GroupType: 505 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 524 GoSliceDataType []*table<struct {},main.structWithCyclicMaps>.array
+      GroupType: 521 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 299
       Name: map<struct {},map[struct {}]main.structWithCyclicMaps>
@@ -22526,8 +22954,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 516 GoSliceDataType []*table<struct {},map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 513 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 532 GoSliceDataType []*table<struct {},map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 529 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 304
       Name: map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -22561,8 +22989,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 524 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 521 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 540 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 537 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 309
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -22596,8 +23024,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 532 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 529 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 548 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 545 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 314
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -22631,8 +23059,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 540 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 537 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 556 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 553 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 319
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -22666,8 +23094,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 548 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 545 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 564 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 561 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 246
       Name: map<struct {},struct {}>
@@ -22701,8 +23129,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 474 GoSliceDataType []*table<struct {},struct {}>.array
-      GroupType: 471 StructureType noalg.map.group[struct {}]struct {}
+      TablePtrSliceType: 490 GoSliceDataType []*table<struct {},struct {}>.array
+      GroupType: 487 StructureType noalg.map.group[struct {}]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 221
       Name: map<uint8,[4]int>
@@ -22736,8 +23164,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 434 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 430 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 450 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 446 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
       ID: 216
       Name: map<uint8,uint8>
@@ -22771,8 +23199,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 425 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 422 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 441 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 438 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
       ID: 229
       Name: map[[4]int][4]int
@@ -22809,26 +23237,26 @@ Types:
       GoKind: 21
       HeaderType: 152 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 1244
+      ID: 1260
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 1.138944e+06
       GoKind: 21
-      HeaderType: 1246 GoSwissMapHeaderType map<int,*main.deepMap3>
+      HeaderType: 1262 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 1278
+      ID: 1294
       Name: map[int]*main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.138304e+06
       GoKind: 21
-      HeaderType: 1280 GoSwissMapHeaderType map<int,*main.deepMap8>
+      HeaderType: 1296 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
-      ID: 1293
+      ID: 1309
       Name: map[int]*main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.138176e+06
       GoKind: 21
-      HeaderType: 1295 GoSwissMapHeaderType map<int,*main.deepMap9>
+      HeaderType: 1311 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 172
       Name: map[int]int
@@ -22837,12 +23265,12 @@ Types:
       GoKind: 21
       HeaderType: 174 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
-      ID: 1308
+      ID: 1324
       Name: map[int]interface {}
       ByteSize: 8
       GoRuntimeType: 1.138048e+06
       GoKind: 21
-      HeaderType: 1310 GoSwissMapHeaderType map<int,interface {}>
+      HeaderType: 1326 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
       ID: 239
       Name: map[int]struct {}
@@ -22950,7 +23378,7 @@ Types:
       GoKind: 21
       HeaderType: 216 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: StructureType
-      ID: 735
+      ID: 751
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1.441152e+06
@@ -22960,7 +23388,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1032
+      ID: 1048
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
       GoRuntimeType: 1.438112e+06
@@ -22970,11 +23398,11 @@ Types:
           Offset: 0
           Type: 137 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 937
+      ID: 953
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1002
+      ID: 1018
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1.613056e+06
@@ -22987,35 +23415,35 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 963
+      ID: 979
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1176
+      ID: 1192
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 961
+      ID: 977
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 939
+      ID: 955
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1186
+      ID: 1202
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1196
+      ID: 1212
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1184
+      ID: 1200
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 898
+      ID: 914
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1.123072e+06
@@ -23023,28 +23451,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 900 PointerType *net.UnknownNetworkError.str
+          Type: 916 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 899 GoStringDataType net.UnknownNetworkError.str
+      Data: 915 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 899
+      ID: 915
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 863
+      ID: 879
       Name: net.canceledError
       GoRuntimeType: 1.295936e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1154
+      ID: 1170
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 1007
+      ID: 1023
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2.12912e+06
@@ -23052,7 +23480,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 1002 GoInterfaceType net.Conn
+          Type: 1018 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 15 GoInterfaceType error
@@ -23063,27 +23491,27 @@ Types:
           Offset: 33
           Type: 4 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 1198
+      ID: 1214
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 1192
+      ID: 1208
       Name: net.noReadFrom
       GoRuntimeType: 1.123328e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1191
+      ID: 1207
       Name: net.noWriteTo
       GoRuntimeType: 1.1232e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 665
+      ID: 681
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
-      ID: 667
+      ID: 683
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1.748288e+06
@@ -23091,7 +23519,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 990 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 1006 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 9 GoStringHeaderType string
@@ -23099,7 +23527,7 @@ Types:
           Offset: 96
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 1180
+      ID: 1196
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.311296e+06
@@ -23107,12 +23535,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1192 StructureType net.noReadFrom
+          Type: 1208 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 1185 PointerType *net.TCPConn
+          Type: 1201 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 1178
+      ID: 1194
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.310752e+06
@@ -23120,24 +23548,24 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1191 StructureType net.noWriteTo
+          Type: 1207 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 1185 PointerType *net.TCPConn
+          Type: 1201 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 941
+      ID: 957
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 965
+      ID: 981
       Name: net.timeoutError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 853
+      ID: 869
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1026
+      ID: 1042
       Name: net/http.bufioFlushWriter
       ByteSize: 16
       GoRuntimeType: 1.429632e+06
@@ -23147,19 +23575,19 @@ Types:
           Offset: 0
           Type: 137 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 556
+      ID: 572
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 840192
       GoKind: 10
     - __kind: BaseType
-      ID: 979
+      ID: 995
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 1.000928e+06
       GoKind: 10
     - __kind: StructureType
-      ID: 643
+      ID: 659
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1.745792e+06
@@ -23170,12 +23598,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 979 BaseType net/http.http2ErrCode
+          Type: 995 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 957
+      ID: 973
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1.91872e+06
@@ -23186,12 +23614,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 979 BaseType net/http.http2ErrCode
+          Type: 995 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 647
+      ID: 663
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1.612576e+06
@@ -23199,16 +23627,16 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 979 BaseType net/http.http2ErrCode
+          Type: 995 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1088
+      ID: 1104
       Name: net/http.http2dataBuffer
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 560
+      ID: 576
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 840384
@@ -23216,18 +23644,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 562 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 578 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 561 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 577 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 561
+      ID: 577
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 566
+      ID: 582
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 840576
@@ -23235,18 +23663,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 568 PointerType *net/http.http2headerFieldNameError.str
+          Type: 584 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 567 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 583 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 567
+      ID: 583
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 563
+      ID: 579
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 840480
@@ -23254,32 +23682,32 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 565 PointerType *net/http.http2headerFieldValueError.str
+          Type: 581 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 564 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 580 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 564
+      ID: 580
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 932
+      ID: 948
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 859
+      ID: 875
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1.295168e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1143
+      ID: 1159
       Name: net/http.http2pipe
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 557
+      ID: 573
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 840288
@@ -23287,18 +23715,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 559 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 575 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 558 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 574 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 558
+      ID: 574
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1028
+      ID: 1044
       Name: net/http.http2stickyErrWriter
       ByteSize: 32
       GoRuntimeType: 1.74656e+06
@@ -23306,22 +23734,22 @@ Types:
       RawFields:
         - Name: conn
           Offset: 0
-          Type: 1002 GoInterfaceType net.Conn
+          Type: 1018 GoInterfaceType net.Conn
         - Name: timeout
           Offset: 16
-          Type: 1107 BaseType time.Duration
+          Type: 1123 BaseType time.Duration
         - Name: err
           Offset: 24
           Type: 111 PointerType *error
     - __kind: ArrayType
-      ID: 1108
+      ID: 1124
       Name: net/http.incomparable
       GoRuntimeType: 913120
       GoKind: 17
       HasCount: true
       Element: 63 GoSubroutineType func()
     - __kind: StructureType
-      ID: 855
+      ID: 871
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1.570784e+06
@@ -23331,11 +23759,11 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1090
+      ID: 1106
       Name: net/http.persistConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 1046
+      ID: 1062
       Name: net/http.persistConnWriter
       ByteSize: 8
       GoRuntimeType: 1.570624e+06
@@ -23343,9 +23771,9 @@ Types:
       RawFields:
         - Name: pc
           Offset: 0
-          Type: 1089 PointerType *net/http.persistConn
+          Type: 1105 PointerType *net/http.persistConn
     - __kind: StructureType
-      ID: 1080
+      ID: 1096
       Name: net/http.readWriteCloserBody
       ByteSize: 24
       GoRuntimeType: 1.819968e+06
@@ -23353,15 +23781,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1108 ArrayType net/http.incomparable
+          Type: 1124 ArrayType net/http.incomparable
         - Name: br
           Offset: 0
-          Type: 1109 PointerType *bufio.Reader
+          Type: 1125 PointerType *bufio.Reader
         - Name: ReadWriteCloser
           Offset: 8
-          Type: 1111 GoInterfaceType io.ReadWriteCloser
+          Type: 1127 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 651
+      ID: 667
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1.430592e+06
@@ -23371,17 +23799,17 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 959
+      ID: 975
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 930
+      ID: 946
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1.493184e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 857
+      ID: 873
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1.570944e+06
@@ -23391,7 +23819,7 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 1123
+      ID: 1139
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
       GoRuntimeType: 2.049504e+06
@@ -23399,16 +23827,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 1002 GoInterfaceType net.Conn
+          Type: 1018 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 1002 GoInterfaceType net.Conn
+          Type: 1018 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 640
+      ID: 656
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1145
+      ID: 1161
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
       GoRuntimeType: 2.065248e+06
@@ -23416,13 +23844,13 @@ Types:
       RawFields:
         - Name: Writer
           Offset: 0
-          Type: 1138 PointerType *bufio.Writer
+          Type: 1154 PointerType *bufio.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1056
+      ID: 1072
       Name: net/http/internal.chunkedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 727
+      ID: 743
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1.75136e+06
@@ -23438,7 +23866,7 @@ Types:
           Offset: 32
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 725
+      ID: 741
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1.614496e+06
@@ -23451,11 +23879,11 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1096
+      ID: 1112
       Name: net/smtp.Client
       ByteSize: 8
     - __kind: StructureType
-      ID: 1058
+      ID: 1074
       Name: net/smtp.dataCloser
       ByteSize: 24
       GoRuntimeType: 1.616736e+06
@@ -23463,16 +23891,16 @@ Types:
       RawFields:
         - Name: c
           Offset: 0
-          Type: 1095 PointerType *net/smtp.Client
+          Type: 1111 PointerType *net/smtp.Client
         - Name: WriteCloser
           Offset: 8
-          Type: 1097 GoInterfaceType io.WriteCloser
+          Type: 1113 GoInterfaceType io.WriteCloser
     - __kind: UnresolvedPointeeType
-      ID: 711
+      ID: 727
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 594
+      ID: 610
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 843264
@@ -23480,26 +23908,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 596 PointerType *net/textproto.ProtocolError.str
+          Type: 612 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 595 GoStringDataType net/textproto.ProtocolError.str
+      Data: 611 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 595
+      ID: 611
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1054
+      ID: 1070
       Name: net/textproto.dotWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 967
+      ID: 983
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 569
+      ID: 585
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 841152
@@ -23507,18 +23935,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 571 PointerType *net/url.EscapeError.str
+          Type: 587 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 570 GoStringDataType net/url.EscapeError.str
+      Data: 586 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 570
+      ID: 586
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 572
+      ID: 588
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 841248
@@ -23526,254 +23954,254 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 574 PointerType *net/url.InvalidHostError.str
+          Type: 590 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 573 GoStringDataType net/url.InvalidHostError.str
+      Data: 589 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 573
+      ID: 589
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: ArrayType
-      ID: 448
+      ID: 464
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
       GoRuntimeType: 689984
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 449 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 465 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 440
+      ID: 456
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
       GoRuntimeType: 690080
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 441 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 457 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 388
+      ID: 404
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
       GoRuntimeType: 690368
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 389 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 405 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 407
+      ID: 423
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
       GoRuntimeType: 690464
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 408 StructureType noalg.struct { key bool; elem main.node }
+      Element: 424 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 346
+      ID: 362
       Name: noalg.[8]struct { key int; elem *main.deepMap2 }
       ByteSize: 128
       GoRuntimeType: 689312
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 347 StructureType noalg.struct { key int; elem *main.deepMap2 }
+      Element: 363 StructureType noalg.struct { key int; elem *main.deepMap2 }
     - __kind: ArrayType
-      ID: 1253
+      ID: 1269
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
       GoRuntimeType: 689216
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1254 StructureType noalg.struct { key int; elem *main.deepMap3 }
+      Element: 1270 StructureType noalg.struct { key int; elem *main.deepMap3 }
     - __kind: ArrayType
-      ID: 1287
+      ID: 1303
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
       ByteSize: 128
       GoRuntimeType: 688736
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1288 StructureType noalg.struct { key int; elem *main.deepMap8 }
+      Element: 1304 StructureType noalg.struct { key int; elem *main.deepMap8 }
     - __kind: ArrayType
-      ID: 1302
+      ID: 1318
       Name: noalg.[8]struct { key int; elem *main.deepMap9 }
       ByteSize: 128
       GoRuntimeType: 688640
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1303 StructureType noalg.struct { key int; elem *main.deepMap9 }
+      Element: 1319 StructureType noalg.struct { key int; elem *main.deepMap9 }
     - __kind: ArrayType
-      ID: 356
+      ID: 372
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
       GoRuntimeType: 687488
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 357 StructureType noalg.struct { key int; elem int }
+      Element: 373 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 1317
+      ID: 1333
       Name: noalg.[8]struct { key int; elem interface {} }
       ByteSize: 192
       GoRuntimeType: 688544
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1318 StructureType noalg.struct { key int; elem interface {} }
+      Element: 1334 StructureType noalg.struct { key int; elem interface {} }
     - __kind: ArrayType
-      ID: 464
+      ID: 480
       Name: noalg.[8]struct { key int; elem struct {} }
       ByteSize: 128
       GoRuntimeType: 690560
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 465 StructureType noalg.struct { key int; elem struct {} }
+      Element: 481 StructureType noalg.struct { key int; elem struct {} }
     - __kind: ArrayType
-      ID: 415
+      ID: 431
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
       GoRuntimeType: 690656
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 416 StructureType noalg.struct { key int; elem uint8 }
+      Element: 432 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 397
+      ID: 413
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
       GoRuntimeType: 690752
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 398 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 414 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 380
+      ID: 396
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 690848
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 381 StructureType noalg.struct { key string; elem []string }
+      Element: 397 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 1015
+      ID: 1031
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 767232
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1016 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 1032 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
-      ID: 372
+      ID: 388
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 690944
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 373 StructureType noalg.struct { key string; elem int }
+      Element: 389 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 364
+      ID: 380
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
       GoRuntimeType: 691040
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 365 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 381 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 456
+      ID: 472
       Name: noalg.[8]struct { key struct {}; elem int }
       ByteSize: 64
       GoRuntimeType: 691136
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 457 StructureType noalg.struct { key struct {}; elem int }
+      Element: 473 StructureType noalg.struct { key struct {}; elem int }
     - __kind: ArrayType
-      ID: 506
+      ID: 522
       Name: noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
       ByteSize: 384
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 507 StructureType noalg.struct { key struct {}; elem main.structWithCyclicMaps }
+      Element: 523 StructureType noalg.struct { key struct {}; elem main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 514
+      ID: 530
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 515 StructureType noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+      Element: 531 StructureType noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 522
+      ID: 538
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 523 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 539 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 530
+      ID: 546
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 531 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 547 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 538
+      ID: 554
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 539 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 555 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 546
+      ID: 562
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 547 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 563 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 472
+      ID: 488
       Name: noalg.[8]struct { key struct {}; elem struct {} }
       GoRuntimeType: 691232
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 473 StructureType noalg.struct { key struct {}; elem struct {} }
+      Element: 489 StructureType noalg.struct { key struct {}; elem struct {} }
     - __kind: ArrayType
-      ID: 431
+      ID: 447
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
       GoRuntimeType: 691328
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 432 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 448 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 423
+      ID: 439
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 691424
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 424 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 440 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 447
+      ID: 463
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
       GoRuntimeType: 1.3072e+06
@@ -23784,9 +24212,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 448 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 464 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 439
+      ID: 455
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
       GoRuntimeType: 1.307456e+06
@@ -23797,9 +24225,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 440 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 456 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 387
+      ID: 403
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
       GoRuntimeType: 1.307712e+06
@@ -23810,9 +24238,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 388 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 404 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 406
+      ID: 422
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
       GoRuntimeType: 1.307968e+06
@@ -23823,9 +24251,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 407 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 423 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 345
+      ID: 361
       Name: noalg.map.group[int]*main.deepMap2
       ByteSize: 136
       GoRuntimeType: 1.306944e+06
@@ -23836,9 +24264,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 346 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
+          Type: 362 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
     - __kind: StructureType
-      ID: 1252
+      ID: 1268
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
       GoRuntimeType: 1.306688e+06
@@ -23849,9 +24277,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1253 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+          Type: 1269 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
     - __kind: StructureType
-      ID: 1286
+      ID: 1302
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
       GoRuntimeType: 1.305408e+06
@@ -23862,9 +24290,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1287 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
+          Type: 1303 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
     - __kind: StructureType
-      ID: 1301
+      ID: 1317
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
       GoRuntimeType: 1.305152e+06
@@ -23875,9 +24303,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1302 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
+          Type: 1318 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
     - __kind: StructureType
-      ID: 355
+      ID: 371
       Name: noalg.map.group[int]int
       ByteSize: 136
       GoRuntimeType: 1.304128e+06
@@ -23888,9 +24316,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 356 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 372 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 1316
+      ID: 1332
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
       GoRuntimeType: 1.304896e+06
@@ -23901,9 +24329,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1317 ArrayType noalg.[8]struct { key int; elem interface {} }
+          Type: 1333 ArrayType noalg.[8]struct { key int; elem interface {} }
     - __kind: StructureType
-      ID: 463
+      ID: 479
       Name: noalg.map.group[int]struct {}
       ByteSize: 136
       GoRuntimeType: 1.308224e+06
@@ -23914,9 +24342,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 464 ArrayType noalg.[8]struct { key int; elem struct {} }
+          Type: 480 ArrayType noalg.[8]struct { key int; elem struct {} }
     - __kind: StructureType
-      ID: 414
+      ID: 430
       Name: noalg.map.group[int]uint8
       ByteSize: 136
       GoRuntimeType: 1.30848e+06
@@ -23927,9 +24355,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 415 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 431 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 396
+      ID: 412
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
       GoRuntimeType: 1.308736e+06
@@ -23940,9 +24368,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 397 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 413 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 379
+      ID: 395
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.308992e+06
@@ -23953,9 +24381,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 380 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 396 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 1014
+      ID: 1030
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1.370432e+06
@@ -23966,9 +24394,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1015 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 1031 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
-      ID: 371
+      ID: 387
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 1.309248e+06
@@ -23979,9 +24407,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 372 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 388 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 363
+      ID: 379
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
       GoRuntimeType: 1.309504e+06
@@ -23992,9 +24420,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 364 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 380 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 455
+      ID: 471
       Name: noalg.map.group[struct {}]int
       ByteSize: 72
       GoRuntimeType: 1.30976e+06
@@ -24005,9 +24433,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 456 ArrayType noalg.[8]struct { key struct {}; elem int }
+          Type: 472 ArrayType noalg.[8]struct { key struct {}; elem int }
     - __kind: StructureType
-      ID: 505
+      ID: 521
       Name: noalg.map.group[struct {}]main.structWithCyclicMaps
       ByteSize: 392
       GoKind: 25
@@ -24017,9 +24445,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 506 ArrayType noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
+          Type: 522 ArrayType noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 513
+      ID: 529
       Name: noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -24029,9 +24457,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 514 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+          Type: 530 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 521
+      ID: 537
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -24041,9 +24469,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 522 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 538 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 529
+      ID: 545
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -24053,9 +24481,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 530 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 546 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 537
+      ID: 553
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -24065,9 +24493,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 538 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 554 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 545
+      ID: 561
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -24077,9 +24505,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 546 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 562 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 471
+      ID: 487
       Name: noalg.map.group[struct {}]struct {}
       ByteSize: 16
       GoRuntimeType: 1.310016e+06
@@ -24090,9 +24518,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 472 ArrayType noalg.[8]struct { key struct {}; elem struct {} }
+          Type: 488 ArrayType noalg.[8]struct { key struct {}; elem struct {} }
     - __kind: StructureType
-      ID: 430
+      ID: 446
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
       GoRuntimeType: 1.310272e+06
@@ -24103,9 +24531,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 431 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 447 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 422
+      ID: 438
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
       GoRuntimeType: 1.310528e+06
@@ -24116,9 +24544,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 423 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 439 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 449
+      ID: 465
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
       GoRuntimeType: 1.307072e+06
@@ -24126,12 +24554,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 433 ArrayType [4]int
+          Type: 449 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 433 ArrayType [4]int
+          Type: 449 ArrayType [4]int
     - __kind: StructureType
-      ID: 441
+      ID: 457
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
       GoRuntimeType: 1.307328e+06
@@ -24139,12 +24567,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 433 ArrayType [4]int
+          Type: 449 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 389
+      ID: 405
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
       GoRuntimeType: 1.307584e+06
@@ -24152,12 +24580,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 390 ArrayType [4]string
+          Type: 406 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 119 ArrayType [2]int
     - __kind: StructureType
-      ID: 408
+      ID: 424
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
       GoRuntimeType: 1.30784e+06
@@ -24170,7 +24598,7 @@ Types:
           Offset: 8
           Type: 252 StructureType main.node
     - __kind: StructureType
-      ID: 347
+      ID: 363
       Name: noalg.struct { key int; elem *main.deepMap2 }
       ByteSize: 16
       GoRuntimeType: 1.306816e+06
@@ -24181,9 +24609,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 348 PointerType *main.deepMap2
+          Type: 364 PointerType *main.deepMap2
     - __kind: StructureType
-      ID: 1254
+      ID: 1270
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
       GoRuntimeType: 1.30656e+06
@@ -24194,9 +24622,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1255 PointerType *main.deepMap3
+          Type: 1271 PointerType *main.deepMap3
     - __kind: StructureType
-      ID: 1288
+      ID: 1304
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
       GoRuntimeType: 1.30528e+06
@@ -24207,9 +24635,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1289 PointerType *main.deepMap8
+          Type: 1305 PointerType *main.deepMap8
     - __kind: StructureType
-      ID: 1303
+      ID: 1319
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
       GoRuntimeType: 1.305024e+06
@@ -24220,9 +24648,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1304 PointerType *main.deepMap9
+          Type: 1320 PointerType *main.deepMap9
     - __kind: StructureType
-      ID: 357
+      ID: 373
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
       GoRuntimeType: 1.304e+06
@@ -24235,7 +24663,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 1318
+      ID: 1334
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
       GoRuntimeType: 1.304768e+06
@@ -24248,7 +24676,7 @@ Types:
           Offset: 8
           Type: 163 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 465
+      ID: 481
       Name: noalg.struct { key int; elem struct {} }
       ByteSize: 16
       GoRuntimeType: 1.308096e+06
@@ -24261,7 +24689,7 @@ Types:
           Offset: 8
           Type: 131 StructureType struct {}
     - __kind: StructureType
-      ID: 416
+      ID: 432
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 1.308352e+06
@@ -24274,7 +24702,7 @@ Types:
           Offset: 8
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 398
+      ID: 414
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
       GoRuntimeType: 1.308608e+06
@@ -24285,9 +24713,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 399 GoSliceHeaderType []main.structWithMap
+          Type: 415 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 381
+      ID: 397
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.308864e+06
@@ -24300,7 +24728,7 @@ Types:
           Offset: 16
           Type: 269 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 1016
+      ID: 1032
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1.370304e+06
@@ -24311,9 +24739,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 1003 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1019 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 373
+      ID: 389
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 1.30912e+06
@@ -24326,7 +24754,7 @@ Types:
           Offset: 16
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 365
+      ID: 381
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
       GoRuntimeType: 1.309376e+06
@@ -24339,7 +24767,7 @@ Types:
           Offset: 16
           Type: 129 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 457
+      ID: 473
       Name: noalg.struct { key struct {}; elem int }
       ByteSize: 8
       GoRuntimeType: 1.309632e+06
@@ -24352,7 +24780,7 @@ Types:
           Offset: 0
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 507
+      ID: 523
       Name: noalg.struct { key struct {}; elem main.structWithCyclicMaps }
       ByteSize: 48
       GoKind: 25
@@ -24364,7 +24792,7 @@ Types:
           Offset: 0
           Type: 291 StructureType main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 515
+      ID: 531
       Name: noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -24376,7 +24804,7 @@ Types:
           Offset: 0
           Type: 292 GoMapType map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 523
+      ID: 539
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -24388,7 +24816,7 @@ Types:
           Offset: 0
           Type: 297 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 531
+      ID: 547
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -24400,7 +24828,7 @@ Types:
           Offset: 0
           Type: 302 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 539
+      ID: 555
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -24412,7 +24840,7 @@ Types:
           Offset: 0
           Type: 307 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 547
+      ID: 563
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -24424,7 +24852,7 @@ Types:
           Offset: 0
           Type: 312 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 473
+      ID: 489
       Name: noalg.struct { key struct {}; elem struct {} }
       GoRuntimeType: 1.309888e+06
       GoKind: 25
@@ -24436,7 +24864,7 @@ Types:
           Offset: 0
           Type: 131 StructureType struct {}
     - __kind: StructureType
-      ID: 432
+      ID: 448
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
       GoRuntimeType: 1.310144e+06
@@ -24447,9 +24875,9 @@ Types:
           Type: 3 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 433 ArrayType [4]int
+          Type: 449 ArrayType [4]int
     - __kind: StructureType
-      ID: 424
+      ID: 440
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
       GoRuntimeType: 1.3104e+06
@@ -24462,19 +24890,19 @@ Types:
           Offset: 1
           Type: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1204
+      ID: 1220
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 834
+      ID: 850
       Name: os.LinkError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 902
+      ID: 918
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1202
+      ID: 1218
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.381696e+06
@@ -24482,12 +24910,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1208 StructureType os.noReadFrom
+          Type: 1224 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 1203 PointerType *os.File
+          Type: 1219 PointerType *os.File
     - __kind: StructureType
-      ID: 1200
+      ID: 1216
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.380896e+06
@@ -24495,36 +24923,36 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1207 StructureType os.noWriteTo
+          Type: 1223 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 1203 PointerType *os.File
+          Type: 1219 PointerType *os.File
     - __kind: StructureType
-      ID: 1208
+      ID: 1224
       Name: os.noReadFrom
       GoRuntimeType: 1.12064e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1207
+      ID: 1223
       Name: os.noWriteTo
       GoRuntimeType: 1.120512e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 867
+      ID: 883
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1010
+      ID: 1026
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1074
+      ID: 1090
       Name: os/exec.prefixSuffixSaver
       ByteSize: 8
     - __kind: StructureType
-      ID: 869
+      ID: 885
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1.72176e+06
@@ -24537,7 +24965,7 @@ Types:
           Offset: 16
           Type: 15 GoInterfaceType error
     - __kind: GoStringHeaderType
-      ID: 605
+      ID: 621
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 846528
@@ -24545,36 +24973,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 607 PointerType *os/user.UnknownGroupIdError.str
+          Type: 623 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 606 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 622 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 606
+      ID: 622
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 604
+      ID: 620
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 846432
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 632
+      ID: 648
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 733
+      ID: 749
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 838
+      ID: 854
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 842
+      ID: 858
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -24586,7 +25014,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 840
+      ID: 856
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1.907776e+06
@@ -24603,7 +25031,7 @@ Types:
           Type: 4 BaseType bool
         - Name: code
           Offset: 17
-          Type: 1008 BaseType internal/abi.BoundsErrorCode
+          Type: 1024 BaseType internal/abi.BoundsErrorCode
     - __kind: UnresolvedPointeeType
       ID: 70
       Name: runtime.cgoCallers
@@ -24619,7 +25047,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 904
+      ID: 920
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1.772608e+06
@@ -24632,7 +25060,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 818
+      ID: 834
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 999488
@@ -24640,13 +25068,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 820 PointerType *runtime.errorString.str
+          Type: 836 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 819 GoStringDataType runtime.errorString.str
+      Data: 835 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 819
+      ID: 835
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -25295,7 +25723,7 @@ Types:
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
-      ID: 334
+      ID: 350
       Name: runtime.p
       ByteSize: 8
     - __kind: StructureType
@@ -25331,7 +25759,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 821
+      ID: 837
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 999584
@@ -25339,13 +25767,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 823 PointerType *runtime.plainError.str
+          Type: 839 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 822 GoStringDataType runtime.plainError.str
+      Data: 838 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 822
+      ID: 838
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -25386,7 +25814,7 @@ Types:
       Name: runtime.synctestBubble
       ByteSize: 8
     - __kind: StructureType
-      ID: 628
+      ID: 644
       Name: runtime.synctestDeadlockError
       ByteSize: 24
       GoRuntimeType: 1.612256e+06
@@ -25458,7 +25886,7 @@ Types:
       Name: runtime.xRegState
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 844
+      ID: 860
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -25470,26 +25898,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 329 PointerType *string.str
+          Type: 345 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 328 GoStringDataType string.str
+      Data: 344 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 328
+      ID: 344
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1141
+      ID: 1157
       Name: strings.Builder
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1044
+      ID: 1060
       Name: strings.appendSliceWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1040
+      ID: 1056
       Name: struct { io.Writer }
       ByteSize: 16
       GoRuntimeType: 1.468192e+06
@@ -25505,7 +25933,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1222
+      ID: 1238
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.476864e+06
@@ -25513,12 +25941,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1223 StructureType sync.noCopy
+          Type: 1239 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 1224 StructureType internal/sync.Mutex
+          Type: 1240 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 1225
+      ID: 1241
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.63008e+06
@@ -25526,15 +25954,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1223 StructureType sync.noCopy
+          Type: 1239 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 1226 StructureType sync/atomic.Bool
+          Type: 1242 StructureType sync/atomic.Bool
         - Name: m
           Offset: 4
-          Type: 1222 StructureType sync.Mutex
+          Type: 1238 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 1228
+      ID: 1244
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.629888e+06
@@ -25542,21 +25970,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 1223 StructureType sync.noCopy
+          Type: 1239 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 1229 StructureType sync/atomic.Uint64
+          Type: 1245 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1223
+      ID: 1239
       Name: sync.noCopy
       GoRuntimeType: 998432
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1226
+      ID: 1242
       Name: sync/atomic.Bool
       ByteSize: 4
       GoRuntimeType: 1.477984e+06
@@ -25564,12 +25992,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1227 StructureType sync/atomic.noCopy
+          Type: 1243 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1231
+      ID: 1247
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.478144e+06
@@ -25577,12 +26005,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1227 StructureType sync/atomic.noCopy
+          Type: 1243 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 10 BaseType int32
     - __kind: StructureType
-      ID: 1229
+      ID: 1245
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.630464e+06
@@ -25590,33 +26018,33 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1227 StructureType sync/atomic.noCopy
+          Type: 1243 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 1230 StructureType sync/atomic.align64
+          Type: 1246 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 8 BaseType uint64
     - __kind: StructureType
-      ID: 1230
+      ID: 1246
       Name: sync/atomic.align64
       GoRuntimeType: 998624
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1227
+      ID: 1243
       Name: sync/atomic.noCopy
       GoRuntimeType: 998528
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 954
+      ID: 970
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1.294272e+06
       GoKind: 12
     - __kind: StructureType
-      ID: 444
+      ID: 460
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -25638,9 +26066,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 445 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 461 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
-      ID: 436
+      ID: 452
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -25662,9 +26090,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 437 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 453 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
-      ID: 384
+      ID: 400
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
@@ -25686,9 +26114,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 385 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 401 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
-      ID: 403
+      ID: 419
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
@@ -25710,9 +26138,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 404 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 420 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
-      ID: 342
+      ID: 358
       Name: table<int,*main.deepMap2>
       ByteSize: 32
       GoKind: 25
@@ -25734,9 +26162,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 343 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
+          Type: 359 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
     - __kind: StructureType
-      ID: 1249
+      ID: 1265
       Name: table<int,*main.deepMap3>
       ByteSize: 32
       GoKind: 25
@@ -25758,9 +26186,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1250 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+          Type: 1266 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
     - __kind: StructureType
-      ID: 1283
+      ID: 1299
       Name: table<int,*main.deepMap8>
       ByteSize: 32
       GoKind: 25
@@ -25782,9 +26210,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1284 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
+          Type: 1300 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
     - __kind: StructureType
-      ID: 1298
+      ID: 1314
       Name: table<int,*main.deepMap9>
       ByteSize: 32
       GoKind: 25
@@ -25806,9 +26234,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1299 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
+          Type: 1315 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
     - __kind: StructureType
-      ID: 352
+      ID: 368
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
@@ -25830,9 +26258,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 353 GoSwissMapGroupsType groupReference<int,int>
+          Type: 369 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 1313
+      ID: 1329
       Name: table<int,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -25854,9 +26282,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1314 GoSwissMapGroupsType groupReference<int,interface {}>
+          Type: 1330 GoSwissMapGroupsType groupReference<int,interface {}>
     - __kind: StructureType
-      ID: 460
+      ID: 476
       Name: table<int,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -25878,9 +26306,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 461 GoSwissMapGroupsType groupReference<int,struct {}>
+          Type: 477 GoSwissMapGroupsType groupReference<int,struct {}>
     - __kind: StructureType
-      ID: 411
+      ID: 427
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -25902,9 +26330,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 412 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 428 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
-      ID: 393
+      ID: 409
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
@@ -25926,9 +26354,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 394 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 410 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 376
+      ID: 392
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -25950,9 +26378,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 377 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 393 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 1011
+      ID: 1027
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -25974,9 +26402,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1012 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 1028 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
-      ID: 368
+      ID: 384
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -25998,9 +26426,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 369 GoSwissMapGroupsType groupReference<string,int>
+          Type: 385 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 360
+      ID: 376
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
@@ -26022,9 +26450,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 361 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 377 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 452
+      ID: 468
       Name: table<struct {},int>
       ByteSize: 32
       GoKind: 25
@@ -26046,9 +26474,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 453 GoSwissMapGroupsType groupReference<struct {},int>
+          Type: 469 GoSwissMapGroupsType groupReference<struct {},int>
     - __kind: StructureType
-      ID: 502
+      ID: 518
       Name: table<struct {},main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -26070,9 +26498,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 503 GoSwissMapGroupsType groupReference<struct {},main.structWithCyclicMaps>
+          Type: 519 GoSwissMapGroupsType groupReference<struct {},main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 510
+      ID: 526
       Name: table<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -26094,9 +26522,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 511 GoSwissMapGroupsType groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
+          Type: 527 GoSwissMapGroupsType groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 518
+      ID: 534
       Name: table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -26118,9 +26546,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 519 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 535 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 526
+      ID: 542
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -26142,9 +26570,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 527 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 543 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 534
+      ID: 550
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -26166,9 +26594,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 535 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 551 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 542
+      ID: 558
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -26190,9 +26618,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 543 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 559 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 468
+      ID: 484
       Name: table<struct {},struct {}>
       ByteSize: 32
       GoKind: 25
@@ -26214,9 +26642,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 469 GoSwissMapGroupsType groupReference<struct {},struct {}>
+          Type: 485 GoSwissMapGroupsType groupReference<struct {},struct {}>
     - __kind: StructureType
-      ID: 427
+      ID: 443
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -26238,9 +26666,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 428 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 444 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
-      ID: 419
+      ID: 435
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
@@ -26262,13 +26690,13 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 420 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 436 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: UnresolvedPointeeType
-      ID: 1174
+      ID: 1190
       Name: text/tabwriter.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 897
+      ID: 913
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1.726176e+06
@@ -26281,21 +26709,21 @@ Types:
           Offset: 16
           Type: 15 GoInterfaceType error
     - __kind: BaseType
-      ID: 1107
+      ID: 1123
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1.936064e+06
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 972
+      ID: 988
       Name: time.Location
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 637
+      ID: 653
       Name: time.ParseError
       ByteSize: 8
     - __kind: StructureType
-      ID: 970
+      ID: 986
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.39584e+06
@@ -26309,9 +26737,9 @@ Types:
           Type: 12 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 971 PointerType *time.Location
+          Type: 987 PointerType *time.Location
     - __kind: GoStringHeaderType
-      ID: 552
+      ID: 568
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 839232
@@ -26319,18 +26747,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 554 PointerType *time.fileSizeError.str
+          Type: 570 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 553 GoStringDataType time.fileSizeError.str
+      Data: 569 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 553
+      ID: 569
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 635
+      ID: 651
       Name: time.parseDurationError
       ByteSize: 8
     - __kind: BaseType
@@ -26376,7 +26804,7 @@ Types:
       GoRuntimeType: 591680
       GoKind: 26
     - __kind: StructureType
-      ID: 990
+      ID: 1006
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2.086016e+06
@@ -26387,10 +26815,10 @@ Types:
           Type: 39 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 991 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 1007 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 992 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 1008 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: off
           Offset: 40
           Type: 7 BaseType int
@@ -26405,18 +26833,18 @@ Types:
           Type: 7 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 993 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 1009 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 6 BaseType uint16
     - __kind: BaseType
-      ID: 993
+      ID: 1009
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 1.005152e+06
       GoKind: 9
     - __kind: StructureType
-      ID: 991
+      ID: 1007
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1.947328e+06
@@ -26441,21 +26869,21 @@ Types:
           Offset: 10
           Type: 6 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 729
+      ID: 745
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 992
+      ID: 1008
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 595392
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1168
+      ID: 1184
       Name: vendor/golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 713
+      ID: 729
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.438272e+06
@@ -26465,13 +26893,13 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: BaseType
-      ID: 597
+      ID: 613
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 843360
       GoKind: 2
     - __kind: StructureType
-      ID: 874
+      ID: 890
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1.721952e+06
@@ -26484,12 +26912,12 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 826
+      ID: 842
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 1.004e+06
       GoKind: 5
-MaxTypeID: 1565
+MaxTypeID: 1582
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x1853d00", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -11,11 +11,11 @@ Probes:
       subprogram: {subprogram: 142}
       events:
         - Kind: Entry
-          Type: 1332 EventRootType Probe[main.stackC]
+          Type: 1349 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0x892908", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1333 EventRootType Probe[main.stackC]Return
+          Type: 1350 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0x89293c", Frameless: false}]
           Condition: null
       probeTemplate: {TemplateString: stackC, Segments: [stackC]}
@@ -30,11 +30,11 @@ Probes:
       subprogram: {subprogram: 56}
       events:
         - Kind: Entry
-          Type: 1196 EventRootType Probe[main.testAny]
+          Type: 1213 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0x88dd68", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1197 EventRootType Probe[main.testAny]Return
+          Type: 1214 EventRootType Probe[main.testAny]Return
           InjectionPoints: [{PC: "0x88dd94", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -55,11 +55,11 @@ Probes:
       subprogram: {subprogram: 58}
       events:
         - Kind: Entry
-          Type: 1199 EventRootType Probe[main.testAnyPtr]
+          Type: 1216 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0x88dde8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1200 EventRootType Probe[main.testAnyPtr]Return
+          Type: 1217 EventRootType Probe[main.testAnyPtr]Return
           InjectionPoints: [{PC: "0x88de14", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -79,11 +79,11 @@ Probes:
       subprogram: {subprogram: 122}
       events:
         - Kind: Entry
-          Type: 1303 EventRootType Probe[main.testArrayArgAndReturn]
+          Type: 1320 EventRootType Probe[main.testArrayArgAndReturn]
           InjectionPoints: [{PC: "0x89166c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1304 EventRootType Probe[main.testArrayArgAndReturn]Return
+          Type: 1321 EventRootType Probe[main.testArrayArgAndReturn]Return
           InjectionPoints: [{PC: "0x891704", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -104,7 +104,7 @@ Probes:
       subprogram: {subprogram: 19}
       events:
         - Kind: Entry
-          Type: 1147 EventRootType Probe[main.testArrayEmptyStructs]
+          Type: 1164 EventRootType Probe[main.testArrayEmptyStructs]
           InjectionPoints: [{PC: "0x88c370", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -125,7 +125,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - Kind: Entry
-          Type: 1143 EventRootType Probe[main.testArrayOfArrays]
+          Type: 1160 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0x88c330", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -146,7 +146,7 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - Kind: Entry
-          Type: 1145 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          Type: 1162 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0x88c350", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -167,7 +167,7 @@ Probes:
       subprogram: {subprogram: 66}
       events:
         - Kind: Entry
-          Type: 1208 EventRootType Probe[main.testArrayOfMaps]
+          Type: 1225 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0x88e450", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -188,7 +188,7 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - Kind: Entry
-          Type: 1144 EventRootType Probe[main.testArrayOfStrings]
+          Type: 1161 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0x88c340", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -208,7 +208,7 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - Kind: Entry
-          Type: 1146 EventRootType Probe[main.testArrayOfStructs]
+          Type: 1163 EventRootType Probe[main.testArrayOfStructs]
           InjectionPoints: [{PC: "0x88c360", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -229,11 +229,11 @@ Probes:
       subprogram: {subprogram: 86}
       events:
         - Kind: Entry
-          Type: 1230 EventRootType Probe[main.testAtomicAdd]
+          Type: 1247 EventRootType Probe[main.testAtomicAdd]
           InjectionPoints: [{PC: "0x88fb40", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1231 EventRootType Probe[main.testAtomicAdd]Return
+          Type: 1248 EventRootType Probe[main.testAtomicAdd]Return
           InjectionPoints: [{PC: "0x88fb7c", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -254,11 +254,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 1165 EventRootType Probe[main.testBigStruct]
+          Type: 1182 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0x88c8c0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1166 EventRootType Probe[main.testBigStruct]Return
+          Type: 1183 EventRootType Probe[main.testBigStruct]Return
           InjectionPoints: [{PC: "0x88c8d8", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -279,7 +279,7 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - Kind: Entry
-          Type: 1132 EventRootType Probe[main.testBoolArray]
+          Type: 1149 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0x88c280", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -300,7 +300,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - Kind: Entry
-          Type: 1129 EventRootType Probe[main.testByteArray]
+          Type: 1146 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0x88c250", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -326,11 +326,11 @@ Probes:
       subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1351 EventRootType Probe[main.testStruct]
+          Type: 1368 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0x892c60", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1352 EventRootType Probe[main.testStruct]Return
+          Type: 1369 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0x892c7c", Frameless: true}]
           Condition: null
     - id: testCaptureExprLine
@@ -345,10 +345,10 @@ Probes:
       segments: []
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1361 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1379 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0x88d608"
               Frameless: false
@@ -373,10 +373,10 @@ Probes:
       segments: [x=, {json: {ref: x}, dsl: x}]
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1362 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1380 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0x88d608"
               Frameless: false
@@ -412,7 +412,7 @@ Probes:
       subprogram: {subprogram: 84}
       events:
         - Kind: Entry
-          Type: 1227 EventRootType Probe[main.testCombinedString]
+          Type: 1244 EventRootType Probe[main.testCombinedString]
           InjectionPoints: [{PC: "0x88f8e0", Frameless: true}]
           Condition: null
     - id: testCaptureExprWithTemplate
@@ -430,7 +430,7 @@ Probes:
       subprogram: {subprogram: 84}
       events:
         - Kind: Entry
-          Type: 1228 EventRootType Probe[main.testCombinedString]
+          Type: 1245 EventRootType Probe[main.testCombinedString]
           InjectionPoints: [{PC: "0x88f8e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -452,7 +452,7 @@ Probes:
       subprogram: {subprogram: 87}
       events:
         - Kind: Entry
-          Type: 1232 EventRootType Probe[main.testChannel]
+          Type: 1249 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0x88fb80", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -481,7 +481,7 @@ Probes:
       subprogram: {subprogram: 83}
       events:
         - Kind: Entry
-          Type: 1226 EventRootType Probe[main.testCombinedByte]
+          Type: 1243 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0x88f8c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -512,7 +512,7 @@ Probes:
       subprogram: {subprogram: 95}
       events:
         - Kind: Entry
-          Type: 1240 EventRootType Probe[main.testCycle]
+          Type: 1257 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0x88fe30", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -533,7 +533,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - Kind: Entry
-          Type: 1171 EventRootType Probe[main.testDeepMap1]
+          Type: 1188 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0x88cca0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -554,7 +554,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - Kind: Entry
-          Type: 1172 EventRootType Probe[main.testDeepMap7]
+          Type: 1189 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0x88ccb0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -575,7 +575,7 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - Kind: Entry
-          Type: 1167 EventRootType Probe[main.testDeepPtr1]
+          Type: 1184 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0x88c990", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -596,7 +596,7 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - Kind: Entry
-          Type: 1168 EventRootType Probe[main.testDeepPtr7]
+          Type: 1185 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0x88c9a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -617,7 +617,7 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - Kind: Entry
-          Type: 1169 EventRootType Probe[main.testDeepSlice1]
+          Type: 1186 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0x88cb40", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -638,7 +638,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - Kind: Entry
-          Type: 1170 EventRootType Probe[main.testDeepSlice7]
+          Type: 1187 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0x88cb50", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -659,7 +659,7 @@ Probes:
       subprogram: {subprogram: 131}
       events:
         - Kind: Entry
-          Type: 1320 EventRootType Probe[main.testEmptySlice]
+          Type: 1337 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0x892530", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -685,7 +685,7 @@ Probes:
       subprogram: {subprogram: 134}
       events:
         - Kind: Entry
-          Type: 1323 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 1340 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0x892560", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -712,7 +712,7 @@ Probes:
       subprogram: {subprogram: 150}
       events:
         - Kind: Entry
-          Type: 1346 EventRootType Probe[main.testEmptyString]
+          Type: 1363 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0x8929e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -733,7 +733,7 @@ Probes:
       subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1359 EventRootType Probe[main.testEmptyStruct]
+          Type: 1376 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0x892d60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -753,7 +753,7 @@ Probes:
       subprogram: {subprogram: 157}
       events:
         - Kind: Entry
-          Type: 1360 EventRootType Probe[main.testEmptyStructPointer]
+          Type: 1377 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0x892d70", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -774,7 +774,7 @@ Probes:
       subprogram: {subprogram: 57}
       events:
         - Kind: Entry
-          Type: 1198 EventRootType Probe[main.testError]
+          Type: 1215 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0x88ddc0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -795,11 +795,11 @@ Probes:
       subprogram: {subprogram: 48}
       events:
         - Kind: Entry
-          Type: 1180 EventRootType Probe[main.testEsotericHeap]
+          Type: 1197 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0x88d368", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1181 EventRootType Probe[main.testEsotericHeap]Return
+          Type: 1198 EventRootType Probe[main.testEsotericHeap]Return
           InjectionPoints: [{PC: "0x88d3a4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -820,11 +820,11 @@ Probes:
       subprogram: {subprogram: 47}
       events:
         - Kind: Entry
-          Type: 1178 EventRootType Probe[main.testEsotericStack]
+          Type: 1195 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0x88d27c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1179 EventRootType Probe[main.testEsotericStack]Return
+          Type: 1196 EventRootType Probe[main.testEsotericStack]Return
           InjectionPoints: [{PC: "0x88d2ec", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -845,11 +845,11 @@ Probes:
       subprogram: {subprogram: 53}
       events:
         - Kind: Entry
-          Type: 1190 EventRootType Probe[main.testFrameless]
+          Type: 1207 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0x88da90", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1191 EventRootType Probe[main.testFrameless]Return
+          Type: 1208 EventRootType Probe[main.testFrameless]Return
           InjectionPoints: [{PC: "0x88da98", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -870,11 +870,11 @@ Probes:
       subprogram: {subprogram: 54}
       events:
         - Kind: Entry
-          Type: 1192 EventRootType Probe[main.testFramelessArray]
+          Type: 1209 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0x88daac", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1193 EventRootType Probe[main.testFramelessArray]Return
+          Type: 1210 EventRootType Probe[main.testFramelessArray]Return
           InjectionPoints: [{PC: "0x88dae8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -898,7 +898,7 @@ Probes:
       subprogram: {subprogram: 54}
       events:
         - Kind: Line
-          Type: 1194 EventRootType Probe[main.testFramelessArray]Line
+          Type: 1211 EventRootType Probe[main.testFramelessArray]Line
           InjectionPoints: [{PC: "0x88daac", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -919,11 +919,11 @@ Probes:
       subprogram: {subprogram: 49}
       events:
         - Kind: Entry
-          Type: 1182 EventRootType Probe[main.testInlinedBA]
+          Type: 1199 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0x88d7a8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1183 EventRootType Probe[main.testInlinedBA]Return
+          Type: 1200 EventRootType Probe[main.testInlinedBA]Return
           InjectionPoints: [{PC: "0x88d800", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -949,11 +949,11 @@ Probes:
       subprogram: {subprogram: 50}
       events:
         - Kind: Entry
-          Type: 1184 EventRootType Probe[main.testInlinedBB]
+          Type: 1201 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0x88d838", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1185 EventRootType Probe[main.testInlinedBB]Return
+          Type: 1202 EventRootType Probe[main.testInlinedBB]Return
           InjectionPoints: [{PC: "0x88d8c0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -979,11 +979,11 @@ Probes:
       subprogram: {subprogram: 51}
       events:
         - Kind: Entry
-          Type: 1186 EventRootType Probe[main.testInlinedBBA]
+          Type: 1203 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0x88d908", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1187 EventRootType Probe[main.testInlinedBBA]Return
+          Type: 1204 EventRootType Probe[main.testInlinedBBA]Return
           InjectionPoints: [{PC: "0x88d944", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1001,10 +1001,10 @@ Probes:
       template: testInlinedBBB
       segments: [testInlinedBBB]
       captureSnapshot: true
-      subprogram: {subprogram: 159}
+      subprogram: {subprogram: 160}
       events:
         - Kind: Entry
-          Type: 1366 EventRootType Probe[main.testInlinedBBB]
+          Type: 1384 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x88d888", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1021,11 +1021,11 @@ Probes:
       subprogram: {subprogram: 52}
       events:
         - Kind: Entry
-          Type: 1188 EventRootType Probe[main.testInlinedBC]
+          Type: 1205 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0x88d988", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1189 EventRootType Probe[main.testInlinedBC]Return
+          Type: 1206 EventRootType Probe[main.testInlinedBC]Return
           InjectionPoints: [{PC: "0x88da78", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1039,10 +1039,10 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Entry
-          Type: 1367 EventRootType Probe[main.testInlinedBCA]
+          Type: 1385 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x88d98c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1059,10 +1059,10 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Line
-          Type: 1368 EventRootType Probe[main.testInlinedBCA]Line
+          Type: 1386 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0x88d98c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1076,10 +1076,10 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Entry
-          Type: 1369 EventRootType Probe[main.testInlinedBCB]
+          Type: 1387 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x88da40", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1096,10 +1096,10 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Line
-          Type: 1370 EventRootType Probe[main.testInlinedBCB]Line
+          Type: 1388 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0x88da40", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1113,10 +1113,10 @@ Probes:
       template: testInlinedFuncFromOtherPackage
       segments: [testInlinedFuncFromOtherPackage]
       captureSnapshot: true
-      subprogram: {subprogram: 165}
+      subprogram: {subprogram: 166}
       events:
         - Kind: Entry
-          Type: 1376 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
+          Type: 1394 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
           InjectionPoints:
             - PC: "0x88bd84"
               Frameless: true
@@ -1135,10 +1135,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Entry
-          Type: 1363 EventRootType Probe[main.testInlinedPrint]
+          Type: 1381 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x88d608"
               Frameless: false
@@ -1152,7 +1152,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1364 EventRootType Probe[main.testInlinedPrint]Return
+          Type: 1382 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0x88d640", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1173,10 +1173,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1365 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1383 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0x88d608"
               Frameless: false
@@ -1204,10 +1204,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 162}
+      subprogram: {subprogram: 163}
       events:
         - Kind: Entry
-          Type: 1371 EventRootType Probe[main.testInlinedSq]
+          Type: 1389 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x88da94", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1228,10 +1228,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 162}
+      subprogram: {subprogram: 163}
       events:
         - Kind: Line
-          Type: 1372 EventRootType Probe[main.testInlinedSq]Line
+          Type: 1390 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0x88da94", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1250,10 +1250,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 163}
+      subprogram: {subprogram: 164}
       events:
         - Kind: Entry
-          Type: 1373 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1391 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0x88dac4"
               Frameless: false
@@ -1278,7 +1278,7 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - Kind: Entry
-          Type: 1135 EventRootType Probe[main.testInt16Array]
+          Type: 1152 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0x88c2b0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1299,7 +1299,7 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - Kind: Entry
-          Type: 1136 EventRootType Probe[main.testInt32Array]
+          Type: 1153 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0x88c2c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1320,7 +1320,7 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - Kind: Entry
-          Type: 1137 EventRootType Probe[main.testInt64Array]
+          Type: 1154 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0x88c2d0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1341,7 +1341,7 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - Kind: Entry
-          Type: 1134 EventRootType Probe[main.testInt8Array]
+          Type: 1151 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0x88c2a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1362,7 +1362,7 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - Kind: Entry
-          Type: 1133 EventRootType Probe[main.testIntArray]
+          Type: 1150 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0x88c290", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1383,7 +1383,7 @@ Probes:
       subprogram: {subprogram: 55}
       events:
         - Kind: Entry
-          Type: 1195 EventRootType Probe[main.testInterface]
+          Type: 1212 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0x88dd40", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1403,11 +1403,11 @@ Probes:
       subprogram: {subprogram: 121}
       events:
         - Kind: Entry
-          Type: 1301 EventRootType Probe[main.testLargeArgAndReturn]
+          Type: 1318 EventRootType Probe[main.testLargeArgAndReturn]
           InjectionPoints: [{PC: "0x891490", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1302 EventRootType Probe[main.testLargeArgAndReturn]Return
+          Type: 1319 EventRootType Probe[main.testLargeArgAndReturn]Return
           InjectionPoints: [{PC: "0x8915e8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1417,6 +1417,49 @@ Probes:
               DSL: arg
               EventKind: Entry
               EventExpressionIndex: 1
+    - id: testLineProbeTemplateWithStructFields
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.executeStructFuncs
+        sourceFile: structs.go
+        lines: ["208"]
+      template: 'sta.a: {sta.a} sta.b: {sta.b} sta.c: {sta.c}'
+      segments:
+        - 'sta.a: '
+        - json: {getmember: [{ref: sta}, a]}
+          dsl: sta.a
+        - ' sta.b: '
+        - json: {getmember: [{ref: sta}, b]}
+          dsl: sta.b
+        - ' sta.c: '
+        - json: {getmember: [{ref: sta}, c]}
+          dsl: sta.c
+      captureSnapshot: false
+      subprogram: {subprogram: 158}
+      events:
+        - Kind: Line
+          Type: 1378 EventRootType Probe[main.executeStructFuncs]Line
+          InjectionPoints: [{PC: "0x8931e8", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: 'sta.a: {sta.a} sta.b: {sta.b} sta.c: {sta.c}'
+        Segments:
+            - 'sta.a: '
+            - JSON: {Base: {Ref: sta}, Member: a}
+              DSL: sta.a
+              EventKind: Line
+              EventExpressionIndex: 0
+            - ' sta.b: '
+            - JSON: {Base: {Ref: sta}, Member: b}
+              DSL: sta.b
+              EventKind: Line
+              EventExpressionIndex: 1
+            - ' sta.c: '
+            - JSON: {Base: {Ref: sta}, Member: c}
+              DSL: sta.c
+              EventKind: Line
+              EventExpressionIndex: 2
     - id: testLinkedList
       version: 0
       type: LOG_PROBE
@@ -1428,7 +1471,7 @@ Probes:
       subprogram: {subprogram: 89}
       events:
         - Kind: Entry
-          Type: 1234 EventRootType Probe[main.testLinkedList]
+          Type: 1251 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0x88fd40", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1452,7 +1495,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - Kind: Line
-          Type: 1175 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          Type: 1192 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x88ccfc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1473,7 +1516,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - Kind: Line
-          Type: 1176 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          Type: 1193 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x88cd90", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1494,7 +1537,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - Kind: Line
-          Type: 1177 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          Type: 1194 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x88ce3c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1536,11 +1579,11 @@ Probes:
       subprogram: {subprogram: 124}
       events:
         - Kind: Entry
-          Type: 1307 EventRootType Probe[main.testManyArgsArrayReturn]
+          Type: 1324 EventRootType Probe[main.testManyArgsArrayReturn]
           InjectionPoints: [{PC: "0x89199c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1308 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          Type: 1325 EventRootType Probe[main.testManyArgsArrayReturn]Return
           InjectionPoints: [{PC: "0x891b0c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1601,7 +1644,7 @@ Probes:
       subprogram: {subprogram: 64}
       events:
         - Kind: Entry
-          Type: 1206 EventRootType Probe[main.testMapArrayToArray]
+          Type: 1223 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0x88e430", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1622,7 +1665,7 @@ Probes:
       subprogram: {subprogram: 70}
       events:
         - Kind: Entry
-          Type: 1213 EventRootType Probe[main.testMapEmbeddedMaps]
+          Type: 1230 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0x88e490", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1643,7 +1686,7 @@ Probes:
       subprogram: {subprogram: 80}
       events:
         - Kind: Entry
-          Type: 1223 EventRootType Probe[main.testMapEmptyKey]
+          Type: 1240 EventRootType Probe[main.testMapEmptyKey]
           InjectionPoints: [{PC: "0x88e530", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1664,7 +1707,7 @@ Probes:
       subprogram: {subprogram: 82}
       events:
         - Kind: Entry
-          Type: 1225 EventRootType Probe[main.testMapEmptyKeyAndValue]
+          Type: 1242 EventRootType Probe[main.testMapEmptyKeyAndValue]
           InjectionPoints: [{PC: "0x88e550", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1685,7 +1728,7 @@ Probes:
       subprogram: {subprogram: 81}
       events:
         - Kind: Entry
-          Type: 1224 EventRootType Probe[main.testMapEmptyValue]
+          Type: 1241 EventRootType Probe[main.testMapEmptyValue]
           InjectionPoints: [{PC: "0x88e540", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1706,7 +1749,7 @@ Probes:
       subprogram: {subprogram: 68}
       events:
         - Kind: Entry
-          Type: 1210 EventRootType Probe[main.testMapIntToInt]
+          Type: 1227 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0x88e470", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1727,7 +1770,7 @@ Probes:
       subprogram: {subprogram: 79}
       events:
         - Kind: Entry
-          Type: 1222 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          Type: 1239 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0x88e520", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1748,7 +1791,7 @@ Probes:
       subprogram: {subprogram: 78}
       events:
         - Kind: Entry
-          Type: 1221 EventRootType Probe[main.testMapLargeKeySmallValue]
+          Type: 1238 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0x88e510", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1771,7 +1814,7 @@ Probes:
       subprogram: {subprogram: 69}
       events:
         - Kind: Entry
-          Type: 1211 EventRootType Probe[main.testMapMassive]
+          Type: 1228 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0x88e480", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1794,7 +1837,7 @@ Probes:
       subprogram: {subprogram: 69}
       events:
         - Kind: Entry
-          Type: 1212 EventRootType Probe[main.testMapMassive]
+          Type: 1229 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0x88e480", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1815,7 +1858,7 @@ Probes:
       subprogram: {subprogram: 77}
       events:
         - Kind: Entry
-          Type: 1220 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          Type: 1237 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0x88e500", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1836,7 +1879,7 @@ Probes:
       subprogram: {subprogram: 76}
       events:
         - Kind: Entry
-          Type: 1219 EventRootType Probe[main.testMapSmallKeySmallValue]
+          Type: 1236 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0x88e4f0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1857,7 +1900,7 @@ Probes:
       subprogram: {subprogram: 62}
       events:
         - Kind: Entry
-          Type: 1204 EventRootType Probe[main.testMapStringToInt]
+          Type: 1221 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0x88e410", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1878,7 +1921,7 @@ Probes:
       subprogram: {subprogram: 63}
       events:
         - Kind: Entry
-          Type: 1205 EventRootType Probe[main.testMapStringToSlice]
+          Type: 1222 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0x88e420", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1899,7 +1942,7 @@ Probes:
       subprogram: {subprogram: 61}
       events:
         - Kind: Entry
-          Type: 1203 EventRootType Probe[main.testMapStringToStruct]
+          Type: 1220 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0x88e400", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1920,7 +1963,7 @@ Probes:
       subprogram: {subprogram: 71}
       events:
         - Kind: Entry
-          Type: 1214 EventRootType Probe[main.testMapWithLinkedList]
+          Type: 1231 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0x88e4a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1941,7 +1984,7 @@ Probes:
       subprogram: {subprogram: 74}
       events:
         - Kind: Entry
-          Type: 1217 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          Type: 1234 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0x88e4d0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1962,7 +2005,7 @@ Probes:
       subprogram: {subprogram: 75}
       events:
         - Kind: Entry
-          Type: 1218 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          Type: 1235 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0x88e4e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1983,7 +2026,7 @@ Probes:
       subprogram: {subprogram: 72}
       events:
         - Kind: Entry
-          Type: 1215 EventRootType Probe[main.testMapWithSmallValue]
+          Type: 1232 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0x88e4b0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2006,7 +2049,7 @@ Probes:
       subprogram: {subprogram: 73}
       events:
         - Kind: Entry
-          Type: 1216 EventRootType Probe[main.testMapWithSmallValueMassive]
+          Type: 1233 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0x88e4c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2027,7 +2070,7 @@ Probes:
       subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1343 EventRootType Probe[main.testMassiveString]
+          Type: 1360 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x8929c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2049,7 +2092,7 @@ Probes:
       subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1344 EventRootType Probe[main.testMassiveString]
+          Type: 1361 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x8929c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2095,11 +2138,11 @@ Probes:
       subprogram: {subprogram: 125}
       events:
         - Kind: Entry
-          Type: 1309 EventRootType Probe[main.testMixedArgsStackReturn]
+          Type: 1326 EventRootType Probe[main.testMixedArgsStackReturn]
           InjectionPoints: [{PC: "0x891b90", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1310 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          Type: 1327 EventRootType Probe[main.testMixedArgsStackReturn]Return
           InjectionPoints: [{PC: "0x891d40", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2164,11 +2207,11 @@ Probes:
       subprogram: {subprogram: 127}
       events:
         - Kind: Entry
-          Type: 1313 EventRootType Probe[main.testMultipleArrayArgs]
+          Type: 1330 EventRootType Probe[main.testMultipleArrayArgs]
           InjectionPoints: [{PC: "0x891e6c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1314 EventRootType Probe[main.testMultipleArrayArgs]Return
+          Type: 1331 EventRootType Probe[main.testMultipleArrayArgs]Return
           InjectionPoints: [{PC: "0x891f10", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2198,11 +2241,11 @@ Probes:
       subprogram: {subprogram: 123}
       events:
         - Kind: Entry
-          Type: 1305 EventRootType Probe[main.testMultipleLargeArgs]
+          Type: 1322 EventRootType Probe[main.testMultipleLargeArgs]
           InjectionPoints: [{PC: "0x891740", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1306 EventRootType Probe[main.testMultipleLargeArgs]Return
+          Type: 1323 EventRootType Probe[main.testMultipleLargeArgs]Return
           InjectionPoints: [{PC: "0x891910", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2227,11 +2270,11 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1259 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1276 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x890a58", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1260 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1277 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x890ae4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2266,7 +2309,7 @@ Probes:
       subprogram: {subprogram: 85}
       events:
         - Kind: Entry
-          Type: 1229 EventRootType Probe[main.testMultipleSimpleParams]
+          Type: 1246 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0x88f9a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2306,11 +2349,11 @@ Probes:
       subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1255 EventRootType Probe[main.testNamedReturn]
+          Type: 1272 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0x8909b8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1256 EventRootType Probe[main.testNamedReturn]Return
+          Type: 1273 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0x890a18", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2336,11 +2379,11 @@ Probes:
       subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1257 EventRootType Probe[main.testNamedReturn]
+          Type: 1274 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0x8909b8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1258 EventRootType Probe[main.testNamedReturn]Return
+          Type: 1275 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0x890a18", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2367,7 +2410,7 @@ Probes:
       subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1355 EventRootType Probe[main.testNestedPointer]
+          Type: 1372 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0x892d00", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2391,7 +2434,7 @@ Probes:
       subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1356 EventRootType Probe[main.testNestedPointer]
+          Type: 1373 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0x892d00", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2421,7 +2464,7 @@ Probes:
       subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1357 EventRootType Probe[main.testNestedPointer]
+          Type: 1374 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0x892d00", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2445,7 +2488,7 @@ Probes:
       subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1358 EventRootType Probe[main.testNestedPointer]
+          Type: 1375 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0x892d00", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2471,7 +2514,7 @@ Probes:
       subprogram: {subprogram: 94}
       events:
         - Kind: Entry
-          Type: 1239 EventRootType Probe[main.testNilPointer]
+          Type: 1256 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0x88fe10", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2497,7 +2540,7 @@ Probes:
       subprogram: {subprogram: 138}
       events:
         - Kind: Entry
-          Type: 1327 EventRootType Probe[main.testNilSlice]
+          Type: 1344 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0x8925a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2523,7 +2566,7 @@ Probes:
       subprogram: {subprogram: 135}
       events:
         - Kind: Entry
-          Type: 1324 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 1341 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0x892570", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2557,7 +2600,7 @@ Probes:
       subprogram: {subprogram: 137}
       events:
         - Kind: Entry
-          Type: 1326 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 1343 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0x892590", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2588,7 +2631,7 @@ Probes:
       subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1342 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 1359 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0x8929b0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2609,7 +2652,7 @@ Probes:
       subprogram: {subprogram: 90}
       events:
         - Kind: Entry
-          Type: 1235 EventRootType Probe[main.testPointerLoop]
+          Type: 1252 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0x88fd50", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2630,7 +2673,7 @@ Probes:
       subprogram: {subprogram: 67}
       events:
         - Kind: Entry
-          Type: 1209 EventRootType Probe[main.testPointerToMap]
+          Type: 1226 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0x88e460", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2651,7 +2694,7 @@ Probes:
       subprogram: {subprogram: 88}
       events:
         - Kind: Entry
-          Type: 1233 EventRootType Probe[main.testPointerToSimpleStruct]
+          Type: 1250 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0x88fd30", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2672,11 +2715,11 @@ Probes:
       subprogram: {subprogram: 101}
       events:
         - Kind: Entry
-          Type: 1251 EventRootType Probe[main.testReturnsAny]
+          Type: 1268 EventRootType Probe[main.testReturnsAny]
           InjectionPoints: [{PC: "0x890648", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1252 EventRootType Probe[main.testReturnsAny]Return
+          Type: 1269 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints:
             - PC: "0x8906e8"
               Frameless: false
@@ -2710,11 +2753,11 @@ Probes:
       subprogram: {subprogram: 100}
       events:
         - Kind: Entry
-          Type: 1249 EventRootType Probe[main.testReturnsAnyAndError]
+          Type: 1266 EventRootType Probe[main.testReturnsAnyAndError]
           InjectionPoints: [{PC: "0x8904c8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1250 EventRootType Probe[main.testReturnsAnyAndError]Return
+          Type: 1267 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
             - PC: "0x890534"
               Frameless: false
@@ -2747,11 +2790,11 @@ Probes:
       subprogram: {subprogram: 110}
       events:
         - Kind: Entry
-          Type: 1279 EventRootType Probe[main.testReturnsArray]
+          Type: 1296 EventRootType Probe[main.testReturnsArray]
           InjectionPoints: [{PC: "0x890e9c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1280 EventRootType Probe[main.testReturnsArray]Return
+          Type: 1297 EventRootType Probe[main.testReturnsArray]Return
           InjectionPoints: [{PC: "0x890ef0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2767,11 +2810,11 @@ Probes:
       subprogram: {subprogram: 111}
       events:
         - Kind: Entry
-          Type: 1281 EventRootType Probe[main.testReturnsArrayOne]
+          Type: 1298 EventRootType Probe[main.testReturnsArrayOne]
           InjectionPoints: [{PC: "0x890f28", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1282 EventRootType Probe[main.testReturnsArrayOne]Return
+          Type: 1299 EventRootType Probe[main.testReturnsArrayOne]Return
           InjectionPoints: [{PC: "0x890f64", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2787,11 +2830,11 @@ Probes:
       subprogram: {subprogram: 112}
       events:
         - Kind: Entry
-          Type: 1283 EventRootType Probe[main.testReturnsArrayZero]
+          Type: 1300 EventRootType Probe[main.testReturnsArrayZero]
           InjectionPoints: [{PC: "0x890f98", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1284 EventRootType Probe[main.testReturnsArrayZero]Return
+          Type: 1301 EventRootType Probe[main.testReturnsArrayZero]Return
           InjectionPoints: [{PC: "0x890fd0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2807,11 +2850,11 @@ Probes:
       subprogram: {subprogram: 114}
       events:
         - Kind: Entry
-          Type: 1287 EventRootType Probe[main.testReturnsBacktrackInt]
+          Type: 1304 EventRootType Probe[main.testReturnsBacktrackInt]
           InjectionPoints: [{PC: "0x891088", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1288 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          Type: 1305 EventRootType Probe[main.testReturnsBacktrackInt]Return
           InjectionPoints: [{PC: "0x8910ec", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2827,11 +2870,11 @@ Probes:
       subprogram: {subprogram: 120}
       events:
         - Kind: Entry
-          Type: 1299 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          Type: 1316 EventRootType Probe[main.testReturnsBoolAndUintptr]
           InjectionPoints: [{PC: "0x891418", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1300 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          Type: 1317 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
           InjectionPoints: [{PC: "0x891458", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2847,11 +2890,11 @@ Probes:
       subprogram: {subprogram: 108}
       events:
         - Kind: Entry
-          Type: 1275 EventRootType Probe[main.testReturnsComplex]
+          Type: 1292 EventRootType Probe[main.testReturnsComplex]
           InjectionPoints: [{PC: "0x890d48", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1276 EventRootType Probe[main.testReturnsComplex]Return
+          Type: 1293 EventRootType Probe[main.testReturnsComplex]Return
           InjectionPoints: [{PC: "0x890d94", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2868,11 +2911,11 @@ Probes:
       subprogram: {subprogram: 99}
       events:
         - Kind: Entry
-          Type: 1247 EventRootType Probe[main.testReturnsError]
+          Type: 1264 EventRootType Probe[main.testReturnsError]
           InjectionPoints: [{PC: "0x890448", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1248 EventRootType Probe[main.testReturnsError]Return
+          Type: 1265 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
             - PC: "0x890478"
               Frameless: false
@@ -2896,11 +2939,11 @@ Probes:
       subprogram: {subprogram: 96}
       events:
         - Kind: Entry
-          Type: 1241 EventRootType Probe[main.testReturnsInt]
+          Type: 1258 EventRootType Probe[main.testReturnsInt]
           InjectionPoints: [{PC: "0x890258", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1242 EventRootType Probe[main.testReturnsInt]Return
+          Type: 1259 EventRootType Probe[main.testReturnsInt]Return
           InjectionPoints: [{PC: "0x89029c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2920,11 +2963,11 @@ Probes:
       subprogram: {subprogram: 98}
       events:
         - Kind: Entry
-          Type: 1245 EventRootType Probe[main.testReturnsIntAndFloat]
+          Type: 1262 EventRootType Probe[main.testReturnsIntAndFloat]
           InjectionPoints: [{PC: "0x890378", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1246 EventRootType Probe[main.testReturnsIntAndFloat]Return
+          Type: 1263 EventRootType Probe[main.testReturnsIntAndFloat]Return
           InjectionPoints: [{PC: "0x890410", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2944,11 +2987,11 @@ Probes:
       subprogram: {subprogram: 97}
       events:
         - Kind: Entry
-          Type: 1243 EventRootType Probe[main.testReturnsIntPointer]
+          Type: 1260 EventRootType Probe[main.testReturnsIntPointer]
           InjectionPoints: [{PC: "0x8902d8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1244 EventRootType Probe[main.testReturnsIntPointer]Return
+          Type: 1261 EventRootType Probe[main.testReturnsIntPointer]Return
           InjectionPoints: [{PC: "0x89033c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2969,11 +3012,11 @@ Probes:
       subprogram: {subprogram: 102}
       events:
         - Kind: Entry
-          Type: 1253 EventRootType Probe[main.testReturnsInterface]
+          Type: 1270 EventRootType Probe[main.testReturnsInterface]
           InjectionPoints: [{PC: "0x890848", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1254 EventRootType Probe[main.testReturnsInterface]Return
+          Type: 1271 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
             - PC: "0x890918"
               Frameless: false
@@ -2997,11 +3040,11 @@ Probes:
       subprogram: {subprogram: 109}
       events:
         - Kind: Entry
-          Type: 1277 EventRootType Probe[main.testReturnsLargeStruct]
+          Type: 1294 EventRootType Probe[main.testReturnsLargeStruct]
           InjectionPoints: [{PC: "0x890dd0", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1278 EventRootType Probe[main.testReturnsLargeStruct]Return
+          Type: 1295 EventRootType Probe[main.testReturnsLargeStruct]Return
           InjectionPoints: [{PC: "0x890e64", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3017,11 +3060,11 @@ Probes:
       subprogram: {subprogram: 107}
       events:
         - Kind: Entry
-          Type: 1273 EventRootType Probe[main.testReturnsManyFloats]
+          Type: 1290 EventRootType Probe[main.testReturnsManyFloats]
           InjectionPoints: [{PC: "0x890c88", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1274 EventRootType Probe[main.testReturnsManyFloats]Return
+          Type: 1291 EventRootType Probe[main.testReturnsManyFloats]Return
           InjectionPoints: [{PC: "0x890d0c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3037,11 +3080,11 @@ Probes:
       subprogram: {subprogram: 116}
       events:
         - Kind: Entry
-          Type: 1291 EventRootType Probe[main.testReturnsMixed]
+          Type: 1308 EventRootType Probe[main.testReturnsMixed]
           InjectionPoints: [{PC: "0x891208", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1292 EventRootType Probe[main.testReturnsMixed]Return
+          Type: 1309 EventRootType Probe[main.testReturnsMixed]Return
           InjectionPoints: [{PC: "0x891260", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3057,11 +3100,11 @@ Probes:
       subprogram: {subprogram: 113}
       events:
         - Kind: Entry
-          Type: 1285 EventRootType Probe[main.testReturnsMixedStruct]
+          Type: 1302 EventRootType Probe[main.testReturnsMixedStruct]
           InjectionPoints: [{PC: "0x891008", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1286 EventRootType Probe[main.testReturnsMixedStruct]Return
+          Type: 1303 EventRootType Probe[main.testReturnsMixedStruct]Return
           InjectionPoints: [{PC: "0x891050", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3077,11 +3120,11 @@ Probes:
       subprogram: {subprogram: 119}
       events:
         - Kind: Entry
-          Type: 1297 EventRootType Probe[main.testReturnsMultipleFloats]
+          Type: 1314 EventRootType Probe[main.testReturnsMultipleFloats]
           InjectionPoints: [{PC: "0x891398", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1298 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          Type: 1315 EventRootType Probe[main.testReturnsMultipleFloats]Return
           InjectionPoints: [{PC: "0x8913dc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3097,11 +3140,11 @@ Probes:
       subprogram: {subprogram: 118}
       events:
         - Kind: Entry
-          Type: 1295 EventRootType Probe[main.testReturnsOnlyFloat]
+          Type: 1312 EventRootType Probe[main.testReturnsOnlyFloat]
           InjectionPoints: [{PC: "0x891328", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1296 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          Type: 1313 EventRootType Probe[main.testReturnsOnlyFloat]Return
           InjectionPoints: [{PC: "0x891368", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3117,11 +3160,11 @@ Probes:
       subprogram: {subprogram: 106}
       events:
         - Kind: Entry
-          Type: 1271 EventRootType Probe[main.testReturnsPrimitives]
+          Type: 1288 EventRootType Probe[main.testReturnsPrimitives]
           InjectionPoints: [{PC: "0x890bf8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1272 EventRootType Probe[main.testReturnsPrimitives]Return
+          Type: 1289 EventRootType Probe[main.testReturnsPrimitives]Return
           InjectionPoints: [{PC: "0x890c50", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3137,11 +3180,11 @@ Probes:
       subprogram: {subprogram: 117}
       events:
         - Kind: Entry
-          Type: 1293 EventRootType Probe[main.testReturnsStructWithArray]
+          Type: 1310 EventRootType Probe[main.testReturnsStructWithArray]
           InjectionPoints: [{PC: "0x89129c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1294 EventRootType Probe[main.testReturnsStructWithArray]Return
+          Type: 1311 EventRootType Probe[main.testReturnsStructWithArray]Return
           InjectionPoints: [{PC: "0x8912f0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3157,11 +3200,11 @@ Probes:
       subprogram: {subprogram: 115}
       events:
         - Kind: Entry
-          Type: 1289 EventRootType Probe[main.testReturnsWideStruct]
+          Type: 1306 EventRootType Probe[main.testReturnsWideStruct]
           InjectionPoints: [{PC: "0x891130", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1290 EventRootType Probe[main.testReturnsWideStruct]Return
+          Type: 1307 EventRootType Probe[main.testReturnsWideStruct]Return
           InjectionPoints: [{PC: "0x8911d4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3178,7 +3221,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - Kind: Entry
-          Type: 1130 EventRootType Probe[main.testRuneArray]
+          Type: 1147 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0x88c260", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3212,11 +3255,11 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1261 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1278 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x890a58", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1262 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1279 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x890ae4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3261,7 +3304,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 1151 EventRootType Probe[main.testSingleBool]
+          Type: 1168 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0x88c6e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3282,7 +3325,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - Kind: Entry
-          Type: 1149 EventRootType Probe[main.testSingleByte]
+          Type: 1166 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0x88c6c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3303,7 +3346,7 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 1162 EventRootType Probe[main.testSingleFloat32]
+          Type: 1179 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0x88c790", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3324,7 +3367,7 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - Kind: Entry
-          Type: 1163 EventRootType Probe[main.testSingleFloat64]
+          Type: 1180 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0x88c7a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3345,7 +3388,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 1152 EventRootType Probe[main.testSingleInt]
+          Type: 1169 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0x88c6f0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3366,7 +3409,7 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - Kind: Entry
-          Type: 1154 EventRootType Probe[main.testSingleInt16]
+          Type: 1171 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0x88c710", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3388,7 +3431,7 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - Kind: Entry
-          Type: 1155 EventRootType Probe[main.testSingleInt32]
+          Type: 1172 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0x88c720", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3409,7 +3452,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - Kind: Entry
-          Type: 1156 EventRootType Probe[main.testSingleInt64]
+          Type: 1173 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0x88c730", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3437,7 +3480,7 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - Kind: Entry
-          Type: 1153 EventRootType Probe[main.testSingleInt8]
+          Type: 1170 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0x88c700", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3467,7 +3510,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 1150 EventRootType Probe[main.testSingleRune]
+          Type: 1167 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0x88c6d0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3488,7 +3531,7 @@ Probes:
       subprogram: {subprogram: 143}
       events:
         - Kind: Entry
-          Type: 1334 EventRootType Probe[main.testSingleString]
+          Type: 1351 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0x892960", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3509,7 +3552,7 @@ Probes:
       subprogram: {subprogram: 29}
       events:
         - Kind: Entry
-          Type: 1157 EventRootType Probe[main.testSingleUint]
+          Type: 1174 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0x88c740", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3530,7 +3573,7 @@ Probes:
       subprogram: {subprogram: 31}
       events:
         - Kind: Entry
-          Type: 1159 EventRootType Probe[main.testSingleUint16]
+          Type: 1176 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0x88c760", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3551,7 +3594,7 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - Kind: Entry
-          Type: 1160 EventRootType Probe[main.testSingleUint32]
+          Type: 1177 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0x88c770", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3572,7 +3615,7 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 1161 EventRootType Probe[main.testSingleUint64]
+          Type: 1178 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0x88c780", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3593,7 +3636,7 @@ Probes:
       subprogram: {subprogram: 30}
       events:
         - Kind: Entry
-          Type: 1158 EventRootType Probe[main.testSingleUint8]
+          Type: 1175 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0x88c750", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3614,7 +3657,7 @@ Probes:
       subprogram: {subprogram: 140}
       events:
         - Kind: Entry
-          Type: 1330 EventRootType Probe[main.testSliceEmptyStructs]
+          Type: 1347 EventRootType Probe[main.testSliceEmptyStructs]
           InjectionPoints: [{PC: "0x8925c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3635,7 +3678,7 @@ Probes:
       subprogram: {subprogram: 132}
       events:
         - Kind: Entry
-          Type: 1321 EventRootType Probe[main.testSliceOfSlices]
+          Type: 1338 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0x892540", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3656,7 +3699,7 @@ Probes:
       subprogram: {subprogram: 65}
       events:
         - Kind: Entry
-          Type: 1207 EventRootType Probe[main.testSmallMap]
+          Type: 1224 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0x88e440", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3676,11 +3719,11 @@ Probes:
       subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1269 EventRootType Probe[main.testSomeNamedReturn]
+          Type: 1286 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0x890b28", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1270 EventRootType Probe[main.testSomeNamedReturn]Return
+          Type: 1287 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0x890bb4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3700,11 +3743,11 @@ Probes:
       subprogram: {subprogram: 126}
       events:
         - Kind: Entry
-          Type: 1311 EventRootType Probe[main.testStackArgRegReturns]
+          Type: 1328 EventRootType Probe[main.testStackArgRegReturns]
           InjectionPoints: [{PC: "0x891dc8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1312 EventRootType Probe[main.testStackArgRegReturns]Return
+          Type: 1329 EventRootType Probe[main.testStackArgRegReturns]Return
           InjectionPoints: [{PC: "0x891e2c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3725,7 +3768,7 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - Kind: Entry
-          Type: 1131 EventRootType Probe[main.testStringArray]
+          Type: 1148 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0x88c270", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3746,7 +3789,7 @@ Probes:
       subprogram: {subprogram: 93}
       events:
         - Kind: Entry
-          Type: 1238 EventRootType Probe[main.testStringPointer]
+          Type: 1255 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0x88fdf0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3767,7 +3810,7 @@ Probes:
       subprogram: {subprogram: 136}
       events:
         - Kind: Entry
-          Type: 1325 EventRootType Probe[main.testStringSlice]
+          Type: 1342 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0x892580", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3788,7 +3831,7 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - Kind: Entry
-          Type: 1173 EventRootType Probe[main.testStringType1]
+          Type: 1190 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0x88ccc0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3809,7 +3852,7 @@ Probes:
       subprogram: {subprogram: 45}
       events:
         - Kind: Entry
-          Type: 1174 EventRootType Probe[main.testStringType2]
+          Type: 1191 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0x88ccd0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3830,11 +3873,11 @@ Probes:
       subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1353 EventRootType Probe[main.testStruct]
+          Type: 1370 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0x892c60", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1354 EventRootType Probe[main.testStruct]Return
+          Type: 1371 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0x892c7c", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3860,7 +3903,7 @@ Probes:
       subprogram: {subprogram: 133}
       events:
         - Kind: Entry
-          Type: 1322 EventRootType Probe[main.testStructSlice]
+          Type: 1339 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0x892550", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3886,7 +3929,7 @@ Probes:
       subprogram: {subprogram: 59}
       events:
         - Kind: Entry
-          Type: 1201 EventRootType Probe[main.testStructWithAny]
+          Type: 1218 EventRootType Probe[main.testStructWithAny]
           InjectionPoints: [{PC: "0x88de40", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3906,11 +3949,11 @@ Probes:
       subprogram: {subprogram: 128}
       events:
         - Kind: Entry
-          Type: 1315 EventRootType Probe[main.testStructWithArrayArg]
+          Type: 1332 EventRootType Probe[main.testStructWithArrayArg]
           InjectionPoints: [{PC: "0x891f4c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1316 EventRootType Probe[main.testStructWithArrayArg]Return
+          Type: 1333 EventRootType Probe[main.testStructWithArrayArg]Return
           InjectionPoints: [{PC: "0x891fdc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3931,11 +3974,11 @@ Probes:
       subprogram: {subprogram: 153}
       events:
         - Kind: Entry
-          Type: 1349 EventRootType Probe[main.testStructWithCyclicMaps]
+          Type: 1366 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0x892b70", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1350 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          Type: 1367 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0x892b88", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3955,7 +3998,7 @@ Probes:
       subprogram: {subprogram: 152}
       events:
         - Kind: Entry
-          Type: 1348 EventRootType Probe[main.testStructWithCyclicSlices]
+          Type: 1365 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0x892b60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3981,7 +4024,7 @@ Probes:
       subprogram: {subprogram: 60}
       events:
         - Kind: Entry
-          Type: 1202 EventRootType Probe[main.testStructWithMap]
+          Type: 1219 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0x88e3f0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4012,7 +4055,7 @@ Probes:
       subprogram: {subprogram: 141}
       events:
         - Kind: Entry
-          Type: 1331 EventRootType Probe[main.testSubslices]
+          Type: 1348 EventRootType Probe[main.testSubslices]
           InjectionPoints: [{PC: "0x8925d0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4051,7 +4094,7 @@ Probes:
       subprogram: {subprogram: 151}
       events:
         - Kind: Entry
-          Type: 1347 EventRootType Probe[main.testSubstrings]
+          Type: 1364 EventRootType Probe[main.testSubstrings]
           InjectionPoints: [{PC: "0x8929f0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4083,11 +4126,11 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1263 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1280 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x890a58", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1264 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1281 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x890ae4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -4107,11 +4150,11 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1265 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1282 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x890a58", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1266 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1283 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x890ae4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -4133,11 +4176,11 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1267 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1284 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x890a58", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1268 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1285 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x890ae4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -4165,7 +4208,7 @@ Probes:
       subprogram: {subprogram: 144}
       events:
         - Kind: Entry
-          Type: 1335 EventRootType Probe[main.testThreeStrings]
+          Type: 1352 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0x892970", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4196,11 +4239,11 @@ Probes:
       subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1336 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1353 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0x892980", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1337 EventRootType Probe[main.testThreeStringsInStruct]Return
+          Type: 1354 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0x892998", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4229,11 +4272,11 @@ Probes:
       subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1338 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1355 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0x892980", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1339 EventRootType Probe[main.testThreeStringsInStruct]Return
+          Type: 1356 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0x892998", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4264,7 +4307,7 @@ Probes:
       subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1340 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1357 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0x8929a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4293,7 +4336,7 @@ Probes:
       subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1341 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1358 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0x8929a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4324,7 +4367,7 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 1164 EventRootType Probe[main.testTypeAlias]
+          Type: 1181 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0x88c7b0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4345,7 +4388,7 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - Kind: Entry
-          Type: 1140 EventRootType Probe[main.testUint16Array]
+          Type: 1157 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0x88c300", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4366,7 +4409,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - Kind: Entry
-          Type: 1141 EventRootType Probe[main.testUint32Array]
+          Type: 1158 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0x88c310", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4387,7 +4430,7 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - Kind: Entry
-          Type: 1142 EventRootType Probe[main.testUint64Array]
+          Type: 1159 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0x88c320", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4408,7 +4451,7 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - Kind: Entry
-          Type: 1139 EventRootType Probe[main.testUint8Array]
+          Type: 1156 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0x88c2f0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4429,7 +4472,7 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - Kind: Entry
-          Type: 1138 EventRootType Probe[main.testUintArray]
+          Type: 1155 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0x88c2e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4450,7 +4493,7 @@ Probes:
       subprogram: {subprogram: 92}
       events:
         - Kind: Entry
-          Type: 1237 EventRootType Probe[main.testUintPointer]
+          Type: 1254 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0x88fd80", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4471,7 +4514,7 @@ Probes:
       subprogram: {subprogram: 130}
       events:
         - Kind: Entry
-          Type: 1319 EventRootType Probe[main.testUintSlice]
+          Type: 1336 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0x892520", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4492,7 +4535,7 @@ Probes:
       subprogram: {subprogram: 149}
       events:
         - Kind: Entry
-          Type: 1345 EventRootType Probe[main.testUnitializedString]
+          Type: 1362 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0x8929d0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4513,7 +4556,7 @@ Probes:
       subprogram: {subprogram: 91}
       events:
         - Kind: Entry
-          Type: 1236 EventRootType Probe[main.testUnsafePointer]
+          Type: 1253 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0x88fd60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4534,7 +4577,7 @@ Probes:
       subprogram: {subprogram: 20}
       events:
         - Kind: Entry
-          Type: 1148 EventRootType Probe[main.testVeryLargeArray]
+          Type: 1165 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0x88c390", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4555,7 +4598,7 @@ Probes:
       subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1328 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1345 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x8925b0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4576,7 +4619,7 @@ Probes:
       subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1329 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1346 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x8925b0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4593,10 +4636,10 @@ Probes:
       template: testWhollyInlinedSubroutine
       segments: [testWhollyInlinedSubroutine]
       captureSnapshot: true
-      subprogram: {subprogram: 164}
+      subprogram: {subprogram: 165}
       events:
         - Kind: Entry
-          Type: 1374 EventRootType Probe[main.firstBehavior.DoSomething]
+          Type: 1392 EventRootType Probe[main.firstBehavior.DoSomething]
           InjectionPoints:
             - PC: "0x88dc68"
               Frameless: false
@@ -4604,7 +4647,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1375 EventRootType Probe[main.firstBehavior.DoSomething]Return
+          Type: 1393 EventRootType Probe[main.firstBehavior.DoSomething]Return
           InjectionPoints: [{PC: "0x88dca0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -4625,11 +4668,11 @@ Probes:
       subprogram: {subprogram: 129}
       events:
         - Kind: Entry
-          Type: 1317 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          Type: 1334 EventRootType Probe[main.testZeroSizeArgAndReturn]
           InjectionPoints: [{PC: "0x892018", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1318 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          Type: 1335 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
           InjectionPoints: [{PC: "0x892084", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -8151,6 +8194,73 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 158
+      Name: main.executeStructFuncs
+      OutOfLinePCRanges: [0x892d90..0x893890]
+      InlinePCRanges: []
+      Variables:
+        - Name: ptrRcvr
+          Type: 316 PointerType *main.receiver
+          Locations: [{Range: 0x892d90..0x893890, Pieces: []}]
+          Role: Local
+        - Name: n
+          Type: 318 StructureType main.nStruct
+          Locations: [{Range: 0x892d90..0x893890, Pieces: []}]
+          Role: Local
+        - Name: ns
+          Type: 257 StructureType main.structWithNoStrings
+          Locations: [{Range: 0x892d90..0x893890, Pieces: []}]
+          Role: Local
+        - Name: cs
+          Type: 319 StructureType main.cStruct
+          Locations: [{Range: 0x892d90..0x893890, Pieces: []}]
+          Role: Local
+        - Name: rcvr
+          Type: 317 StructureType main.receiver
+          Locations: [{Range: 0x892d90..0x893890, Pieces: []}]
+          Role: Local
+        - Name: ts
+          Type: 320 StructureType main.threestrings
+          Locations:
+            - Range: 0x892db8..0x893890
+              Pieces: [{Size: 48, Op: {CfaOffset: -2072}}]
+          Role: Local
+        - Name: s
+          Type: 311 StructureType main.aStruct
+          Locations:
+            - Range: 0x892e0c..0x893890
+              Pieces: [{Size: 56, Op: {CfaOffset: -1912}}]
+          Role: Local
+        - Name: b
+          Type: 321 StructureType main.bStruct
+          Locations:
+            - Range: 0x892e6c..0x893890
+              Pieces: [{Size: 72, Op: {CfaOffset: -2072}}]
+          Role: Local
+        - Name: tenStr
+          Type: 322 StructureType main.tenStrings
+          Locations:
+            - Range: 0x893098..0x893890
+              Pieces: [{Size: 160, Op: {CfaOffset: -2072}}]
+          Role: Local
+        - Name: deep
+          Type: 323 StructureType main.deepStruct1
+          Locations:
+            - Range: 0x8930d8..0x893890
+              Pieces: [{Size: 48, Op: {CfaOffset: -2160}}]
+          Role: Local
+        - Name: fields
+          Type: 329 StructureType main.lotsOfFields
+          Locations:
+            - Range: 0x893138..0x893890
+              Pieces: [{Size: 26, Op: {CfaOffset: -2160}}]
+          Role: Local
+        - Name: sta
+          Type: 330 StructureType main.structWithTwoArrays
+          Locations:
+            - Range: 0x893190..0x893890
+              Pieces: [{Size: 72, Op: {CfaOffset: -2160}}]
+          Role: Local
+    - ID: 159
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0x88d5f0..0x88d660]
       InlinePCRanges:
@@ -8179,28 +8289,28 @@ Subprograms:
             - Range: 0x88d8f0..0x88d914
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 159
+    - ID: 160
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x88d888..0x88d8c0]
           RootRanges: [0x88d820..0x88d8f0]
       Variables: []
-    - ID: 160
+    - ID: 161
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x88d98c..0x88d9d0]
           RootRanges: [0x88d970..0x88da90]
       Variables: []
-    - ID: 161
+    - ID: 162
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x88da40..0x88da78]
           RootRanges: [0x88d970..0x88da90]
       Variables: []
-    - ID: 162
+    - ID: 163
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -8213,7 +8323,7 @@ Subprograms:
             - Range: 0x88da90..0x88da98
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 163
+    - ID: 164
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -8230,7 +8340,7 @@ Subprograms:
             - Range: 0x88db48..0x88dc50
               Pieces: [{Size: 40, Op: {CfaOffset: -120}}]
           Role: Parameter
-    - ID: 164
+    - ID: 165
       Name: main.firstBehavior.DoSomething
       OutOfLinePCRanges: [0x88dc50..0x88dcd0]
       InlinePCRanges:
@@ -8238,7 +8348,7 @@ Subprograms:
           RootRanges: [0x893a90..0x893b40]
       Variables:
         - Name: b
-          Type: 316 StructureType main.firstBehavior
+          Type: 333 StructureType main.firstBehavior
           Locations:
             - Range: 0x88dc50..0x88dc7c
               Pieces:
@@ -8267,7 +8377,7 @@ Subprograms:
             - Range: 0x88dca1..0x88dcd0
               Pieces: []
           Role: Return
-    - ID: 165
+    - ID: 166
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -8283,20 +8393,20 @@ Types:
       ByteSize: 8
       Pointee: 133 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 1068
+      ID: 1085
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 1069 PointerType *main.deepSlice3
+      Pointee: 1086 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 1087
+      ID: 1104
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 1088 PointerType *main.deepSlice8
+      Pointee: 1105 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 1093
+      ID: 1110
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 1094 PointerType *main.deepSlice9
+      Pointee: 1111 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 148
       Name: '**main.stringType2'
@@ -8304,7 +8414,7 @@ Types:
       GoKind: 22
       Pointee: 149 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 1064
+      ID: 1081
       Name: '**main.t'
       ByteSize: 8
       Pointee: 243 PointerType *main.t
@@ -8316,115 +8426,115 @@ Types:
       GoKind: 22
       Pointee: 88 PointerType *string
     - __kind: PointerType
-      ID: 327
+      ID: 344
       Name: '*[]*main.deepSlice2.array'
       ByteSize: 8
-      Pointee: 326 GoSliceDataType []*main.deepSlice2.array
+      Pointee: 343 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 1072
+      ID: 1089
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 1071 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 1088 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 1091
+      ID: 1108
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 1090 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 1107 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 1097
+      ID: 1114
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 1096 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 1113 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
-      ID: 324
+      ID: 341
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 323 GoSliceDataType []*string.array
+      Pointee: 340 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 393
+      ID: 410
       Name: '*[][][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 392 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Pointee: 409 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 279
       Name: '*[][][][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 276 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 391
+      ID: 408
       Name: '*[][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 390 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Pointee: 407 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 277
       Name: '*[][][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 274 GoSliceHeaderType [][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 389
+      ID: 406
       Name: '*[][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 388 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Pointee: 405 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 275
       Name: '*[][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 272 GoSliceHeaderType [][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 387
+      ID: 404
       Name: '*[][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 386 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Pointee: 403 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 273
       Name: '*[][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 270 GoSliceHeaderType [][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 385
+      ID: 402
       Name: '*[][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 384 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Pointee: 401 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 371
+      ID: 388
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 370 GoSliceDataType [][]uint.array
+      Pointee: 387 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 377
+      ID: 394
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 376 GoSliceDataType []bool.array
+      Pointee: 393 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 856
+      ID: 873
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 855 GoSliceDataType []float64.array
+      Pointee: 872 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 1100
+      ID: 1117
       Name: '*[]interface {}.array'
       ByteSize: 8
-      Pointee: 1099 GoSliceDataType []interface {}.array
+      Pointee: 1116 GoSliceDataType []interface {}.array
     - __kind: PointerType
       ID: 271
       Name: '*[]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 268 GoSliceHeaderType []main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 383
+      ID: 400
       Name: '*[]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 382 GoSliceDataType []main.structWithCyclicSlices.array
+      Pointee: 399 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 407
+      ID: 424
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 406 GoSliceDataType []main.structWithMap.array
+      Pointee: 423 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 373
+      ID: 390
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 372 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 389 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
       ID: 39
       Name: '*[]runtime.ancestorInfo'
@@ -8433,101 +8543,101 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 375
+      ID: 392
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 374 GoSliceDataType []string.array
+      Pointee: 391 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 381
+      ID: 398
       Name: '*[]struct {}.array'
       ByteSize: 8
-      Pointee: 380 GoSliceDataType []struct {}.array
+      Pointee: 397 GoSliceDataType []struct {}.array
     - __kind: PointerType
       ID: 254
       Name: '*[]uint'
       ByteSize: 8
       Pointee: 252 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 369
+      ID: 386
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 368 GoSliceDataType []uint.array
+      Pointee: 385 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 379
+      ID: 396
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 378 GoSliceDataType []uint16.array
+      Pointee: 395 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 320
+      ID: 337
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 319 GoSliceDataType []uint8.array
+      Pointee: 336 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 322
+      ID: 339
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 321 GoSliceDataType []uintptr.array
+      Pointee: 338 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 981
+      ID: 998
       Name: '*archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1.849952e+06
       GoKind: 22
-      Pointee: 982 UnresolvedPointeeType archive/tar.Writer
+      Pointee: 999 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
-      ID: 633
+      ID: 650
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 858592
       GoKind: 22
-      Pointee: 634 GoSliceHeaderType archive/tar.headerError
+      Pointee: 651 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 636
+      ID: 653
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 635 GoSliceDataType archive/tar.headerError.array
+      Pointee: 652 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 921
+      ID: 938
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.253568e+06
       GoKind: 22
-      Pointee: 922 UnresolvedPointeeType archive/tar.regFileWriter
+      Pointee: 939 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
-      ID: 869
+      ID: 886
       Name: '*archive/zip.countWriter'
       ByteSize: 8
       GoRuntimeType: 858784
       GoKind: 22
-      Pointee: 870 UnresolvedPointeeType archive/zip.countWriter
+      Pointee: 887 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
-      ID: 871
+      ID: 888
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
       GoRuntimeType: 858880
       GoKind: 22
-      Pointee: 872 StructureType archive/zip.dirWriter
+      Pointee: 889 StructureType archive/zip.dirWriter
     - __kind: PointerType
-      ID: 968
+      ID: 985
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.77424e+06
       GoKind: 22
-      Pointee: 969 UnresolvedPointeeType archive/zip.fileWriter
+      Pointee: 986 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
-      ID: 897
+      ID: 914
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1.017088e+06
       GoKind: 22
-      Pointee: 898 StructureType archive/zip.nopCloser
+      Pointee: 915 StructureType archive/zip.nopCloser
     - __kind: PointerType
-      ID: 899
+      ID: 916
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
       GoRuntimeType: 1.017344e+06
       GoKind: 22
-      Pointee: 900 UnresolvedPointeeType archive/zip.pooledFlateWriter
+      Pointee: 917 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -8561,30 +8671,30 @@ Types:
       ByteSize: 8
       Pointee: 141 GoHMapBucketType bucket<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1076
+      ID: 1093
       Name: '*bucket<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1077 GoHMapBucketType bucket<int,*main.deepMap3>
+      Pointee: 1094 GoHMapBucketType bucket<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1104
+      ID: 1121
       Name: '*bucket<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1105 GoHMapBucketType bucket<int,*main.deepMap8>
+      Pointee: 1122 GoHMapBucketType bucket<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1113
+      ID: 1130
       Name: '*bucket<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1114 GoHMapBucketType bucket<int,*main.deepMap9>
+      Pointee: 1131 GoHMapBucketType bucket<int,*main.deepMap9>
     - __kind: PointerType
       ID: 164
       Name: '*bucket<int,int>'
       ByteSize: 8
       Pointee: 165 GoHMapBucketType bucket<int,int>
     - __kind: PointerType
-      ID: 1122
+      ID: 1139
       Name: '*bucket<int,interface {}>'
       ByteSize: 8
-      Pointee: 1123 GoHMapBucketType bucket<int,interface {}>
+      Pointee: 1140 GoHMapBucketType bucket<int,interface {}>
     - __kind: PointerType
       ID: 231
       Name: '*bucket<int,struct {}>'
@@ -8606,10 +8716,10 @@ Types:
       ByteSize: 8
       Pointee: 180 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 825
+      ID: 842
       Name: '*bucket<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 826 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 843 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 174
       Name: '*bucket<string,int>'
@@ -8671,393 +8781,393 @@ Types:
       ByteSize: 8
       Pointee: 207 GoHMapBucketType bucket<uint8,uint8>
     - __kind: PointerType
-      ID: 945
+      ID: 962
       Name: '*bufio.Reader'
       ByteSize: 8
       GoRuntimeType: 2.030432e+06
       GoKind: 22
-      Pointee: 946 UnresolvedPointeeType bufio.Reader
+      Pointee: 963 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
-      ID: 970
+      ID: 987
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1.81568e+06
       GoKind: 22
-      Pointee: 971 UnresolvedPointeeType bufio.Writer
+      Pointee: 988 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
-      ID: 1017
+      ID: 1034
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.123392e+06
       GoKind: 22
-      Pointee: 1018 UnresolvedPointeeType bytes.Buffer
+      Pointee: 1035 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 546
+      ID: 563
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 841216
       GoKind: 22
-      Pointee: 441 BaseType compress/flate.CorruptInputError
+      Pointee: 458 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 547
+      ID: 564
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 841312
       GoKind: 22
-      Pointee: 442 GoStringHeaderType compress/flate.InternalError
+      Pointee: 459 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 444
+      ID: 461
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 443 GoStringDataType compress/flate.InternalError.str
+      Pointee: 460 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 919
+      ID: 936
       Name: '*compress/flate.Writer'
       ByteSize: 8
       GoRuntimeType: 1.243808e+06
       GoKind: 22
-      Pointee: 920 UnresolvedPointeeType compress/flate.Writer
+      Pointee: 937 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
-      ID: 865
+      ID: 882
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
       GoRuntimeType: 841408
       GoKind: 22
-      Pointee: 866 UnresolvedPointeeType compress/flate.dictWriter
+      Pointee: 883 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
-      ID: 941
+      ID: 958
       Name: '*compress/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.600864e+06
       GoKind: 22
-      Pointee: 942 UnresolvedPointeeType compress/gzip.Writer
+      Pointee: 959 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
-      ID: 777
+      ID: 794
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.11824e+06
       GoKind: 22
-      Pointee: 778 StructureType context.deadlineExceededError
+      Pointee: 795 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 626
+      ID: 643
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 853504
       GoKind: 22
-      Pointee: 455 BaseType crypto/aes.KeySizeError
+      Pointee: 472 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 627
+      ID: 644
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 853696
       GoKind: 22
-      Pointee: 456 BaseType crypto/des.KeySizeError
+      Pointee: 473 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 931
+      ID: 948
       Name: '*crypto/hmac.hmac'
       ByteSize: 8
       GoRuntimeType: 1.37424e+06
       GoKind: 22
-      Pointee: 932 UnresolvedPointeeType crypto/hmac.hmac
+      Pointee: 949 UnresolvedPointeeType crypto/hmac.hmac
     - __kind: PointerType
-      ID: 956
+      ID: 973
       Name: '*crypto/md5.digest'
       ByteSize: 8
       GoRuntimeType: 1.679872e+06
       GoKind: 22
-      Pointee: 957 UnresolvedPointeeType crypto/md5.digest
+      Pointee: 974 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
-      ID: 628
+      ID: 645
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 853984
       GoKind: 22
-      Pointee: 457 BaseType crypto/rc4.KeySizeError
+      Pointee: 474 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 964
+      ID: 981
       Name: '*crypto/sha1.digest'
       ByteSize: 8
       GoRuntimeType: 1.771424e+06
       GoKind: 22
-      Pointee: 965 UnresolvedPointeeType crypto/sha1.digest
+      Pointee: 982 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
-      ID: 958
+      ID: 975
       Name: '*crypto/sha256.digest'
       ByteSize: 8
       GoRuntimeType: 1.68032e+06
       GoKind: 22
-      Pointee: 959 UnresolvedPointeeType crypto/sha256.digest
+      Pointee: 976 UnresolvedPointeeType crypto/sha256.digest
     - __kind: PointerType
-      ID: 960
+      ID: 977
       Name: '*crypto/sha512.digest'
       ByteSize: 8
       GoRuntimeType: 1.680768e+06
       GoKind: 22
-      Pointee: 961 UnresolvedPointeeType crypto/sha512.digest
+      Pointee: 978 UnresolvedPointeeType crypto/sha512.digest
     - __kind: PointerType
-      ID: 552
+      ID: 569
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 842848
       GoKind: 22
-      Pointee: 445 BaseType crypto/tls.AlertError
+      Pointee: 462 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 717
+      ID: 734
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1.004928e+06
       GoKind: 22
-      Pointee: 718 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 735 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 1043
+      ID: 1060
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2.232512e+06
       GoKind: 22
-      Pointee: 1044 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 1061 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 550
+      ID: 567
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 842656
       GoKind: 22
-      Pointee: 551 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 568 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 548
+      ID: 565
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 842560
       GoKind: 22
-      Pointee: 549 StructureType crypto/tls.RecordHeaderError
+      Pointee: 566 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 716
+      ID: 733
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1.003264e+06
       GoKind: 22
-      Pointee: 673 BaseType crypto/tls.alert
+      Pointee: 690 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 929
+      ID: 946
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
       GoRuntimeType: 1.37136e+06
       GoKind: 22
-      Pointee: 930 UnresolvedPointeeType crypto/tls.cthWrapper
+      Pointee: 947 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
-      ID: 936
+      ID: 953
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
       GoRuntimeType: 1.450432e+06
       GoKind: 22
-      Pointee: 937 UnresolvedPointeeType crypto/tls.finishedHash
+      Pointee: 954 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
-      ID: 812
+      ID: 829
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1.244128e+06
       GoKind: 22
-      Pointee: 813 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 830 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 827
+      ID: 844
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 1.907104e+06
       GoKind: 22
-      Pointee: 828 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 845 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 622
+      ID: 639
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 852448
       GoKind: 22
-      Pointee: 623 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 640 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 616
+      ID: 633
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 851968
       GoKind: 22
-      Pointee: 617 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 634 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 618
+      ID: 635
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 852064
       GoKind: 22
-      Pointee: 619 StructureType crypto/x509.HostnameError
+      Pointee: 636 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 615
+      ID: 632
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 851872
       GoKind: 22
-      Pointee: 454 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 471 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 722
+      ID: 739
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1.010816e+06
       GoKind: 22
-      Pointee: 723 StructureType crypto/x509.SystemRootsError
+      Pointee: 740 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 624
+      ID: 641
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 852544
       GoKind: 22
-      Pointee: 625 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 642 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 620
+      ID: 637
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 852352
       GoKind: 22
-      Pointee: 621 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 638 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 637
+      ID: 654
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 859072
       GoKind: 22
-      Pointee: 638 StructureType encoding/asn1.StructuralError
+      Pointee: 655 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 641
+      ID: 658
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 859264
       GoKind: 22
-      Pointee: 642 StructureType encoding/asn1.SyntaxError
+      Pointee: 659 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 639
+      ID: 656
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 859168
       GoKind: 22
-      Pointee: 640 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 657 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 538
+      ID: 555
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 839488
       GoKind: 22
-      Pointee: 439 BaseType encoding/base64.CorruptInputError
+      Pointee: 456 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 887
+      ID: 904
       Name: '*encoding/base64.encoder'
       ByteSize: 8
       GoRuntimeType: 1.000064e+06
       GoKind: 22
-      Pointee: 888 UnresolvedPointeeType encoding/base64.encoder
+      Pointee: 905 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
-      ID: 541
+      ID: 558
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 840352
       GoKind: 22
-      Pointee: 440 BaseType encoding/hex.InvalidByteError
+      Pointee: 457 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 509
+      ID: 526
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 834208
       GoKind: 22
-      Pointee: 510 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 527 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 708
+      ID: 725
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 995712
       GoKind: 22
-      Pointee: 709 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 726 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 501
+      ID: 518
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 833824
       GoKind: 22
-      Pointee: 502 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 519 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 507
+      ID: 524
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 834112
       GoKind: 22
-      Pointee: 508 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 525 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 505
+      ID: 522
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 834016
       GoKind: 22
-      Pointee: 506 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 523 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 503
+      ID: 520
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 833920
       GoKind: 22
-      Pointee: 504 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 521 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 1023
+      ID: 1040
       Name: '*encoding/json.encodeState'
       ByteSize: 8
       GoRuntimeType: 2.14896e+06
       GoKind: 22
-      Pointee: 1024 UnresolvedPointeeType encoding/json.encodeState
+      Pointee: 1041 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 511
+      ID: 528
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 834592
       GoKind: 22
-      Pointee: 512 StructureType encoding/json.jsonError
+      Pointee: 529 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 895
+      ID: 912
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
       GoRuntimeType: 1.013632e+06
       GoKind: 22
-      Pointee: 896 UnresolvedPointeeType encoding/pem.lineBreaker
+      Pointee: 913 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
-      ID: 610
+      ID: 627
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 850912
       GoKind: 22
-      Pointee: 611 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 628 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 608
+      ID: 625
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 850816
       GoKind: 22
-      Pointee: 609 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 626 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 612
+      ID: 629
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 851008
       GoKind: 22
-      Pointee: 451 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 468 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 453
+      ID: 470
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 452 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 469 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 613
+      ID: 630
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 851104
       GoKind: 22
-      Pointee: 614 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 631 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
-      ID: 1001
+      ID: 1018
       Name: '*encoding/xml.printer'
       ByteSize: 8
       GoRuntimeType: 2.018912e+06
       GoKind: 22
-      Pointee: 1002 UnresolvedPointeeType encoding/xml.printer
+      Pointee: 1019 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
       ID: 99
       Name: '*error'
@@ -9066,19 +9176,19 @@ Types:
       GoKind: 22
       Pointee: 18 GoInterfaceType error
     - __kind: PointerType
-      ID: 479
+      ID: 496
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 824512
       GoKind: 22
-      Pointee: 480 UnresolvedPointeeType errors.errorString
+      Pointee: 497 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 675
+      ID: 692
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 980352
       GoKind: 22
-      Pointee: 676 UnresolvedPointeeType errors.joinError
+      Pointee: 693 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 101
       Name: '*float32'
@@ -9094,806 +9204,806 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 1011
+      ID: 1028
       Name: '*fmt.pp'
       ByteSize: 8
       GoRuntimeType: 2.114688e+06
       GoKind: 22
-      Pointee: 1012 UnresolvedPointeeType fmt.pp
+      Pointee: 1029 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
-      ID: 677
+      ID: 694
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 980480
       GoKind: 22
-      Pointee: 678 UnresolvedPointeeType fmt.wrapError
+      Pointee: 695 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 679
+      ID: 696
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 980608
       GoKind: 22
-      Pointee: 680 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 697 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 539
+      ID: 556
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 839872
       GoKind: 22
-      Pointee: 540 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 557 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 520
+      ID: 537
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 836992
       GoKind: 22
-      Pointee: 521 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 538 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 522
+      ID: 539
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 837088
       GoKind: 22
-      Pointee: 523 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 540 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 839
+      ID: 856
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 836800
       GoKind: 22
-      Pointee: 840 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 857 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 526
+      ID: 543
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 837376
       GoKind: 22
-      Pointee: 527 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 544 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 841
+      ID: 858
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 836896
       GoKind: 22
-      Pointee: 842 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 859 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 524
+      ID: 541
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 837184
       GoKind: 22
-      Pointee: 433 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 450 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 435
+      ID: 452
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 434 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 451 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 519
+      ID: 536
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 836704
       GoKind: 22
-      Pointee: 430 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 447 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 432
+      ID: 449
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 431 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 448 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 525
+      ID: 542
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 837280
       GoKind: 22
-      Pointee: 436 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 453 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 438
+      ID: 455
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 437 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 454 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 909
+      ID: 926
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
       GoRuntimeType: 1.124e+06
       GoKind: 22
-      Pointee: 910 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      Pointee: 927 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
-      ID: 989
+      ID: 1006
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
       GoRuntimeType: 1.922112e+06
       GoKind: 22
-      Pointee: 990 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      Pointee: 1007 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
-      ID: 631
+      ID: 648
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 857536
       GoKind: 22
-      Pointee: 632 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 649 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 786
+      ID: 803
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1.127328e+06
       GoKind: 22
-      Pointee: 787 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 804 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 1019
+      ID: 1036
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
       GoRuntimeType: 2.124928e+06
       GoKind: 22
-      Pointee: 1020 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      Pointee: 1037 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
-      ID: 559
+      ID: 576
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 846400
       GoKind: 22
-      Pointee: 560 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 577 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 566
+      ID: 583
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 847456
       GoKind: 22
-      Pointee: 567 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 584 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 561
+      ID: 578
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 847168
       GoKind: 22
-      Pointee: 450 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 467 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 564
+      ID: 581
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 847360
       GoKind: 22
-      Pointee: 565 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 582 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 562
+      ID: 579
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 847264
       GoKind: 22
-      Pointee: 563 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 580 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 582
+      ID: 599
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 849376
       GoKind: 22
-      Pointee: 583 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 600 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 586
+      ID: 603
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 849568
       GoKind: 22
-      Pointee: 587 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 604 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 584
+      ID: 601
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 849472
       GoKind: 22
-      Pointee: 585 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 602 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 580
+      ID: 597
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 849280
       GoKind: 22
-      Pointee: 581 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 598 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 858
+      ID: 875
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 857 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 874 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 594
+      ID: 611
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 849952
       GoKind: 22
-      Pointee: 595 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 612 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 588
+      ID: 605
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 849664
       GoKind: 22
-      Pointee: 589 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 606 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 592
+      ID: 609
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 849856
       GoKind: 22
-      Pointee: 593 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 610 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 590
+      ID: 607
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 849760
       GoKind: 22
-      Pointee: 591 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 608 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 596
+      ID: 613
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 850048
       GoKind: 22
-      Pointee: 597 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 614 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 602
+      ID: 619
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 850336
       GoKind: 22
-      Pointee: 603 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 620 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 604
+      ID: 621
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 850432
       GoKind: 22
-      Pointee: 605 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 622 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 600
+      ID: 617
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 850240
       GoKind: 22
-      Pointee: 601 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 618 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 598
+      ID: 615
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 850144
       GoKind: 22
-      Pointee: 599 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 616 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 606
+      ID: 623
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 850624
       GoKind: 22
-      Pointee: 607 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 624 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 528
+      ID: 545
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 838528
       GoKind: 22
-      Pointee: 529 StructureType github.com/cihub/seelog.baseError
+      Pointee: 546 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 948
+      ID: 965
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1.67696e+06
       GoKind: 22
-      Pointee: 949 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 966 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 530
+      ID: 547
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 838624
       GoKind: 22
-      Pointee: 531 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 548 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 927
+      ID: 944
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
       GoRuntimeType: 1.37024e+06
       GoKind: 22
-      Pointee: 928 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+      Pointee: 945 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
-      ID: 883
+      ID: 900
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
       GoRuntimeType: 999040
       GoKind: 22
-      Pointee: 884 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+      Pointee: 901 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
-      ID: 917
+      ID: 934
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.241888e+06
       GoKind: 22
-      Pointee: 918 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+      Pointee: 935 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
-      ID: 534
+      ID: 551
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 838816
       GoKind: 22
-      Pointee: 535 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 552 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 979
+      ID: 996
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.84016e+06
       GoKind: 22
-      Pointee: 980 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+      Pointee: 997 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
-      ID: 994
+      ID: 1011
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
       GoRuntimeType: 1.993568e+06
       GoKind: 22
-      Pointee: 991 StructureType github.com/cihub/seelog.rollingFileWriterSize
+      Pointee: 1008 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
-      ID: 993
+      ID: 1010
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
       GoRuntimeType: 1.993184e+06
       GoKind: 22
-      Pointee: 992 StructureType github.com/cihub/seelog.rollingFileWriterTime
+      Pointee: 1009 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
-      ID: 885
+      ID: 902
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
       GoRuntimeType: 999168
       GoKind: 22
-      Pointee: 886 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+      Pointee: 903 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
-      ID: 532
+      ID: 549
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 838720
       GoKind: 22
-      Pointee: 533 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 550 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 536
+      ID: 553
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 838912
       GoKind: 22
-      Pointee: 537 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 554 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 952
+      ID: 969
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.678528e+06
       GoKind: 22
-      Pointee: 953 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+      Pointee: 970 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
-      ID: 985
+      ID: 1002
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1.876032e+06
       GoKind: 22
-      Pointee: 986 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+      Pointee: 1003 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
-      ID: 987
+      ID: 1004
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.906784e+06
       GoKind: 22
-      Pointee: 988 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+      Pointee: 1005 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
-      ID: 817
+      ID: 834
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1.255968e+06
       GoKind: 22
-      Pointee: 818 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 835 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 730
+      ID: 747
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.025024e+06
       GoKind: 22
-      Pointee: 731 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 748 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 728
+      ID: 745
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1.024896e+06
       GoKind: 22
-      Pointee: 729 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 746 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 732
+      ID: 749
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.028992e+06
       GoKind: 22
-      Pointee: 733 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 750 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 734
+      ID: 751
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1.02912e+06
       GoKind: 22
-      Pointee: 735 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 752 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 938
+      ID: 955
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
       GoRuntimeType: 1.47808e+06
       GoKind: 22
-      Pointee: 939 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+      Pointee: 956 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
-      ID: 724
+      ID: 741
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.011584e+06
       GoKind: 22
-      Pointee: 725 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 742 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 542
+      ID: 559
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 840544
       GoKind: 22
-      Pointee: 543 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 560 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 1035
+      ID: 1052
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
       GoRuntimeType: 2.211616e+06
       GoKind: 22
-      Pointee: 1036 UnresolvedPointeeType github.com/json-iterator/go.Stream
+      Pointee: 1053 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
-      ID: 788
+      ID: 805
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1.13552e+06
       GoKind: 22
-      Pointee: 789 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 806 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 761
+      ID: 778
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1.1144e+06
       GoKind: 22
-      Pointee: 762 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 779 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 755
+      ID: 772
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1.114016e+06
       GoKind: 22
-      Pointee: 756 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 773 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 694
+      ID: 711
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 989568
       GoKind: 22
-      Pointee: 695 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 712 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 767
+      ID: 784
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1.114784e+06
       GoKind: 22
-      Pointee: 768 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 785 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 693
+      ID: 710
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 989440
       GoKind: 22
-      Pointee: 672 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 689 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 759
+      ID: 776
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1.114272e+06
       GoKind: 22
-      Pointee: 760 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 777 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 757
+      ID: 774
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1.114144e+06
       GoKind: 22
-      Pointee: 758 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 775 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 765
+      ID: 782
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1.114656e+06
       GoKind: 22
-      Pointee: 766 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 783 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 763
+      ID: 780
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1.114528e+06
       GoKind: 22
-      Pointee: 764 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 781 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 1039
+      ID: 1056
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
       GoRuntimeType: 2.222656e+06
       GoKind: 22
-      Pointee: 1040 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+      Pointee: 1057 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
-      ID: 771
+      ID: 788
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1.115168e+06
       GoKind: 22
-      Pointee: 772 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 789 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 698
+      ID: 715
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 989824
       GoKind: 22
-      Pointee: 699 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 716 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 696
+      ID: 713
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 989696
       GoKind: 22
-      Pointee: 697 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 714 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 769
+      ID: 786
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1.11504e+06
       GoKind: 22
-      Pointee: 770 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 787 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 653
+      ID: 670
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 871168
       GoKind: 22
-      Pointee: 462 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 479 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 464
+      ID: 481
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 463 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 480 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 830
+      ID: 847
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1.476544e+06
       GoKind: 22
-      Pointee: 831 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 848 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 738
+      ID: 755
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1.043968e+06
       GoKind: 22
-      Pointee: 739 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 756 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 915
+      ID: 932
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
       GoRuntimeType: 1.174432e+06
       GoKind: 22
-      Pointee: 916 StructureType go.uber.org/zap.nopCloserSink
+      Pointee: 933 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
-      ID: 999
+      ID: 1016
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.008544e+06
       GoKind: 22
-      Pointee: 1000 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+      Pointee: 1017 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
-      ID: 901
+      ID: 918
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
       GoRuntimeType: 1.046272e+06
       GoKind: 22
-      Pointee: 902 StructureType go.uber.org/zap/zapcore.writerWrapper
+      Pointee: 919 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
-      ID: 654
+      ID: 671
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 872416
       GoKind: 22
-      Pointee: 465 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 482 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 796
+      ID: 813
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1.176096e+06
       GoKind: 22
-      Pointee: 797 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 814 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 657
+      ID: 674
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 872704
       GoKind: 22
-      Pointee: 658 StructureType golang.org/x/net/http2.connError
+      Pointee: 675 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 656
+      ID: 673
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 872608
       GoKind: 22
-      Pointee: 469 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 486 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 471
+      ID: 488
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 470 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 487 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 660
+      ID: 677
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 872896
       GoKind: 22
-      Pointee: 475 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 492 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 477
+      ID: 494
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 476 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 493 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 659
+      ID: 676
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 872800
       GoKind: 22
-      Pointee: 472 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 489 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 474
+      ID: 491
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 473 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 490 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 655
+      ID: 672
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 872512
       GoKind: 22
-      Pointee: 466 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 483 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 468
+      ID: 485
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 467 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 484 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 997
+      ID: 1014
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.006624e+06
       GoKind: 22
-      Pointee: 998 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1015 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 661
+      ID: 678
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 872992
       GoKind: 22
-      Pointee: 662 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 679 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 663
+      ID: 680
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 873088
       GoKind: 22
-      Pointee: 478 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 495 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 649
+      ID: 666
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 866560
       GoKind: 22
-      Pointee: 650 StructureType google.golang.org/grpc.dropError
+      Pointee: 667 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 794
+      ID: 811
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1.173024e+06
       GoKind: 22
-      Pointee: 795 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 812 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 819
+      ID: 836
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1.263328e+06
       GoKind: 22
-      Pointee: 820 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 837 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 651
+      ID: 668
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 869440
       GoKind: 22
-      Pointee: 652 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 669 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 962
+      ID: 979
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1.685248e+06
       GoKind: 22
-      Pointee: 963 StructureType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 980 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 913
+      ID: 930
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
       GoRuntimeType: 1.169568e+06
       GoKind: 22
-      Pointee: 914 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+      Pointee: 931 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
-      ID: 736
+      ID: 753
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1.038208e+06
       GoKind: 22
-      Pointee: 737 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 754 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 873
+      ID: 890
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
       GoRuntimeType: 869536
       GoKind: 22
-      Pointee: 874 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+      Pointee: 891 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
-      ID: 629
+      ID: 646
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 855424
       GoKind: 22
-      Pointee: 630 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 647 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 726
+      ID: 743
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1.01504e+06
       GoKind: 22
-      Pointee: 727 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 744 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 792
+      ID: 809
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.14128e+06
       GoKind: 22
-      Pointee: 793 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 810 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 790
+      ID: 807
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1.141024e+06
       GoKind: 22
-      Pointee: 791 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 808 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 643
+      ID: 660
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 860128
       GoKind: 22
-      Pointee: 644 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 661 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 645
+      ID: 662
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 860224
       GoKind: 22
-      Pointee: 646 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 663 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 574
+      ID: 591
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 847840
       GoKind: 22
-      Pointee: 575 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 592 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 950
+      ID: 967
       Name: '*hash/crc32.digest'
       ByteSize: 8
       GoRuntimeType: 1.677632e+06
       GoKind: 22
-      Pointee: 951 UnresolvedPointeeType hash/crc32.digest
+      Pointee: 968 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
       ID: 219
       Name: '*hash<[4]int,[4]int>'
@@ -9920,30 +10030,30 @@ Types:
       ByteSize: 8
       Pointee: 139 GoHMapHeaderType hash<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1074
+      ID: 1091
       Name: '*hash<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1075 GoHMapHeaderType hash<int,*main.deepMap3>
+      Pointee: 1092 GoHMapHeaderType hash<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1102
+      ID: 1119
       Name: '*hash<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1103 GoHMapHeaderType hash<int,*main.deepMap8>
+      Pointee: 1120 GoHMapHeaderType hash<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1111
+      ID: 1128
       Name: '*hash<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1112 GoHMapHeaderType hash<int,*main.deepMap9>
+      Pointee: 1129 GoHMapHeaderType hash<int,*main.deepMap9>
     - __kind: PointerType
       ID: 162
       Name: '*hash<int,int>'
       ByteSize: 8
       Pointee: 163 GoHMapHeaderType hash<int,int>
     - __kind: PointerType
-      ID: 1120
+      ID: 1137
       Name: '*hash<int,interface {}>'
       ByteSize: 8
-      Pointee: 1121 GoHMapHeaderType hash<int,interface {}>
+      Pointee: 1138 GoHMapHeaderType hash<int,interface {}>
     - __kind: PointerType
       ID: 229
       Name: '*hash<int,struct {}>'
@@ -9965,10 +10075,10 @@ Types:
       ByteSize: 8
       Pointee: 178 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 823
+      ID: 840
       Name: '*hash<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 824 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 841 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 172
       Name: '*hash<string,int>'
@@ -10030,12 +10140,12 @@ Types:
       ByteSize: 8
       Pointee: 205 GoHMapHeaderType hash<uint8,uint8>
     - __kind: PointerType
-      ID: 664
+      ID: 681
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 873856
       GoKind: 22
-      Pointee: 665 UnresolvedPointeeType html/template.Error
+      Pointee: 682 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 94
       Name: '*int'
@@ -10079,82 +10189,82 @@ Types:
       GoKind: 22
       Pointee: 152 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 544
+      ID: 561
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 840928
       GoKind: 22
-      Pointee: 545 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 562 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 859
+      ID: 876
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
       GoRuntimeType: 829120
       GoKind: 22
-      Pointee: 860 UnresolvedPointeeType internal/godebug.runtimeStderr
+      Pointee: 877 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
-      ID: 753
+      ID: 770
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.113248e+06
       GoKind: 22
-      Pointee: 754 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 771 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 1041
+      ID: 1058
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2.227328e+06
       GoKind: 22
-      Pointee: 1042 UnresolvedPointeeType internal/poll.FD
+      Pointee: 1059 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 751
+      ID: 768
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1.11312e+06
       GoKind: 22
-      Pointee: 752 StructureType internal/poll.errNetClosing
+      Pointee: 769 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 481
+      ID: 498
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 828256
       GoKind: 22
-      Pointee: 482 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 499 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 905
+      ID: 922
       Name: '*io.PipeWriter'
       ByteSize: 8
       GoRuntimeType: 1.104544e+06
       GoKind: 22
-      Pointee: 906 UnresolvedPointeeType io.PipeWriter
+      Pointee: 923 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
-      ID: 903
+      ID: 920
       Name: '*io.discard'
       ByteSize: 8
       GoRuntimeType: 1.10416e+06
       GoKind: 22
-      Pointee: 904 StructureType io.discard
+      Pointee: 921 StructureType io.discard
     - __kind: PointerType
-      ID: 877
+      ID: 894
       Name: '*io.multiWriter'
       ByteSize: 8
       GoRuntimeType: 981376
       GoKind: 22
-      Pointee: 878 UnresolvedPointeeType io.multiWriter
+      Pointee: 895 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
-      ID: 749
+      ID: 766
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1.112864e+06
       GoKind: 22
-      Pointee: 750 UnresolvedPointeeType io/fs.PathError
+      Pointee: 767 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 954
+      ID: 971
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 1.678752e+06
       GoKind: 22
-      Pointee: 955 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+      Pointee: 972 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
       ID: 312
       Name: '*main.anotherStruct'
@@ -10162,19 +10272,19 @@ Types:
       GoKind: 22
       Pointee: 313 StructureType main.anotherStruct
     - __kind: PointerType
-      ID: 331
+      ID: 348
       Name: '*main.deepMap2'
       ByteSize: 8
       GoRuntimeType: 356512
       GoKind: 22
-      Pointee: 332 StructureType main.deepMap2
+      Pointee: 349 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 1079
+      ID: 1096
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 356448
       GoKind: 22
-      Pointee: 1080 UnresolvedPointeeType main.deepMap3
+      Pointee: 1097 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 144
       Name: '*main.deepMap7'
@@ -10183,19 +10293,19 @@ Types:
       GoKind: 22
       Pointee: 145 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 1107
+      ID: 1124
       Name: '*main.deepMap8'
       ByteSize: 8
       GoRuntimeType: 356128
       GoKind: 22
-      Pointee: 1108 StructureType main.deepMap8
+      Pointee: 1125 StructureType main.deepMap8
     - __kind: PointerType
-      ID: 1116
+      ID: 1133
       Name: '*main.deepMap9'
       ByteSize: 8
       GoRuntimeType: 356064
       GoKind: 22
-      Pointee: 1117 StructureType main.deepMap9
+      Pointee: 1134 StructureType main.deepMap9
     - __kind: PointerType
       ID: 126
       Name: '*main.deepPtr2'
@@ -10204,12 +10314,12 @@ Types:
       GoKind: 22
       Pointee: 127 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 1045
+      ID: 1062
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 357024
       GoKind: 22
-      Pointee: 1046 UnresolvedPointeeType main.deepPtr3
+      Pointee: 1063 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 128
       Name: '*main.deepPtr7'
@@ -10218,33 +10328,33 @@ Types:
       GoKind: 22
       Pointee: 129 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 1082
+      ID: 1099
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 356704
       GoKind: 22
-      Pointee: 1083 StructureType main.deepPtr8
+      Pointee: 1100 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 1084
+      ID: 1101
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 356640
       GoKind: 22
-      Pointee: 1085 StructureType main.deepPtr9
+      Pointee: 1102 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 133
       Name: '*main.deepSlice2'
       ByteSize: 8
       GoRuntimeType: 357664
       GoKind: 22
-      Pointee: 325 StructureType main.deepSlice2
+      Pointee: 342 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 1069
+      ID: 1086
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 357600
       GoKind: 22
-      Pointee: 1070 UnresolvedPointeeType main.deepSlice3
+      Pointee: 1087 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 134
       Name: '*main.deepSlice7'
@@ -10253,19 +10363,19 @@ Types:
       GoKind: 22
       Pointee: 135 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 1088
+      ID: 1105
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 357280
       GoKind: 22
-      Pointee: 1089 StructureType main.deepSlice8
+      Pointee: 1106 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 1094
+      ID: 1111
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 357216
       GoKind: 22
-      Pointee: 1095 StructureType main.deepSlice9
+      Pointee: 1112 StructureType main.deepSlice9
     - __kind: PointerType
       ID: 315
       Name: '*main.emptyStruct'
@@ -10280,14 +10390,14 @@ Types:
       GoKind: 22
       Pointee: 155 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 1061
+      ID: 1078
       Name: '*main.firstBehavior'
       ByteSize: 8
       GoRuntimeType: 824224
       GoKind: 22
-      Pointee: 316 StructureType main.firstBehavior
+      Pointee: 333 StructureType main.firstBehavior
     - __kind: PointerType
-      ID: 1126
+      ID: 1143
       Name: '*main.nestedStruct'
       ByteSize: 8
       GoRuntimeType: 357920
@@ -10307,19 +10417,25 @@ Types:
       GoKind: 22
       Pointee: 266 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 1062
+      ID: 316
+      Name: '*main.receiver'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 317 StructureType main.receiver
+    - __kind: PointerType
+      ID: 1079
       Name: '*main.secondBehavior'
       ByteSize: 8
       GoRuntimeType: 824320
       GoKind: 22
-      Pointee: 1063 StructureType main.secondBehavior
+      Pointee: 1080 StructureType main.secondBehavior
     - __kind: PointerType
-      ID: 1050
+      ID: 1067
       Name: '*main.somethingImpl'
       ByteSize: 8
       GoRuntimeType: 824416
       GoKind: 22
-      Pointee: 1051 UnresolvedPointeeType main.somethingImpl
+      Pointee: 1068 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
       ID: 146
       Name: '*main.stringType1'
@@ -10327,28 +10443,28 @@ Types:
       GoKind: 22
       Pointee: 147 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 1048
+      ID: 1065
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 1047 GoStringDataType main.stringType1.str
+      Pointee: 1064 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 149
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 1049 GoStringHeaderType main.stringType2
+      Pointee: 1066 GoStringHeaderType main.stringType2
     - __kind: PointerType
-      ID: 1128
+      ID: 1145
       Name: '*main.stringType2.str'
       ByteSize: 8
-      Pointee: 1127 GoStringDataType main.stringType2.str
+      Pointee: 1144 GoStringDataType main.stringType2.str
     - __kind: PointerType
       ID: 269
       Name: '*main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 267 StructureType main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 348
+      ID: 365
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 356000
@@ -10372,10 +10488,10 @@ Types:
       GoKind: 22
       Pointee: 244 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 1066
+      ID: 1083
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 1065 GoSliceDataType main.t.array
+      Pointee: 1082 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 264
       Name: '*main.threeStringStruct'
@@ -10389,554 +10505,554 @@ Types:
       GoKind: 22
       Pointee: 171 GoMapType map[string]int
     - __kind: PointerType
-      ID: 578
+      ID: 595
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 848704
       GoKind: 22
-      Pointee: 579 StructureType math/big.ErrNaN
+      Pointee: 596 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 867
+      ID: 884
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
       GoRuntimeType: 843328
       GoKind: 22
-      Pointee: 868 StructureType mime/multipart.writerOnly·1
+      Pointee: 885 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
-      ID: 780
+      ID: 797
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1.121568e+06
       GoKind: 22
-      Pointee: 781 UnresolvedPointeeType net.AddrError
+      Pointee: 798 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 806
+      ID: 823
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1.240128e+06
       GoKind: 22
-      Pointee: 807 UnresolvedPointeeType net.DNSError
+      Pointee: 824 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 1005
+      ID: 1022
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2.08688e+06
       GoKind: 22
-      Pointee: 1006 UnresolvedPointeeType net.IPConn
+      Pointee: 1023 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 804
+      ID: 821
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1.239808e+06
       GoKind: 22
-      Pointee: 805 UnresolvedPointeeType net.OpError
+      Pointee: 822 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 782
+      ID: 799
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.121696e+06
       GoKind: 22
-      Pointee: 783 UnresolvedPointeeType net.ParseError
+      Pointee: 800 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 1015
+      ID: 1032
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2.116736e+06
       GoKind: 22
-      Pointee: 1016 UnresolvedPointeeType net.TCPConn
+      Pointee: 1033 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 1025
+      ID: 1042
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2.161696e+06
       GoKind: 22
-      Pointee: 1026 UnresolvedPointeeType net.UDPConn
+      Pointee: 1043 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 1013
+      ID: 1030
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2.116224e+06
       GoKind: 22
-      Pointee: 1014 UnresolvedPointeeType net.UnixConn
+      Pointee: 1031 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 779
+      ID: 796
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1.1208e+06
       GoKind: 22
-      Pointee: 742 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 759 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 744
+      ID: 761
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 743 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 760 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 710
+      ID: 727
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 996480
       GoKind: 22
-      Pointee: 711 StructureType net.canceledError
+      Pointee: 728 StructureType net.canceledError
     - __kind: PointerType
-      ID: 983
+      ID: 1000
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 1.873728e+06
       GoKind: 22
-      Pointee: 984 UnresolvedPointeeType net.conn
+      Pointee: 1001 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 848
+      ID: 865
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1.717952e+06
       GoKind: 22
-      Pointee: 849 StructureType net.dialResult·1
+      Pointee: 866 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 1027
+      ID: 1044
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2.165952e+06
       GoKind: 22
-      Pointee: 1028 UnresolvedPointeeType net.netFD
+      Pointee: 1045 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 513
+      ID: 530
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 835552
       GoKind: 22
-      Pointee: 514 UnresolvedPointeeType net.notFoundError
+      Pointee: 531 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 515
+      ID: 532
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 836224
       GoKind: 22
-      Pointee: 516 StructureType net.result·2
+      Pointee: 533 StructureType net.result·2
     - __kind: PointerType
-      ID: 1009
+      ID: 1026
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.100768e+06
       GoKind: 22
-      Pointee: 1010 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 1027 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 1007
+      ID: 1024
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.100288e+06
       GoKind: 22
-      Pointee: 1008 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 1025 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 784
+      ID: 801
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1.122336e+06
       GoKind: 22
-      Pointee: 785 UnresolvedPointeeType net.temporaryError
+      Pointee: 802 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 808
+      ID: 825
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.240288e+06
       GoKind: 22
-      Pointee: 809 UnresolvedPointeeType net.timeoutError
+      Pointee: 826 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 700
+      ID: 717
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 992256
       GoKind: 22
-      Pointee: 701 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 718 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
-      ID: 861
+      ID: 878
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
       GoRuntimeType: 831424
       GoKind: 22
-      Pointee: 862 StructureType net/http.bufioFlushWriter
+      Pointee: 879 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
-      ID: 490
+      ID: 507
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 832096
       GoKind: 22
-      Pointee: 411 BaseType net/http.http2ConnectionError
+      Pointee: 428 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 491
+      ID: 508
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 832192
       GoKind: 22
-      Pointee: 492 StructureType net/http.http2GoAwayError
+      Pointee: 509 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 800
+      ID: 817
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1.235968e+06
       GoKind: 22
-      Pointee: 801 StructureType net/http.http2StreamError
+      Pointee: 818 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 495
+      ID: 512
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 832672
       GoKind: 22
-      Pointee: 496 StructureType net/http.http2connError
+      Pointee: 513 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 923
+      ID: 940
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
       GoRuntimeType: 1.36688e+06
       GoKind: 22
-      Pointee: 924 UnresolvedPointeeType net/http.http2dataBuffer
+      Pointee: 941 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 494
+      ID: 511
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 832576
       GoKind: 22
-      Pointee: 415 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 432 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 417
+      ID: 434
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 416 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 433 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 498
+      ID: 515
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 832864
       GoKind: 22
-      Pointee: 421 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 438 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 423
+      ID: 440
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 422 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 439 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 497
+      ID: 514
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 832768
       GoKind: 22
-      Pointee: 418 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 435 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 420
+      ID: 437
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 419 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 436 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 775
+      ID: 792
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1.117344e+06
       GoKind: 22
-      Pointee: 776 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 793 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 706
+      ID: 723
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 992896
       GoKind: 22
-      Pointee: 707 StructureType net/http.http2noCachedConnError
+      Pointee: 724 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 974
+      ID: 991
       Name: '*net/http.http2pipe'
       ByteSize: 8
       GoRuntimeType: 1.817728e+06
       GoKind: 22
-      Pointee: 975 UnresolvedPointeeType net/http.http2pipe
+      Pointee: 992 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 493
+      ID: 510
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 832480
       GoKind: 22
-      Pointee: 412 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 429 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 414
+      ID: 431
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 413 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 430 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 863
+      ID: 880
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
       GoRuntimeType: 832960
       GoKind: 22
-      Pointee: 864 StructureType net/http.http2stickyErrWriter
+      Pointee: 881 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
-      ID: 702
+      ID: 719
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 992512
       GoKind: 22
-      Pointee: 703 StructureType net/http.nothingWrittenError
+      Pointee: 720 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 925
+      ID: 942
       Name: '*net/http.persistConn'
       ByteSize: 8
       GoRuntimeType: 2.03168e+06
       GoKind: 22
-      Pointee: 926 UnresolvedPointeeType net/http.persistConn
+      Pointee: 943 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
-      ID: 881
+      ID: 898
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
       GoRuntimeType: 992384
       GoKind: 22
-      Pointee: 882 StructureType net/http.persistConnWriter
+      Pointee: 899 StructureType net/http.persistConnWriter
     - __kind: PointerType
-      ID: 907
+      ID: 924
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1.11632e+06
       GoKind: 22
-      Pointee: 908 StructureType net/http.readWriteCloserBody
+      Pointee: 925 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 499
+      ID: 516
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 833056
       GoKind: 22
-      Pointee: 500 StructureType net/http.requestBodyReadError
+      Pointee: 517 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 802
+      ID: 819
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.237088e+06
       GoKind: 22
-      Pointee: 803 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 820 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 773
+      ID: 790
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1.117216e+06
       GoKind: 22
-      Pointee: 774 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 791 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 704
+      ID: 721
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 992640
       GoKind: 22
-      Pointee: 705 StructureType net/http.transportReadFromServerError
+      Pointee: 722 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 488
+      ID: 505
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 831328
       GoKind: 22
-      Pointee: 489 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 506 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 976
+      ID: 993
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
       GoRuntimeType: 1.819264e+06
       GoKind: 22
-      Pointee: 977 StructureType net/http/internal.FlushAfterChunkWriter
+      Pointee: 994 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
-      ID: 891
+      ID: 908
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
       GoRuntimeType: 1.005952e+06
       GoKind: 22
-      Pointee: 892 UnresolvedPointeeType net/http/internal.chunkedWriter
+      Pointee: 909 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
-      ID: 570
+      ID: 587
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 847648
       GoKind: 22
-      Pointee: 571 StructureType net/netip.parseAddrError
+      Pointee: 588 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 568
+      ID: 585
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 847552
       GoKind: 22
-      Pointee: 569 StructureType net/netip.parsePrefixError
+      Pointee: 586 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 933
+      ID: 950
       Name: '*net/smtp.Client'
       ByteSize: 8
       GoRuntimeType: 1.981344e+06
       GoKind: 22
-      Pointee: 934 UnresolvedPointeeType net/smtp.Client
+      Pointee: 951 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
-      ID: 893
+      ID: 910
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
       GoRuntimeType: 1.011072e+06
       GoKind: 22
-      Pointee: 894 StructureType net/smtp.dataCloser
+      Pointee: 911 StructureType net/smtp.dataCloser
     - __kind: PointerType
-      ID: 554
+      ID: 571
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 843520
       GoKind: 22
-      Pointee: 555 UnresolvedPointeeType net/textproto.Error
+      Pointee: 572 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 553
+      ID: 570
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 843424
       GoKind: 22
-      Pointee: 446 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 463 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 448
+      ID: 465
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 447 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 464 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 889
+      ID: 906
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
       GoRuntimeType: 1.005312e+06
       GoKind: 22
-      Pointee: 890 UnresolvedPointeeType net/textproto.dotWriter
+      Pointee: 907 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
-      ID: 810
+      ID: 827
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1.240608e+06
       GoKind: 22
-      Pointee: 811 UnresolvedPointeeType net/url.Error
+      Pointee: 828 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 517
+      ID: 534
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 836320
       GoKind: 22
-      Pointee: 424 GoStringHeaderType net/url.EscapeError
+      Pointee: 441 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 426
+      ID: 443
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 425 GoStringDataType net/url.EscapeError.str
+      Pointee: 442 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 518
+      ID: 535
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 836416
       GoKind: 22
-      Pointee: 427 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 444 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 429
+      ID: 446
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 428 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 445 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
-      ID: 1033
+      ID: 1050
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2.2032e+06
       GoKind: 22
-      Pointee: 1034 UnresolvedPointeeType os.File
+      Pointee: 1051 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 681
+      ID: 698
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 983424
       GoKind: 22
-      Pointee: 682 UnresolvedPointeeType os.LinkError
+      Pointee: 699 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 745
+      ID: 762
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1.105824e+06
       GoKind: 22
-      Pointee: 746 UnresolvedPointeeType os.SyscallError
+      Pointee: 763 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 1031
+      ID: 1048
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.200256e+06
       GoKind: 22
-      Pointee: 1032 StructureType os.fileWithoutReadFrom
+      Pointee: 1049 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 1029
+      ID: 1046
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.19952e+06
       GoKind: 22
-      Pointee: 1030 StructureType os.fileWithoutWriteTo
+      Pointee: 1047 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 712
+      ID: 729
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1.001984e+06
       GoKind: 22
-      Pointee: 713 UnresolvedPointeeType os/exec.Error
+      Pointee: 730 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 851
+      ID: 868
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 1.953312e+06
       GoKind: 22
-      Pointee: 852 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 869 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 911
+      ID: 928
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
       GoRuntimeType: 1.128352e+06
       GoKind: 22
-      Pointee: 912 UnresolvedPointeeType os/exec.prefixSuffixSaver
+      Pointee: 929 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
-      ID: 714
+      ID: 731
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1.002112e+06
       GoKind: 22
-      Pointee: 715 StructureType os/exec.wrappedError
+      Pointee: 732 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 648
+      ID: 665
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 864640
       GoKind: 22
-      Pointee: 459 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 476 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 461
+      ID: 478
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 460 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 477 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 647
+      ID: 664
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 864544
       GoKind: 22
-      Pointee: 458 BaseType os/user.UnknownUserIdError
+      Pointee: 475 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 483
+      ID: 500
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 829024
       GoKind: 22
-      Pointee: 484 UnresolvedPointeeType reflect.ValueError
+      Pointee: 501 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 576
+      ID: 593
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 848320
       GoKind: 22
-      Pointee: 577 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 594 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 684
+      ID: 701
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 984960
       GoKind: 22
-      Pointee: 685 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 702 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 689
+      ID: 706
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 986880
       GoKind: 22
-      Pointee: 690 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 707 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
@@ -10952,12 +11068,12 @@ Types:
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 686
+      ID: 703
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 985088
       GoKind: 22
-      Pointee: 687 StructureType runtime.boundsError
+      Pointee: 704 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 60
       Name: '*runtime.cgoCallers'
@@ -10973,24 +11089,24 @@ Types:
       GoKind: 22
       Pointee: 48 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 747
+      ID: 764
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1.1112e+06
       GoKind: 22
-      Pointee: 748 StructureType runtime.errorAddressString
+      Pointee: 765 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 683
+      ID: 700
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 984704
       GoKind: 22
-      Pointee: 666 GoStringHeaderType runtime.errorString
+      Pointee: 683 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 668
+      ID: 685
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 667 GoStringDataType runtime.errorString.str
+      Pointee: 684 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 53
       Name: '*runtime.g'
@@ -11013,17 +11129,17 @@ Types:
       GoKind: 22
       Pointee: 143 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
-      ID: 688
+      ID: 705
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 986624
       GoKind: 22
-      Pointee: 669 GoStringHeaderType runtime.plainError
+      Pointee: 686 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 671
+      ID: 688
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 670 GoStringDataType runtime.plainError.str
+      Pointee: 687 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
@@ -11046,12 +11162,12 @@ Types:
       GoKind: 22
       Pointee: 73 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 691
+      ID: 708
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 987136
       GoKind: 22
-      Pointee: 692 UnresolvedPointeeType strconv.NumError
+      Pointee: 709 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 88
       Name: '*string'
@@ -11060,83 +11176,83 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 318
+      ID: 335
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 317 GoStringDataType string.str
+      Pointee: 334 GoStringDataType string.str
     - __kind: PointerType
-      ID: 972
+      ID: 989
       Name: '*strings.Builder'
       ByteSize: 8
       GoRuntimeType: 1.816448e+06
       GoKind: 22
-      Pointee: 973 UnresolvedPointeeType strings.Builder
+      Pointee: 990 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
-      ID: 879
+      ID: 896
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
       GoRuntimeType: 987264
       GoKind: 22
-      Pointee: 880 UnresolvedPointeeType strings.appendSliceWriter
+      Pointee: 897 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
-      ID: 875
+      ID: 892
       Name: '*struct { io.Writer }'
       ByteSize: 8
       GoRuntimeType: 920448
       GoKind: 22
-      Pointee: 876 StructureType struct { io.Writer }
+      Pointee: 893 StructureType struct { io.Writer }
     - __kind: PointerType
       ID: 262
       Name: '*struct {}'
       ByteSize: 8
       Pointee: 118 StructureType struct {}
     - __kind: PointerType
-      ID: 799
+      ID: 816
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1.235328e+06
       GoKind: 22
-      Pointee: 798 BaseType syscall.Errno
+      Pointee: 815 BaseType syscall.Errno
     - __kind: PointerType
-      ID: 1003
+      ID: 1020
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
       GoRuntimeType: 2.019296e+06
       GoKind: 22
-      Pointee: 1004 UnresolvedPointeeType text/tabwriter.Writer
+      Pointee: 1021 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
-      ID: 740
+      ID: 757
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1.047808e+06
       GoKind: 22
-      Pointee: 741 StructureType text/template.ExecError
+      Pointee: 758 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 815
+      ID: 832
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.432e+06
       GoKind: 22
-      Pointee: 816 UnresolvedPointeeType time.Location
+      Pointee: 833 UnresolvedPointeeType time.Location
     - __kind: PointerType
-      ID: 486
+      ID: 503
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 829888
       GoKind: 22
-      Pointee: 487 UnresolvedPointeeType time.ParseError
+      Pointee: 504 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 485
+      ID: 502
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 829792
       GoKind: 22
-      Pointee: 408 GoStringHeaderType time.fileSizeError
+      Pointee: 425 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 410
+      ID: 427
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 409 GoStringDataType time.fileSizeError.str
+      Pointee: 426 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
       ID: 100
       Name: '*uint'
@@ -11180,59 +11296,95 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: PointerType
-      ID: 966
+      ID: 983
       Name: '*vendor/golang.org/x/crypto/sha3.state'
       ByteSize: 8
       GoRuntimeType: 1.772704e+06
       GoKind: 22
-      Pointee: 967 UnresolvedPointeeType vendor/golang.org/x/crypto/sha3.state
+      Pointee: 984 UnresolvedPointeeType vendor/golang.org/x/crypto/sha3.state
     - __kind: PointerType
-      ID: 572
+      ID: 589
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 847744
       GoKind: 22
-      Pointee: 573 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 590 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 995
+      ID: 1012
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 1.995872e+06
       GoKind: 22
-      Pointee: 996 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1013 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 556
+      ID: 573
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 843904
       GoKind: 22
-      Pointee: 557 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 574 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 558
+      ID: 575
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 844000
       GoKind: 22
-      Pointee: 449 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 466 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 719
+      ID: 736
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1.005696e+06
       GoKind: 22
-      Pointee: 720 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 737 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 721
+      ID: 738
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1.005824e+06
       GoKind: 22
-      Pointee: 674 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 691 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1376
+      ID: 1394
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
     - __kind: EventRootType
-      ID: 1374
+      ID: 1378
+      Name: Probe[main.executeStructFuncs]Line
+      ByteSize: 66
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: sta.a
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 331 ArrayType [3]uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 11, name: sta}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: sta.b
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 11, name: sta}
+                  Offset: 24
+                  ByteSize: 1
+        - Name: sta.c
+          Offset: 26
+          Kind: template_segment
+          Expression:
+            Type: 332 ArrayType [5]int64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 11, name: sta}
+                  Offset: 32
+                  ByteSize: 40
+    - __kind: EventRootType
+      ID: 1392
       Name: Probe[main.firstBehavior.DoSomething]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11241,14 +11393,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 316 StructureType main.firstBehavior
+            Type: 333 StructureType main.firstBehavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 0, name: b}
+                  Variable: {subprogram: 165, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1375
+      ID: 1393
       Name: Probe[main.firstBehavior.DoSomething]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11260,14 +11412,14 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 1, name: ~r0}
+                  Variable: {subprogram: 165, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1332
+      ID: 1349
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1333
+      ID: 1350
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11283,7 +11435,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1199
+      ID: 1216
       Name: Probe[main.testAnyPtr]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11309,7 +11461,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1200
+      ID: 1217
       Name: Probe[main.testAnyPtr]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11325,7 +11477,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1196
+      ID: 1213
       Name: Probe[main.testAny]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11351,7 +11503,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1197
+      ID: 1214
       Name: Probe[main.testAny]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11367,7 +11519,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1303
+      ID: 1320
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11393,7 +11545,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1304
+      ID: 1321
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11409,7 +11561,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1147
+      ID: 1164
       Name: Probe[main.testArrayEmptyStructs]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11435,7 +11587,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1145
+      ID: 1162
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 129
       PresenceBitsetSize: 1
@@ -11461,7 +11613,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1143
+      ID: 1160
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -11487,7 +11639,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1208
+      ID: 1225
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11513,7 +11665,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1144
+      ID: 1161
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -11539,7 +11691,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1146
+      ID: 1163
       Name: Probe[main.testArrayOfStructs]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -11565,7 +11717,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1230
+      ID: 1247
       Name: Probe[main.testAtomicAdd]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11591,7 +11743,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1231
+      ID: 1248
       Name: Probe[main.testAtomicAdd]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11607,7 +11759,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1165
+      ID: 1182
       Name: Probe[main.testBigStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -11633,10 +11785,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1166
+      ID: 1183
       Name: Probe[main.testBigStruct]Return
     - __kind: EventRootType
-      ID: 1132
+      ID: 1149
       Name: Probe[main.testBoolArray]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -11662,7 +11814,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1129
+      ID: 1146
       Name: Probe[main.testByteArray]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -11688,7 +11840,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1232
+      ID: 1249
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11714,7 +11866,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1226
+      ID: 1243
       Name: Probe[main.testCombinedByte]
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -11780,7 +11932,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1227
+      ID: 1244
       Name: Probe[main.testCombinedString]
       ByteSize: 18
       PresenceBitsetSize: 1
@@ -11806,7 +11958,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1228
+      ID: 1245
       Name: Probe[main.testCombinedString]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -11842,7 +11994,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1240
+      ID: 1257
       Name: Probe[main.testCycle]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11868,7 +12020,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1171
+      ID: 1188
       Name: Probe[main.testDeepMap1]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11894,7 +12046,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1172
+      ID: 1189
       Name: Probe[main.testDeepMap7]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11920,7 +12072,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1167
+      ID: 1184
       Name: Probe[main.testDeepPtr1]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11946,7 +12098,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1168
+      ID: 1185
       Name: Probe[main.testDeepPtr7]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11972,7 +12124,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1169
+      ID: 1186
       Name: Probe[main.testDeepSlice1]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11998,7 +12150,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1170
+      ID: 1187
       Name: Probe[main.testDeepSlice7]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12024,7 +12176,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1323
+      ID: 1340
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -12070,7 +12222,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1320
+      ID: 1337
       Name: Probe[main.testEmptySlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12096,7 +12248,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1346
+      ID: 1363
       Name: Probe[main.testEmptyString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12122,7 +12274,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1360
+      ID: 1377
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12148,7 +12300,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1359
+      ID: 1376
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -12174,7 +12326,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1198
+      ID: 1215
       Name: Probe[main.testError]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12200,7 +12352,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1180
+      ID: 1197
       Name: Probe[main.testEsotericHeap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12226,10 +12378,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1181
+      ID: 1198
       Name: Probe[main.testEsotericHeap]Return
     - __kind: EventRootType
-      ID: 1178
+      ID: 1195
       Name: Probe[main.testEsotericStack]
       ByteSize: 129
       PresenceBitsetSize: 1
@@ -12255,10 +12407,10 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1179
+      ID: 1196
       Name: Probe[main.testEsotericStack]Return
     - __kind: EventRootType
-      ID: 1192
+      ID: 1209
       Name: Probe[main.testFramelessArray]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12284,7 +12436,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1194
+      ID: 1211
       Name: Probe[main.testFramelessArray]Line
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -12320,7 +12472,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1193
+      ID: 1210
       Name: Probe[main.testFramelessArray]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12336,7 +12488,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1190
+      ID: 1207
       Name: Probe[main.testFrameless]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12362,7 +12514,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1191
+      ID: 1208
       Name: Probe[main.testFrameless]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12378,7 +12530,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1182
+      ID: 1199
       Name: Probe[main.testInlinedBA]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12404,10 +12556,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1183
+      ID: 1200
       Name: Probe[main.testInlinedBA]Return
     - __kind: EventRootType
-      ID: 1186
+      ID: 1203
       Name: Probe[main.testInlinedBBA]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12433,13 +12585,13 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1187
+      ID: 1204
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1366
+      ID: 1384
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 1184
+      ID: 1201
       Name: Probe[main.testInlinedBB]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12485,28 +12637,28 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1185
+      ID: 1202
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1367
+      ID: 1385
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1368
+      ID: 1386
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1369
+      ID: 1387
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1370
+      ID: 1388
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
-      ID: 1188
+      ID: 1205
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 1189
+      ID: 1206
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1363
+      ID: 1381
       Name: Probe[main.testInlinedPrint]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12518,7 +12670,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12528,11 +12680,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1361
+      ID: 1379
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12544,11 +12696,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1362
+      ID: 1380
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12560,7 +12712,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x_val
@@ -12570,11 +12722,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1365
+      ID: 1383
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12586,7 +12738,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12596,14 +12748,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1364
+      ID: 1382
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1371
+      ID: 1389
       Name: Probe[main.testInlinedSq]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12615,7 +12767,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12625,11 +12777,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1372
+      ID: 1390
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12641,7 +12793,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12651,11 +12803,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1373
+      ID: 1391
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12667,7 +12819,7 @@ Types:
             Type: 156 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: a}
+                  Variable: {subprogram: 164, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: a
@@ -12677,11 +12829,11 @@ Types:
             Type: 156 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: a}
+                  Variable: {subprogram: 164, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1135
+      ID: 1152
       Name: Probe[main.testInt16Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12707,7 +12859,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1136
+      ID: 1153
       Name: Probe[main.testInt32Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12733,7 +12885,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1137
+      ID: 1154
       Name: Probe[main.testInt64Array]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12759,7 +12911,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1134
+      ID: 1151
       Name: Probe[main.testInt8Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -12785,7 +12937,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1133
+      ID: 1150
       Name: Probe[main.testIntArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12811,7 +12963,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1195
+      ID: 1212
       Name: Probe[main.testInterface]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12837,7 +12989,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1301
+      ID: 1318
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 161
       PresenceBitsetSize: 1
@@ -12863,7 +13015,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1302
+      ID: 1319
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12879,7 +13031,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1234
+      ID: 1251
       Name: Probe[main.testLinkedList]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12905,36 +13057,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1175
+      ID: 1192
       Name: Probe[main.testLongFunctionWithChangingState]Line
     - __kind: EventRootType
-      ID: 1176
-      Name: Probe[main.testLongFunctionWithChangingState]Line
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: aPerArch
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 1, name: aPerArch}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: b
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 2, name: b}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1177
+      ID: 1193
       Name: Probe[main.testLongFunctionWithChangingState]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12960,7 +13086,33 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1307
+      ID: 1194
+      Name: Probe[main.testLongFunctionWithChangingState]Line
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: aPerArch
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 1, name: aPerArch}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1324
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 147
       PresenceBitsetSize: 3
@@ -13146,7 +13298,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1308
+      ID: 1325
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13162,7 +13314,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1206
+      ID: 1223
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13188,7 +13340,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1213
+      ID: 1230
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13214,7 +13366,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1225
+      ID: 1242
       Name: Probe[main.testMapEmptyKeyAndValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13240,7 +13392,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1223
+      ID: 1240
       Name: Probe[main.testMapEmptyKey]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13266,7 +13418,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1224
+      ID: 1241
       Name: Probe[main.testMapEmptyValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13292,7 +13444,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1210
+      ID: 1227
       Name: Probe[main.testMapIntToInt]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13318,7 +13470,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1222
+      ID: 1239
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13344,7 +13496,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1221
+      ID: 1238
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13370,7 +13522,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1211
+      ID: 1228
       Name: Probe[main.testMapMassive]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13396,7 +13548,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1212
+      ID: 1229
       Name: Probe[main.testMapMassive]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13422,7 +13574,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1220
+      ID: 1237
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13448,7 +13600,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1219
+      ID: 1236
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13474,7 +13626,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1204
+      ID: 1221
       Name: Probe[main.testMapStringToInt]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13500,7 +13652,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1205
+      ID: 1222
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13526,7 +13678,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1203
+      ID: 1220
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13552,7 +13704,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1214
+      ID: 1231
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13578,7 +13730,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1218
+      ID: 1235
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13604,7 +13756,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1217
+      ID: 1234
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13630,7 +13782,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1216
+      ID: 1233
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13656,7 +13808,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1215
+      ID: 1232
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13682,7 +13834,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1343
+      ID: 1360
       Name: Probe[main.testMassiveString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13708,7 +13860,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1344
+      ID: 1361
       Name: Probe[main.testMassiveString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13734,7 +13886,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1309
+      ID: 1326
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 163
       PresenceBitsetSize: 3
@@ -13920,7 +14072,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1310
+      ID: 1327
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13936,7 +14088,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1313
+      ID: 1330
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13982,7 +14134,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1314
+      ID: 1331
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -14008,7 +14160,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1305
+      ID: 1322
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 321
       PresenceBitsetSize: 1
@@ -14054,7 +14206,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1306
+      ID: 1323
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -14070,7 +14222,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1259
+      ID: 1276
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14096,7 +14248,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1261
+      ID: 1278
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14142,7 +14294,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1263
+      ID: 1280
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14158,7 +14310,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1265
+      ID: 1282
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14174,7 +14326,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1267
+      ID: 1284
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14190,7 +14342,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1260
+      ID: 1277
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14216,7 +14368,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1262
+      ID: 1279
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -14282,7 +14434,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1264
+      ID: 1281
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14308,7 +14460,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1266
+      ID: 1283
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14334,7 +14486,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1268
+      ID: 1285
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14360,7 +14512,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1229
+      ID: 1246
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 62
       PresenceBitsetSize: 2
@@ -14466,7 +14618,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1255
+      ID: 1272
       Name: Probe[main.testNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14492,7 +14644,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1257
+      ID: 1274
       Name: Probe[main.testNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14518,7 +14670,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1256
+      ID: 1273
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14534,7 +14686,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1258
+      ID: 1275
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14560,7 +14712,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1355
+      ID: 1372
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14586,7 +14738,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1356
+      ID: 1373
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14608,10 +14760,10 @@ Types:
                   Bias: 8
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1357
+      ID: 1374
       Name: Probe[main.testNestedPointer]
     - __kind: EventRootType
-      ID: 1358
+      ID: 1375
       Name: Probe[main.testNestedPointer]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -14633,7 +14785,7 @@ Types:
                   Bias: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1239
+      ID: 1256
       Name: Probe[main.testNilPointer]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14679,7 +14831,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1324
+      ID: 1341
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -14725,7 +14877,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1326
+      ID: 1343
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 67
       PresenceBitsetSize: 1
@@ -14791,7 +14943,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1327
+      ID: 1344
       Name: Probe[main.testNilSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -14817,7 +14969,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1342
+      ID: 1359
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14843,7 +14995,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1235
+      ID: 1252
       Name: Probe[main.testPointerLoop]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14869,7 +15021,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1209
+      ID: 1226
       Name: Probe[main.testPointerToMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14895,7 +15047,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1233
+      ID: 1250
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14921,7 +15073,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1249
+      ID: 1266
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 35
       PresenceBitsetSize: 1
@@ -14967,7 +15119,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1250
+      ID: 1267
       Name: Probe[main.testReturnsAnyAndError]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14993,7 +15145,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1251
+      ID: 1268
       Name: Probe[main.testReturnsAny]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15019,7 +15171,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1252
+      ID: 1269
       Name: Probe[main.testReturnsAny]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15035,10 +15187,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1281
+      ID: 1298
       Name: Probe[main.testReturnsArrayOne]
     - __kind: EventRootType
-      ID: 1282
+      ID: 1299
       Name: Probe[main.testReturnsArrayOne]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15054,10 +15206,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1283
+      ID: 1300
       Name: Probe[main.testReturnsArrayZero]
     - __kind: EventRootType
-      ID: 1284
+      ID: 1301
       Name: Probe[main.testReturnsArrayZero]Return
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -15073,10 +15225,10 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1279
+      ID: 1296
       Name: Probe[main.testReturnsArray]
     - __kind: EventRootType
-      ID: 1280
+      ID: 1297
       Name: Probe[main.testReturnsArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15092,10 +15244,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1287
+      ID: 1304
       Name: Probe[main.testReturnsBacktrackInt]
     - __kind: EventRootType
-      ID: 1288
+      ID: 1305
       Name: Probe[main.testReturnsBacktrackInt]Return
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -15191,10 +15343,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1299
+      ID: 1316
       Name: Probe[main.testReturnsBoolAndUintptr]
     - __kind: EventRootType
-      ID: 1300
+      ID: 1317
       Name: Probe[main.testReturnsBoolAndUintptr]Return
       ByteSize: 10
       PresenceBitsetSize: 1
@@ -15220,10 +15372,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1275
+      ID: 1292
       Name: Probe[main.testReturnsComplex]
     - __kind: EventRootType
-      ID: 1276
+      ID: 1293
       Name: Probe[main.testReturnsComplex]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15249,7 +15401,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1247
+      ID: 1264
       Name: Probe[main.testReturnsError]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -15275,7 +15427,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1248
+      ID: 1265
       Name: Probe[main.testReturnsError]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15291,7 +15443,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1245
+      ID: 1262
       Name: Probe[main.testReturnsIntAndFloat]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15317,7 +15469,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1246
+      ID: 1263
       Name: Probe[main.testReturnsIntAndFloat]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15343,7 +15495,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1243
+      ID: 1260
       Name: Probe[main.testReturnsIntPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15369,7 +15521,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1244
+      ID: 1261
       Name: Probe[main.testReturnsIntPointer]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15385,7 +15537,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1241
+      ID: 1258
       Name: Probe[main.testReturnsInt]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15411,7 +15563,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1242
+      ID: 1259
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15427,7 +15579,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1253
+      ID: 1270
       Name: Probe[main.testReturnsInterface]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15453,7 +15605,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1254
+      ID: 1271
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15469,10 +15621,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1277
+      ID: 1294
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1278
+      ID: 1295
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -15488,10 +15640,10 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1273
+      ID: 1290
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1274
+      ID: 1291
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 139
       PresenceBitsetSize: 3
@@ -15667,10 +15819,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1285
+      ID: 1302
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1286
+      ID: 1303
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15686,10 +15838,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1291
+      ID: 1308
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1292
+      ID: 1309
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -15745,10 +15897,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1297
+      ID: 1314
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1298
+      ID: 1315
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -15774,10 +15926,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1295
+      ID: 1312
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1296
+      ID: 1313
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15793,10 +15945,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1271
+      ID: 1288
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1272
+      ID: 1289
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -15882,10 +16034,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1293
+      ID: 1310
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1294
+      ID: 1311
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15901,10 +16053,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1289
+      ID: 1306
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1290
+      ID: 1307
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -15920,7 +16072,7 @@ Types:
                   Offset: 0
                   ByteSize: 88
     - __kind: EventRootType
-      ID: 1130
+      ID: 1147
       Name: Probe[main.testRuneArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15946,7 +16098,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1151
+      ID: 1168
       Name: Probe[main.testSingleBool]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -15972,7 +16124,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1149
+      ID: 1166
       Name: Probe[main.testSingleByte]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -15998,7 +16150,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1162
+      ID: 1179
       Name: Probe[main.testSingleFloat32]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -16024,7 +16176,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1163
+      ID: 1180
       Name: Probe[main.testSingleFloat64]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16050,7 +16202,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1154
+      ID: 1171
       Name: Probe[main.testSingleInt16]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -16076,7 +16228,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1155
+      ID: 1172
       Name: Probe[main.testSingleInt32]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -16102,7 +16254,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1156
+      ID: 1173
       Name: Probe[main.testSingleInt64]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16128,7 +16280,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1153
+      ID: 1170
       Name: Probe[main.testSingleInt8]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -16174,7 +16326,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1152
+      ID: 1169
       Name: Probe[main.testSingleInt]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16200,7 +16352,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1150
+      ID: 1167
       Name: Probe[main.testSingleRune]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -16226,7 +16378,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1334
+      ID: 1351
       Name: Probe[main.testSingleString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16252,7 +16404,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1159
+      ID: 1176
       Name: Probe[main.testSingleUint16]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -16278,7 +16430,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1160
+      ID: 1177
       Name: Probe[main.testSingleUint32]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -16304,7 +16456,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1161
+      ID: 1178
       Name: Probe[main.testSingleUint64]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16330,7 +16482,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1158
+      ID: 1175
       Name: Probe[main.testSingleUint8]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -16356,7 +16508,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1157
+      ID: 1174
       Name: Probe[main.testSingleUint]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16382,7 +16534,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1330
+      ID: 1347
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16408,7 +16560,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1321
+      ID: 1338
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16434,7 +16586,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1207
+      ID: 1224
       Name: Probe[main.testSmallMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16460,7 +16612,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1269
+      ID: 1286
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16486,7 +16638,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1270
+      ID: 1287
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16522,7 +16674,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1311
+      ID: 1328
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -16548,7 +16700,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1312
+      ID: 1329
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16584,7 +16736,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1131
+      ID: 1148
       Name: Probe[main.testStringArray]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -16610,7 +16762,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1238
+      ID: 1255
       Name: Probe[main.testStringPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16636,7 +16788,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1325
+      ID: 1342
       Name: Probe[main.testStringSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16662,7 +16814,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1173
+      ID: 1190
       Name: Probe[main.testStringType1]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16688,7 +16840,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1174
+      ID: 1191
       Name: Probe[main.testStringType2]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16714,7 +16866,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1322
+      ID: 1339
       Name: Probe[main.testStructSlice]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -16760,7 +16912,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1201
+      ID: 1218
       Name: Probe[main.testStructWithAny]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16786,7 +16938,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1315
+      ID: 1332
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16812,7 +16964,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1316
+      ID: 1333
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16838,7 +16990,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1349
+      ID: 1366
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16864,10 +17016,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1350
+      ID: 1367
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1348
+      ID: 1365
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 289
       PresenceBitsetSize: 1
@@ -16893,7 +17045,7 @@ Types:
                   Offset: 0
                   ByteSize: 144
     - __kind: EventRootType
-      ID: 1202
+      ID: 1219
       Name: Probe[main.testStructWithMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16919,7 +17071,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1351
+      ID: 1368
       Name: Probe[main.testStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16935,7 +17087,7 @@ Types:
                   Offset: 8
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1353
+      ID: 1370
       Name: Probe[main.testStruct]
       ByteSize: 113
       PresenceBitsetSize: 1
@@ -16961,13 +17113,13 @@ Types:
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1352
+      ID: 1369
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1354
+      ID: 1371
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1331
+      ID: 1348
       Name: Probe[main.testSubslices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -17033,7 +17185,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1347
+      ID: 1364
       Name: Probe[main.testSubstrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17099,7 +17251,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1340
+      ID: 1357
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17125,7 +17277,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1341
+      ID: 1358
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17170,7 +17322,7 @@ Types:
                   Bias: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1336
+      ID: 1353
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17196,7 +17348,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1338
+      ID: 1355
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17232,13 +17384,13 @@ Types:
                   Offset: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1337
+      ID: 1354
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1339
+      ID: 1356
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1335
+      ID: 1352
       Name: Probe[main.testThreeStrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17304,7 +17456,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1164
+      ID: 1181
       Name: Probe[main.testTypeAlias]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -17330,7 +17482,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1140
+      ID: 1157
       Name: Probe[main.testUint16Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -17356,7 +17508,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1141
+      ID: 1158
       Name: Probe[main.testUint32Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17382,7 +17534,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1142
+      ID: 1159
       Name: Probe[main.testUint64Array]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17408,7 +17560,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1139
+      ID: 1156
       Name: Probe[main.testUint8Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -17434,7 +17586,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1138
+      ID: 1155
       Name: Probe[main.testUintArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17460,7 +17612,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1237
+      ID: 1254
       Name: Probe[main.testUintPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17486,7 +17638,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1319
+      ID: 1336
       Name: Probe[main.testUintSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17512,7 +17664,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1345
+      ID: 1362
       Name: Probe[main.testUnitializedString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17538,7 +17690,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1236
+      ID: 1253
       Name: Probe[main.testUnsafePointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17564,7 +17716,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1148
+      ID: 1165
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 1601
       PresenceBitsetSize: 1
@@ -17590,7 +17742,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1328
+      ID: 1345
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17616,7 +17768,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1329
+      ID: 1346
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17642,7 +17794,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1317
+      ID: 1334
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17688,7 +17840,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1318
+      ID: 1335
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -17940,7 +18092,15 @@ Types:
       HasCount: true
       Element: 32 StructureType internal/runtime/atomic.Uint32
     - __kind: ArrayType
-      ID: 358
+      ID: 331
+      Name: '[3]uint64'
+      ByteSize: 24
+      GoKind: 17
+      Count: 3
+      HasCount: true
+      Element: 10 BaseType uint64
+    - __kind: ArrayType
+      ID: 375
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 622912
@@ -17949,7 +18109,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 343
+      ID: 360
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 623200
@@ -17975,7 +18135,15 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 843
+      ID: 332
+      Name: '[5]int64'
+      ByteSize: 40
+      GoKind: 17
+      Count: 5
+      HasCount: true
+      Element: 14 BaseType int64
+    - __kind: ArrayType
+      ID: 860
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 624352
@@ -18002,7 +18170,7 @@ Types:
       HasCount: true
       Element: 79 StructureType runtime.pcvalueCacheEnt
     - __kind: ArrayType
-      ID: 328
+      ID: 345
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 620320
@@ -18026,15 +18194,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 326 GoSliceDataType []*main.deepSlice2.array
+      Data: 343 GoSliceDataType []*main.deepSlice2.array
     - __kind: GoSliceDataType
-      ID: 326
+      ID: 343
       Name: '[]*main.deepSlice2.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 133 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 1067
+      ID: 1084
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 447136
@@ -18042,22 +18210,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1068 PointerType **main.deepSlice3
+          Type: 1085 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1071 GoSliceDataType []*main.deepSlice3.array
+      Data: 1088 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 1071
+      ID: 1088
       Name: '[]*main.deepSlice3.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1069 PointerType *main.deepSlice3
+      Element: 1086 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 1086
+      ID: 1103
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 446816
@@ -18065,22 +18233,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1087 PointerType **main.deepSlice8
+          Type: 1104 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1090 GoSliceDataType []*main.deepSlice8.array
+      Data: 1107 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 1090
+      ID: 1107
       Name: '[]*main.deepSlice8.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1088 PointerType *main.deepSlice8
+      Element: 1105 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 1092
+      ID: 1109
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 446752
@@ -18088,20 +18256,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1093 PointerType **main.deepSlice9
+          Type: 1110 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1096 GoSliceDataType []*main.deepSlice9.array
+      Data: 1113 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 1096
+      ID: 1113
       Name: '[]*main.deepSlice9.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1094 PointerType *main.deepSlice9
+      Element: 1111 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 122
       Name: '[]*string'
@@ -18118,9 +18286,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 323 GoSliceDataType []*string.array
+      Data: 340 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 323
+      ID: 340
       Name: '[]*string.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -18140,9 +18308,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 392 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Data: 409 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 392
+      ID: 409
       Name: '[][][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -18162,9 +18330,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 390 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Data: 407 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 390
+      ID: 407
       Name: '[][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -18184,9 +18352,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 388 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Data: 405 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 388
+      ID: 405
       Name: '[][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -18206,9 +18374,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 386 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Data: 403 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 386
+      ID: 403
       Name: '[][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -18228,9 +18396,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 384 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Data: 401 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 384
+      ID: 401
       Name: '[][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -18250,9 +18418,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 370 GoSliceDataType [][]uint.array
+      Data: 387 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 370
+      ID: 387
       Name: '[][]uint.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -18273,177 +18441,177 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 376 GoSliceDataType []bool.array
+      Data: 393 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 376
+      ID: 393
       Name: '[]bool.array'
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 4 BaseType bool
     - __kind: GoSliceDataType
-      ID: 362
+      ID: 379
       Name: '[]bucket<[4]int,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 528
       Element: 222 GoHMapBucketType bucket<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 361
+      ID: 378
       Name: '[]bucket<[4]int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 280
       Element: 217 GoHMapBucketType bucket<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 345
+      ID: 362
       Name: '[]bucket<[4]string,[2]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 656
       Element: 185 GoHMapBucketType bucket<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 352
+      ID: 369
       Name: '[]bucket<bool,main.node>.array'
       DynamicSizeClass: hashmap
       ByteSize: 152
       Element: 197 GoHMapBucketType bucket<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 333
+      ID: 350
       Name: '[]bucket<int,*main.deepMap2>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
       Element: 141 GoHMapBucketType bucket<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 1081
+      ID: 1098
       Name: '[]bucket<int,*main.deepMap3>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
-      Element: 1077 GoHMapBucketType bucket<int,*main.deepMap3>
+      Element: 1094 GoHMapBucketType bucket<int,*main.deepMap3>
     - __kind: GoSliceDataType
-      ID: 1109
+      ID: 1126
       Name: '[]bucket<int,*main.deepMap8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
-      Element: 1105 GoHMapBucketType bucket<int,*main.deepMap8>
+      Element: 1122 GoHMapBucketType bucket<int,*main.deepMap8>
     - __kind: GoSliceDataType
-      ID: 1118
+      ID: 1135
       Name: '[]bucket<int,*main.deepMap9>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
-      Element: 1114 GoHMapBucketType bucket<int,*main.deepMap9>
+      Element: 1131 GoHMapBucketType bucket<int,*main.deepMap9>
     - __kind: GoSliceDataType
-      ID: 335
+      ID: 352
       Name: '[]bucket<int,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
       Element: 165 GoHMapBucketType bucket<int,int>
     - __kind: GoSliceDataType
-      ID: 1125
+      ID: 1142
       Name: '[]bucket<int,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
-      Element: 1123 GoHMapBucketType bucket<int,interface {}>
+      Element: 1140 GoHMapBucketType bucket<int,interface {}>
     - __kind: GoSliceDataType
-      ID: 366
+      ID: 383
       Name: '[]bucket<int,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
       Element: 232 GoHMapBucketType bucket<int,struct {}>
     - __kind: GoSliceDataType
-      ID: 354
+      ID: 371
       Name: '[]bucket<int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 88
       Element: 202 GoHMapBucketType bucket<int,uint8>
     - __kind: GoSliceDataType
-      ID: 349
+      ID: 366
       Name: '[]bucket<string,[]main.structWithMap>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
       Element: 192 GoHMapBucketType bucket<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 341
+      ID: 358
       Name: '[]bucket<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
       Element: 180 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 854
+      ID: 871
       Name: '[]bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
-      Element: 826 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 843 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 339
+      ID: 356
       Name: '[]bucket<string,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
       Element: 175 GoHMapBucketType bucket<string,int>
     - __kind: GoSliceDataType
-      ID: 338
+      ID: 355
       Name: '[]bucket<string,main.nestedStruct>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
       Element: 170 GoHMapBucketType bucket<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 364
+      ID: 381
       Name: '[]bucket<struct {},int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
       Element: 227 GoHMapBucketType bucket<struct {},int>
     - __kind: GoSliceDataType
-      ID: 395
+      ID: 412
       Name: '[]bucket<struct {},main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 400
       Element: 285 GoHMapBucketType bucket<struct {},main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 397
+      ID: 414
       Name: '[]bucket<struct {},map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
       Element: 290 GoHMapBucketType bucket<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 399
+      ID: 416
       Name: '[]bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
       Element: 295 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 401
+      ID: 418
       Name: '[]bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
       Element: 300 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 403
+      ID: 420
       Name: '[]bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
       Element: 305 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 405
+      ID: 422
       Name: '[]bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
       Element: 310 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 367
+      ID: 384
       Name: '[]bucket<struct {},struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 16
       Element: 237 GoHMapBucketType bucket<struct {},struct {}>
     - __kind: GoSliceDataType
-      ID: 359
+      ID: 376
       Name: '[]bucket<uint8,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 280
       Element: 212 GoHMapBucketType bucket<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 356
+      ID: 373
       Name: '[]bucket<uint8,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 32
       Element: 207 GoHMapBucketType bucket<uint8,uint8>
     - __kind: GoSliceHeaderType
-      ID: 838
+      ID: 855
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 454368
@@ -18458,15 +18626,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 855 GoSliceDataType []float64.array
+      Data: 872 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 855
+      ID: 872
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 17 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 1098
+      ID: 1115
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 454816
@@ -18481,56 +18649,56 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1099 GoSliceDataType []interface {}.array
+      Data: 1116 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 1099
+      ID: 1116
       Name: '[]interface {}.array'
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 152 GoEmptyInterfaceType interface {}
     - __kind: ArrayType
-      ID: 360
+      ID: 377
       Name: '[]key<[4]int>'
       ByteSize: 256
       Count: 8
       HasCount: true
-      Element: 358 ArrayType [4]int
+      Element: 375 ArrayType [4]int
     - __kind: ArrayType
-      ID: 342
+      ID: 359
       Name: '[]key<[4]string>'
       ByteSize: 512
       Count: 8
       HasCount: true
-      Element: 343 ArrayType [4]string
+      Element: 360 ArrayType [4]string
     - __kind: ArrayType
-      ID: 350
+      ID: 367
       Name: '[]key<bool>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 4 BaseType bool
     - __kind: ArrayType
-      ID: 329
+      ID: 346
       Name: '[]key<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 336
+      ID: 353
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 11 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 363
+      ID: 380
       Name: '[]key<struct {}>'
       Count: 8
       HasCount: true
       Element: 118 StructureType struct {}
     - __kind: ArrayType
-      ID: 355
+      ID: 372
       Name: '[]key<uint8>'
       ByteSize: 8
       Count: 8
@@ -18551,15 +18719,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 382 GoSliceDataType []main.structWithCyclicSlices.array
+      Data: 399 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 382
+      ID: 399
       Name: '[]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 144
       Element: 267 StructureType main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 347
+      ID: 364
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 447456
@@ -18567,16 +18735,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 348 PointerType *main.structWithMap
+          Type: 365 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 406 GoSliceDataType []main.structWithMap.array
+      Data: 423 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 406
+      ID: 423
       Name: '[]main.structWithMap.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -18596,9 +18764,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 372 GoSliceDataType []main.structWithNoStrings.array
+      Data: 389 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 372
+      ID: 389
       Name: '[]main.structWithNoStrings.array'
       DynamicSizeClass: slice
       ByteSize: 2
@@ -18623,9 +18791,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 374 GoSliceDataType []string.array
+      Data: 391 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 374
+      ID: 391
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -18646,9 +18814,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 380 GoSliceDataType []struct {}.array
+      Data: 397 GoSliceDataType []struct {}.array
     - __kind: GoSliceDataType
-      ID: 380
+      ID: 397
       Name: '[]struct {}.array'
       DynamicSizeClass: slice
       Element: 118 StructureType struct {}
@@ -18668,9 +18836,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 368 GoSliceDataType []uint.array
+      Data: 385 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 368
+      ID: 385
       Name: '[]uint.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -18691,9 +18859,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 378 GoSliceDataType []uint16.array
+      Data: 395 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 378
+      ID: 395
       Name: '[]uint16.array'
       DynamicSizeClass: slice
       ByteSize: 2
@@ -18714,9 +18882,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 319 GoSliceDataType []uint8.array
+      Data: 336 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 319
+      ID: 336
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -18737,165 +18905,165 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 321 GoSliceDataType []uintptr.array
+      Data: 338 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 321
+      ID: 338
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 1 BaseType uintptr
     - __kind: ArrayType
-      ID: 330
+      ID: 347
       Name: '[]val<*main.deepMap2>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 331 PointerType *main.deepMap2
+      Element: 348 PointerType *main.deepMap2
     - __kind: ArrayType
-      ID: 1078
+      ID: 1095
       Name: '[]val<*main.deepMap3>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 1079 PointerType *main.deepMap3
+      Element: 1096 PointerType *main.deepMap3
     - __kind: ArrayType
-      ID: 1106
+      ID: 1123
       Name: '[]val<*main.deepMap8>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 1107 PointerType *main.deepMap8
+      Element: 1124 PointerType *main.deepMap8
     - __kind: ArrayType
-      ID: 1115
+      ID: 1132
       Name: '[]val<*main.deepMap9>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 1116 PointerType *main.deepMap9
+      Element: 1133 PointerType *main.deepMap9
     - __kind: ArrayType
-      ID: 344
+      ID: 361
       Name: '[]val<[2]int>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 106 ArrayType [2]int
     - __kind: ArrayType
-      ID: 357
+      ID: 374
       Name: '[]val<[4]int>'
       ByteSize: 256
       Count: 8
       HasCount: true
-      Element: 358 ArrayType [4]int
+      Element: 375 ArrayType [4]int
     - __kind: ArrayType
-      ID: 346
+      ID: 363
       Name: '[]val<[]main.structWithMap>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 347 GoSliceHeaderType []main.structWithMap
+      Element: 364 GoSliceHeaderType []main.structWithMap
     - __kind: ArrayType
-      ID: 340
+      ID: 357
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
       Element: 258 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 853
+      ID: 870
       Name: '[]val<github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 845 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+      Element: 862 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: ArrayType
-      ID: 334
+      ID: 351
       Name: '[]val<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 1124
+      ID: 1141
       Name: '[]val<interface {}>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 152 GoEmptyInterfaceType interface {}
     - __kind: ArrayType
-      ID: 337
+      ID: 354
       Name: '[]val<main.nestedStruct>'
       ByteSize: 192
       Count: 8
       HasCount: true
       Element: 116 StructureType main.nestedStruct
     - __kind: ArrayType
-      ID: 351
+      ID: 368
       Name: '[]val<main.node>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 241 StructureType main.node
     - __kind: ArrayType
-      ID: 394
+      ID: 411
       Name: '[]val<main.structWithCyclicMaps>'
       ByteSize: 384
       Count: 8
       HasCount: true
       Element: 280 StructureType main.structWithCyclicMaps
     - __kind: ArrayType
-      ID: 396
+      ID: 413
       Name: '[]val<map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 281 GoMapType map[struct {}]main.structWithCyclicMaps
     - __kind: ArrayType
-      ID: 398
+      ID: 415
       Name: '[]val<map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 286 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: ArrayType
-      ID: 400
+      ID: 417
       Name: '[]val<map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 291 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: ArrayType
-      ID: 402
+      ID: 419
       Name: '[]val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 296 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: ArrayType
-      ID: 404
+      ID: 421
       Name: '[]val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 301 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: ArrayType
-      ID: 365
+      ID: 382
       Name: '[]val<struct {}>'
       Count: 8
       HasCount: true
       Element: 118 StructureType struct {}
     - __kind: ArrayType
-      ID: 353
+      ID: 370
       Name: '[]val<uint8>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 982
+      ID: 999
       Name: archive/tar.Writer
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 634
+      ID: 651
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 858688
@@ -18910,33 +19078,33 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 635 GoSliceDataType archive/tar.headerError.array
+      Data: 652 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 635
+      ID: 652
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 922
+      ID: 939
       Name: archive/tar.regFileWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 870
+      ID: 887
       Name: archive/zip.countWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 872
+      ID: 889
       Name: archive/zip.dirWriter
       GoRuntimeType: 1.078912e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 969
+      ID: 986
       Name: archive/zip.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 898
+      ID: 915
       Name: archive/zip.nopCloser
       ByteSize: 16
       GoRuntimeType: 1.37696e+06
@@ -18946,7 +19114,7 @@ Types:
           Offset: 0
           Type: 124 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 900
+      ID: 917
       Name: archive/zip.pooledFlateWriter
       ByteSize: 8
     - __kind: BaseType
@@ -18962,18 +19130,18 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 360 ArrayType []key<[4]int>
+          Type: 377 ArrayType []key<[4]int>
         - Name: values
           Offset: 264
-          Type: 357 ArrayType []val<[4]int>
+          Type: 374 ArrayType []val<[4]int>
         - Name: overflow
           Offset: 520
           Type: 221 PointerType *bucket<[4]int,[4]int>
-      KeyType: 358 ArrayType [4]int
-      ValueType: 358 ArrayType [4]int
+      KeyType: 375 ArrayType [4]int
+      ValueType: 375 ArrayType [4]int
     - __kind: GoHMapBucketType
       ID: 217
       Name: bucket<[4]int,uint8>
@@ -18981,17 +19149,17 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 360 ArrayType []key<[4]int>
+          Type: 377 ArrayType []key<[4]int>
         - Name: values
           Offset: 264
-          Type: 353 ArrayType []val<uint8>
+          Type: 370 ArrayType []val<uint8>
         - Name: overflow
           Offset: 272
           Type: 216 PointerType *bucket<[4]int,uint8>
-      KeyType: 358 ArrayType [4]int
+      KeyType: 375 ArrayType [4]int
       ValueType: 3 BaseType uint8
     - __kind: GoHMapBucketType
       ID: 185
@@ -19000,17 +19168,17 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 342 ArrayType []key<[4]string>
+          Type: 359 ArrayType []key<[4]string>
         - Name: values
           Offset: 520
-          Type: 344 ArrayType []val<[2]int>
+          Type: 361 ArrayType []val<[2]int>
         - Name: overflow
           Offset: 648
           Type: 184 PointerType *bucket<[4]string,[2]int>
-      KeyType: 343 ArrayType [4]string
+      KeyType: 360 ArrayType [4]string
       ValueType: 106 ArrayType [2]int
     - __kind: GoHMapBucketType
       ID: 197
@@ -19019,13 +19187,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 350 ArrayType []key<bool>
+          Type: 367 ArrayType []key<bool>
         - Name: values
           Offset: 16
-          Type: 351 ArrayType []val<main.node>
+          Type: 368 ArrayType []val<main.node>
         - Name: overflow
           Offset: 144
           Type: 196 PointerType *bucket<bool,main.node>
@@ -19038,75 +19206,75 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 329 ArrayType []key<int>
+          Type: 346 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 330 ArrayType []val<*main.deepMap2>
+          Type: 347 ArrayType []val<*main.deepMap2>
         - Name: overflow
           Offset: 136
           Type: 140 PointerType *bucket<int,*main.deepMap2>
       KeyType: 9 BaseType int
-      ValueType: 331 PointerType *main.deepMap2
+      ValueType: 348 PointerType *main.deepMap2
     - __kind: GoHMapBucketType
-      ID: 1077
+      ID: 1094
       Name: bucket<int,*main.deepMap3>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 329 ArrayType []key<int>
+          Type: 346 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 1078 ArrayType []val<*main.deepMap3>
+          Type: 1095 ArrayType []val<*main.deepMap3>
         - Name: overflow
           Offset: 136
-          Type: 1076 PointerType *bucket<int,*main.deepMap3>
+          Type: 1093 PointerType *bucket<int,*main.deepMap3>
       KeyType: 9 BaseType int
-      ValueType: 1079 PointerType *main.deepMap3
+      ValueType: 1096 PointerType *main.deepMap3
     - __kind: GoHMapBucketType
-      ID: 1105
+      ID: 1122
       Name: bucket<int,*main.deepMap8>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 329 ArrayType []key<int>
+          Type: 346 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 1106 ArrayType []val<*main.deepMap8>
+          Type: 1123 ArrayType []val<*main.deepMap8>
         - Name: overflow
           Offset: 136
-          Type: 1104 PointerType *bucket<int,*main.deepMap8>
+          Type: 1121 PointerType *bucket<int,*main.deepMap8>
       KeyType: 9 BaseType int
-      ValueType: 1107 PointerType *main.deepMap8
+      ValueType: 1124 PointerType *main.deepMap8
     - __kind: GoHMapBucketType
-      ID: 1114
+      ID: 1131
       Name: bucket<int,*main.deepMap9>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 329 ArrayType []key<int>
+          Type: 346 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 1115 ArrayType []val<*main.deepMap9>
+          Type: 1132 ArrayType []val<*main.deepMap9>
         - Name: overflow
           Offset: 136
-          Type: 1113 PointerType *bucket<int,*main.deepMap9>
+          Type: 1130 PointerType *bucket<int,*main.deepMap9>
       KeyType: 9 BaseType int
-      ValueType: 1116 PointerType *main.deepMap9
+      ValueType: 1133 PointerType *main.deepMap9
     - __kind: GoHMapBucketType
       ID: 165
       Name: bucket<int,int>
@@ -19114,35 +19282,35 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 329 ArrayType []key<int>
+          Type: 346 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 334 ArrayType []val<int>
+          Type: 351 ArrayType []val<int>
         - Name: overflow
           Offset: 136
           Type: 164 PointerType *bucket<int,int>
       KeyType: 9 BaseType int
       ValueType: 9 BaseType int
     - __kind: GoHMapBucketType
-      ID: 1123
+      ID: 1140
       Name: bucket<int,interface {}>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 329 ArrayType []key<int>
+          Type: 346 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 1124 ArrayType []val<interface {}>
+          Type: 1141 ArrayType []val<interface {}>
         - Name: overflow
           Offset: 200
-          Type: 1122 PointerType *bucket<int,interface {}>
+          Type: 1139 PointerType *bucket<int,interface {}>
       KeyType: 9 BaseType int
       ValueType: 152 GoEmptyInterfaceType interface {}
     - __kind: GoHMapBucketType
@@ -19152,13 +19320,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 329 ArrayType []key<int>
+          Type: 346 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 365 ArrayType []val<struct {}>
+          Type: 382 ArrayType []val<struct {}>
         - Name: overflow
           Offset: 72
           Type: 231 PointerType *bucket<int,struct {}>
@@ -19171,13 +19339,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 329 ArrayType []key<int>
+          Type: 346 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 353 ArrayType []val<uint8>
+          Type: 370 ArrayType []val<uint8>
         - Name: overflow
           Offset: 80
           Type: 201 PointerType *bucket<int,uint8>
@@ -19190,18 +19358,18 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 336 ArrayType []key<string>
+          Type: 353 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 346 ArrayType []val<[]main.structWithMap>
+          Type: 363 ArrayType []val<[]main.structWithMap>
         - Name: overflow
           Offset: 328
           Type: 191 PointerType *bucket<string,[]main.structWithMap>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 347 GoSliceHeaderType []main.structWithMap
+      ValueType: 364 GoSliceHeaderType []main.structWithMap
     - __kind: GoHMapBucketType
       ID: 180
       Name: bucket<string,[]string>
@@ -19209,37 +19377,37 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 336 ArrayType []key<string>
+          Type: 353 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 340 ArrayType []val<[]string>
+          Type: 357 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
           Type: 179 PointerType *bucket<string,[]string>
       KeyType: 11 GoStringHeaderType string
       ValueType: 258 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 826
+      ID: 843
       Name: bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 336 ArrayType []key<string>
+          Type: 353 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 853 ArrayType []val<github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 870 ArrayType []val<github.com/DataDog/go-tuf/data.HexBytes>
         - Name: overflow
           Offset: 328
-          Type: 825 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 842 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 845 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+      ValueType: 862 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoHMapBucketType
       ID: 175
       Name: bucket<string,int>
@@ -19247,13 +19415,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 336 ArrayType []key<string>
+          Type: 353 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 334 ArrayType []val<int>
+          Type: 351 ArrayType []val<int>
         - Name: overflow
           Offset: 200
           Type: 174 PointerType *bucket<string,int>
@@ -19266,13 +19434,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 336 ArrayType []key<string>
+          Type: 353 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 337 ArrayType []val<main.nestedStruct>
+          Type: 354 ArrayType []val<main.nestedStruct>
         - Name: overflow
           Offset: 328
           Type: 169 PointerType *bucket<string,main.nestedStruct>
@@ -19285,13 +19453,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 363 ArrayType []key<struct {}>
+          Type: 380 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 334 ArrayType []val<int>
+          Type: 351 ArrayType []val<int>
         - Name: overflow
           Offset: 72
           Type: 226 PointerType *bucket<struct {},int>
@@ -19304,13 +19472,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 363 ArrayType []key<struct {}>
+          Type: 380 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 394 ArrayType []val<main.structWithCyclicMaps>
+          Type: 411 ArrayType []val<main.structWithCyclicMaps>
         - Name: overflow
           Offset: 392
           Type: 284 PointerType *bucket<struct {},main.structWithCyclicMaps>
@@ -19323,13 +19491,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 363 ArrayType []key<struct {}>
+          Type: 380 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 396 ArrayType []val<map[struct {}]main.structWithCyclicMaps>
+          Type: 413 ArrayType []val<map[struct {}]main.structWithCyclicMaps>
         - Name: overflow
           Offset: 72
           Type: 289 PointerType *bucket<struct {},map[struct {}]main.structWithCyclicMaps>
@@ -19342,13 +19510,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 363 ArrayType []key<struct {}>
+          Type: 380 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 398 ArrayType []val<map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 415 ArrayType []val<map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: overflow
           Offset: 72
           Type: 294 PointerType *bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -19361,13 +19529,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 363 ArrayType []key<struct {}>
+          Type: 380 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 400 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 417 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: overflow
           Offset: 72
           Type: 299 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -19380,13 +19548,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 363 ArrayType []key<struct {}>
+          Type: 380 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 402 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 419 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: overflow
           Offset: 72
           Type: 304 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -19399,13 +19567,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 363 ArrayType []key<struct {}>
+          Type: 380 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 404 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 421 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: overflow
           Offset: 72
           Type: 309 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -19418,13 +19586,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 363 ArrayType []key<struct {}>
+          Type: 380 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 365 ArrayType []val<struct {}>
+          Type: 382 ArrayType []val<struct {}>
         - Name: overflow
           Offset: 8
           Type: 236 PointerType *bucket<struct {},struct {}>
@@ -19437,18 +19605,18 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 355 ArrayType []key<uint8>
+          Type: 372 ArrayType []key<uint8>
         - Name: values
           Offset: 16
-          Type: 357 ArrayType []val<[4]int>
+          Type: 374 ArrayType []val<[4]int>
         - Name: overflow
           Offset: 272
           Type: 211 PointerType *bucket<uint8,[4]int>
       KeyType: 3 BaseType uint8
-      ValueType: 358 ArrayType [4]int
+      ValueType: 375 ArrayType [4]int
     - __kind: GoHMapBucketType
       ID: 207
       Name: bucket<uint8,uint8>
@@ -19456,28 +19624,28 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 328 ArrayType [8]uint8
+          Type: 345 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 355 ArrayType []key<uint8>
+          Type: 372 ArrayType []key<uint8>
         - Name: values
           Offset: 16
-          Type: 353 ArrayType []val<uint8>
+          Type: 370 ArrayType []val<uint8>
         - Name: overflow
           Offset: 24
           Type: 206 PointerType *bucket<uint8,uint8>
       KeyType: 3 BaseType uint8
       ValueType: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 946
+      ID: 963
       Name: bufio.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 971
+      ID: 988
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1018
+      ID: 1035
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
@@ -19503,13 +19671,13 @@ Types:
       GoRuntimeType: 532416
       GoKind: 15
     - __kind: BaseType
-      ID: 441
+      ID: 458
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 764800
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 442
+      ID: 459
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 764896
@@ -19517,92 +19685,92 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 444 PointerType *compress/flate.InternalError.str
+          Type: 461 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 443 GoStringDataType compress/flate.InternalError.str
+      Data: 460 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 443
+      ID: 460
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 920
+      ID: 937
       Name: compress/flate.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 866
+      ID: 883
       Name: compress/flate.dictWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 942
+      ID: 959
       Name: compress/gzip.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 778
+      ID: 795
       Name: context.deadlineExceededError
       GoRuntimeType: 1.296736e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 455
+      ID: 472
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 767392
       GoKind: 2
     - __kind: BaseType
-      ID: 456
+      ID: 473
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 767488
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 932
+      ID: 949
       Name: crypto/hmac.hmac
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 957
+      ID: 974
       Name: crypto/md5.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 457
+      ID: 474
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 767584
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 965
+      ID: 982
       Name: crypto/sha1.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 959
+      ID: 976
       Name: crypto/sha256.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 961
+      ID: 978
       Name: crypto/sha512.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 445
+      ID: 462
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 765376
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 718
+      ID: 735
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1044
+      ID: 1061
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 551
+      ID: 568
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 549
+      ID: 566
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1.606048e+06
@@ -19613,34 +19781,34 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 843 ArrayType [5]uint8
+          Type: 860 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 844 GoInterfaceType net.Conn
+          Type: 861 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 673
+      ID: 690
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 951936
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 930
+      ID: 947
       Name: crypto/tls.cthWrapper
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 937
+      ID: 954
       Name: crypto/tls.finishedHash
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 813
+      ID: 830
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 828
+      ID: 845
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 623
+      ID: 640
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1.60912e+06
@@ -19648,21 +19816,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 827 PointerType *crypto/x509.Certificate
+          Type: 844 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 846 BaseType crypto/x509.InvalidReason
+          Type: 863 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 617
+      ID: 634
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1.076224e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 619
+      ID: 636
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1.409312e+06
@@ -19670,24 +19838,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 827 PointerType *crypto/x509.Certificate
+          Type: 844 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 454
+      ID: 471
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 767008
       GoKind: 2
     - __kind: BaseType
-      ID: 846
+      ID: 863
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 537920
       GoKind: 2
     - __kind: StructureType
-      ID: 723
+      ID: 740
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1.37328e+06
@@ -19697,13 +19865,13 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 625
+      ID: 642
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1.07648e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 621
+      ID: 638
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1.608928e+06
@@ -19711,15 +19879,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 827 PointerType *crypto/x509.Certificate
+          Type: 844 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 18 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 827 PointerType *crypto/x509.Certificate
+          Type: 844 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 638
+      ID: 655
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1.254208e+06
@@ -19729,7 +19897,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 642
+      ID: 659
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1.254368e+06
@@ -19739,55 +19907,55 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 640
+      ID: 657
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 439
+      ID: 456
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 764416
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 888
+      ID: 905
       Name: encoding/base64.encoder
       ByteSize: 8
     - __kind: BaseType
-      ID: 440
+      ID: 457
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 764608
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 510
+      ID: 527
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 709
+      ID: 726
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 502
+      ID: 519
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 508
+      ID: 525
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 506
+      ID: 523
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 504
+      ID: 521
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1024
+      ID: 1041
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 512
+      ID: 529
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1.238848e+06
@@ -19797,19 +19965,19 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 896
+      ID: 913
       Name: encoding/pem.lineBreaker
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 611
+      ID: 628
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 609
+      ID: 626
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 451
+      ID: 468
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 766912
@@ -19817,22 +19985,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 453 PointerType *encoding/xml.UnmarshalError.str
+          Type: 470 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 452 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 469 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 452
+      ID: 469
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 614
+      ID: 631
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1002
+      ID: 1019
       Name: encoding/xml.printer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -19849,11 +20017,11 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 480
+      ID: 497
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 676
+      ID: 693
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -19869,15 +20037,15 @@ Types:
       GoRuntimeType: 532608
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 1012
+      ID: 1029
       Name: fmt.pp
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 678
+      ID: 695
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 680
+      ID: 697
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -19893,11 +20061,11 @@ Types:
       GoRuntimeType: 778144
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 540
+      ID: 557
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 521
+      ID: 538
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1.60432e+06
@@ -19905,7 +20073,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 836 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 853 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 9 BaseType int
@@ -19913,25 +20081,25 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 523
+      ID: 540
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 840
+      ID: 857
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 527
+      ID: 544
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1.07264e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 842
+      ID: 859
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 433
+      ID: 450
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 763840
@@ -19939,18 +20107,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 435 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 452 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 434 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 451 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 434
+      ID: 451
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 836
+      ID: 853
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2.075136e+06
@@ -19958,7 +20126,7 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 837 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 854 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -19973,7 +20141,7 @@ Types:
           Type: 17 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 838 GoSliceHeaderType []float64
+          Type: 855 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 14 BaseType int64
@@ -19982,10 +20150,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 839 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 856 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 841 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 858 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
           Type: 258 GoSliceHeaderType []string
@@ -19999,13 +20167,13 @@ Types:
           Offset: 184
           Type: 14 BaseType int64
     - __kind: BaseType
-      ID: 837
+      ID: 854
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 534464
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 430
+      ID: 447
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 763744
@@ -20013,18 +20181,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 432 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 449 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 431 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 448 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 431
+      ID: 448
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 436
+      ID: 453
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 763936
@@ -20032,60 +20200,60 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 438 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 455 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 437 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 454 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 437
+      ID: 454
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 910
+      ID: 927
       Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 990
+      ID: 1007
       Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 632
+      ID: 649
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 787
+      ID: 804
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1020
+      ID: 1037
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 560
+      ID: 577
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 567
+      ID: 584
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1.075456e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 450
+      ID: 467
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 766048
       GoKind: 2
     - __kind: StructureType
-      ID: 565
+      ID: 582
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1.075328e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 563
+      ID: 580
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1.407392e+06
@@ -20098,7 +20266,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 583
+      ID: 600
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1.408192e+06
@@ -20111,7 +20279,7 @@ Types:
           Offset: 16
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 587
+      ID: 604
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1.608352e+06
@@ -20127,7 +20295,7 @@ Types:
           Offset: 24
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 585
+      ID: 602
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1.248608e+06
@@ -20137,7 +20305,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 581
+      ID: 598
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1.248288e+06
@@ -20147,14 +20315,14 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 822
+      ID: 839
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1.135776e+06
       GoKind: 21
-      HeaderType: 824 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 841 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 845
+      ID: 862
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1.009408e+06
@@ -20169,15 +20337,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 857 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 874 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 857
+      ID: 874
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 595
+      ID: 612
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1.408512e+06
@@ -20185,12 +20353,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 822 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 839 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 822 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 839 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 589
+      ID: 606
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1.248768e+06
@@ -20200,7 +20368,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 593
+      ID: 610
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1.608544e+06
@@ -20211,12 +20379,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 845 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 862 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 845 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 862 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 591
+      ID: 608
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1.408352e+06
@@ -20229,7 +20397,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 597
+      ID: 614
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1.248928e+06
@@ -20237,9 +20405,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 814 StructureType time.Time
+          Type: 831 StructureType time.Time
     - __kind: StructureType
-      ID: 603
+      ID: 620
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1.408832e+06
@@ -20252,7 +20420,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 605
+      ID: 622
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1.249248e+06
@@ -20262,7 +20430,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 601
+      ID: 618
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1.408672e+06
@@ -20275,7 +20443,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 599
+      ID: 616
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1.249088e+06
@@ -20285,7 +20453,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 607
+      ID: 624
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1.408992e+06
@@ -20298,7 +20466,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 529
+      ID: 546
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1.241088e+06
@@ -20308,11 +20476,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 949
+      ID: 966
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 531
+      ID: 548
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1.241248e+06
@@ -20320,21 +20488,21 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 529 StructureType github.com/cihub/seelog.baseError
+          Type: 546 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 928
+      ID: 945
       Name: github.com/cihub/seelog.connWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 884
+      ID: 901
       Name: github.com/cihub/seelog.consoleWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 918
+      ID: 935
       Name: github.com/cihub/seelog.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 535
+      ID: 552
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1.241568e+06
@@ -20342,13 +20510,13 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 529 StructureType github.com/cihub/seelog.baseError
+          Type: 546 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 980
+      ID: 997
       Name: github.com/cihub/seelog.rollingFileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 991
+      ID: 1008
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
       GoRuntimeType: 1.969408e+06
@@ -20356,12 +20524,12 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 979 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 996 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: maxFileSize
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 992
+      ID: 1009
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
       GoRuntimeType: 1.9928e+06
@@ -20369,7 +20537,7 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 979 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 996 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: timePattern
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -20377,11 +20545,11 @@ Types:
           Offset: 24
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 886
+      ID: 903
       Name: github.com/cihub/seelog.smtpWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 533
+      ID: 550
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1.241408e+06
@@ -20389,9 +20557,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 529 StructureType github.com/cihub/seelog.baseError
+          Type: 546 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 537
+      ID: 554
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1.241728e+06
@@ -20399,64 +20567,64 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 529 StructureType github.com/cihub/seelog.baseError
+          Type: 546 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 953
+      ID: 970
       Name: github.com/cihub/seelog/archive/gzip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 986
+      ID: 1003
       Name: github.com/cihub/seelog/archive/tar.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 988
+      ID: 1005
       Name: github.com/cihub/seelog/archive/zip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 818
+      ID: 835
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 731
+      ID: 748
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 729
+      ID: 746
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 733
+      ID: 750
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 735
+      ID: 752
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 939
+      ID: 956
       Name: github.com/gogo/protobuf/proto.textWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 725
+      ID: 742
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 543
+      ID: 560
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1.242688e+06
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 1036
+      ID: 1053
       Name: github.com/json-iterator/go.Stream
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 789
+      ID: 806
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 762
+      ID: 779
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1.713024e+06
@@ -20472,11 +20640,11 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 756
+      ID: 773
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 695
+      ID: 712
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1.510048e+06
@@ -20489,7 +20657,7 @@ Types:
           Offset: 1
           Type: 15 BaseType int8
     - __kind: StructureType
-      ID: 768
+      ID: 785
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1.713472e+06
@@ -20505,13 +20673,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 672
+      ID: 689
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 949344
       GoKind: 8
     - __kind: StructureType
-      ID: 760
+      ID: 777
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1.7128e+06
@@ -20527,13 +20695,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 847
+      ID: 864
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 762016
       GoKind: 8
     - __kind: StructureType
-      ID: 758
+      ID: 775
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1.712576e+06
@@ -20541,15 +20709,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 847 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 864 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 847 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 864 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 766
+      ID: 783
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1.631168e+06
@@ -20562,7 +20730,7 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 764
+      ID: 781
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1.713248e+06
@@ -20578,11 +20746,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1040
+      ID: 1057
       Name: github.com/tinylib/msgp/msgp.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 772
+      ID: 789
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1.43296e+06
@@ -20592,19 +20760,19 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 699
+      ID: 716
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1.195616e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 697
+      ID: 714
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1.195488e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 770
+      ID: 787
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1.63136e+06
@@ -20617,7 +20785,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 462
+      ID: 479
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 769408
@@ -20625,22 +20793,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 464 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 481 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 463 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 480 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 463
+      ID: 480
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 831
+      ID: 848
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 739
+      ID: 756
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1.266048e+06
@@ -20650,7 +20818,7 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 916
+      ID: 933
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
       GoRuntimeType: 1.486912e+06
@@ -20658,13 +20826,13 @@ Types:
       RawFields:
         - Name: WriteSyncer
           Offset: 0
-          Type: 940 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+          Type: 957 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
     - __kind: UnresolvedPointeeType
-      ID: 1000
+      ID: 1017
       Name: go.uber.org/zap/buffer.Buffer
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 940
+      ID: 957
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
       GoRuntimeType: 1.086336e+06
@@ -20677,7 +20845,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 902
+      ID: 919
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
       GoRuntimeType: 1.38176e+06
@@ -20687,19 +20855,19 @@ Types:
           Offset: 0
           Type: 124 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 465
+      ID: 482
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 769984
       GoKind: 10
     - __kind: BaseType
-      ID: 829
+      ID: 846
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 962592
       GoKind: 10
     - __kind: StructureType
-      ID: 797
+      ID: 814
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1.751552e+06
@@ -20710,12 +20878,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 829 BaseType golang.org/x/net/http2.ErrCode
+          Type: 846 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 658
+      ID: 675
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1.416192e+06
@@ -20723,12 +20891,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 829 BaseType golang.org/x/net/http2.ErrCode
+          Type: 846 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 469
+      ID: 486
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 770176
@@ -20736,18 +20904,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 471 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 488 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 470 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 487 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 470
+      ID: 487
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 475
+      ID: 492
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 770368
@@ -20755,18 +20923,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 477 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 494 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 476 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 493 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 476
+      ID: 493
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 472
+      ID: 489
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 770272
@@ -20774,18 +20942,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 474 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 491 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 473 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 490 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 473
+      ID: 490
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 466
+      ID: 483
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 770080
@@ -20793,22 +20961,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 468 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 485 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 467 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 484 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 467
+      ID: 484
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 998
+      ID: 1015
       Name: golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 662
+      ID: 679
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.266688e+06
@@ -20818,13 +20986,13 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: BaseType
-      ID: 478
+      ID: 495
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 770464
       GoKind: 2
     - __kind: StructureType
-      ID: 650
+      ID: 667
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1.261728e+06
@@ -20834,11 +21002,11 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 795
+      ID: 812
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 820
+      ID: 837
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1.777312e+06
@@ -20854,7 +21022,7 @@ Types:
           Offset: 24
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 652
+      ID: 669
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1.415712e+06
@@ -20867,7 +21035,7 @@ Types:
           Offset: 16
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 963
+      ID: 980
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
       GoRuntimeType: 1.830784e+06
@@ -20875,16 +21043,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 844 GoInterfaceType net.Conn
+          Type: 861 GoInterfaceType net.Conn
         - Name: r
           Offset: 16
-          Type: 978 GoInterfaceType io.Reader
+          Type: 995 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 914
+      ID: 931
       Name: google.golang.org/grpc/internal/transport.bufWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 737
+      ID: 754
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1.37936e+06
@@ -20894,29 +21062,29 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 874
+      ID: 891
       Name: google.golang.org/grpc/mem.writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 630
+      ID: 647
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 727
+      ID: 744
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 793
+      ID: 810
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 791
+      ID: 808
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1.326496e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 644
+      ID: 661
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1.255008e+06
@@ -20926,7 +21094,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 646
+      ID: 663
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1.255168e+06
@@ -20936,11 +21104,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 575
+      ID: 592
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 951
+      ID: 968
       Name: hash/crc32.digest
       ByteSize: 8
     - __kind: GoHMapHeaderType
@@ -20976,7 +21144,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 222 GoHMapBucketType bucket<[4]int,[4]int>
-      BucketsType: 362 GoSliceDataType []bucket<[4]int,[4]int>.array
+      BucketsType: 379 GoSliceDataType []bucket<[4]int,[4]int>.array
     - __kind: GoHMapHeaderType
       ID: 215
       Name: hash<[4]int,uint8>
@@ -21010,7 +21178,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 217 GoHMapBucketType bucket<[4]int,uint8>
-      BucketsType: 361 GoSliceDataType []bucket<[4]int,uint8>.array
+      BucketsType: 378 GoSliceDataType []bucket<[4]int,uint8>.array
     - __kind: GoHMapHeaderType
       ID: 183
       Name: hash<[4]string,[2]int>
@@ -21044,7 +21212,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 185 GoHMapBucketType bucket<[4]string,[2]int>
-      BucketsType: 345 GoSliceDataType []bucket<[4]string,[2]int>.array
+      BucketsType: 362 GoSliceDataType []bucket<[4]string,[2]int>.array
     - __kind: GoHMapHeaderType
       ID: 195
       Name: hash<bool,main.node>
@@ -21078,7 +21246,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 197 GoHMapBucketType bucket<bool,main.node>
-      BucketsType: 352 GoSliceDataType []bucket<bool,main.node>.array
+      BucketsType: 369 GoSliceDataType []bucket<bool,main.node>.array
     - __kind: GoHMapHeaderType
       ID: 139
       Name: hash<int,*main.deepMap2>
@@ -21112,9 +21280,9 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 141 GoHMapBucketType bucket<int,*main.deepMap2>
-      BucketsType: 333 GoSliceDataType []bucket<int,*main.deepMap2>.array
+      BucketsType: 350 GoSliceDataType []bucket<int,*main.deepMap2>.array
     - __kind: GoHMapHeaderType
-      ID: 1075
+      ID: 1092
       Name: hash<int,*main.deepMap3>
       ByteSize: 48
       RawFields:
@@ -21135,20 +21303,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 1076 PointerType *bucket<int,*main.deepMap3>
+          Type: 1093 PointerType *bucket<int,*main.deepMap3>
         - Name: oldbuckets
           Offset: 24
-          Type: 1076 PointerType *bucket<int,*main.deepMap3>
+          Type: 1093 PointerType *bucket<int,*main.deepMap3>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
-      BucketType: 1077 GoHMapBucketType bucket<int,*main.deepMap3>
-      BucketsType: 1081 GoSliceDataType []bucket<int,*main.deepMap3>.array
+      BucketType: 1094 GoHMapBucketType bucket<int,*main.deepMap3>
+      BucketsType: 1098 GoSliceDataType []bucket<int,*main.deepMap3>.array
     - __kind: GoHMapHeaderType
-      ID: 1103
+      ID: 1120
       Name: hash<int,*main.deepMap8>
       ByteSize: 48
       RawFields:
@@ -21169,20 +21337,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 1104 PointerType *bucket<int,*main.deepMap8>
+          Type: 1121 PointerType *bucket<int,*main.deepMap8>
         - Name: oldbuckets
           Offset: 24
-          Type: 1104 PointerType *bucket<int,*main.deepMap8>
+          Type: 1121 PointerType *bucket<int,*main.deepMap8>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
-      BucketType: 1105 GoHMapBucketType bucket<int,*main.deepMap8>
-      BucketsType: 1109 GoSliceDataType []bucket<int,*main.deepMap8>.array
+      BucketType: 1122 GoHMapBucketType bucket<int,*main.deepMap8>
+      BucketsType: 1126 GoSliceDataType []bucket<int,*main.deepMap8>.array
     - __kind: GoHMapHeaderType
-      ID: 1112
+      ID: 1129
       Name: hash<int,*main.deepMap9>
       ByteSize: 48
       RawFields:
@@ -21203,18 +21371,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 1113 PointerType *bucket<int,*main.deepMap9>
+          Type: 1130 PointerType *bucket<int,*main.deepMap9>
         - Name: oldbuckets
           Offset: 24
-          Type: 1113 PointerType *bucket<int,*main.deepMap9>
+          Type: 1130 PointerType *bucket<int,*main.deepMap9>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
-      BucketType: 1114 GoHMapBucketType bucket<int,*main.deepMap9>
-      BucketsType: 1118 GoSliceDataType []bucket<int,*main.deepMap9>.array
+      BucketType: 1131 GoHMapBucketType bucket<int,*main.deepMap9>
+      BucketsType: 1135 GoSliceDataType []bucket<int,*main.deepMap9>.array
     - __kind: GoHMapHeaderType
       ID: 163
       Name: hash<int,int>
@@ -21248,9 +21416,9 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 165 GoHMapBucketType bucket<int,int>
-      BucketsType: 335 GoSliceDataType []bucket<int,int>.array
+      BucketsType: 352 GoSliceDataType []bucket<int,int>.array
     - __kind: GoHMapHeaderType
-      ID: 1121
+      ID: 1138
       Name: hash<int,interface {}>
       ByteSize: 48
       RawFields:
@@ -21271,18 +21439,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 1122 PointerType *bucket<int,interface {}>
+          Type: 1139 PointerType *bucket<int,interface {}>
         - Name: oldbuckets
           Offset: 24
-          Type: 1122 PointerType *bucket<int,interface {}>
+          Type: 1139 PointerType *bucket<int,interface {}>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
-      BucketType: 1123 GoHMapBucketType bucket<int,interface {}>
-      BucketsType: 1125 GoSliceDataType []bucket<int,interface {}>.array
+      BucketType: 1140 GoHMapBucketType bucket<int,interface {}>
+      BucketsType: 1142 GoSliceDataType []bucket<int,interface {}>.array
     - __kind: GoHMapHeaderType
       ID: 230
       Name: hash<int,struct {}>
@@ -21316,7 +21484,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 232 GoHMapBucketType bucket<int,struct {}>
-      BucketsType: 366 GoSliceDataType []bucket<int,struct {}>.array
+      BucketsType: 383 GoSliceDataType []bucket<int,struct {}>.array
     - __kind: GoHMapHeaderType
       ID: 200
       Name: hash<int,uint8>
@@ -21350,7 +21518,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 202 GoHMapBucketType bucket<int,uint8>
-      BucketsType: 354 GoSliceDataType []bucket<int,uint8>.array
+      BucketsType: 371 GoSliceDataType []bucket<int,uint8>.array
     - __kind: GoHMapHeaderType
       ID: 190
       Name: hash<string,[]main.structWithMap>
@@ -21384,7 +21552,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 192 GoHMapBucketType bucket<string,[]main.structWithMap>
-      BucketsType: 349 GoSliceDataType []bucket<string,[]main.structWithMap>.array
+      BucketsType: 366 GoSliceDataType []bucket<string,[]main.structWithMap>.array
     - __kind: GoHMapHeaderType
       ID: 178
       Name: hash<string,[]string>
@@ -21418,9 +21586,9 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 180 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 341 GoSliceDataType []bucket<string,[]string>.array
+      BucketsType: 358 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 824
+      ID: 841
       Name: hash<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       RawFields:
@@ -21441,18 +21609,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 825 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 842 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: oldbuckets
           Offset: 24
-          Type: 825 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 842 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
-      BucketType: 826 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
-      BucketsType: 854 GoSliceDataType []bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      BucketType: 843 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      BucketsType: 871 GoSliceDataType []bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array
     - __kind: GoHMapHeaderType
       ID: 173
       Name: hash<string,int>
@@ -21486,7 +21654,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 175 GoHMapBucketType bucket<string,int>
-      BucketsType: 339 GoSliceDataType []bucket<string,int>.array
+      BucketsType: 356 GoSliceDataType []bucket<string,int>.array
     - __kind: GoHMapHeaderType
       ID: 168
       Name: hash<string,main.nestedStruct>
@@ -21520,7 +21688,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 170 GoHMapBucketType bucket<string,main.nestedStruct>
-      BucketsType: 338 GoSliceDataType []bucket<string,main.nestedStruct>.array
+      BucketsType: 355 GoSliceDataType []bucket<string,main.nestedStruct>.array
     - __kind: GoHMapHeaderType
       ID: 225
       Name: hash<struct {},int>
@@ -21554,7 +21722,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 227 GoHMapBucketType bucket<struct {},int>
-      BucketsType: 364 GoSliceDataType []bucket<struct {},int>.array
+      BucketsType: 381 GoSliceDataType []bucket<struct {},int>.array
     - __kind: GoHMapHeaderType
       ID: 283
       Name: hash<struct {},main.structWithCyclicMaps>
@@ -21588,7 +21756,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 285 GoHMapBucketType bucket<struct {},main.structWithCyclicMaps>
-      BucketsType: 395 GoSliceDataType []bucket<struct {},main.structWithCyclicMaps>.array
+      BucketsType: 412 GoSliceDataType []bucket<struct {},main.structWithCyclicMaps>.array
     - __kind: GoHMapHeaderType
       ID: 288
       Name: hash<struct {},map[struct {}]main.structWithCyclicMaps>
@@ -21622,7 +21790,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 290 GoHMapBucketType bucket<struct {},map[struct {}]main.structWithCyclicMaps>
-      BucketsType: 397 GoSliceDataType []bucket<struct {},map[struct {}]main.structWithCyclicMaps>.array
+      BucketsType: 414 GoSliceDataType []bucket<struct {},map[struct {}]main.structWithCyclicMaps>.array
     - __kind: GoHMapHeaderType
       ID: 293
       Name: hash<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -21656,7 +21824,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 295 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
-      BucketsType: 399 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      BucketsType: 416 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
     - __kind: GoHMapHeaderType
       ID: 298
       Name: hash<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -21690,7 +21858,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 300 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
-      BucketsType: 401 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      BucketsType: 418 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
     - __kind: GoHMapHeaderType
       ID: 303
       Name: hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -21724,7 +21892,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 305 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
-      BucketsType: 403 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      BucketsType: 420 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
     - __kind: GoHMapHeaderType
       ID: 308
       Name: hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -21758,7 +21926,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 310 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
-      BucketsType: 405 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      BucketsType: 422 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
     - __kind: GoHMapHeaderType
       ID: 235
       Name: hash<struct {},struct {}>
@@ -21792,7 +21960,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 237 GoHMapBucketType bucket<struct {},struct {}>
-      BucketsType: 367 GoSliceDataType []bucket<struct {},struct {}>.array
+      BucketsType: 384 GoSliceDataType []bucket<struct {},struct {}>.array
     - __kind: GoHMapHeaderType
       ID: 210
       Name: hash<uint8,[4]int>
@@ -21826,7 +21994,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 212 GoHMapBucketType bucket<uint8,[4]int>
-      BucketsType: 359 GoSliceDataType []bucket<uint8,[4]int>.array
+      BucketsType: 376 GoSliceDataType []bucket<uint8,[4]int>.array
     - __kind: GoHMapHeaderType
       ID: 205
       Name: hash<uint8,uint8>
@@ -21860,9 +22028,9 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 207 GoHMapBucketType bucket<uint8,uint8>
-      BucketsType: 356 GoSliceDataType []bucket<uint8,uint8>.array
+      BucketsType: 373 GoSliceDataType []bucket<uint8,uint8>.array
     - __kind: UnresolvedPointeeType
-      ID: 665
+      ID: 682
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -21909,7 +22077,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 545
+      ID: 562
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -21935,25 +22103,25 @@ Types:
           Offset: 296
           Type: 2 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 860
+      ID: 877
       Name: internal/godebug.runtimeStderr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 754
+      ID: 771
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1042
+      ID: 1059
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 752
+      ID: 769
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1.293696e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 482
+      ID: 499
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -22034,11 +22202,11 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 906
+      ID: 923
       Name: io.PipeWriter
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 947
+      ID: 964
       Name: io.ReadWriteCloser
       ByteSize: 16
       GoRuntimeType: 1.104288e+06
@@ -22051,7 +22219,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 978
+      ID: 995
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 981504
@@ -22064,7 +22232,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 935
+      ID: 952
       Name: io.WriteCloser
       ByteSize: 16
       GoRuntimeType: 1.069056e+06
@@ -22090,21 +22258,21 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 904
+      ID: 921
       Name: io.discard
       GoRuntimeType: 1.281536e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 878
+      ID: 895
       Name: io.multiWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 750
+      ID: 767
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 955
+      ID: 972
       Name: log/slog/internal/buffer.Buffer
       ByteSize: 8
     - __kind: StructureType
@@ -22133,7 +22301,25 @@ Types:
       RawFields:
         - Name: nested
           Offset: 0
-          Type: 1126 PointerType *main.nestedStruct
+          Type: 1143 PointerType *main.nestedStruct
+    - __kind: StructureType
+      ID: 321
+      Name: main.bStruct
+      ByteSize: 72
+      GoKind: 25
+      RawFields:
+        - Name: aInt16
+          Offset: 0
+          Type: 89 BaseType int16
+        - Name: nested
+          Offset: 8
+          Type: 311 StructureType main.aStruct
+        - Name: aBool
+          Offset: 64
+          Type: 4 BaseType bool
+        - Name: aInt32
+          Offset: 68
+          Type: 13 BaseType int32
     - __kind: GoInterfaceType
       ID: 157
       Name: main.behavior
@@ -22163,6 +22349,21 @@ Types:
           Offset: 32
           Type: 124 GoInterfaceType io.Writer
     - __kind: StructureType
+      ID: 319
+      Name: main.cStruct
+      ByteSize: 24
+      GoKind: 25
+      RawFields:
+        - Name: aInt32
+          Offset: 0
+          Type: 13 BaseType int32
+        - Name: aUint
+          Offset: 8
+          Type: 12 BaseType uint
+        - Name: nested
+          Offset: 16
+          Type: 257 StructureType main.structWithNoStrings
+    - __kind: StructureType
       ID: 136
       Name: main.deepMap1
       ByteSize: 8
@@ -22173,7 +22374,7 @@ Types:
           Offset: 0
           Type: 137 GoMapType map[int]*main.deepMap2
     - __kind: StructureType
-      ID: 332
+      ID: 349
       Name: main.deepMap2
       ByteSize: 8
       GoRuntimeType: 1.100576e+06
@@ -22181,9 +22382,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1073 GoMapType map[int]*main.deepMap3
+          Type: 1090 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 1080
+      ID: 1097
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -22195,9 +22396,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1101 GoMapType map[int]*main.deepMap8
+          Type: 1118 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 1108
+      ID: 1125
       Name: main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.099808e+06
@@ -22205,9 +22406,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1110 GoMapType map[int]*main.deepMap9
+          Type: 1127 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 1117
+      ID: 1134
       Name: main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.09968e+06
@@ -22215,7 +22416,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1119 GoMapType map[int]interface {}
+          Type: 1136 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 125
       Name: main.deepPtr1
@@ -22235,9 +22436,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1045 PointerType *main.deepPtr3
+          Type: 1062 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 1046
+      ID: 1063
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -22249,9 +22450,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1082 PointerType *main.deepPtr8
+          Type: 1099 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 1083
+      ID: 1100
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1.10096e+06
@@ -22259,9 +22460,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1084 PointerType *main.deepPtr9
+          Type: 1101 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 1085
+      ID: 1102
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1.100832e+06
@@ -22281,7 +22482,7 @@ Types:
           Offset: 0
           Type: 131 GoSliceHeaderType []*main.deepSlice2
     - __kind: StructureType
-      ID: 325
+      ID: 342
       Name: main.deepSlice2
       ByteSize: 24
       GoRuntimeType: 1.10288e+06
@@ -22289,9 +22490,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1067 GoSliceHeaderType []*main.deepSlice3
+          Type: 1084 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 1070
+      ID: 1087
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -22303,9 +22504,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1086 GoSliceHeaderType []*main.deepSlice8
+          Type: 1103 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 1089
+      ID: 1106
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1.102112e+06
@@ -22313,9 +22514,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1092 GoSliceHeaderType []*main.deepSlice9
+          Type: 1109 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 1095
+      ID: 1112
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1.101984e+06
@@ -22323,7 +22524,73 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1098 GoSliceHeaderType []interface {}
+          Type: 1115 GoSliceHeaderType []interface {}
+    - __kind: StructureType
+      ID: 323
+      Name: main.deepStruct1
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: b
+          Offset: 8
+          Type: 324 StructureType main.deepStruct2
+    - __kind: StructureType
+      ID: 324
+      Name: main.deepStruct2
+      ByteSize: 40
+      GoKind: 25
+      RawFields:
+        - Name: c
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: d
+          Offset: 8
+          Type: 325 StructureType main.deepStruct3
+    - __kind: StructureType
+      ID: 325
+      Name: main.deepStruct3
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: e
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: f
+          Offset: 8
+          Type: 326 StructureType main.deepStruct4
+    - __kind: StructureType
+      ID: 326
+      Name: main.deepStruct4
+      ByteSize: 24
+      GoKind: 25
+      RawFields:
+        - Name: g
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: h
+          Offset: 8
+          Type: 327 StructureType main.deepStruct5
+    - __kind: StructureType
+      ID: 327
+      Name: main.deepStruct5
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: i
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: j
+          Offset: 8
+          Type: 328 StructureType main.deepStruct6
+    - __kind: StructureType
+      ID: 328
+      Name: main.deepStruct6
+      ByteSize: 8
+      GoKind: 25
+      RawFields: [{Name: k, Offset: 0, Type: 9 BaseType int}]
     - __kind: StructureType
       ID: 314
       Name: main.emptyStruct
@@ -22341,16 +22608,16 @@ Types:
           Type: 150 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 1052 StructureType sync.Mutex
+          Type: 1069 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 1053 StructureType sync.Once
+          Type: 1070 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 1056 StructureType sync.WaitGroup
+          Type: 1073 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 1060 StructureType sync/atomic.Int32
+          Type: 1077 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 150
       Name: main.esotericStack
@@ -22380,7 +22647,7 @@ Types:
           Offset: 56
           Type: 57 GoSubroutineType func()
     - __kind: StructureType
-      ID: 316
+      ID: 333
       Name: main.firstBehavior
       ByteSize: 16
       GoRuntimeType: 1.232128e+06
@@ -22426,6 +22693,90 @@ Types:
           Offset: 72
           Type: 9 BaseType int
     - __kind: StructureType
+      ID: 329
+      Name: main.lotsOfFields
+      ByteSize: 26
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 3 BaseType uint8
+        - Name: b
+          Offset: 1
+          Type: 3 BaseType uint8
+        - Name: c
+          Offset: 2
+          Type: 3 BaseType uint8
+        - Name: d
+          Offset: 3
+          Type: 3 BaseType uint8
+        - Name: e
+          Offset: 4
+          Type: 3 BaseType uint8
+        - Name: f
+          Offset: 5
+          Type: 3 BaseType uint8
+        - Name: g
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: h
+          Offset: 7
+          Type: 3 BaseType uint8
+        - Name: i
+          Offset: 8
+          Type: 3 BaseType uint8
+        - Name: j
+          Offset: 9
+          Type: 3 BaseType uint8
+        - Name: k
+          Offset: 10
+          Type: 3 BaseType uint8
+        - Name: l
+          Offset: 11
+          Type: 3 BaseType uint8
+        - Name: m
+          Offset: 12
+          Type: 3 BaseType uint8
+        - Name: n
+          Offset: 13
+          Type: 3 BaseType uint8
+        - Name: o
+          Offset: 14
+          Type: 3 BaseType uint8
+        - Name: p
+          Offset: 15
+          Type: 3 BaseType uint8
+        - Name: q
+          Offset: 16
+          Type: 3 BaseType uint8
+        - Name: r
+          Offset: 17
+          Type: 3 BaseType uint8
+        - Name: s
+          Offset: 18
+          Type: 3 BaseType uint8
+        - Name: t
+          Offset: 19
+          Type: 3 BaseType uint8
+        - Name: u
+          Offset: 20
+          Type: 3 BaseType uint8
+        - Name: v
+          Offset: 21
+          Type: 3 BaseType uint8
+        - Name: w
+          Offset: 22
+          Type: 3 BaseType uint8
+        - Name: x
+          Offset: 23
+          Type: 3 BaseType uint8
+        - Name: y
+          Offset: 24
+          Type: 3 BaseType uint8
+        - Name: z
+          Offset: 25
+          Type: 3 BaseType uint8
+    - __kind: StructureType
       ID: 249
       Name: main.mixedStruct
       ByteSize: 24
@@ -22440,6 +22791,21 @@ Types:
         - Name: c
           Offset: 16
           Type: 9 BaseType int
+    - __kind: StructureType
+      ID: 318
+      Name: main.nStruct
+      ByteSize: 24
+      GoKind: 25
+      RawFields:
+        - Name: aBool
+          Offset: 0
+          Type: 4 BaseType bool
+        - Name: aInt
+          Offset: 8
+          Type: 9 BaseType int
+        - Name: aInt16
+          Offset: 16
+          Type: 89 BaseType int16
     - __kind: StructureType
       ID: 116
       Name: main.nestedStruct
@@ -22476,7 +22842,13 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1063
+      ID: 317
+      Name: main.receiver
+      ByteSize: 8
+      GoKind: 25
+      RawFields: [{Name: u, Offset: 0, Type: 12 BaseType uint}]
+    - __kind: StructureType
+      ID: 1080
       Name: main.secondBehavior
       ByteSize: 8
       GoRuntimeType: 1.232288e+06
@@ -22496,7 +22868,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1051
+      ID: 1068
       Name: main.somethingImpl
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -22507,31 +22879,31 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1048 PointerType *main.stringType1.str
+          Type: 1065 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 1047 GoStringDataType main.stringType1.str
+      Data: 1064 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 1047
+      ID: 1064
       Name: main.stringType1.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 1049
+      ID: 1066
       Name: main.stringType2
       ByteSize: 16
       GoKind: 24
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1128 PointerType *main.stringType2.str
+          Type: 1145 PointerType *main.stringType2.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 1127 GoStringDataType main.stringType2.str
+      Data: 1144 GoStringDataType main.stringType2.str
     - __kind: GoStringDataType
-      ID: 1127
+      ID: 1144
       Name: main.stringType2.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -22628,6 +23000,21 @@ Types:
           Offset: 1
           Type: 4 BaseType bool
     - __kind: StructureType
+      ID: 330
+      Name: main.structWithTwoArrays
+      ByteSize: 72
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 331 ArrayType [3]uint64
+        - Name: b
+          Offset: 24
+          Type: 3 BaseType uint8
+        - Name: c
+          Offset: 32
+          Type: 332 ArrayType [5]int64
+    - __kind: StructureType
       ID: 240
       Name: main.structWithTwoValues
       ByteSize: 16
@@ -22647,23 +23034,74 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1064 PointerType **main.t
+          Type: 1081 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1065 GoSliceDataType main.t.array
+      Data: 1082 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 1065
+      ID: 1082
       Name: main.t.array
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 243 PointerType *main.t
     - __kind: StructureType
+      ID: 322
+      Name: main.tenStrings
+      ByteSize: 160
+      GoKind: 25
+      RawFields:
+        - Name: first
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+        - Name: second
+          Offset: 16
+          Type: 11 GoStringHeaderType string
+        - Name: third
+          Offset: 32
+          Type: 11 GoStringHeaderType string
+        - Name: fourth
+          Offset: 48
+          Type: 11 GoStringHeaderType string
+        - Name: fifth
+          Offset: 64
+          Type: 11 GoStringHeaderType string
+        - Name: sixth
+          Offset: 80
+          Type: 11 GoStringHeaderType string
+        - Name: seventh
+          Offset: 96
+          Type: 11 GoStringHeaderType string
+        - Name: eighth
+          Offset: 112
+          Type: 11 GoStringHeaderType string
+        - Name: ninth
+          Offset: 128
+          Type: 11 GoStringHeaderType string
+        - Name: tenth
+          Offset: 144
+          Type: 11 GoStringHeaderType string
+    - __kind: StructureType
       ID: 263
       Name: main.threeStringStruct
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+        - Name: b
+          Offset: 16
+          Type: 11 GoStringHeaderType string
+        - Name: c
+          Offset: 32
+          Type: 11 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 320
+      Name: main.threestrings
       ByteSize: 48
       GoKind: 25
       RawFields:
@@ -22756,26 +23194,26 @@ Types:
       GoKind: 21
       HeaderType: 139 GoHMapHeaderType hash<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 1073
+      ID: 1090
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 880000
       GoKind: 21
-      HeaderType: 1075 GoHMapHeaderType hash<int,*main.deepMap3>
+      HeaderType: 1092 GoHMapHeaderType hash<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 1101
+      ID: 1118
       Name: map[int]*main.deepMap8
       ByteSize: 8
       GoRuntimeType: 879520
       GoKind: 21
-      HeaderType: 1103 GoHMapHeaderType hash<int,*main.deepMap8>
+      HeaderType: 1120 GoHMapHeaderType hash<int,*main.deepMap8>
     - __kind: GoMapType
-      ID: 1110
+      ID: 1127
       Name: map[int]*main.deepMap9
       ByteSize: 8
       GoRuntimeType: 879424
       GoKind: 21
-      HeaderType: 1112 GoHMapHeaderType hash<int,*main.deepMap9>
+      HeaderType: 1129 GoHMapHeaderType hash<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 161
       Name: map[int]int
@@ -22784,12 +23222,12 @@ Types:
       GoKind: 21
       HeaderType: 163 GoHMapHeaderType hash<int,int>
     - __kind: GoMapType
-      ID: 1119
+      ID: 1136
       Name: map[int]interface {}
       ByteSize: 8
       GoRuntimeType: 879328
       GoKind: 21
-      HeaderType: 1121 GoHMapHeaderType hash<int,interface {}>
+      HeaderType: 1138 GoHMapHeaderType hash<int,interface {}>
     - __kind: GoMapType
       ID: 228
       Name: map[int]struct {}
@@ -22897,7 +23335,7 @@ Types:
       GoKind: 21
       HeaderType: 205 GoHMapHeaderType hash<uint8,uint8>
     - __kind: StructureType
-      ID: 579
+      ID: 596
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1.247968e+06
@@ -22907,7 +23345,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 868
+      ID: 885
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
       GoRuntimeType: 1.244768e+06
@@ -22917,11 +23355,11 @@ Types:
           Offset: 0
           Type: 124 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 781
+      ID: 798
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 844
+      ID: 861
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1.406112e+06
@@ -22934,35 +23372,35 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 807
+      ID: 824
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1006
+      ID: 1023
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 805
+      ID: 822
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 783
+      ID: 800
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1016
+      ID: 1033
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1026
+      ID: 1043
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1014
+      ID: 1031
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 742
+      ID: 759
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1.072256e+06
@@ -22970,28 +23408,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 744 PointerType *net.UnknownNetworkError.str
+          Type: 761 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 743 GoStringDataType net.UnknownNetworkError.str
+      Data: 760 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 743
+      ID: 760
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 711
+      ID: 728
       Name: net.canceledError
       GoRuntimeType: 1.196512e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 984
+      ID: 1001
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 849
+      ID: 866
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 1.968704e+06
@@ -22999,7 +23437,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 844 GoInterfaceType net.Conn
+          Type: 861 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 18 GoInterfaceType error
@@ -23010,27 +23448,27 @@ Types:
           Offset: 33
           Type: 4 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 1028
+      ID: 1045
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 1022
+      ID: 1039
       Name: net.noReadFrom
       GoRuntimeType: 1.072512e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1021
+      ID: 1038
       Name: net.noWriteTo
       GoRuntimeType: 1.072384e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 514
+      ID: 531
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
-      ID: 516
+      ID: 533
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1.604128e+06
@@ -23038,7 +23476,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 832 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 849 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 11 GoStringHeaderType string
@@ -23046,7 +23484,7 @@ Types:
           Offset: 96
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 1010
+      ID: 1027
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.145024e+06
@@ -23054,12 +23492,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1022 StructureType net.noReadFrom
+          Type: 1039 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 1015 PointerType *net.TCPConn
+          Type: 1032 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 1008
+      ID: 1025
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.14448e+06
@@ -23067,24 +23505,24 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1021 StructureType net.noWriteTo
+          Type: 1038 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 1015 PointerType *net.TCPConn
+          Type: 1032 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 785
+      ID: 802
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 809
+      ID: 826
       Name: net.timeoutError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 701
+      ID: 718
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: StructureType
-      ID: 862
+      ID: 879
       Name: net/http.bufioFlushWriter
       ByteSize: 16
       GoRuntimeType: 1.236288e+06
@@ -23094,19 +23532,19 @@ Types:
           Offset: 0
           Type: 124 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 411
+      ID: 428
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 762496
       GoKind: 10
     - __kind: BaseType
-      ID: 821
+      ID: 838
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 949440
       GoKind: 10
     - __kind: StructureType
-      ID: 492
+      ID: 509
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1.602208e+06
@@ -23117,12 +23555,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 821 BaseType net/http.http2ErrCode
+          Type: 838 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 801
+      ID: 818
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1.767584e+06
@@ -23133,12 +23571,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 821 BaseType net/http.http2ErrCode
+          Type: 838 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 496
+      ID: 513
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1.405632e+06
@@ -23146,16 +23584,16 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 821 BaseType net/http.http2ErrCode
+          Type: 838 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 924
+      ID: 941
       Name: net/http.http2dataBuffer
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 415
+      ID: 432
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 762688
@@ -23163,18 +23601,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 417 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 434 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 416 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 433 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 416
+      ID: 433
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 421
+      ID: 438
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 762880
@@ -23182,18 +23620,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 423 PointerType *net/http.http2headerFieldNameError.str
+          Type: 440 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 422 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 439 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 422
+      ID: 439
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 418
+      ID: 435
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 762784
@@ -23201,32 +23639,32 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 420 PointerType *net/http.http2headerFieldValueError.str
+          Type: 437 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 419 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 436 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 419
+      ID: 436
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 776
+      ID: 793
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 707
+      ID: 724
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1.195872e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 975
+      ID: 992
       Name: net/http.http2pipe
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 412
+      ID: 429
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 762592
@@ -23234,18 +23672,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 414 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 431 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 413 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 430 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 413
+      ID: 430
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 864
+      ID: 881
       Name: net/http.http2stickyErrWriter
       ByteSize: 32
       GoRuntimeType: 1.602976e+06
@@ -23253,22 +23691,22 @@ Types:
       RawFields:
         - Name: conn
           Offset: 0
-          Type: 844 GoInterfaceType net.Conn
+          Type: 861 GoInterfaceType net.Conn
         - Name: timeout
           Offset: 16
-          Type: 943 BaseType time.Duration
+          Type: 960 BaseType time.Duration
         - Name: err
           Offset: 24
           Type: 99 PointerType *error
     - __kind: ArrayType
-      ID: 944
+      ID: 961
       Name: net/http.incomparable
       GoRuntimeType: 831136
       GoKind: 17
       HasCount: true
       Element: 57 GoSubroutineType func()
     - __kind: StructureType
-      ID: 703
+      ID: 720
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1.36752e+06
@@ -23278,11 +23716,11 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 926
+      ID: 943
       Name: net/http.persistConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 882
+      ID: 899
       Name: net/http.persistConnWriter
       ByteSize: 8
       GoRuntimeType: 1.36736e+06
@@ -23290,9 +23728,9 @@ Types:
       RawFields:
         - Name: pc
           Offset: 0
-          Type: 925 PointerType *net/http.persistConn
+          Type: 942 PointerType *net/http.persistConn
     - __kind: StructureType
-      ID: 908
+      ID: 925
       Name: net/http.readWriteCloserBody
       ByteSize: 24
       GoRuntimeType: 1.674272e+06
@@ -23300,15 +23738,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 944 ArrayType net/http.incomparable
+          Type: 961 ArrayType net/http.incomparable
         - Name: br
           Offset: 0
-          Type: 945 PointerType *bufio.Reader
+          Type: 962 PointerType *bufio.Reader
         - Name: ReadWriteCloser
           Offset: 8
-          Type: 947 GoInterfaceType io.ReadWriteCloser
+          Type: 964 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 500
+      ID: 517
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1.237248e+06
@@ -23318,17 +23756,17 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 803
+      ID: 820
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 774
+      ID: 791
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1.296416e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 705
+      ID: 722
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1.36768e+06
@@ -23338,11 +23776,11 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 489
+      ID: 506
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 977
+      ID: 994
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
       GoRuntimeType: 1.905824e+06
@@ -23350,13 +23788,13 @@ Types:
       RawFields:
         - Name: Writer
           Offset: 0
-          Type: 970 PointerType *bufio.Writer
+          Type: 987 PointerType *bufio.Writer
     - __kind: UnresolvedPointeeType
-      ID: 892
+      ID: 909
       Name: net/http/internal.chunkedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 571
+      ID: 588
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1.607968e+06
@@ -23372,7 +23810,7 @@ Types:
           Offset: 32
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 569
+      ID: 586
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1.407552e+06
@@ -23385,11 +23823,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 934
+      ID: 951
       Name: net/smtp.Client
       ByteSize: 8
     - __kind: StructureType
-      ID: 894
+      ID: 911
       Name: net/smtp.dataCloser
       ByteSize: 24
       GoRuntimeType: 1.409472e+06
@@ -23397,16 +23835,16 @@ Types:
       RawFields:
         - Name: c
           Offset: 0
-          Type: 933 PointerType *net/smtp.Client
+          Type: 950 PointerType *net/smtp.Client
         - Name: WriteCloser
           Offset: 8
-          Type: 935 GoInterfaceType io.WriteCloser
+          Type: 952 GoInterfaceType io.WriteCloser
     - __kind: UnresolvedPointeeType
-      ID: 555
+      ID: 572
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 446
+      ID: 463
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 765472
@@ -23414,26 +23852,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 448 PointerType *net/textproto.ProtocolError.str
+          Type: 465 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 447 GoStringDataType net/textproto.ProtocolError.str
+      Data: 464 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 447
+      ID: 464
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 890
+      ID: 907
       Name: net/textproto.dotWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 811
+      ID: 828
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 424
+      ID: 441
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 763456
@@ -23441,18 +23879,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 426 PointerType *net/url.EscapeError.str
+          Type: 443 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 425 GoStringDataType net/url.EscapeError.str
+      Data: 442 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 425
+      ID: 442
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 427
+      ID: 444
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 763552
@@ -23460,30 +23898,30 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 429 PointerType *net/url.InvalidHostError.str
+          Type: 446 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 428 GoStringDataType net/url.InvalidHostError.str
+      Data: 445 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 428
+      ID: 445
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1034
+      ID: 1051
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 682
+      ID: 699
       Name: os.LinkError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 746
+      ID: 763
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1032
+      ID: 1049
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.213216e+06
@@ -23491,12 +23929,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1038 StructureType os.noReadFrom
+          Type: 1055 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 1033 PointerType *os.File
+          Type: 1050 PointerType *os.File
     - __kind: StructureType
-      ID: 1030
+      ID: 1047
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.212416e+06
@@ -23504,36 +23942,36 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1037 StructureType os.noWriteTo
+          Type: 1054 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 1033 PointerType *os.File
+          Type: 1050 PointerType *os.File
     - __kind: StructureType
-      ID: 1038
+      ID: 1055
       Name: os.noReadFrom
       GoRuntimeType: 1.069952e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1037
+      ID: 1054
       Name: os.noWriteTo
       GoRuntimeType: 1.069824e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 713
+      ID: 730
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 852
+      ID: 869
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 912
+      ID: 929
       Name: os/exec.prefixSuffixSaver
       ByteSize: 8
     - __kind: StructureType
-      ID: 715
+      ID: 732
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1.510624e+06
@@ -23546,7 +23984,7 @@ Types:
           Offset: 16
           Type: 18 GoInterfaceType error
     - __kind: GoStringHeaderType
-      ID: 459
+      ID: 476
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 768640
@@ -23554,36 +23992,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 461 PointerType *os/user.UnknownGroupIdError.str
+          Type: 478 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 460 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 477 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 460
+      ID: 477
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 458
+      ID: 475
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 768544
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 484
+      ID: 501
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 577
+      ID: 594
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 685
+      ID: 702
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 690
+      ID: 707
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -23595,7 +24033,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 687
+      ID: 704
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1.757152e+06
@@ -23612,9 +24050,9 @@ Types:
           Type: 4 BaseType bool
         - Name: code
           Offset: 17
-          Type: 850 BaseType runtime.boundsErrorCode
+          Type: 867 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 850
+      ID: 867
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 532800
@@ -23634,7 +24072,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 748
+      ID: 765
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1.628096e+06
@@ -23647,7 +24085,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 666
+      ID: 683
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 948288
@@ -23655,13 +24093,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 668 PointerType *runtime.errorString.str
+          Type: 685 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 667 GoStringDataType runtime.errorString.str
+      Data: 684 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 667
+      ID: 684
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -24287,7 +24725,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 669
+      ID: 686
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 948864
@@ -24295,13 +24733,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 671 PointerType *runtime.plainError.str
+          Type: 688 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 670 GoStringDataType runtime.plainError.str
+      Data: 687 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 670
+      ID: 687
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -24383,7 +24821,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 692
+      ID: 709
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -24395,26 +24833,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 318 PointerType *string.str
+          Type: 335 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 317 GoStringDataType string.str
+      Data: 334 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 317
+      ID: 334
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 973
+      ID: 990
       Name: strings.Builder
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 880
+      ID: 897
       Name: strings.appendSliceWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 876
+      ID: 893
       Name: struct { io.Writer }
       ByteSize: 16
       GoRuntimeType: 1.273216e+06
@@ -24430,7 +24868,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1052
+      ID: 1069
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.281856e+06
@@ -24443,7 +24881,7 @@ Types:
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1053
+      ID: 1070
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.282976e+06
@@ -24451,12 +24889,12 @@ Types:
       RawFields:
         - Name: done
           Offset: 0
-          Type: 1054 StructureType sync/atomic.Uint32
+          Type: 1071 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 1052 StructureType sync.Mutex
+          Type: 1069 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 1056
+      ID: 1073
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.421824e+06
@@ -24464,21 +24902,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 1057 StructureType sync.noCopy
+          Type: 1074 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 1058 StructureType sync/atomic.Uint64
+          Type: 1075 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1057
+      ID: 1074
       Name: sync.noCopy
       GoRuntimeType: 947232
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1060
+      ID: 1077
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.283296e+06
@@ -24486,12 +24924,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1055 StructureType sync/atomic.noCopy
+          Type: 1072 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 13 BaseType int32
     - __kind: StructureType
-      ID: 1054
+      ID: 1071
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1.283456e+06
@@ -24499,12 +24937,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1055 StructureType sync/atomic.noCopy
+          Type: 1072 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1058
+      ID: 1075
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.422208e+06
@@ -24512,37 +24950,37 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1055 StructureType sync/atomic.noCopy
+          Type: 1072 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 1059 StructureType sync/atomic.align64
+          Type: 1076 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 10 BaseType uint64
     - __kind: StructureType
-      ID: 1059
+      ID: 1076
       Name: sync/atomic.align64
       GoRuntimeType: 947424
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1055
+      ID: 1072
       Name: sync/atomic.noCopy
       GoRuntimeType: 947328
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 798
+      ID: 815
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1.195104e+06
       GoKind: 12
     - __kind: UnresolvedPointeeType
-      ID: 1004
+      ID: 1021
       Name: text/tabwriter.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 741
+      ID: 758
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1.51504e+06
@@ -24555,21 +24993,21 @@ Types:
           Offset: 16
           Type: 18 GoInterfaceType error
     - __kind: BaseType
-      ID: 943
+      ID: 960
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1.783424e+06
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 816
+      ID: 833
       Name: time.Location
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 487
+      ID: 504
       Name: time.ParseError
       ByteSize: 8
     - __kind: StructureType
-      ID: 814
+      ID: 831
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.22544e+06
@@ -24583,9 +25021,9 @@ Types:
           Type: 14 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 815 PointerType *time.Location
+          Type: 832 PointerType *time.Location
     - __kind: GoStringHeaderType
-      ID: 408
+      ID: 425
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 761632
@@ -24593,13 +25031,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 410 PointerType *time.fileSizeError.str
+          Type: 427 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 409 GoStringDataType time.fileSizeError.str
+      Data: 426 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 409
+      ID: 426
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -24646,11 +25084,11 @@ Types:
       GoRuntimeType: 532736
       GoKind: 26
     - __kind: UnresolvedPointeeType
-      ID: 967
+      ID: 984
       Name: vendor/golang.org/x/crypto/sha3.state
       ByteSize: 8
     - __kind: StructureType
-      ID: 832
+      ID: 849
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 1.927552e+06
@@ -24661,10 +25099,10 @@ Types:
           Type: 38 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 833 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 850 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 834 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 851 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: off
           Offset: 40
           Type: 9 BaseType int
@@ -24679,18 +25117,18 @@ Types:
           Type: 9 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 835 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 852 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 7 BaseType uint16
     - __kind: BaseType
-      ID: 835
+      ID: 852
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 953568
       GoKind: 9
     - __kind: StructureType
-      ID: 833
+      ID: 850
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1.79392e+06
@@ -24715,21 +25153,21 @@ Types:
           Offset: 10
           Type: 7 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 573
+      ID: 590
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 834
+      ID: 851
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 536384
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 996
+      ID: 1013
       Name: vendor/golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 557
+      ID: 574
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.245088e+06
@@ -24739,13 +25177,13 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: BaseType
-      ID: 449
+      ID: 466
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 765568
       GoKind: 2
     - __kind: StructureType
-      ID: 720
+      ID: 737
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1.510816e+06
@@ -24758,12 +25196,12 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 674
+      ID: 691
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 952416
       GoKind: 5
-MaxTypeID: 1376
+MaxTypeID: 1394
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x12cd8e0", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -11,11 +11,11 @@ Probes:
       subprogram: {subprogram: 142}
       events:
         - Kind: Entry
-          Type: 1507 EventRootType Probe[main.stackC]
+          Type: 1523 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0x84fef8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1508 EventRootType Probe[main.stackC]Return
+          Type: 1524 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0x84ff2c", Frameless: false}]
           Condition: null
       probeTemplate: {TemplateString: stackC, Segments: [stackC]}
@@ -30,11 +30,11 @@ Probes:
       subprogram: {subprogram: 56}
       events:
         - Kind: Entry
-          Type: 1371 EventRootType Probe[main.testAny]
+          Type: 1387 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0x84b458", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1372 EventRootType Probe[main.testAny]Return
+          Type: 1388 EventRootType Probe[main.testAny]Return
           InjectionPoints: [{PC: "0x84b484", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -55,11 +55,11 @@ Probes:
       subprogram: {subprogram: 58}
       events:
         - Kind: Entry
-          Type: 1374 EventRootType Probe[main.testAnyPtr]
+          Type: 1390 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0x84b4d8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1375 EventRootType Probe[main.testAnyPtr]Return
+          Type: 1391 EventRootType Probe[main.testAnyPtr]Return
           InjectionPoints: [{PC: "0x84b504", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -79,11 +79,11 @@ Probes:
       subprogram: {subprogram: 122}
       events:
         - Kind: Entry
-          Type: 1478 EventRootType Probe[main.testArrayArgAndReturn]
+          Type: 1494 EventRootType Probe[main.testArrayArgAndReturn]
           InjectionPoints: [{PC: "0x84ecfc", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1479 EventRootType Probe[main.testArrayArgAndReturn]Return
+          Type: 1495 EventRootType Probe[main.testArrayArgAndReturn]Return
           InjectionPoints: [{PC: "0x84ed94", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -104,7 +104,7 @@ Probes:
       subprogram: {subprogram: 19}
       events:
         - Kind: Entry
-          Type: 1322 EventRootType Probe[main.testArrayEmptyStructs]
+          Type: 1338 EventRootType Probe[main.testArrayEmptyStructs]
           InjectionPoints: [{PC: "0x849aa0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -125,7 +125,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - Kind: Entry
-          Type: 1318 EventRootType Probe[main.testArrayOfArrays]
+          Type: 1334 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0x849a60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -146,7 +146,7 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - Kind: Entry
-          Type: 1320 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          Type: 1336 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0x849a80", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -167,7 +167,7 @@ Probes:
       subprogram: {subprogram: 66}
       events:
         - Kind: Entry
-          Type: 1383 EventRootType Probe[main.testArrayOfMaps]
+          Type: 1399 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0x84bb40", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -188,7 +188,7 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - Kind: Entry
-          Type: 1319 EventRootType Probe[main.testArrayOfStrings]
+          Type: 1335 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0x849a70", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -208,7 +208,7 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - Kind: Entry
-          Type: 1321 EventRootType Probe[main.testArrayOfStructs]
+          Type: 1337 EventRootType Probe[main.testArrayOfStructs]
           InjectionPoints: [{PC: "0x849a90", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -229,11 +229,11 @@ Probes:
       subprogram: {subprogram: 86}
       events:
         - Kind: Entry
-          Type: 1405 EventRootType Probe[main.testAtomicAdd]
+          Type: 1421 EventRootType Probe[main.testAtomicAdd]
           InjectionPoints: [{PC: "0x84d2e0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1406 EventRootType Probe[main.testAtomicAdd]Return
+          Type: 1422 EventRootType Probe[main.testAtomicAdd]Return
           InjectionPoints: [{PC: "0x84d31c", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -254,11 +254,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 1340 EventRootType Probe[main.testBigStruct]
+          Type: 1356 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0x849ff0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1341 EventRootType Probe[main.testBigStruct]Return
+          Type: 1357 EventRootType Probe[main.testBigStruct]Return
           InjectionPoints: [{PC: "0x84a008", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -279,7 +279,7 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - Kind: Entry
-          Type: 1307 EventRootType Probe[main.testBoolArray]
+          Type: 1323 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0x8499b0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -300,7 +300,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - Kind: Entry
-          Type: 1304 EventRootType Probe[main.testByteArray]
+          Type: 1320 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0x849980", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -326,11 +326,11 @@ Probes:
       subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1526 EventRootType Probe[main.testStruct]
+          Type: 1542 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0x850250", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1527 EventRootType Probe[main.testStruct]Return
+          Type: 1543 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0x85026c", Frameless: true}]
           Condition: null
     - id: testCaptureExprLine
@@ -345,10 +345,10 @@ Probes:
       segments: []
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1536 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1553 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0x84ad18"
               Frameless: false
@@ -373,10 +373,10 @@ Probes:
       segments: [x=, {json: {ref: x}, dsl: x}]
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1537 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1554 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0x84ad18"
               Frameless: false
@@ -412,7 +412,7 @@ Probes:
       subprogram: {subprogram: 84}
       events:
         - Kind: Entry
-          Type: 1402 EventRootType Probe[main.testCombinedString]
+          Type: 1418 EventRootType Probe[main.testCombinedString]
           InjectionPoints: [{PC: "0x84d080", Frameless: true}]
           Condition: null
     - id: testCaptureExprWithTemplate
@@ -430,7 +430,7 @@ Probes:
       subprogram: {subprogram: 84}
       events:
         - Kind: Entry
-          Type: 1403 EventRootType Probe[main.testCombinedString]
+          Type: 1419 EventRootType Probe[main.testCombinedString]
           InjectionPoints: [{PC: "0x84d080", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -452,7 +452,7 @@ Probes:
       subprogram: {subprogram: 87}
       events:
         - Kind: Entry
-          Type: 1407 EventRootType Probe[main.testChannel]
+          Type: 1423 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0x84d320", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -481,7 +481,7 @@ Probes:
       subprogram: {subprogram: 83}
       events:
         - Kind: Entry
-          Type: 1401 EventRootType Probe[main.testCombinedByte]
+          Type: 1417 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0x84d060", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -512,7 +512,7 @@ Probes:
       subprogram: {subprogram: 95}
       events:
         - Kind: Entry
-          Type: 1415 EventRootType Probe[main.testCycle]
+          Type: 1431 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0x84d5d0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -533,7 +533,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - Kind: Entry
-          Type: 1346 EventRootType Probe[main.testDeepMap1]
+          Type: 1362 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0x84a3d0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -554,7 +554,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - Kind: Entry
-          Type: 1347 EventRootType Probe[main.testDeepMap7]
+          Type: 1363 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0x84a3e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -575,7 +575,7 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - Kind: Entry
-          Type: 1342 EventRootType Probe[main.testDeepPtr1]
+          Type: 1358 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0x84a0c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -596,7 +596,7 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - Kind: Entry
-          Type: 1343 EventRootType Probe[main.testDeepPtr7]
+          Type: 1359 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0x84a0d0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -617,7 +617,7 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - Kind: Entry
-          Type: 1344 EventRootType Probe[main.testDeepSlice1]
+          Type: 1360 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0x84a270", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -638,7 +638,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - Kind: Entry
-          Type: 1345 EventRootType Probe[main.testDeepSlice7]
+          Type: 1361 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0x84a280", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -659,7 +659,7 @@ Probes:
       subprogram: {subprogram: 131}
       events:
         - Kind: Entry
-          Type: 1495 EventRootType Probe[main.testEmptySlice]
+          Type: 1511 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0x84fb20", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -685,7 +685,7 @@ Probes:
       subprogram: {subprogram: 134}
       events:
         - Kind: Entry
-          Type: 1498 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 1514 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0x84fb50", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -712,7 +712,7 @@ Probes:
       subprogram: {subprogram: 150}
       events:
         - Kind: Entry
-          Type: 1521 EventRootType Probe[main.testEmptyString]
+          Type: 1537 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0x84ffd0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -733,7 +733,7 @@ Probes:
       subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1534 EventRootType Probe[main.testEmptyStruct]
+          Type: 1550 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0x850350", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -753,7 +753,7 @@ Probes:
       subprogram: {subprogram: 157}
       events:
         - Kind: Entry
-          Type: 1535 EventRootType Probe[main.testEmptyStructPointer]
+          Type: 1551 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0x850360", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -774,7 +774,7 @@ Probes:
       subprogram: {subprogram: 57}
       events:
         - Kind: Entry
-          Type: 1373 EventRootType Probe[main.testError]
+          Type: 1389 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0x84b4b0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -795,11 +795,11 @@ Probes:
       subprogram: {subprogram: 48}
       events:
         - Kind: Entry
-          Type: 1355 EventRootType Probe[main.testEsotericHeap]
+          Type: 1371 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0x84aa78", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1356 EventRootType Probe[main.testEsotericHeap]Return
+          Type: 1372 EventRootType Probe[main.testEsotericHeap]Return
           InjectionPoints: [{PC: "0x84aab4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -820,11 +820,11 @@ Probes:
       subprogram: {subprogram: 47}
       events:
         - Kind: Entry
-          Type: 1353 EventRootType Probe[main.testEsotericStack]
+          Type: 1369 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0x84a9ac", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1354 EventRootType Probe[main.testEsotericStack]Return
+          Type: 1370 EventRootType Probe[main.testEsotericStack]Return
           InjectionPoints: [{PC: "0x84aa1c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -845,11 +845,11 @@ Probes:
       subprogram: {subprogram: 53}
       events:
         - Kind: Entry
-          Type: 1365 EventRootType Probe[main.testFrameless]
+          Type: 1381 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0x84b190", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1366 EventRootType Probe[main.testFrameless]Return
+          Type: 1382 EventRootType Probe[main.testFrameless]Return
           InjectionPoints: [{PC: "0x84b198", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -870,11 +870,11 @@ Probes:
       subprogram: {subprogram: 54}
       events:
         - Kind: Entry
-          Type: 1367 EventRootType Probe[main.testFramelessArray]
+          Type: 1383 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0x84b1ac", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1368 EventRootType Probe[main.testFramelessArray]Return
+          Type: 1384 EventRootType Probe[main.testFramelessArray]Return
           InjectionPoints: [{PC: "0x84b1e8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -898,7 +898,7 @@ Probes:
       subprogram: {subprogram: 54}
       events:
         - Kind: Line
-          Type: 1369 EventRootType Probe[main.testFramelessArray]Line
+          Type: 1385 EventRootType Probe[main.testFramelessArray]Line
           InjectionPoints: [{PC: "0x84b1ac", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -919,11 +919,11 @@ Probes:
       subprogram: {subprogram: 49}
       events:
         - Kind: Entry
-          Type: 1357 EventRootType Probe[main.testInlinedBA]
+          Type: 1373 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0x84aeb8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1358 EventRootType Probe[main.testInlinedBA]Return
+          Type: 1374 EventRootType Probe[main.testInlinedBA]Return
           InjectionPoints: [{PC: "0x84af10", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -949,11 +949,11 @@ Probes:
       subprogram: {subprogram: 50}
       events:
         - Kind: Entry
-          Type: 1359 EventRootType Probe[main.testInlinedBB]
+          Type: 1375 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0x84af48", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1360 EventRootType Probe[main.testInlinedBB]Return
+          Type: 1376 EventRootType Probe[main.testInlinedBB]Return
           InjectionPoints: [{PC: "0x84afd0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -979,11 +979,11 @@ Probes:
       subprogram: {subprogram: 51}
       events:
         - Kind: Entry
-          Type: 1361 EventRootType Probe[main.testInlinedBBA]
+          Type: 1377 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0x84b008", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1362 EventRootType Probe[main.testInlinedBBA]Return
+          Type: 1378 EventRootType Probe[main.testInlinedBBA]Return
           InjectionPoints: [{PC: "0x84b044", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1001,10 +1001,10 @@ Probes:
       template: testInlinedBBB
       segments: [testInlinedBBB]
       captureSnapshot: true
-      subprogram: {subprogram: 159}
+      subprogram: {subprogram: 160}
       events:
         - Kind: Entry
-          Type: 1541 EventRootType Probe[main.testInlinedBBB]
+          Type: 1558 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x84af98", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1021,11 +1021,11 @@ Probes:
       subprogram: {subprogram: 52}
       events:
         - Kind: Entry
-          Type: 1363 EventRootType Probe[main.testInlinedBC]
+          Type: 1379 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0x84b088", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1364 EventRootType Probe[main.testInlinedBC]Return
+          Type: 1380 EventRootType Probe[main.testInlinedBC]Return
           InjectionPoints: [{PC: "0x84b178", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1039,10 +1039,10 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Entry
-          Type: 1542 EventRootType Probe[main.testInlinedBCA]
+          Type: 1559 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x84b08c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1059,10 +1059,10 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Line
-          Type: 1543 EventRootType Probe[main.testInlinedBCA]Line
+          Type: 1560 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0x84b08c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1076,10 +1076,10 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Entry
-          Type: 1544 EventRootType Probe[main.testInlinedBCB]
+          Type: 1561 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x84b140", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1096,10 +1096,10 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Line
-          Type: 1545 EventRootType Probe[main.testInlinedBCB]Line
+          Type: 1562 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0x84b140", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1113,10 +1113,10 @@ Probes:
       template: testInlinedFuncFromOtherPackage
       segments: [testInlinedFuncFromOtherPackage]
       captureSnapshot: true
-      subprogram: {subprogram: 165}
+      subprogram: {subprogram: 166}
       events:
         - Kind: Entry
-          Type: 1551 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
+          Type: 1568 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
           InjectionPoints:
             - PC: "0x8494b8"
               Frameless: true
@@ -1135,10 +1135,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Entry
-          Type: 1538 EventRootType Probe[main.testInlinedPrint]
+          Type: 1555 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x84ad18"
               Frameless: false
@@ -1152,7 +1152,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1539 EventRootType Probe[main.testInlinedPrint]Return
+          Type: 1556 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0x84ad50", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1173,10 +1173,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1540 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1557 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0x84ad18"
               Frameless: false
@@ -1204,10 +1204,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 162}
+      subprogram: {subprogram: 163}
       events:
         - Kind: Entry
-          Type: 1546 EventRootType Probe[main.testInlinedSq]
+          Type: 1563 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x84b194", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1228,10 +1228,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 162}
+      subprogram: {subprogram: 163}
       events:
         - Kind: Line
-          Type: 1547 EventRootType Probe[main.testInlinedSq]Line
+          Type: 1564 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0x84b194", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1250,10 +1250,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 163}
+      subprogram: {subprogram: 164}
       events:
         - Kind: Entry
-          Type: 1548 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1565 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0x84b1c4"
               Frameless: false
@@ -1278,7 +1278,7 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - Kind: Entry
-          Type: 1310 EventRootType Probe[main.testInt16Array]
+          Type: 1326 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0x8499e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1299,7 +1299,7 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - Kind: Entry
-          Type: 1311 EventRootType Probe[main.testInt32Array]
+          Type: 1327 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0x8499f0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1320,7 +1320,7 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - Kind: Entry
-          Type: 1312 EventRootType Probe[main.testInt64Array]
+          Type: 1328 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0x849a00", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1341,7 +1341,7 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - Kind: Entry
-          Type: 1309 EventRootType Probe[main.testInt8Array]
+          Type: 1325 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0x8499d0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1362,7 +1362,7 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - Kind: Entry
-          Type: 1308 EventRootType Probe[main.testIntArray]
+          Type: 1324 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0x8499c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1383,7 +1383,7 @@ Probes:
       subprogram: {subprogram: 55}
       events:
         - Kind: Entry
-          Type: 1370 EventRootType Probe[main.testInterface]
+          Type: 1386 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0x84b430", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1403,11 +1403,11 @@ Probes:
       subprogram: {subprogram: 121}
       events:
         - Kind: Entry
-          Type: 1476 EventRootType Probe[main.testLargeArgAndReturn]
+          Type: 1492 EventRootType Probe[main.testLargeArgAndReturn]
           InjectionPoints: [{PC: "0x84eb40", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1477 EventRootType Probe[main.testLargeArgAndReturn]Return
+          Type: 1493 EventRootType Probe[main.testLargeArgAndReturn]Return
           InjectionPoints: [{PC: "0x84ec98", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1417,6 +1417,49 @@ Probes:
               DSL: arg
               EventKind: Entry
               EventExpressionIndex: 1
+    - id: testLineProbeTemplateWithStructFields
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.executeStructFuncs
+        sourceFile: structs.go
+        lines: ["208"]
+      template: 'sta.a: {sta.a} sta.b: {sta.b} sta.c: {sta.c}'
+      segments:
+        - 'sta.a: '
+        - json: {getmember: [{ref: sta}, a]}
+          dsl: sta.a
+        - ' sta.b: '
+        - json: {getmember: [{ref: sta}, b]}
+          dsl: sta.b
+        - ' sta.c: '
+        - json: {getmember: [{ref: sta}, c]}
+          dsl: sta.c
+      captureSnapshot: false
+      subprogram: {subprogram: 158}
+      events:
+        - Kind: Line
+          Type: 1552 EventRootType Probe[main.executeStructFuncs]Line
+          InjectionPoints: [{PC: "0x8507c8", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: 'sta.a: {sta.a} sta.b: {sta.b} sta.c: {sta.c}'
+        Segments:
+            - 'sta.a: '
+            - JSON: {Base: {Ref: sta}, Member: a}
+              DSL: sta.a
+              EventKind: Line
+              EventExpressionIndex: 0
+            - ' sta.b: '
+            - JSON: {Base: {Ref: sta}, Member: b}
+              DSL: sta.b
+              EventKind: Line
+              EventExpressionIndex: 1
+            - ' sta.c: '
+            - JSON: {Base: {Ref: sta}, Member: c}
+              DSL: sta.c
+              EventKind: Line
+              EventExpressionIndex: 2
     - id: testLinkedList
       version: 0
       type: LOG_PROBE
@@ -1428,7 +1471,7 @@ Probes:
       subprogram: {subprogram: 89}
       events:
         - Kind: Entry
-          Type: 1409 EventRootType Probe[main.testLinkedList]
+          Type: 1425 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0x84d4e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1452,7 +1495,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - Kind: Line
-          Type: 1350 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          Type: 1366 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x84a42c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1473,7 +1516,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - Kind: Line
-          Type: 1351 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          Type: 1367 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x84a4bc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1494,7 +1537,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - Kind: Line
-          Type: 1352 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          Type: 1368 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x84a564", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1536,11 +1579,11 @@ Probes:
       subprogram: {subprogram: 124}
       events:
         - Kind: Entry
-          Type: 1482 EventRootType Probe[main.testManyArgsArrayReturn]
+          Type: 1498 EventRootType Probe[main.testManyArgsArrayReturn]
           InjectionPoints: [{PC: "0x84effc", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1483 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          Type: 1499 EventRootType Probe[main.testManyArgsArrayReturn]Return
           InjectionPoints: [{PC: "0x84f168", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1601,7 +1644,7 @@ Probes:
       subprogram: {subprogram: 64}
       events:
         - Kind: Entry
-          Type: 1381 EventRootType Probe[main.testMapArrayToArray]
+          Type: 1397 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0x84bb20", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1622,7 +1665,7 @@ Probes:
       subprogram: {subprogram: 70}
       events:
         - Kind: Entry
-          Type: 1388 EventRootType Probe[main.testMapEmbeddedMaps]
+          Type: 1404 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0x84bb80", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1643,7 +1686,7 @@ Probes:
       subprogram: {subprogram: 80}
       events:
         - Kind: Entry
-          Type: 1398 EventRootType Probe[main.testMapEmptyKey]
+          Type: 1414 EventRootType Probe[main.testMapEmptyKey]
           InjectionPoints: [{PC: "0x84bc20", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1664,7 +1707,7 @@ Probes:
       subprogram: {subprogram: 82}
       events:
         - Kind: Entry
-          Type: 1400 EventRootType Probe[main.testMapEmptyKeyAndValue]
+          Type: 1416 EventRootType Probe[main.testMapEmptyKeyAndValue]
           InjectionPoints: [{PC: "0x84bc40", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1685,7 +1728,7 @@ Probes:
       subprogram: {subprogram: 81}
       events:
         - Kind: Entry
-          Type: 1399 EventRootType Probe[main.testMapEmptyValue]
+          Type: 1415 EventRootType Probe[main.testMapEmptyValue]
           InjectionPoints: [{PC: "0x84bc30", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1706,7 +1749,7 @@ Probes:
       subprogram: {subprogram: 68}
       events:
         - Kind: Entry
-          Type: 1385 EventRootType Probe[main.testMapIntToInt]
+          Type: 1401 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0x84bb60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1727,7 +1770,7 @@ Probes:
       subprogram: {subprogram: 79}
       events:
         - Kind: Entry
-          Type: 1397 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          Type: 1413 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0x84bc10", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1748,7 +1791,7 @@ Probes:
       subprogram: {subprogram: 78}
       events:
         - Kind: Entry
-          Type: 1396 EventRootType Probe[main.testMapLargeKeySmallValue]
+          Type: 1412 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0x84bc00", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1771,7 +1814,7 @@ Probes:
       subprogram: {subprogram: 69}
       events:
         - Kind: Entry
-          Type: 1386 EventRootType Probe[main.testMapMassive]
+          Type: 1402 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0x84bb70", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1794,7 +1837,7 @@ Probes:
       subprogram: {subprogram: 69}
       events:
         - Kind: Entry
-          Type: 1387 EventRootType Probe[main.testMapMassive]
+          Type: 1403 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0x84bb70", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1815,7 +1858,7 @@ Probes:
       subprogram: {subprogram: 77}
       events:
         - Kind: Entry
-          Type: 1395 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          Type: 1411 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0x84bbf0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1836,7 +1879,7 @@ Probes:
       subprogram: {subprogram: 76}
       events:
         - Kind: Entry
-          Type: 1394 EventRootType Probe[main.testMapSmallKeySmallValue]
+          Type: 1410 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0x84bbe0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1857,7 +1900,7 @@ Probes:
       subprogram: {subprogram: 62}
       events:
         - Kind: Entry
-          Type: 1379 EventRootType Probe[main.testMapStringToInt]
+          Type: 1395 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0x84bb00", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1878,7 +1921,7 @@ Probes:
       subprogram: {subprogram: 63}
       events:
         - Kind: Entry
-          Type: 1380 EventRootType Probe[main.testMapStringToSlice]
+          Type: 1396 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0x84bb10", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1899,7 +1942,7 @@ Probes:
       subprogram: {subprogram: 61}
       events:
         - Kind: Entry
-          Type: 1378 EventRootType Probe[main.testMapStringToStruct]
+          Type: 1394 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0x84baf0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1920,7 +1963,7 @@ Probes:
       subprogram: {subprogram: 71}
       events:
         - Kind: Entry
-          Type: 1389 EventRootType Probe[main.testMapWithLinkedList]
+          Type: 1405 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0x84bb90", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1941,7 +1984,7 @@ Probes:
       subprogram: {subprogram: 74}
       events:
         - Kind: Entry
-          Type: 1392 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          Type: 1408 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0x84bbc0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1962,7 +2005,7 @@ Probes:
       subprogram: {subprogram: 75}
       events:
         - Kind: Entry
-          Type: 1393 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          Type: 1409 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0x84bbd0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1983,7 +2026,7 @@ Probes:
       subprogram: {subprogram: 72}
       events:
         - Kind: Entry
-          Type: 1390 EventRootType Probe[main.testMapWithSmallValue]
+          Type: 1406 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0x84bba0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2006,7 +2049,7 @@ Probes:
       subprogram: {subprogram: 73}
       events:
         - Kind: Entry
-          Type: 1391 EventRootType Probe[main.testMapWithSmallValueMassive]
+          Type: 1407 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0x84bbb0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2027,7 +2070,7 @@ Probes:
       subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1518 EventRootType Probe[main.testMassiveString]
+          Type: 1534 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x84ffb0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2049,7 +2092,7 @@ Probes:
       subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1519 EventRootType Probe[main.testMassiveString]
+          Type: 1535 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x84ffb0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2095,11 +2138,11 @@ Probes:
       subprogram: {subprogram: 125}
       events:
         - Kind: Entry
-          Type: 1484 EventRootType Probe[main.testMixedArgsStackReturn]
+          Type: 1500 EventRootType Probe[main.testMixedArgsStackReturn]
           InjectionPoints: [{PC: "0x84f1d0", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1485 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          Type: 1501 EventRootType Probe[main.testMixedArgsStackReturn]Return
           InjectionPoints: [{PC: "0x84f37c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2164,11 +2207,11 @@ Probes:
       subprogram: {subprogram: 127}
       events:
         - Kind: Entry
-          Type: 1488 EventRootType Probe[main.testMultipleArrayArgs]
+          Type: 1504 EventRootType Probe[main.testMultipleArrayArgs]
           InjectionPoints: [{PC: "0x84f47c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1489 EventRootType Probe[main.testMultipleArrayArgs]Return
+          Type: 1505 EventRootType Probe[main.testMultipleArrayArgs]Return
           InjectionPoints: [{PC: "0x84f524", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2198,11 +2241,11 @@ Probes:
       subprogram: {subprogram: 123}
       events:
         - Kind: Entry
-          Type: 1480 EventRootType Probe[main.testMultipleLargeArgs]
+          Type: 1496 EventRootType Probe[main.testMultipleLargeArgs]
           InjectionPoints: [{PC: "0x84edd0", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1481 EventRootType Probe[main.testMultipleLargeArgs]Return
+          Type: 1497 EventRootType Probe[main.testMultipleLargeArgs]Return
           InjectionPoints: [{PC: "0x84efa0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2227,11 +2270,11 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1434 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1450 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x84e118", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1435 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1451 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x84e1a4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2266,7 +2309,7 @@ Probes:
       subprogram: {subprogram: 85}
       events:
         - Kind: Entry
-          Type: 1404 EventRootType Probe[main.testMultipleSimpleParams]
+          Type: 1420 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0x84d140", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2306,11 +2349,11 @@ Probes:
       subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1430 EventRootType Probe[main.testNamedReturn]
+          Type: 1446 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0x84e078", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1431 EventRootType Probe[main.testNamedReturn]Return
+          Type: 1447 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0x84e0d8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2336,11 +2379,11 @@ Probes:
       subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1432 EventRootType Probe[main.testNamedReturn]
+          Type: 1448 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0x84e078", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1433 EventRootType Probe[main.testNamedReturn]Return
+          Type: 1449 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0x84e0d8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2367,7 +2410,7 @@ Probes:
       subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1530 EventRootType Probe[main.testNestedPointer]
+          Type: 1546 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0x8502f0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2391,7 +2434,7 @@ Probes:
       subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1531 EventRootType Probe[main.testNestedPointer]
+          Type: 1547 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0x8502f0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2421,7 +2464,7 @@ Probes:
       subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1532 EventRootType Probe[main.testNestedPointer]
+          Type: 1548 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0x8502f0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2445,7 +2488,7 @@ Probes:
       subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1533 EventRootType Probe[main.testNestedPointer]
+          Type: 1549 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0x8502f0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2471,7 +2514,7 @@ Probes:
       subprogram: {subprogram: 94}
       events:
         - Kind: Entry
-          Type: 1414 EventRootType Probe[main.testNilPointer]
+          Type: 1430 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0x84d5b0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2497,7 +2540,7 @@ Probes:
       subprogram: {subprogram: 138}
       events:
         - Kind: Entry
-          Type: 1502 EventRootType Probe[main.testNilSlice]
+          Type: 1518 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0x84fb90", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2523,7 +2566,7 @@ Probes:
       subprogram: {subprogram: 135}
       events:
         - Kind: Entry
-          Type: 1499 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 1515 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0x84fb60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2557,7 +2600,7 @@ Probes:
       subprogram: {subprogram: 137}
       events:
         - Kind: Entry
-          Type: 1501 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 1517 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0x84fb80", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2588,7 +2631,7 @@ Probes:
       subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1517 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 1533 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0x84ffa0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2609,7 +2652,7 @@ Probes:
       subprogram: {subprogram: 90}
       events:
         - Kind: Entry
-          Type: 1410 EventRootType Probe[main.testPointerLoop]
+          Type: 1426 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0x84d4f0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2630,7 +2673,7 @@ Probes:
       subprogram: {subprogram: 67}
       events:
         - Kind: Entry
-          Type: 1384 EventRootType Probe[main.testPointerToMap]
+          Type: 1400 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0x84bb50", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2651,7 +2694,7 @@ Probes:
       subprogram: {subprogram: 88}
       events:
         - Kind: Entry
-          Type: 1408 EventRootType Probe[main.testPointerToSimpleStruct]
+          Type: 1424 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0x84d4d0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2672,11 +2715,11 @@ Probes:
       subprogram: {subprogram: 101}
       events:
         - Kind: Entry
-          Type: 1426 EventRootType Probe[main.testReturnsAny]
+          Type: 1442 EventRootType Probe[main.testReturnsAny]
           InjectionPoints: [{PC: "0x84dd18", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1427 EventRootType Probe[main.testReturnsAny]Return
+          Type: 1443 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints:
             - PC: "0x84ddb4"
               Frameless: false
@@ -2710,11 +2753,11 @@ Probes:
       subprogram: {subprogram: 100}
       events:
         - Kind: Entry
-          Type: 1424 EventRootType Probe[main.testReturnsAnyAndError]
+          Type: 1440 EventRootType Probe[main.testReturnsAnyAndError]
           InjectionPoints: [{PC: "0x84db98", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1425 EventRootType Probe[main.testReturnsAnyAndError]Return
+          Type: 1441 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
             - PC: "0x84dbec"
               Frameless: false
@@ -2747,11 +2790,11 @@ Probes:
       subprogram: {subprogram: 110}
       events:
         - Kind: Entry
-          Type: 1454 EventRootType Probe[main.testReturnsArray]
+          Type: 1470 EventRootType Probe[main.testReturnsArray]
           InjectionPoints: [{PC: "0x84e54c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1455 EventRootType Probe[main.testReturnsArray]Return
+          Type: 1471 EventRootType Probe[main.testReturnsArray]Return
           InjectionPoints: [{PC: "0x84e5a0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2767,11 +2810,11 @@ Probes:
       subprogram: {subprogram: 111}
       events:
         - Kind: Entry
-          Type: 1456 EventRootType Probe[main.testReturnsArrayOne]
+          Type: 1472 EventRootType Probe[main.testReturnsArrayOne]
           InjectionPoints: [{PC: "0x84e5d8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1457 EventRootType Probe[main.testReturnsArrayOne]Return
+          Type: 1473 EventRootType Probe[main.testReturnsArrayOne]Return
           InjectionPoints: [{PC: "0x84e614", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2787,11 +2830,11 @@ Probes:
       subprogram: {subprogram: 112}
       events:
         - Kind: Entry
-          Type: 1458 EventRootType Probe[main.testReturnsArrayZero]
+          Type: 1474 EventRootType Probe[main.testReturnsArrayZero]
           InjectionPoints: [{PC: "0x84e648", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1459 EventRootType Probe[main.testReturnsArrayZero]Return
+          Type: 1475 EventRootType Probe[main.testReturnsArrayZero]Return
           InjectionPoints: [{PC: "0x84e680", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2807,11 +2850,11 @@ Probes:
       subprogram: {subprogram: 114}
       events:
         - Kind: Entry
-          Type: 1462 EventRootType Probe[main.testReturnsBacktrackInt]
+          Type: 1478 EventRootType Probe[main.testReturnsBacktrackInt]
           InjectionPoints: [{PC: "0x84e738", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1463 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          Type: 1479 EventRootType Probe[main.testReturnsBacktrackInt]Return
           InjectionPoints: [{PC: "0x84e79c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2827,11 +2870,11 @@ Probes:
       subprogram: {subprogram: 120}
       events:
         - Kind: Entry
-          Type: 1474 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          Type: 1490 EventRootType Probe[main.testReturnsBoolAndUintptr]
           InjectionPoints: [{PC: "0x84eac8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1475 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          Type: 1491 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
           InjectionPoints: [{PC: "0x84eb08", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2847,11 +2890,11 @@ Probes:
       subprogram: {subprogram: 108}
       events:
         - Kind: Entry
-          Type: 1450 EventRootType Probe[main.testReturnsComplex]
+          Type: 1466 EventRootType Probe[main.testReturnsComplex]
           InjectionPoints: [{PC: "0x84e3f8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1451 EventRootType Probe[main.testReturnsComplex]Return
+          Type: 1467 EventRootType Probe[main.testReturnsComplex]Return
           InjectionPoints: [{PC: "0x84e444", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2868,11 +2911,11 @@ Probes:
       subprogram: {subprogram: 99}
       events:
         - Kind: Entry
-          Type: 1422 EventRootType Probe[main.testReturnsError]
+          Type: 1438 EventRootType Probe[main.testReturnsError]
           InjectionPoints: [{PC: "0x84db18", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1423 EventRootType Probe[main.testReturnsError]Return
+          Type: 1439 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
             - PC: "0x84db48"
               Frameless: false
@@ -2896,11 +2939,11 @@ Probes:
       subprogram: {subprogram: 96}
       events:
         - Kind: Entry
-          Type: 1416 EventRootType Probe[main.testReturnsInt]
+          Type: 1432 EventRootType Probe[main.testReturnsInt]
           InjectionPoints: [{PC: "0x84d928", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1417 EventRootType Probe[main.testReturnsInt]Return
+          Type: 1433 EventRootType Probe[main.testReturnsInt]Return
           InjectionPoints: [{PC: "0x84d96c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2920,11 +2963,11 @@ Probes:
       subprogram: {subprogram: 98}
       events:
         - Kind: Entry
-          Type: 1420 EventRootType Probe[main.testReturnsIntAndFloat]
+          Type: 1436 EventRootType Probe[main.testReturnsIntAndFloat]
           InjectionPoints: [{PC: "0x84da48", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1421 EventRootType Probe[main.testReturnsIntAndFloat]Return
+          Type: 1437 EventRootType Probe[main.testReturnsIntAndFloat]Return
           InjectionPoints: [{PC: "0x84dae0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2944,11 +2987,11 @@ Probes:
       subprogram: {subprogram: 97}
       events:
         - Kind: Entry
-          Type: 1418 EventRootType Probe[main.testReturnsIntPointer]
+          Type: 1434 EventRootType Probe[main.testReturnsIntPointer]
           InjectionPoints: [{PC: "0x84d9a8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1419 EventRootType Probe[main.testReturnsIntPointer]Return
+          Type: 1435 EventRootType Probe[main.testReturnsIntPointer]Return
           InjectionPoints: [{PC: "0x84da08", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2969,11 +3012,11 @@ Probes:
       subprogram: {subprogram: 102}
       events:
         - Kind: Entry
-          Type: 1428 EventRootType Probe[main.testReturnsInterface]
+          Type: 1444 EventRootType Probe[main.testReturnsInterface]
           InjectionPoints: [{PC: "0x84df18", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1429 EventRootType Probe[main.testReturnsInterface]Return
+          Type: 1445 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
             - PC: "0x84dfe4"
               Frameless: false
@@ -2997,11 +3040,11 @@ Probes:
       subprogram: {subprogram: 109}
       events:
         - Kind: Entry
-          Type: 1452 EventRootType Probe[main.testReturnsLargeStruct]
+          Type: 1468 EventRootType Probe[main.testReturnsLargeStruct]
           InjectionPoints: [{PC: "0x84e480", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1453 EventRootType Probe[main.testReturnsLargeStruct]Return
+          Type: 1469 EventRootType Probe[main.testReturnsLargeStruct]Return
           InjectionPoints: [{PC: "0x84e514", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3017,11 +3060,11 @@ Probes:
       subprogram: {subprogram: 107}
       events:
         - Kind: Entry
-          Type: 1448 EventRootType Probe[main.testReturnsManyFloats]
+          Type: 1464 EventRootType Probe[main.testReturnsManyFloats]
           InjectionPoints: [{PC: "0x84e338", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1449 EventRootType Probe[main.testReturnsManyFloats]Return
+          Type: 1465 EventRootType Probe[main.testReturnsManyFloats]Return
           InjectionPoints: [{PC: "0x84e3bc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3037,11 +3080,11 @@ Probes:
       subprogram: {subprogram: 116}
       events:
         - Kind: Entry
-          Type: 1466 EventRootType Probe[main.testReturnsMixed]
+          Type: 1482 EventRootType Probe[main.testReturnsMixed]
           InjectionPoints: [{PC: "0x84e8b8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1467 EventRootType Probe[main.testReturnsMixed]Return
+          Type: 1483 EventRootType Probe[main.testReturnsMixed]Return
           InjectionPoints: [{PC: "0x84e910", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3057,11 +3100,11 @@ Probes:
       subprogram: {subprogram: 113}
       events:
         - Kind: Entry
-          Type: 1460 EventRootType Probe[main.testReturnsMixedStruct]
+          Type: 1476 EventRootType Probe[main.testReturnsMixedStruct]
           InjectionPoints: [{PC: "0x84e6b8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1461 EventRootType Probe[main.testReturnsMixedStruct]Return
+          Type: 1477 EventRootType Probe[main.testReturnsMixedStruct]Return
           InjectionPoints: [{PC: "0x84e700", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3077,11 +3120,11 @@ Probes:
       subprogram: {subprogram: 119}
       events:
         - Kind: Entry
-          Type: 1472 EventRootType Probe[main.testReturnsMultipleFloats]
+          Type: 1488 EventRootType Probe[main.testReturnsMultipleFloats]
           InjectionPoints: [{PC: "0x84ea48", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1473 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          Type: 1489 EventRootType Probe[main.testReturnsMultipleFloats]Return
           InjectionPoints: [{PC: "0x84ea8c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3097,11 +3140,11 @@ Probes:
       subprogram: {subprogram: 118}
       events:
         - Kind: Entry
-          Type: 1470 EventRootType Probe[main.testReturnsOnlyFloat]
+          Type: 1486 EventRootType Probe[main.testReturnsOnlyFloat]
           InjectionPoints: [{PC: "0x84e9d8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1471 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          Type: 1487 EventRootType Probe[main.testReturnsOnlyFloat]Return
           InjectionPoints: [{PC: "0x84ea18", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3117,11 +3160,11 @@ Probes:
       subprogram: {subprogram: 106}
       events:
         - Kind: Entry
-          Type: 1446 EventRootType Probe[main.testReturnsPrimitives]
+          Type: 1462 EventRootType Probe[main.testReturnsPrimitives]
           InjectionPoints: [{PC: "0x84e2a8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1447 EventRootType Probe[main.testReturnsPrimitives]Return
+          Type: 1463 EventRootType Probe[main.testReturnsPrimitives]Return
           InjectionPoints: [{PC: "0x84e300", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3137,11 +3180,11 @@ Probes:
       subprogram: {subprogram: 117}
       events:
         - Kind: Entry
-          Type: 1468 EventRootType Probe[main.testReturnsStructWithArray]
+          Type: 1484 EventRootType Probe[main.testReturnsStructWithArray]
           InjectionPoints: [{PC: "0x84e94c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1469 EventRootType Probe[main.testReturnsStructWithArray]Return
+          Type: 1485 EventRootType Probe[main.testReturnsStructWithArray]Return
           InjectionPoints: [{PC: "0x84e9a0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3157,11 +3200,11 @@ Probes:
       subprogram: {subprogram: 115}
       events:
         - Kind: Entry
-          Type: 1464 EventRootType Probe[main.testReturnsWideStruct]
+          Type: 1480 EventRootType Probe[main.testReturnsWideStruct]
           InjectionPoints: [{PC: "0x84e7e0", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1465 EventRootType Probe[main.testReturnsWideStruct]Return
+          Type: 1481 EventRootType Probe[main.testReturnsWideStruct]Return
           InjectionPoints: [{PC: "0x84e884", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3178,7 +3221,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - Kind: Entry
-          Type: 1305 EventRootType Probe[main.testRuneArray]
+          Type: 1321 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0x849990", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3212,11 +3255,11 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1436 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1452 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x84e118", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1437 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1453 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x84e1a4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3261,7 +3304,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 1326 EventRootType Probe[main.testSingleBool]
+          Type: 1342 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0x849e10", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3282,7 +3325,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - Kind: Entry
-          Type: 1324 EventRootType Probe[main.testSingleByte]
+          Type: 1340 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0x849df0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3303,7 +3346,7 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 1337 EventRootType Probe[main.testSingleFloat32]
+          Type: 1353 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0x849ec0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3324,7 +3367,7 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - Kind: Entry
-          Type: 1338 EventRootType Probe[main.testSingleFloat64]
+          Type: 1354 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0x849ed0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3345,7 +3388,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 1327 EventRootType Probe[main.testSingleInt]
+          Type: 1343 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0x849e20", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3366,7 +3409,7 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - Kind: Entry
-          Type: 1329 EventRootType Probe[main.testSingleInt16]
+          Type: 1345 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0x849e40", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3388,7 +3431,7 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - Kind: Entry
-          Type: 1330 EventRootType Probe[main.testSingleInt32]
+          Type: 1346 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0x849e50", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3409,7 +3452,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - Kind: Entry
-          Type: 1331 EventRootType Probe[main.testSingleInt64]
+          Type: 1347 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0x849e60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3437,7 +3480,7 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - Kind: Entry
-          Type: 1328 EventRootType Probe[main.testSingleInt8]
+          Type: 1344 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0x849e30", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3467,7 +3510,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 1325 EventRootType Probe[main.testSingleRune]
+          Type: 1341 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0x849e00", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3488,7 +3531,7 @@ Probes:
       subprogram: {subprogram: 143}
       events:
         - Kind: Entry
-          Type: 1509 EventRootType Probe[main.testSingleString]
+          Type: 1525 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0x84ff50", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3509,7 +3552,7 @@ Probes:
       subprogram: {subprogram: 29}
       events:
         - Kind: Entry
-          Type: 1332 EventRootType Probe[main.testSingleUint]
+          Type: 1348 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0x849e70", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3530,7 +3573,7 @@ Probes:
       subprogram: {subprogram: 31}
       events:
         - Kind: Entry
-          Type: 1334 EventRootType Probe[main.testSingleUint16]
+          Type: 1350 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0x849e90", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3551,7 +3594,7 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - Kind: Entry
-          Type: 1335 EventRootType Probe[main.testSingleUint32]
+          Type: 1351 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0x849ea0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3572,7 +3615,7 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 1336 EventRootType Probe[main.testSingleUint64]
+          Type: 1352 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0x849eb0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3593,7 +3636,7 @@ Probes:
       subprogram: {subprogram: 30}
       events:
         - Kind: Entry
-          Type: 1333 EventRootType Probe[main.testSingleUint8]
+          Type: 1349 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0x849e80", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3614,7 +3657,7 @@ Probes:
       subprogram: {subprogram: 140}
       events:
         - Kind: Entry
-          Type: 1505 EventRootType Probe[main.testSliceEmptyStructs]
+          Type: 1521 EventRootType Probe[main.testSliceEmptyStructs]
           InjectionPoints: [{PC: "0x84fbb0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3635,7 +3678,7 @@ Probes:
       subprogram: {subprogram: 132}
       events:
         - Kind: Entry
-          Type: 1496 EventRootType Probe[main.testSliceOfSlices]
+          Type: 1512 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0x84fb30", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3656,7 +3699,7 @@ Probes:
       subprogram: {subprogram: 65}
       events:
         - Kind: Entry
-          Type: 1382 EventRootType Probe[main.testSmallMap]
+          Type: 1398 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0x84bb30", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3676,11 +3719,11 @@ Probes:
       subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1444 EventRootType Probe[main.testSomeNamedReturn]
+          Type: 1460 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0x84e1e8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1445 EventRootType Probe[main.testSomeNamedReturn]Return
+          Type: 1461 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0x84e270", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3700,11 +3743,11 @@ Probes:
       subprogram: {subprogram: 126}
       events:
         - Kind: Entry
-          Type: 1486 EventRootType Probe[main.testStackArgRegReturns]
+          Type: 1502 EventRootType Probe[main.testStackArgRegReturns]
           InjectionPoints: [{PC: "0x84f3d8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1487 EventRootType Probe[main.testStackArgRegReturns]Return
+          Type: 1503 EventRootType Probe[main.testStackArgRegReturns]Return
           InjectionPoints: [{PC: "0x84f43c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3725,7 +3768,7 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - Kind: Entry
-          Type: 1306 EventRootType Probe[main.testStringArray]
+          Type: 1322 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0x8499a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3746,7 +3789,7 @@ Probes:
       subprogram: {subprogram: 93}
       events:
         - Kind: Entry
-          Type: 1413 EventRootType Probe[main.testStringPointer]
+          Type: 1429 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0x84d590", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3767,7 +3810,7 @@ Probes:
       subprogram: {subprogram: 136}
       events:
         - Kind: Entry
-          Type: 1500 EventRootType Probe[main.testStringSlice]
+          Type: 1516 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0x84fb70", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3788,7 +3831,7 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - Kind: Entry
-          Type: 1348 EventRootType Probe[main.testStringType1]
+          Type: 1364 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0x84a3f0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3809,7 +3852,7 @@ Probes:
       subprogram: {subprogram: 45}
       events:
         - Kind: Entry
-          Type: 1349 EventRootType Probe[main.testStringType2]
+          Type: 1365 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0x84a400", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3830,11 +3873,11 @@ Probes:
       subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1528 EventRootType Probe[main.testStruct]
+          Type: 1544 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0x850250", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1529 EventRootType Probe[main.testStruct]Return
+          Type: 1545 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0x85026c", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3860,7 +3903,7 @@ Probes:
       subprogram: {subprogram: 133}
       events:
         - Kind: Entry
-          Type: 1497 EventRootType Probe[main.testStructSlice]
+          Type: 1513 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0x84fb40", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3886,7 +3929,7 @@ Probes:
       subprogram: {subprogram: 59}
       events:
         - Kind: Entry
-          Type: 1376 EventRootType Probe[main.testStructWithAny]
+          Type: 1392 EventRootType Probe[main.testStructWithAny]
           InjectionPoints: [{PC: "0x84b530", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3906,11 +3949,11 @@ Probes:
       subprogram: {subprogram: 128}
       events:
         - Kind: Entry
-          Type: 1490 EventRootType Probe[main.testStructWithArrayArg]
+          Type: 1506 EventRootType Probe[main.testStructWithArrayArg]
           InjectionPoints: [{PC: "0x84f55c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1491 EventRootType Probe[main.testStructWithArrayArg]Return
+          Type: 1507 EventRootType Probe[main.testStructWithArrayArg]Return
           InjectionPoints: [{PC: "0x84f5ec", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3931,11 +3974,11 @@ Probes:
       subprogram: {subprogram: 153}
       events:
         - Kind: Entry
-          Type: 1524 EventRootType Probe[main.testStructWithCyclicMaps]
+          Type: 1540 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0x850160", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1525 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          Type: 1541 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0x850178", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3955,7 +3998,7 @@ Probes:
       subprogram: {subprogram: 152}
       events:
         - Kind: Entry
-          Type: 1523 EventRootType Probe[main.testStructWithCyclicSlices]
+          Type: 1539 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0x850150", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3981,7 +4024,7 @@ Probes:
       subprogram: {subprogram: 60}
       events:
         - Kind: Entry
-          Type: 1377 EventRootType Probe[main.testStructWithMap]
+          Type: 1393 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0x84bae0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4012,7 +4055,7 @@ Probes:
       subprogram: {subprogram: 141}
       events:
         - Kind: Entry
-          Type: 1506 EventRootType Probe[main.testSubslices]
+          Type: 1522 EventRootType Probe[main.testSubslices]
           InjectionPoints: [{PC: "0x84fbc0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4051,7 +4094,7 @@ Probes:
       subprogram: {subprogram: 151}
       events:
         - Kind: Entry
-          Type: 1522 EventRootType Probe[main.testSubstrings]
+          Type: 1538 EventRootType Probe[main.testSubstrings]
           InjectionPoints: [{PC: "0x84ffe0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4083,11 +4126,11 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1438 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1454 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x84e118", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1439 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1455 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x84e1a4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -4107,11 +4150,11 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1440 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1456 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x84e118", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1441 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1457 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x84e1a4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -4133,11 +4176,11 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1442 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1458 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x84e118", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1443 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1459 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x84e1a4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -4165,7 +4208,7 @@ Probes:
       subprogram: {subprogram: 144}
       events:
         - Kind: Entry
-          Type: 1510 EventRootType Probe[main.testThreeStrings]
+          Type: 1526 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0x84ff60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4196,11 +4239,11 @@ Probes:
       subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1511 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1527 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0x84ff70", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1512 EventRootType Probe[main.testThreeStringsInStruct]Return
+          Type: 1528 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0x84ff88", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4229,11 +4272,11 @@ Probes:
       subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1513 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1529 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0x84ff70", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1514 EventRootType Probe[main.testThreeStringsInStruct]Return
+          Type: 1530 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0x84ff88", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4264,7 +4307,7 @@ Probes:
       subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1515 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1531 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0x84ff90", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4293,7 +4336,7 @@ Probes:
       subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1516 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1532 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0x84ff90", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4324,7 +4367,7 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 1339 EventRootType Probe[main.testTypeAlias]
+          Type: 1355 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0x849ee0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4345,7 +4388,7 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - Kind: Entry
-          Type: 1315 EventRootType Probe[main.testUint16Array]
+          Type: 1331 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0x849a30", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4366,7 +4409,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - Kind: Entry
-          Type: 1316 EventRootType Probe[main.testUint32Array]
+          Type: 1332 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0x849a40", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4387,7 +4430,7 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - Kind: Entry
-          Type: 1317 EventRootType Probe[main.testUint64Array]
+          Type: 1333 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0x849a50", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4408,7 +4451,7 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - Kind: Entry
-          Type: 1314 EventRootType Probe[main.testUint8Array]
+          Type: 1330 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0x849a20", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4429,7 +4472,7 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - Kind: Entry
-          Type: 1313 EventRootType Probe[main.testUintArray]
+          Type: 1329 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0x849a10", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4450,7 +4493,7 @@ Probes:
       subprogram: {subprogram: 92}
       events:
         - Kind: Entry
-          Type: 1412 EventRootType Probe[main.testUintPointer]
+          Type: 1428 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0x84d520", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4471,7 +4514,7 @@ Probes:
       subprogram: {subprogram: 130}
       events:
         - Kind: Entry
-          Type: 1494 EventRootType Probe[main.testUintSlice]
+          Type: 1510 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0x84fb10", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4492,7 +4535,7 @@ Probes:
       subprogram: {subprogram: 149}
       events:
         - Kind: Entry
-          Type: 1520 EventRootType Probe[main.testUnitializedString]
+          Type: 1536 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0x84ffc0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4513,7 +4556,7 @@ Probes:
       subprogram: {subprogram: 91}
       events:
         - Kind: Entry
-          Type: 1411 EventRootType Probe[main.testUnsafePointer]
+          Type: 1427 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0x84d500", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4534,7 +4577,7 @@ Probes:
       subprogram: {subprogram: 20}
       events:
         - Kind: Entry
-          Type: 1323 EventRootType Probe[main.testVeryLargeArray]
+          Type: 1339 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0x849ac0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4555,7 +4598,7 @@ Probes:
       subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1503 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1519 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x84fba0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4576,7 +4619,7 @@ Probes:
       subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1504 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1520 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x84fba0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4593,10 +4636,10 @@ Probes:
       template: testWhollyInlinedSubroutine
       segments: [testWhollyInlinedSubroutine]
       captureSnapshot: true
-      subprogram: {subprogram: 164}
+      subprogram: {subprogram: 165}
       events:
         - Kind: Entry
-          Type: 1549 EventRootType Probe[main.firstBehavior.DoSomething]
+          Type: 1566 EventRootType Probe[main.firstBehavior.DoSomething]
           InjectionPoints:
             - PC: "0x84b368"
               Frameless: false
@@ -4604,7 +4647,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1550 EventRootType Probe[main.firstBehavior.DoSomething]Return
+          Type: 1567 EventRootType Probe[main.firstBehavior.DoSomething]Return
           InjectionPoints: [{PC: "0x84b3a0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -4625,11 +4668,11 @@ Probes:
       subprogram: {subprogram: 129}
       events:
         - Kind: Entry
-          Type: 1492 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          Type: 1508 EventRootType Probe[main.testZeroSizeArgAndReturn]
           InjectionPoints: [{PC: "0x84f628", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1493 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          Type: 1509 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
           InjectionPoints: [{PC: "0x84f690", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -8151,6 +8194,69 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 158
+      Name: main.executeStructFuncs
+      OutOfLinePCRanges: [0x850380..0x850e70]
+      InlinePCRanges: []
+      Variables:
+        - Name: n
+          Type: 319 StructureType main.nStruct
+          Locations: [{Range: 0x850380..0x850e70, Pieces: []}]
+          Role: Local
+        - Name: ns
+          Type: 260 StructureType main.structWithNoStrings
+          Locations: [{Range: 0x850380..0x850e70, Pieces: []}]
+          Role: Local
+        - Name: cs
+          Type: 320 StructureType main.cStruct
+          Locations: [{Range: 0x850380..0x850e70, Pieces: []}]
+          Role: Local
+        - Name: rcvr
+          Type: 321 StructureType main.receiver
+          Locations: [{Range: 0x850380..0x850e70, Pieces: []}]
+          Role: Local
+        - Name: ts
+          Type: 322 StructureType main.threestrings
+          Locations:
+            - Range: 0x8503a8..0x850e70
+              Pieces: [{Size: 48, Op: {CfaOffset: -2072}}]
+          Role: Local
+        - Name: s
+          Type: 314 StructureType main.aStruct
+          Locations:
+            - Range: 0x8503fc..0x850e70
+              Pieces: [{Size: 56, Op: {CfaOffset: -1912}}]
+          Role: Local
+        - Name: b
+          Type: 323 StructureType main.bStruct
+          Locations:
+            - Range: 0x850458..0x850e70
+              Pieces: [{Size: 72, Op: {CfaOffset: -2072}}]
+          Role: Local
+        - Name: tenStr
+          Type: 324 StructureType main.tenStrings
+          Locations:
+            - Range: 0x850678..0x850e70
+              Pieces: [{Size: 160, Op: {CfaOffset: -2072}}]
+          Role: Local
+        - Name: deep
+          Type: 325 StructureType main.deepStruct1
+          Locations:
+            - Range: 0x8506b8..0x850e70
+              Pieces: [{Size: 48, Op: {CfaOffset: -2160}}]
+          Role: Local
+        - Name: fields
+          Type: 331 StructureType main.lotsOfFields
+          Locations:
+            - Range: 0x850718..0x850e70
+              Pieces: [{Size: 26, Op: {CfaOffset: -2160}}]
+          Role: Local
+        - Name: sta
+          Type: 332 StructureType main.structWithTwoArrays
+          Locations:
+            - Range: 0x850770..0x850e70
+              Pieces: [{Size: 72, Op: {CfaOffset: -2160}}]
+          Role: Local
+    - ID: 159
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0x84ad00..0x84ad70]
       InlinePCRanges:
@@ -8179,28 +8285,28 @@ Subprograms:
             - Range: 0x84aff0..0x84b014
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 159
+    - ID: 160
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x84af98..0x84afd0]
           RootRanges: [0x84af30..0x84aff0]
       Variables: []
-    - ID: 160
+    - ID: 161
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x84b08c..0x84b0d0]
           RootRanges: [0x84b070..0x84b190]
       Variables: []
-    - ID: 161
+    - ID: 162
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x84b140..0x84b178]
           RootRanges: [0x84b070..0x84b190]
       Variables: []
-    - ID: 162
+    - ID: 163
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -8213,7 +8319,7 @@ Subprograms:
             - Range: 0x84b190..0x84b198
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 163
+    - ID: 164
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -8230,7 +8336,7 @@ Subprograms:
             - Range: 0x84b248..0x84b350
               Pieces: [{Size: 40, Op: {CfaOffset: -120}}]
           Role: Parameter
-    - ID: 164
+    - ID: 165
       Name: main.firstBehavior.DoSomething
       OutOfLinePCRanges: [0x84b350..0x84b3c0]
       InlinePCRanges:
@@ -8238,7 +8344,7 @@ Subprograms:
           RootRanges: [0x851040..0x8510f0]
       Variables:
         - Name: b
-          Type: 319 StructureType main.firstBehavior
+          Type: 335 StructureType main.firstBehavior
           Locations:
             - Range: 0x84b350..0x84b37c
               Pieces:
@@ -8267,7 +8373,7 @@ Subprograms:
             - Range: 0x84b3a1..0x84b3c0
               Pieces: []
           Role: Return
-    - ID: 165
+    - ID: 166
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -8283,20 +8389,20 @@ Types:
       ByteSize: 8
       Pointee: 138 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 1219
+      ID: 1235
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 1220 PointerType *main.deepSlice3
+      Pointee: 1236 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 1244
+      ID: 1260
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 1245 PointerType *main.deepSlice8
+      Pointee: 1261 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 1250
+      ID: 1266
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 1251 PointerType *main.deepSlice9
+      Pointee: 1267 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 151
       Name: '**main.stringType2'
@@ -8304,7 +8410,7 @@ Types:
       GoKind: 22
       Pointee: 152 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 1215
+      ID: 1231
       Name: '**main.t'
       ByteSize: 8
       Pointee: 246 PointerType *main.t
@@ -8341,30 +8447,30 @@ Types:
       ByteSize: 8
       Pointee: 146 PointerType *table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1227
+      ID: 1243
       Name: '**table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1228 PointerType *table<int,*main.deepMap3>
+      Pointee: 1244 PointerType *table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1261
+      ID: 1277
       Name: '**table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1262 PointerType *table<int,*main.deepMap8>
+      Pointee: 1278 PointerType *table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1276
+      ID: 1292
       Name: '**table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1277 PointerType *table<int,*main.deepMap9>
+      Pointee: 1293 PointerType *table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 167
       Name: '**table<int,int>'
       ByteSize: 8
       Pointee: 168 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 1291
+      ID: 1307
       Name: '**table<int,interface {}>'
       ByteSize: 8
-      Pointee: 1292 PointerType *table<int,interface {}>
+      Pointee: 1308 PointerType *table<int,interface {}>
     - __kind: PointerType
       ID: 234
       Name: '**table<int,struct {}>'
@@ -8386,10 +8492,10 @@ Types:
       ByteSize: 8
       Pointee: 183 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 962
+      ID: 978
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 963 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 979 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 177
       Name: '**table<string,int>'
@@ -8451,115 +8557,115 @@ Types:
       ByteSize: 8
       Pointee: 210 PointerType *table<uint8,uint8>
     - __kind: PointerType
-      ID: 330
+      ID: 346
       Name: '*[]*main.deepSlice2.array'
       ByteSize: 8
-      Pointee: 329 GoSliceDataType []*main.deepSlice2.array
+      Pointee: 345 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 1223
+      ID: 1239
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 1222 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 1238 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 1248
+      ID: 1264
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 1247 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 1263 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 1254
+      ID: 1270
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 1253 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 1269 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
-      ID: 327
+      ID: 343
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 326 GoSliceDataType []*string.array
+      Pointee: 342 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 490
+      ID: 506
       Name: '*[][][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 489 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Pointee: 505 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 282
       Name: '*[][][][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 279 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 488
+      ID: 504
       Name: '*[][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 487 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Pointee: 503 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 280
       Name: '*[][][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 277 GoSliceHeaderType [][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 486
+      ID: 502
       Name: '*[][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 485 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Pointee: 501 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 278
       Name: '*[][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 275 GoSliceHeaderType [][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 484
+      ID: 500
       Name: '*[][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 483 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Pointee: 499 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 276
       Name: '*[][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 273 GoSliceHeaderType [][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 482
+      ID: 498
       Name: '*[][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 481 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Pointee: 497 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 468
+      ID: 484
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 467 GoSliceDataType [][]uint.array
+      Pointee: 483 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 474
+      ID: 490
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 473 GoSliceDataType []bool.array
+      Pointee: 489 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 999
+      ID: 1015
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 998 GoSliceDataType []float64.array
+      Pointee: 1014 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 1257
+      ID: 1273
       Name: '*[]interface {}.array'
       ByteSize: 8
-      Pointee: 1256 GoSliceDataType []interface {}.array
+      Pointee: 1272 GoSliceDataType []interface {}.array
     - __kind: PointerType
       ID: 274
       Name: '*[]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 271 GoSliceHeaderType []main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 480
+      ID: 496
       Name: '*[]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 479 GoSliceDataType []main.structWithCyclicSlices.array
+      Pointee: 495 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 540
+      ID: 556
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 539 GoSliceDataType []main.structWithMap.array
+      Pointee: 555 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 470
+      ID: 486
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 469 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 485 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
       ID: 39
       Name: '*[]runtime.ancestorInfo'
@@ -8568,101 +8674,101 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 472
+      ID: 488
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 471 GoSliceDataType []string.array
+      Pointee: 487 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 478
+      ID: 494
       Name: '*[]struct {}.array'
       ByteSize: 8
-      Pointee: 477 GoSliceDataType []struct {}.array
+      Pointee: 493 GoSliceDataType []struct {}.array
     - __kind: PointerType
       ID: 257
       Name: '*[]uint'
       ByteSize: 8
       Pointee: 255 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 466
+      ID: 482
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 465 GoSliceDataType []uint.array
+      Pointee: 481 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 476
+      ID: 492
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 475 GoSliceDataType []uint16.array
+      Pointee: 491 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 323
+      ID: 339
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 322 GoSliceDataType []uint8.array
+      Pointee: 338 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 325
+      ID: 341
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 324 GoSliceDataType []uintptr.array
+      Pointee: 340 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 1129
+      ID: 1145
       Name: '*archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1.978304e+06
       GoKind: 22
-      Pointee: 1130 UnresolvedPointeeType archive/tar.Writer
+      Pointee: 1146 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
-      ID: 770
+      ID: 786
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 926944
       GoKind: 22
-      Pointee: 771 GoSliceHeaderType archive/tar.headerError
+      Pointee: 787 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 773
+      ID: 789
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 772 GoSliceDataType archive/tar.headerError.array
+      Pointee: 788 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 1064
+      ID: 1080
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.432192e+06
       GoKind: 22
-      Pointee: 1065 UnresolvedPointeeType archive/tar.regFileWriter
+      Pointee: 1081 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
-      ID: 1012
+      ID: 1028
       Name: '*archive/zip.countWriter'
       ByteSize: 8
       GoRuntimeType: 927136
       GoKind: 22
-      Pointee: 1013 UnresolvedPointeeType archive/zip.countWriter
+      Pointee: 1029 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
-      ID: 1014
+      ID: 1030
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
       GoRuntimeType: 927232
       GoKind: 22
-      Pointee: 1015 StructureType archive/zip.dirWriter
+      Pointee: 1031 StructureType archive/zip.dirWriter
     - __kind: PointerType
-      ID: 1112
+      ID: 1128
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.897984e+06
       GoKind: 22
-      Pointee: 1113 UnresolvedPointeeType archive/zip.fileWriter
+      Pointee: 1129 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
-      ID: 1040
+      ID: 1056
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1.053568e+06
       GoKind: 22
-      Pointee: 1041 StructureType archive/zip.nopCloser
+      Pointee: 1057 StructureType archive/zip.nopCloser
     - __kind: PointerType
-      ID: 1042
+      ID: 1058
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
       GoRuntimeType: 1.053824e+06
       GoKind: 22
-      Pointee: 1043 UnresolvedPointeeType archive/zip.pooledFlateWriter
+      Pointee: 1059 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -8671,421 +8777,421 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 1087
+      ID: 1103
       Name: '*bufio.Reader'
       ByteSize: 8
       GoRuntimeType: 2.166432e+06
       GoKind: 22
-      Pointee: 1088 UnresolvedPointeeType bufio.Reader
+      Pointee: 1104 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
-      ID: 1116
+      ID: 1132
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1.942496e+06
       GoKind: 22
-      Pointee: 1117 UnresolvedPointeeType bufio.Writer
+      Pointee: 1133 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
-      ID: 1167
+      ID: 1183
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.263712e+06
       GoKind: 22
-      Pointee: 1168 UnresolvedPointeeType bytes.Buffer
+      Pointee: 1184 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 682
+      ID: 698
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 909568
       GoKind: 22
-      Pointee: 574 BaseType compress/flate.CorruptInputError
+      Pointee: 590 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 683
+      ID: 699
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 909664
       GoKind: 22
-      Pointee: 575 GoStringHeaderType compress/flate.InternalError
+      Pointee: 591 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 577
+      ID: 593
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 576 GoStringDataType compress/flate.InternalError.str
+      Pointee: 592 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 1062
+      ID: 1078
       Name: '*compress/flate.Writer'
       ByteSize: 8
       GoRuntimeType: 1.421632e+06
       GoKind: 22
-      Pointee: 1063 UnresolvedPointeeType compress/flate.Writer
+      Pointee: 1079 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
-      ID: 1008
+      ID: 1024
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
       GoRuntimeType: 909760
       GoKind: 22
-      Pointee: 1009 UnresolvedPointeeType compress/flate.dictWriter
+      Pointee: 1025 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
-      ID: 1084
+      ID: 1100
       Name: '*compress/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.719968e+06
       GoKind: 22
-      Pointee: 1085 UnresolvedPointeeType compress/gzip.Writer
+      Pointee: 1101 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
-      ID: 914
+      ID: 930
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.20016e+06
       GoKind: 22
-      Pointee: 915 StructureType context.deadlineExceededError
+      Pointee: 931 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 762
+      ID: 778
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 921568
       GoKind: 22
-      Pointee: 588 BaseType crypto/aes.KeySizeError
+      Pointee: 604 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 763
+      ID: 779
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 921760
       GoKind: 22
-      Pointee: 589 BaseType crypto/des.KeySizeError
+      Pointee: 605 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 764
+      ID: 780
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 922048
       GoKind: 22
-      Pointee: 590 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 606 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 1074
+      ID: 1090
       Name: '*crypto/internal/fips140/hmac.HMAC'
       ByteSize: 8
       GoRuntimeType: 1.562272e+06
       GoKind: 22
-      Pointee: 1075 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
+      Pointee: 1091 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
     - __kind: PointerType
-      ID: 1108
+      ID: 1124
       Name: '*crypto/internal/fips140/sha256.Digest'
       ByteSize: 8
       GoRuntimeType: 1.85664e+06
       GoKind: 22
-      Pointee: 1109 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
+      Pointee: 1125 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
     - __kind: PointerType
-      ID: 1140
+      ID: 1156
       Name: '*crypto/internal/fips140/sha3.Digest'
       ByteSize: 8
       GoRuntimeType: 2.11376e+06
       GoKind: 22
-      Pointee: 1141 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
+      Pointee: 1157 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
     - __kind: PointerType
-      ID: 1114
+      ID: 1130
       Name: '*crypto/internal/fips140/sha3.SHAKE'
       ByteSize: 8
       GoRuntimeType: 1.898496e+06
       GoKind: 22
-      Pointee: 1115 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
+      Pointee: 1131 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
     - __kind: PointerType
-      ID: 1110
+      ID: 1126
       Name: '*crypto/internal/fips140/sha512.Digest'
       ByteSize: 8
       GoRuntimeType: 1.857088e+06
       GoKind: 22
-      Pointee: 1111 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
+      Pointee: 1127 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
     - __kind: PointerType
-      ID: 1106
+      ID: 1122
       Name: '*crypto/md5.digest'
       ByteSize: 8
       GoRuntimeType: 1.849472e+06
       GoKind: 22
-      Pointee: 1107 UnresolvedPointeeType crypto/md5.digest
+      Pointee: 1123 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
-      ID: 765
+      ID: 781
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 922336
       GoKind: 22
-      Pointee: 591 BaseType crypto/rc4.KeySizeError
+      Pointee: 607 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 1124
+      ID: 1140
       Name: '*crypto/sha1.digest'
       ByteSize: 8
       GoRuntimeType: 1.947872e+06
       GoKind: 22
-      Pointee: 1125 UnresolvedPointeeType crypto/sha1.digest
+      Pointee: 1141 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
-      ID: 1096
+      ID: 1112
       Name: '*crypto/sha3.SHA3'
       ByteSize: 8
       GoRuntimeType: 1.803456e+06
       GoKind: 22
-      Pointee: 1097 UnresolvedPointeeType crypto/sha3.SHA3
+      Pointee: 1113 UnresolvedPointeeType crypto/sha3.SHA3
     - __kind: PointerType
-      ID: 688
+      ID: 704
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 911200
       GoKind: 22
-      Pointee: 578 BaseType crypto/tls.AlertError
+      Pointee: 594 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 854
+      ID: 870
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1.042176e+06
       GoKind: 22
-      Pointee: 855 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 871 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 1193
+      ID: 1209
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2.375584e+06
       GoKind: 22
-      Pointee: 1194 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 1210 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 686
+      ID: 702
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 911008
       GoKind: 22
-      Pointee: 687 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 703 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 684
+      ID: 700
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 910912
       GoKind: 22
-      Pointee: 685 StructureType crypto/tls.RecordHeaderError
+      Pointee: 701 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 853
+      ID: 869
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1.040512e+06
       GoKind: 22
-      Pointee: 810 BaseType crypto/tls.alert
+      Pointee: 826 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 1072
+      ID: 1088
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
       GoRuntimeType: 1.555232e+06
       GoKind: 22
-      Pointee: 1073 UnresolvedPointeeType crypto/tls.cthWrapper
+      Pointee: 1089 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
-      ID: 1079
+      ID: 1095
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
       GoRuntimeType: 1.637664e+06
       GoKind: 22
-      Pointee: 1080 UnresolvedPointeeType crypto/tls.finishedHash
+      Pointee: 1096 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
-      ID: 949
+      ID: 965
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1.421952e+06
       GoKind: 22
-      Pointee: 950 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 966 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 964
+      ID: 980
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.036352e+06
       GoKind: 22
-      Pointee: 965 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 981 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 758
+      ID: 774
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 920608
       GoKind: 22
-      Pointee: 759 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 775 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 752
+      ID: 768
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 920128
       GoKind: 22
-      Pointee: 753 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 769 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 754
+      ID: 770
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 920224
       GoKind: 22
-      Pointee: 755 StructureType crypto/x509.HostnameError
+      Pointee: 771 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 751
+      ID: 767
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 920032
       GoKind: 22
-      Pointee: 587 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 603 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 859
+      ID: 875
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1.047936e+06
       GoKind: 22
-      Pointee: 860 StructureType crypto/x509.SystemRootsError
+      Pointee: 876 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 760
+      ID: 776
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 920704
       GoKind: 22
-      Pointee: 761 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 777 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 756
+      ID: 772
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 920512
       GoKind: 22
-      Pointee: 757 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 773 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 774
+      ID: 790
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 927424
       GoKind: 22
-      Pointee: 775 StructureType encoding/asn1.StructuralError
+      Pointee: 791 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 778
+      ID: 794
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 927616
       GoKind: 22
-      Pointee: 779 StructureType encoding/asn1.SyntaxError
+      Pointee: 795 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 776
+      ID: 792
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 927520
       GoKind: 22
-      Pointee: 777 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 793 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 672
+      ID: 688
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 907648
       GoKind: 22
-      Pointee: 572 BaseType encoding/base64.CorruptInputError
+      Pointee: 588 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 1030
+      ID: 1046
       Name: '*encoding/base64.encoder'
       ByteSize: 8
       GoRuntimeType: 1.037696e+06
       GoKind: 22
-      Pointee: 1031 UnresolvedPointeeType encoding/base64.encoder
+      Pointee: 1047 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
-      ID: 675
+      ID: 691
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 908512
       GoKind: 22
-      Pointee: 573 BaseType encoding/hex.InvalidByteError
+      Pointee: 589 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 643
+      ID: 659
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 902368
       GoKind: 22
-      Pointee: 644 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 660 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 845
+      ID: 861
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1.033984e+06
       GoKind: 22
-      Pointee: 846 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 862 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 635
+      ID: 651
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 901984
       GoKind: 22
-      Pointee: 636 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 652 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 641
+      ID: 657
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 902272
       GoKind: 22
-      Pointee: 642 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 658 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 639
+      ID: 655
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 902176
       GoKind: 22
-      Pointee: 640 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 656 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 637
+      ID: 653
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 902080
       GoKind: 22
-      Pointee: 638 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 654 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 1173
+      ID: 1189
       Name: '*encoding/json.encodeState'
       ByteSize: 8
       GoRuntimeType: 2.288736e+06
       GoKind: 22
-      Pointee: 1174 UnresolvedPointeeType encoding/json.encodeState
+      Pointee: 1190 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 645
+      ID: 661
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 902752
       GoKind: 22
-      Pointee: 646 StructureType encoding/json.jsonError
+      Pointee: 662 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 1038
+      ID: 1054
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
       GoRuntimeType: 1.050496e+06
       GoKind: 22
-      Pointee: 1039 UnresolvedPointeeType encoding/pem.lineBreaker
+      Pointee: 1055 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
-      ID: 746
+      ID: 762
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 919072
       GoKind: 22
-      Pointee: 747 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 763 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 744
+      ID: 760
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 918976
       GoKind: 22
-      Pointee: 745 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 761 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 748
+      ID: 764
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 919168
       GoKind: 22
-      Pointee: 584 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 600 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 586
+      ID: 602
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 585 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 601 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 749
+      ID: 765
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 919264
       GoKind: 22
-      Pointee: 750 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 766 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
-      ID: 1151
+      ID: 1167
       Name: '*encoding/xml.printer'
       ByteSize: 8
       GoRuntimeType: 2.152192e+06
       GoKind: 22
-      Pointee: 1152 UnresolvedPointeeType encoding/xml.printer
+      Pointee: 1168 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
       ID: 104
       Name: '*error'
@@ -9094,19 +9200,19 @@ Types:
       GoKind: 22
       Pointee: 14 GoInterfaceType error
     - __kind: PointerType
-      ID: 613
+      ID: 629
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 892672
       GoKind: 22
-      Pointee: 614 UnresolvedPointeeType errors.errorString
+      Pointee: 630 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 812
+      ID: 828
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1.01888e+06
       GoKind: 22
-      Pointee: 813 UnresolvedPointeeType errors.joinError
+      Pointee: 829 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 106
       Name: '*float32'
@@ -9122,813 +9228,813 @@ Types:
       GoKind: 22
       Pointee: 18 BaseType float64
     - __kind: PointerType
-      ID: 1161
+      ID: 1177
       Name: '*fmt.pp'
       ByteSize: 8
       GoRuntimeType: 2.256032e+06
       GoKind: 22
-      Pointee: 1162 UnresolvedPointeeType fmt.pp
+      Pointee: 1178 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
-      ID: 814
+      ID: 830
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.019008e+06
       GoKind: 22
-      Pointee: 815 UnresolvedPointeeType fmt.wrapError
+      Pointee: 831 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 816
+      ID: 832
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1.019136e+06
       GoKind: 22
-      Pointee: 817 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 833 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 673
+      ID: 689
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 908032
       GoKind: 22
-      Pointee: 674 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 690 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 654
+      ID: 670
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 905152
       GoKind: 22
-      Pointee: 655 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 671 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 656
+      ID: 672
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 905248
       GoKind: 22
-      Pointee: 657 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 673 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 976
+      ID: 992
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 904960
       GoKind: 22
-      Pointee: 977 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 993 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 660
+      ID: 676
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 905536
       GoKind: 22
-      Pointee: 661 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 677 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 978
+      ID: 994
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 905056
       GoKind: 22
-      Pointee: 979 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 995 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 658
+      ID: 674
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 905344
       GoKind: 22
-      Pointee: 566 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 582 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 568
+      ID: 584
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 567 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 583 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 653
+      ID: 669
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 904864
       GoKind: 22
-      Pointee: 563 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 579 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 565
+      ID: 581
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 564 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 580 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 659
+      ID: 675
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 905440
       GoKind: 22
-      Pointee: 569 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 585 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 571
+      ID: 587
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 570 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 586 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 1052
+      ID: 1068
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
       GoRuntimeType: 1.205664e+06
       GoKind: 22
-      Pointee: 1053 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      Pointee: 1069 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
-      ID: 1137
+      ID: 1153
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
       GoRuntimeType: 2.05136e+06
       GoKind: 22
-      Pointee: 1138 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      Pointee: 1154 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
-      ID: 768
+      ID: 784
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 925888
       GoKind: 22
-      Pointee: 769 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 785 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 923
+      ID: 939
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1.209248e+06
       GoKind: 22
-      Pointee: 924 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 940 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 1169
+      ID: 1185
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
       GoRuntimeType: 2.26576e+06
       GoKind: 22
-      Pointee: 1170 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      Pointee: 1186 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
-      ID: 695
+      ID: 711
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 914560
       GoKind: 22
-      Pointee: 696 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 712 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 702
+      ID: 718
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 915616
       GoKind: 22
-      Pointee: 703 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 719 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 697
+      ID: 713
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 915328
       GoKind: 22
-      Pointee: 583 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 599 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 700
+      ID: 716
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 915520
       GoKind: 22
-      Pointee: 701 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 717 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 698
+      ID: 714
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 915424
       GoKind: 22
-      Pointee: 699 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 715 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 718
+      ID: 734
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 917536
       GoKind: 22
-      Pointee: 719 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 735 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 722
+      ID: 738
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 917728
       GoKind: 22
-      Pointee: 723 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 739 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 720
+      ID: 736
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 917632
       GoKind: 22
-      Pointee: 721 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 737 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 716
+      ID: 732
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 917440
       GoKind: 22
-      Pointee: 717 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 733 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 1001
+      ID: 1017
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 1000 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 1016 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 730
+      ID: 746
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 918112
       GoKind: 22
-      Pointee: 731 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 747 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 724
+      ID: 740
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 917824
       GoKind: 22
-      Pointee: 725 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 741 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 728
+      ID: 744
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 918016
       GoKind: 22
-      Pointee: 729 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 745 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 726
+      ID: 742
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 917920
       GoKind: 22
-      Pointee: 727 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 743 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 732
+      ID: 748
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 918208
       GoKind: 22
-      Pointee: 733 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 749 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 738
+      ID: 754
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 918496
       GoKind: 22
-      Pointee: 739 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 755 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 740
+      ID: 756
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 918592
       GoKind: 22
-      Pointee: 741 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 757 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 736
+      ID: 752
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 918400
       GoKind: 22
-      Pointee: 737 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 753 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 734
+      ID: 750
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 918304
       GoKind: 22
-      Pointee: 735 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 751 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 742
+      ID: 758
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 918784
       GoKind: 22
-      Pointee: 743 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 759 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 662
+      ID: 678
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 906688
       GoKind: 22
-      Pointee: 663 StructureType github.com/cihub/seelog.baseError
+      Pointee: 679 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 1090
+      ID: 1106
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1.796064e+06
       GoKind: 22
-      Pointee: 1091 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 1107 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 664
+      ID: 680
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 906784
       GoKind: 22
-      Pointee: 665 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 681 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 1070
+      ID: 1086
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
       GoRuntimeType: 1.554112e+06
       GoKind: 22
-      Pointee: 1071 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+      Pointee: 1087 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
-      ID: 1026
+      ID: 1042
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
       GoRuntimeType: 1.036672e+06
       GoKind: 22
-      Pointee: 1027 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+      Pointee: 1043 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
-      ID: 1060
+      ID: 1076
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.419712e+06
       GoKind: 22
-      Pointee: 1061 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+      Pointee: 1077 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
-      ID: 668
+      ID: 684
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 906976
       GoKind: 22
-      Pointee: 669 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 685 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 1127
+      ID: 1143
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.968224e+06
       GoKind: 22
-      Pointee: 1128 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+      Pointee: 1144 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
-      ID: 1144
+      ID: 1160
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
       GoRuntimeType: 2.125344e+06
       GoKind: 22
-      Pointee: 1139 StructureType github.com/cihub/seelog.rollingFileWriterSize
+      Pointee: 1155 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
-      ID: 1143
+      ID: 1159
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
       GoRuntimeType: 2.12496e+06
       GoKind: 22
-      Pointee: 1142 StructureType github.com/cihub/seelog.rollingFileWriterTime
+      Pointee: 1158 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
-      ID: 1028
+      ID: 1044
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
       GoRuntimeType: 1.0368e+06
       GoKind: 22
-      Pointee: 1029 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+      Pointee: 1045 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
-      ID: 666
+      ID: 682
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 906880
       GoKind: 22
-      Pointee: 667 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 683 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 670
+      ID: 686
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 907072
       GoKind: 22
-      Pointee: 671 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 687 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 1092
+      ID: 1108
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.797856e+06
       GoKind: 22
-      Pointee: 1093 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+      Pointee: 1109 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
-      ID: 1133
+      ID: 1149
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 2.00496e+06
       GoKind: 22
-      Pointee: 1134 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+      Pointee: 1150 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
-      ID: 1135
+      ID: 1151
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
       GoRuntimeType: 2.036032e+06
       GoKind: 22
-      Pointee: 1136 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+      Pointee: 1152 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
-      ID: 954
+      ID: 970
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1.434592e+06
       GoKind: 22
-      Pointee: 955 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 971 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 867
+      ID: 883
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.062016e+06
       GoKind: 22
-      Pointee: 868 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 884 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 865
+      ID: 881
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1.061888e+06
       GoKind: 22
-      Pointee: 866 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 882 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 869
+      ID: 885
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.065984e+06
       GoKind: 22
-      Pointee: 870 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 886 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 871
+      ID: 887
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1.066112e+06
       GoKind: 22
-      Pointee: 872 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 888 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 1081
+      ID: 1097
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
       GoRuntimeType: 1.664736e+06
       GoKind: 22
-      Pointee: 1082 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+      Pointee: 1098 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
-      ID: 861
+      ID: 877
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.048576e+06
       GoKind: 22
-      Pointee: 862 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 878 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 676
+      ID: 692
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 908704
       GoKind: 22
-      Pointee: 677 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 693 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 1185
+      ID: 1201
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
       GoRuntimeType: 2.351808e+06
       GoKind: 22
-      Pointee: 1186 UnresolvedPointeeType github.com/json-iterator/go.Stream
+      Pointee: 1202 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
-      ID: 925
+      ID: 941
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1.217696e+06
       GoKind: 22
-      Pointee: 926 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 942 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 898
+      ID: 914
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1.196448e+06
       GoKind: 22
-      Pointee: 899 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 915 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 892
+      ID: 908
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1.196064e+06
       GoKind: 22
-      Pointee: 893 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 909 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 831
+      ID: 847
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1.027968e+06
       GoKind: 22
-      Pointee: 832 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 848 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 904
+      ID: 920
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1.196832e+06
       GoKind: 22
-      Pointee: 905 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 921 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 830
+      ID: 846
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1.02784e+06
       GoKind: 22
-      Pointee: 809 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 825 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 896
+      ID: 912
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1.19632e+06
       GoKind: 22
-      Pointee: 897 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 913 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 894
+      ID: 910
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1.196192e+06
       GoKind: 22
-      Pointee: 895 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 911 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 902
+      ID: 918
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1.196704e+06
       GoKind: 22
-      Pointee: 903 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 919 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 900
+      ID: 916
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1.196576e+06
       GoKind: 22
-      Pointee: 901 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 917 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 1189
+      ID: 1205
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
       GoRuntimeType: 2.363616e+06
       GoKind: 22
-      Pointee: 1190 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+      Pointee: 1206 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
-      ID: 908
+      ID: 924
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1.197216e+06
       GoKind: 22
-      Pointee: 909 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 925 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 835
+      ID: 851
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1.028224e+06
       GoKind: 22
-      Pointee: 836 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 852 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 833
+      ID: 849
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1.028096e+06
       GoKind: 22
-      Pointee: 834 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 850 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 906
+      ID: 922
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1.197088e+06
       GoKind: 22
-      Pointee: 907 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 923 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 790
+      ID: 806
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 940384
       GoKind: 22
-      Pointee: 596 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 612 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 598
+      ID: 614
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 597 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 613 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 967
+      ID: 983
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1.6632e+06
       GoKind: 22
-      Pointee: 968 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 984 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 875
+      ID: 891
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1.080832e+06
       GoKind: 22
-      Pointee: 876 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 892 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 1058
+      ID: 1074
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
       GoRuntimeType: 1.257248e+06
       GoKind: 22
-      Pointee: 1059 StructureType go.uber.org/zap.nopCloserSink
+      Pointee: 1075 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
-      ID: 1149
+      ID: 1165
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.14032e+06
       GoKind: 22
-      Pointee: 1150 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+      Pointee: 1166 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
-      ID: 1044
+      ID: 1060
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
       GoRuntimeType: 1.083136e+06
       GoKind: 22
-      Pointee: 1045 StructureType go.uber.org/zap/zapcore.writerWrapper
+      Pointee: 1061 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
-      ID: 791
+      ID: 807
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 941632
       GoKind: 22
-      Pointee: 599 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 615 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 933
+      ID: 949
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1.258912e+06
       GoKind: 22
-      Pointee: 934 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 950 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 794
+      ID: 810
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 941920
       GoKind: 22
-      Pointee: 795 StructureType golang.org/x/net/http2.connError
+      Pointee: 811 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 793
+      ID: 809
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 941824
       GoKind: 22
-      Pointee: 603 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 619 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 605
+      ID: 621
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 604 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 620 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 797
+      ID: 813
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 942112
       GoKind: 22
-      Pointee: 609 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 625 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 611
+      ID: 627
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 610 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 626 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 796
+      ID: 812
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 942016
       GoKind: 22
-      Pointee: 606 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 622 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 608
+      ID: 624
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 607 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 623 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 792
+      ID: 808
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 941728
       GoKind: 22
-      Pointee: 600 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 616 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 602
+      ID: 618
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 601 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 617 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1147
+      ID: 1163
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.1384e+06
       GoKind: 22
-      Pointee: 1148 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1164 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 798
+      ID: 814
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 942208
       GoKind: 22
-      Pointee: 799 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 815 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 800
+      ID: 816
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 942304
       GoKind: 22
-      Pointee: 612 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 628 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 786
+      ID: 802
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 935584
       GoKind: 22
-      Pointee: 787 StructureType google.golang.org/grpc.dropError
+      Pointee: 803 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 931
+      ID: 947
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1.255968e+06
       GoKind: 22
-      Pointee: 932 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 948 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 956
+      ID: 972
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1.441952e+06
       GoKind: 22
-      Pointee: 957 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 973 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 788
+      ID: 804
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 938656
       GoKind: 22
-      Pointee: 789 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 805 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 1098
+      ID: 1114
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1.803904e+06
       GoKind: 22
-      Pointee: 1099 StructureType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 1115 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 1056
+      ID: 1072
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
       GoRuntimeType: 1.252512e+06
       GoKind: 22
-      Pointee: 1057 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+      Pointee: 1073 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
-      ID: 873
+      ID: 889
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1.075072e+06
       GoKind: 22
-      Pointee: 874 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 890 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 1016
+      ID: 1032
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
       GoRuntimeType: 938752
       GoKind: 22
-      Pointee: 1017 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+      Pointee: 1033 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
-      ID: 766
+      ID: 782
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 923776
       GoKind: 22
-      Pointee: 767 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 783 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 863
+      ID: 879
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1.051904e+06
       GoKind: 22
-      Pointee: 864 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 880 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 929
+      ID: 945
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.223968e+06
       GoKind: 22
-      Pointee: 930 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 946 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 927
+      ID: 943
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1.223712e+06
       GoKind: 22
-      Pointee: 928 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 944 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 780
+      ID: 796
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 928480
       GoKind: 22
-      Pointee: 781 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 797 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 782
+      ID: 798
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 928576
       GoKind: 22
-      Pointee: 783 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 799 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 710
+      ID: 726
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 916000
       GoKind: 22
-      Pointee: 711 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 727 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 1104
+      ID: 1120
       Name: '*hash/crc32.digest'
       ByteSize: 8
       GoRuntimeType: 1.844544e+06
       GoKind: 22
-      Pointee: 1105 UnresolvedPointeeType hash/crc32.digest
+      Pointee: 1121 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
-      ID: 801
+      ID: 817
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 943072
       GoKind: 22
-      Pointee: 802 UnresolvedPointeeType html/template.Error
+      Pointee: 818 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 99
       Name: '*int'
@@ -9972,89 +10078,89 @@ Types:
       GoKind: 22
       Pointee: 155 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 680
+      ID: 696
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 909280
       GoKind: 22
-      Pointee: 681 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 697 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 678
+      ID: 694
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 909184
       GoKind: 22
-      Pointee: 679 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 695 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 1002
+      ID: 1018
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
       GoRuntimeType: 897184
       GoKind: 22
-      Pointee: 1003 UnresolvedPointeeType internal/godebug.runtimeStderr
+      Pointee: 1019 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
-      ID: 890
+      ID: 906
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.195296e+06
       GoKind: 22
-      Pointee: 891 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 907 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 1191
+      ID: 1207
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2.369248e+06
       GoKind: 22
-      Pointee: 1192 UnresolvedPointeeType internal/poll.FD
+      Pointee: 1208 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 888
+      ID: 904
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1.195168e+06
       GoKind: 22
-      Pointee: 889 StructureType internal/poll.errNetClosing
+      Pointee: 905 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 615
+      ID: 631
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 896416
       GoKind: 22
-      Pointee: 616 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 632 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 1048
+      ID: 1064
       Name: '*io.PipeWriter'
       ByteSize: 8
       GoRuntimeType: 1.186976e+06
       GoKind: 22
-      Pointee: 1049 UnresolvedPointeeType io.PipeWriter
+      Pointee: 1065 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
-      ID: 1046
+      ID: 1062
       Name: '*io.discard'
       ByteSize: 8
       GoRuntimeType: 1.186592e+06
       GoKind: 22
-      Pointee: 1047 StructureType io.discard
+      Pointee: 1063 StructureType io.discard
     - __kind: PointerType
-      ID: 1020
+      ID: 1036
       Name: '*io.multiWriter'
       ByteSize: 8
       GoRuntimeType: 1.019904e+06
       GoKind: 22
-      Pointee: 1021 UnresolvedPointeeType io.multiWriter
+      Pointee: 1037 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
-      ID: 886
+      ID: 902
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1.194912e+06
       GoKind: 22
-      Pointee: 887 UnresolvedPointeeType io/fs.PathError
+      Pointee: 903 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 1094
+      ID: 1110
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 1.79808e+06
       GoKind: 22
-      Pointee: 1095 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+      Pointee: 1111 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
       ID: 315
       Name: '*main.anotherStruct'
@@ -10062,19 +10168,19 @@ Types:
       GoKind: 22
       Pointee: 316 StructureType main.anotherStruct
     - __kind: PointerType
-      ID: 337
+      ID: 353
       Name: '*main.deepMap2'
       ByteSize: 8
       GoRuntimeType: 383680
       GoKind: 22
-      Pointee: 338 StructureType main.deepMap2
+      Pointee: 354 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 1235
+      ID: 1251
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 383616
       GoKind: 22
-      Pointee: 1236 UnresolvedPointeeType main.deepMap3
+      Pointee: 1252 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 147
       Name: '*main.deepMap7'
@@ -10083,19 +10189,19 @@ Types:
       GoKind: 22
       Pointee: 148 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 1269
+      ID: 1285
       Name: '*main.deepMap8'
       ByteSize: 8
       GoRuntimeType: 383296
       GoKind: 22
-      Pointee: 1270 StructureType main.deepMap8
+      Pointee: 1286 StructureType main.deepMap8
     - __kind: PointerType
-      ID: 1284
+      ID: 1300
       Name: '*main.deepMap9'
       ByteSize: 8
       GoRuntimeType: 383232
       GoKind: 22
-      Pointee: 1285 StructureType main.deepMap9
+      Pointee: 1301 StructureType main.deepMap9
     - __kind: PointerType
       ID: 131
       Name: '*main.deepPtr2'
@@ -10104,12 +10210,12 @@ Types:
       GoKind: 22
       Pointee: 132 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 1195
+      ID: 1211
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 384192
       GoKind: 22
-      Pointee: 1196 UnresolvedPointeeType main.deepPtr3
+      Pointee: 1212 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 133
       Name: '*main.deepPtr7'
@@ -10118,33 +10224,33 @@ Types:
       GoKind: 22
       Pointee: 134 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 1239
+      ID: 1255
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 383872
       GoKind: 22
-      Pointee: 1240 StructureType main.deepPtr8
+      Pointee: 1256 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 1241
+      ID: 1257
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 383808
       GoKind: 22
-      Pointee: 1242 StructureType main.deepPtr9
+      Pointee: 1258 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 138
       Name: '*main.deepSlice2'
       ByteSize: 8
       GoRuntimeType: 384832
       GoKind: 22
-      Pointee: 328 StructureType main.deepSlice2
+      Pointee: 344 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 1220
+      ID: 1236
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 384768
       GoKind: 22
-      Pointee: 1221 UnresolvedPointeeType main.deepSlice3
+      Pointee: 1237 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 139
       Name: '*main.deepSlice7'
@@ -10153,19 +10259,19 @@ Types:
       GoKind: 22
       Pointee: 140 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 1245
+      ID: 1261
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 384448
       GoKind: 22
-      Pointee: 1246 StructureType main.deepSlice8
+      Pointee: 1262 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 1251
+      ID: 1267
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 384384
       GoKind: 22
-      Pointee: 1252 StructureType main.deepSlice9
+      Pointee: 1268 StructureType main.deepSlice9
     - __kind: PointerType
       ID: 318
       Name: '*main.emptyStruct'
@@ -10180,14 +10286,14 @@ Types:
       GoKind: 22
       Pointee: 158 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 1212
+      ID: 1228
       Name: '*main.firstBehavior'
       ByteSize: 8
       GoRuntimeType: 892384
       GoKind: 22
-      Pointee: 319 StructureType main.firstBehavior
+      Pointee: 335 StructureType main.firstBehavior
     - __kind: PointerType
-      ID: 1301
+      ID: 1317
       Name: '*main.nestedStruct'
       ByteSize: 8
       GoRuntimeType: 385088
@@ -10207,19 +10313,19 @@ Types:
       GoKind: 22
       Pointee: 269 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 1213
+      ID: 1229
       Name: '*main.secondBehavior'
       ByteSize: 8
       GoRuntimeType: 892480
       GoKind: 22
-      Pointee: 1214 StructureType main.secondBehavior
+      Pointee: 1230 StructureType main.secondBehavior
     - __kind: PointerType
-      ID: 1200
+      ID: 1216
       Name: '*main.somethingImpl'
       ByteSize: 8
       GoRuntimeType: 892576
       GoKind: 22
-      Pointee: 1201 UnresolvedPointeeType main.somethingImpl
+      Pointee: 1217 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
       ID: 149
       Name: '*main.stringType1'
@@ -10227,28 +10333,28 @@ Types:
       GoKind: 22
       Pointee: 150 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 1198
+      ID: 1214
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 1197 GoStringDataType main.stringType1.str
+      Pointee: 1213 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 152
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 1199 GoStringHeaderType main.stringType2
+      Pointee: 1215 GoStringHeaderType main.stringType2
     - __kind: PointerType
-      ID: 1303
+      ID: 1319
       Name: '*main.stringType2.str'
       ByteSize: 8
-      Pointee: 1302 GoStringDataType main.stringType2.str
+      Pointee: 1318 GoStringDataType main.stringType2.str
     - __kind: PointerType
       ID: 272
       Name: '*main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 270 StructureType main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 389
+      ID: 405
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 383168
@@ -10272,10 +10378,10 @@ Types:
       GoKind: 22
       Pointee: 247 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 1217
+      ID: 1233
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 1216 GoSliceDataType main.t.array
+      Pointee: 1232 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 267
       Name: '*main.threeStringStruct'
@@ -10308,30 +10414,30 @@ Types:
       ByteSize: 8
       Pointee: 144 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1225
+      ID: 1241
       Name: '*map<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1226 GoSwissMapHeaderType map<int,*main.deepMap3>
+      Pointee: 1242 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1259
+      ID: 1275
       Name: '*map<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1260 GoSwissMapHeaderType map<int,*main.deepMap8>
+      Pointee: 1276 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1274
+      ID: 1290
       Name: '*map<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1275 GoSwissMapHeaderType map<int,*main.deepMap9>
+      Pointee: 1291 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: PointerType
       ID: 165
       Name: '*map<int,int>'
       ByteSize: 8
       Pointee: 166 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 1289
+      ID: 1305
       Name: '*map<int,interface {}>'
       ByteSize: 8
-      Pointee: 1290 GoSwissMapHeaderType map<int,interface {}>
+      Pointee: 1306 GoSwissMapHeaderType map<int,interface {}>
     - __kind: PointerType
       ID: 232
       Name: '*map<int,struct {}>'
@@ -10353,10 +10459,10 @@ Types:
       ByteSize: 8
       Pointee: 181 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 960
+      ID: 976
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 961 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 977 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 175
       Name: '*map<string,int>'
@@ -10424,696 +10530,696 @@ Types:
       GoKind: 22
       Pointee: 174 GoMapType map[string]int
     - __kind: PointerType
-      ID: 714
+      ID: 730
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 916864
       GoKind: 22
-      Pointee: 715 StructureType math/big.ErrNaN
+      Pointee: 731 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 1010
+      ID: 1026
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
       GoRuntimeType: 911680
       GoKind: 22
-      Pointee: 1011 StructureType mime/multipart.writerOnly·1
+      Pointee: 1027 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
-      ID: 917
+      ID: 933
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1.203488e+06
       GoKind: 22
-      Pointee: 918 UnresolvedPointeeType net.AddrError
+      Pointee: 934 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 943
+      ID: 959
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1.417952e+06
       GoKind: 22
-      Pointee: 944 UnresolvedPointeeType net.DNSError
+      Pointee: 960 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 1155
+      ID: 1171
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2.226368e+06
       GoKind: 22
-      Pointee: 1156 UnresolvedPointeeType net.IPConn
+      Pointee: 1172 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 941
+      ID: 957
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1.417632e+06
       GoKind: 22
-      Pointee: 942 UnresolvedPointeeType net.OpError
+      Pointee: 958 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 919
+      ID: 935
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.203616e+06
       GoKind: 22
-      Pointee: 920 UnresolvedPointeeType net.ParseError
+      Pointee: 936 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 1165
+      ID: 1181
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2.257056e+06
       GoKind: 22
-      Pointee: 1166 UnresolvedPointeeType net.TCPConn
+      Pointee: 1182 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 1175
+      ID: 1191
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2.302048e+06
       GoKind: 22
-      Pointee: 1176 UnresolvedPointeeType net.UDPConn
+      Pointee: 1192 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 1163
+      ID: 1179
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2.256544e+06
       GoKind: 22
-      Pointee: 1164 UnresolvedPointeeType net.UnixConn
+      Pointee: 1180 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 916
+      ID: 932
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1.20272e+06
       GoKind: 22
-      Pointee: 879 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 895 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 881
+      ID: 897
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 880 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 896 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 847
+      ID: 863
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1.03488e+06
       GoKind: 22
-      Pointee: 848 StructureType net.canceledError
+      Pointee: 864 StructureType net.canceledError
     - __kind: PointerType
-      ID: 1131
+      ID: 1147
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 2.00208e+06
       GoKind: 22
-      Pointee: 1132 UnresolvedPointeeType net.conn
+      Pointee: 1148 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 985
+      ID: 1001
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1.83984e+06
       GoKind: 22
-      Pointee: 986 StructureType net.dialResult·1
+      Pointee: 1002 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 1177
+      ID: 1193
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2.306304e+06
       GoKind: 22
-      Pointee: 1178 UnresolvedPointeeType net.netFD
+      Pointee: 1194 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 647
+      ID: 663
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 903712
       GoKind: 22
-      Pointee: 648 UnresolvedPointeeType net.notFoundError
+      Pointee: 664 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 649
+      ID: 665
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 904384
       GoKind: 22
-      Pointee: 650 StructureType net.result·2
+      Pointee: 666 StructureType net.result·2
     - __kind: PointerType
-      ID: 1159
+      ID: 1175
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.242592e+06
       GoKind: 22
-      Pointee: 1160 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 1176 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 1157
+      ID: 1173
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.242112e+06
       GoKind: 22
-      Pointee: 1158 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 1174 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 921
+      ID: 937
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1.204256e+06
       GoKind: 22
-      Pointee: 922 UnresolvedPointeeType net.temporaryError
+      Pointee: 938 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 945
+      ID: 961
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.418112e+06
       GoKind: 22
-      Pointee: 946 UnresolvedPointeeType net.timeoutError
+      Pointee: 962 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 837
+      ID: 853
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1.030656e+06
       GoKind: 22
-      Pointee: 838 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 854 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
-      ID: 1004
+      ID: 1020
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
       GoRuntimeType: 899488
       GoKind: 22
-      Pointee: 1005 StructureType net/http.bufioFlushWriter
+      Pointee: 1021 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
-      ID: 624
+      ID: 640
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 900160
       GoKind: 22
-      Pointee: 544 BaseType net/http.http2ConnectionError
+      Pointee: 560 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 625
+      ID: 641
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 900256
       GoKind: 22
-      Pointee: 626 StructureType net/http.http2GoAwayError
+      Pointee: 642 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 937
+      ID: 953
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1.413792e+06
       GoKind: 22
-      Pointee: 938 StructureType net/http.http2StreamError
+      Pointee: 954 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 629
+      ID: 645
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 900832
       GoKind: 22
-      Pointee: 630 StructureType net/http.http2connError
+      Pointee: 646 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 1066
+      ID: 1082
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
       GoRuntimeType: 1.550592e+06
       GoKind: 22
-      Pointee: 1067 UnresolvedPointeeType net/http.http2dataBuffer
+      Pointee: 1083 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 628
+      ID: 644
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 900736
       GoKind: 22
-      Pointee: 548 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 564 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 550
+      ID: 566
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 549 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 565 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 632
+      ID: 648
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 901024
       GoKind: 22
-      Pointee: 554 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 570 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 556
+      ID: 572
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 555 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 571 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 631
+      ID: 647
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 900928
       GoKind: 22
-      Pointee: 551 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 567 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 553
+      ID: 569
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 552 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 568 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 912
+      ID: 928
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1.199264e+06
       GoKind: 22
-      Pointee: 913 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 929 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 843
+      ID: 859
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1.031296e+06
       GoKind: 22
-      Pointee: 844 StructureType net/http.http2noCachedConnError
+      Pointee: 860 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 1120
+      ID: 1136
       Name: '*net/http.http2pipe'
       ByteSize: 8
       GoRuntimeType: 1.944544e+06
       GoKind: 22
-      Pointee: 1121 UnresolvedPointeeType net/http.http2pipe
+      Pointee: 1137 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 627
+      ID: 643
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 900640
       GoKind: 22
-      Pointee: 545 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 561 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 547
+      ID: 563
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 546 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 562 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1006
+      ID: 1022
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
       GoRuntimeType: 901120
       GoKind: 22
-      Pointee: 1007 StructureType net/http.http2stickyErrWriter
+      Pointee: 1023 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
-      ID: 839
+      ID: 855
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1.030912e+06
       GoKind: 22
-      Pointee: 840 StructureType net/http.nothingWrittenError
+      Pointee: 856 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 1068
+      ID: 1084
       Name: '*net/http.persistConn'
       ByteSize: 8
       GoRuntimeType: 2.16768e+06
       GoKind: 22
-      Pointee: 1069 UnresolvedPointeeType net/http.persistConn
+      Pointee: 1085 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
-      ID: 1024
+      ID: 1040
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
       GoRuntimeType: 1.030784e+06
       GoKind: 22
-      Pointee: 1025 StructureType net/http.persistConnWriter
+      Pointee: 1041 StructureType net/http.persistConnWriter
     - __kind: PointerType
-      ID: 1050
+      ID: 1066
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1.198368e+06
       GoKind: 22
-      Pointee: 1051 StructureType net/http.readWriteCloserBody
+      Pointee: 1067 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 633
+      ID: 649
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 901216
       GoKind: 22
-      Pointee: 634 StructureType net/http.requestBodyReadError
+      Pointee: 650 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 939
+      ID: 955
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.414912e+06
       GoKind: 22
-      Pointee: 940 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 956 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 910
+      ID: 926
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1.199136e+06
       GoKind: 22
-      Pointee: 911 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 927 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 841
+      ID: 857
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1.03104e+06
       GoKind: 22
-      Pointee: 842 StructureType net/http.transportReadFromServerError
+      Pointee: 858 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 1102
+      ID: 1118
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
       GoRuntimeType: 1.83648e+06
       GoKind: 22
-      Pointee: 1103 StructureType net/http.unencryptedNetConnInTLSConn
+      Pointee: 1119 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 622
+      ID: 638
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 899392
       GoKind: 22
-      Pointee: 623 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 639 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 1122
+      ID: 1138
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
       GoRuntimeType: 1.94608e+06
       GoKind: 22
-      Pointee: 1123 StructureType net/http/internal.FlushAfterChunkWriter
+      Pointee: 1139 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
-      ID: 1034
+      ID: 1050
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
       GoRuntimeType: 1.043328e+06
       GoKind: 22
-      Pointee: 1035 UnresolvedPointeeType net/http/internal.chunkedWriter
+      Pointee: 1051 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
-      ID: 706
+      ID: 722
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 915808
       GoKind: 22
-      Pointee: 707 StructureType net/netip.parseAddrError
+      Pointee: 723 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 704
+      ID: 720
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 915712
       GoKind: 22
-      Pointee: 705 StructureType net/netip.parsePrefixError
+      Pointee: 721 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 1076
+      ID: 1092
       Name: '*net/smtp.Client'
       ByteSize: 8
       GoRuntimeType: 2.112352e+06
       GoKind: 22
-      Pointee: 1077 UnresolvedPointeeType net/smtp.Client
+      Pointee: 1093 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
-      ID: 1036
+      ID: 1052
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
       GoRuntimeType: 1.048192e+06
       GoKind: 22
-      Pointee: 1037 StructureType net/smtp.dataCloser
+      Pointee: 1053 StructureType net/smtp.dataCloser
     - __kind: PointerType
-      ID: 690
+      ID: 706
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 911872
       GoKind: 22
-      Pointee: 691 UnresolvedPointeeType net/textproto.Error
+      Pointee: 707 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 689
+      ID: 705
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 911776
       GoKind: 22
-      Pointee: 579 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 595 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 581
+      ID: 597
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 580 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 596 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 1032
+      ID: 1048
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
       GoRuntimeType: 1.04256e+06
       GoKind: 22
-      Pointee: 1033 UnresolvedPointeeType net/textproto.dotWriter
+      Pointee: 1049 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
-      ID: 947
+      ID: 963
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1.418432e+06
       GoKind: 22
-      Pointee: 948 UnresolvedPointeeType net/url.Error
+      Pointee: 964 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 651
+      ID: 667
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 904480
       GoKind: 22
-      Pointee: 557 GoStringHeaderType net/url.EscapeError
+      Pointee: 573 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 559
+      ID: 575
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 558 GoStringDataType net/url.EscapeError.str
+      Pointee: 574 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 652
+      ID: 668
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 904576
       GoKind: 22
-      Pointee: 560 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 576 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 562
+      ID: 578
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 561 GoStringDataType net/url.InvalidHostError.str
-    - __kind: PointerType
-      ID: 435
-      Name: '*noalg.map.group[[4]int][4]int'
-      ByteSize: 8
-      Pointee: 436 StructureType noalg.map.group[[4]int][4]int
-    - __kind: PointerType
-      ID: 427
-      Name: '*noalg.map.group[[4]int]uint8'
-      ByteSize: 8
-      Pointee: 428 StructureType noalg.map.group[[4]int]uint8
-    - __kind: PointerType
-      ID: 375
-      Name: '*noalg.map.group[[4]string][2]int'
-      ByteSize: 8
-      Pointee: 376 StructureType noalg.map.group[[4]string][2]int
-    - __kind: PointerType
-      ID: 394
-      Name: '*noalg.map.group[bool]main.node'
-      ByteSize: 8
-      Pointee: 395 StructureType noalg.map.group[bool]main.node
-    - __kind: PointerType
-      ID: 333
-      Name: '*noalg.map.group[int]*main.deepMap2'
-      ByteSize: 8
-      Pointee: 334 StructureType noalg.map.group[int]*main.deepMap2
-    - __kind: PointerType
-      ID: 1231
-      Name: '*noalg.map.group[int]*main.deepMap3'
-      ByteSize: 8
-      Pointee: 1232 StructureType noalg.map.group[int]*main.deepMap3
-    - __kind: PointerType
-      ID: 1265
-      Name: '*noalg.map.group[int]*main.deepMap8'
-      ByteSize: 8
-      Pointee: 1266 StructureType noalg.map.group[int]*main.deepMap8
-    - __kind: PointerType
-      ID: 1280
-      Name: '*noalg.map.group[int]*main.deepMap9'
-      ByteSize: 8
-      Pointee: 1281 StructureType noalg.map.group[int]*main.deepMap9
-    - __kind: PointerType
-      ID: 343
-      Name: '*noalg.map.group[int]int'
-      ByteSize: 8
-      Pointee: 344 StructureType noalg.map.group[int]int
-    - __kind: PointerType
-      ID: 1295
-      Name: '*noalg.map.group[int]interface {}'
-      ByteSize: 8
-      Pointee: 1296 StructureType noalg.map.group[int]interface {}
+      Pointee: 577 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
       ID: 451
-      Name: '*noalg.map.group[int]struct {}'
+      Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 452 StructureType noalg.map.group[int]struct {}
-    - __kind: PointerType
-      ID: 402
-      Name: '*noalg.map.group[int]uint8'
-      ByteSize: 8
-      Pointee: 403 StructureType noalg.map.group[int]uint8
-    - __kind: PointerType
-      ID: 384
-      Name: '*noalg.map.group[string][]main.structWithMap'
-      ByteSize: 8
-      Pointee: 385 StructureType noalg.map.group[string][]main.structWithMap
-    - __kind: PointerType
-      ID: 367
-      Name: '*noalg.map.group[string][]string'
-      ByteSize: 8
-      Pointee: 368 StructureType noalg.map.group[string][]string
-    - __kind: PointerType
-      ID: 992
-      Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
-      ByteSize: 8
-      Pointee: 993 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-    - __kind: PointerType
-      ID: 359
-      Name: '*noalg.map.group[string]int'
-      ByteSize: 8
-      Pointee: 360 StructureType noalg.map.group[string]int
-    - __kind: PointerType
-      ID: 351
-      Name: '*noalg.map.group[string]main.nestedStruct'
-      ByteSize: 8
-      Pointee: 352 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 452 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
       ID: 443
-      Name: '*noalg.map.group[struct {}]int'
+      Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 444 StructureType noalg.map.group[struct {}]int
+      Pointee: 444 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 493
-      Name: '*noalg.map.group[struct {}]main.structWithCyclicMaps'
+      ID: 391
+      Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 494 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
-    - __kind: PointerType
-      ID: 501
-      Name: '*noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps'
-      ByteSize: 8
-      Pointee: 502 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
-    - __kind: PointerType
-      ID: 509
-      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
-      ByteSize: 8
-      Pointee: 510 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-    - __kind: PointerType
-      ID: 517
-      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
-      ByteSize: 8
-      Pointee: 518 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-    - __kind: PointerType
-      ID: 525
-      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
-      ByteSize: 8
-      Pointee: 526 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-    - __kind: PointerType
-      ID: 533
-      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
-      ByteSize: 8
-      Pointee: 534 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-    - __kind: PointerType
-      ID: 459
-      Name: '*noalg.map.group[struct {}]struct {}'
-      ByteSize: 8
-      Pointee: 460 StructureType noalg.map.group[struct {}]struct {}
-    - __kind: PointerType
-      ID: 418
-      Name: '*noalg.map.group[uint8][4]int'
-      ByteSize: 8
-      Pointee: 419 StructureType noalg.map.group[uint8][4]int
+      Pointee: 392 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
       ID: 410
+      Name: '*noalg.map.group[bool]main.node'
+      ByteSize: 8
+      Pointee: 411 StructureType noalg.map.group[bool]main.node
+    - __kind: PointerType
+      ID: 349
+      Name: '*noalg.map.group[int]*main.deepMap2'
+      ByteSize: 8
+      Pointee: 350 StructureType noalg.map.group[int]*main.deepMap2
+    - __kind: PointerType
+      ID: 1247
+      Name: '*noalg.map.group[int]*main.deepMap3'
+      ByteSize: 8
+      Pointee: 1248 StructureType noalg.map.group[int]*main.deepMap3
+    - __kind: PointerType
+      ID: 1281
+      Name: '*noalg.map.group[int]*main.deepMap8'
+      ByteSize: 8
+      Pointee: 1282 StructureType noalg.map.group[int]*main.deepMap8
+    - __kind: PointerType
+      ID: 1296
+      Name: '*noalg.map.group[int]*main.deepMap9'
+      ByteSize: 8
+      Pointee: 1297 StructureType noalg.map.group[int]*main.deepMap9
+    - __kind: PointerType
+      ID: 359
+      Name: '*noalg.map.group[int]int'
+      ByteSize: 8
+      Pointee: 360 StructureType noalg.map.group[int]int
+    - __kind: PointerType
+      ID: 1311
+      Name: '*noalg.map.group[int]interface {}'
+      ByteSize: 8
+      Pointee: 1312 StructureType noalg.map.group[int]interface {}
+    - __kind: PointerType
+      ID: 467
+      Name: '*noalg.map.group[int]struct {}'
+      ByteSize: 8
+      Pointee: 468 StructureType noalg.map.group[int]struct {}
+    - __kind: PointerType
+      ID: 418
+      Name: '*noalg.map.group[int]uint8'
+      ByteSize: 8
+      Pointee: 419 StructureType noalg.map.group[int]uint8
+    - __kind: PointerType
+      ID: 400
+      Name: '*noalg.map.group[string][]main.structWithMap'
+      ByteSize: 8
+      Pointee: 401 StructureType noalg.map.group[string][]main.structWithMap
+    - __kind: PointerType
+      ID: 383
+      Name: '*noalg.map.group[string][]string'
+      ByteSize: 8
+      Pointee: 384 StructureType noalg.map.group[string][]string
+    - __kind: PointerType
+      ID: 1008
+      Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
+      ByteSize: 8
+      Pointee: 1009 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+    - __kind: PointerType
+      ID: 375
+      Name: '*noalg.map.group[string]int'
+      ByteSize: 8
+      Pointee: 376 StructureType noalg.map.group[string]int
+    - __kind: PointerType
+      ID: 367
+      Name: '*noalg.map.group[string]main.nestedStruct'
+      ByteSize: 8
+      Pointee: 368 StructureType noalg.map.group[string]main.nestedStruct
+    - __kind: PointerType
+      ID: 459
+      Name: '*noalg.map.group[struct {}]int'
+      ByteSize: 8
+      Pointee: 460 StructureType noalg.map.group[struct {}]int
+    - __kind: PointerType
+      ID: 509
+      Name: '*noalg.map.group[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 510 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 517
+      Name: '*noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 518 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 525
+      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 526 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 533
+      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 534 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 541
+      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 542 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 549
+      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 550 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 475
+      Name: '*noalg.map.group[struct {}]struct {}'
+      ByteSize: 8
+      Pointee: 476 StructureType noalg.map.group[struct {}]struct {}
+    - __kind: PointerType
+      ID: 434
+      Name: '*noalg.map.group[uint8][4]int'
+      ByteSize: 8
+      Pointee: 435 StructureType noalg.map.group[uint8][4]int
+    - __kind: PointerType
+      ID: 426
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 411 StructureType noalg.map.group[uint8]uint8
+      Pointee: 427 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
-      ID: 1183
+      ID: 1199
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2.34496e+06
       GoKind: 22
-      Pointee: 1184 UnresolvedPointeeType os.File
+      Pointee: 1200 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 818
+      ID: 834
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1.021952e+06
       GoKind: 22
-      Pointee: 819 UnresolvedPointeeType os.LinkError
+      Pointee: 835 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 882
+      ID: 898
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1.188256e+06
       GoKind: 22
-      Pointee: 883 UnresolvedPointeeType os.SyscallError
+      Pointee: 899 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 1181
+      ID: 1197
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.34128e+06
       GoKind: 22
-      Pointee: 1182 StructureType os.fileWithoutReadFrom
+      Pointee: 1198 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 1179
+      ID: 1195
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.340544e+06
       GoKind: 22
-      Pointee: 1180 StructureType os.fileWithoutWriteTo
+      Pointee: 1196 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 849
+      ID: 865
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1.039232e+06
       GoKind: 22
-      Pointee: 850 UnresolvedPointeeType os/exec.Error
+      Pointee: 866 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 988
+      ID: 1004
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2.082208e+06
       GoKind: 22
-      Pointee: 989 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 1005 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 1054
+      ID: 1070
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
       GoRuntimeType: 1.210528e+06
       GoKind: 22
-      Pointee: 1055 UnresolvedPointeeType os/exec.prefixSuffixSaver
+      Pointee: 1071 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
-      ID: 851
+      ID: 867
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1.03936e+06
       GoKind: 22
-      Pointee: 852 StructureType os/exec.wrappedError
+      Pointee: 868 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 785
+      ID: 801
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 933664
       GoKind: 22
-      Pointee: 593 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 609 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 595
+      ID: 611
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 594 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 610 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 784
+      ID: 800
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 933568
       GoKind: 22
-      Pointee: 592 BaseType os/user.UnknownUserIdError
+      Pointee: 608 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 617
+      ID: 633
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 897088
       GoKind: 22
-      Pointee: 618 UnresolvedPointeeType reflect.ValueError
+      Pointee: 634 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 712
+      ID: 728
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 916480
       GoKind: 22
-      Pointee: 713 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 729 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 822
+      ID: 838
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1.023488e+06
       GoKind: 22
-      Pointee: 823 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 839 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 826
+      ID: 842
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1.02528e+06
       GoKind: 22
-      Pointee: 827 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 843 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
@@ -11129,12 +11235,12 @@ Types:
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 824
+      ID: 840
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1.023616e+06
       GoKind: 22
-      Pointee: 825 StructureType runtime.boundsError
+      Pointee: 841 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 62
       Name: '*runtime.cgoCallers'
@@ -11150,24 +11256,24 @@ Types:
       GoKind: 22
       Pointee: 48 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 884
+      ID: 900
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1.193632e+06
       GoKind: 22
-      Pointee: 885 StructureType runtime.errorAddressString
+      Pointee: 901 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 820
+      ID: 836
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1.023104e+06
       GoKind: 22
-      Pointee: 803 GoStringHeaderType runtime.errorString
+      Pointee: 819 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 805
+      ID: 821
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 804 GoStringDataType runtime.errorString.str
+      Pointee: 820 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 55
       Name: '*runtime.g'
@@ -11183,17 +11289,17 @@ Types:
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
-      ID: 821
+      ID: 837
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1.023232e+06
       GoKind: 22
-      Pointee: 806 GoStringHeaderType runtime.plainError
+      Pointee: 822 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 808
+      ID: 824
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 807 GoStringDataType runtime.plainError.str
+      Pointee: 823 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
@@ -11223,12 +11329,12 @@ Types:
       GoKind: 22
       Pointee: 77 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 828
+      ID: 844
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1.025536e+06
       GoKind: 22
-      Pointee: 829 UnresolvedPointeeType strconv.NumError
+      Pointee: 845 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 93
       Name: '*string'
@@ -11237,218 +11343,218 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 321
+      ID: 337
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 320 GoStringDataType string.str
+      Pointee: 336 GoStringDataType string.str
     - __kind: PointerType
-      ID: 1118
+      ID: 1134
       Name: '*strings.Builder'
       ByteSize: 8
       GoRuntimeType: 1.943264e+06
       GoKind: 22
-      Pointee: 1119 UnresolvedPointeeType strings.Builder
+      Pointee: 1135 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
-      ID: 1022
+      ID: 1038
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
       GoRuntimeType: 1.025664e+06
       GoKind: 22
-      Pointee: 1023 UnresolvedPointeeType strings.appendSliceWriter
+      Pointee: 1039 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
-      ID: 1018
+      ID: 1034
       Name: '*struct { io.Writer }'
       ByteSize: 8
       GoRuntimeType: 966464
       GoKind: 22
-      Pointee: 1019 StructureType struct { io.Writer }
+      Pointee: 1035 StructureType struct { io.Writer }
     - __kind: PointerType
       ID: 265
       Name: '*struct {}'
       ByteSize: 8
       Pointee: 123 StructureType struct {}
     - __kind: PointerType
-      ID: 936
+      ID: 952
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1.413152e+06
       GoKind: 22
-      Pointee: 935 BaseType syscall.Errno
+      Pointee: 951 BaseType syscall.Errno
     - __kind: PointerType
       ID: 225
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 433 StructureType table<[4]int,[4]int>
+      Pointee: 449 StructureType table<[4]int,[4]int>
     - __kind: PointerType
       ID: 220
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 425 StructureType table<[4]int,uint8>
+      Pointee: 441 StructureType table<[4]int,uint8>
     - __kind: PointerType
       ID: 188
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 373 StructureType table<[4]string,[2]int>
+      Pointee: 389 StructureType table<[4]string,[2]int>
     - __kind: PointerType
       ID: 200
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 392 StructureType table<bool,main.node>
+      Pointee: 408 StructureType table<bool,main.node>
     - __kind: PointerType
       ID: 146
       Name: '*table<int,*main.deepMap2>'
       ByteSize: 8
-      Pointee: 331 StructureType table<int,*main.deepMap2>
+      Pointee: 347 StructureType table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1228
+      ID: 1244
       Name: '*table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1229 StructureType table<int,*main.deepMap3>
+      Pointee: 1245 StructureType table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1262
+      ID: 1278
       Name: '*table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1263 StructureType table<int,*main.deepMap8>
+      Pointee: 1279 StructureType table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1277
+      ID: 1293
       Name: '*table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1278 StructureType table<int,*main.deepMap9>
+      Pointee: 1294 StructureType table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 168
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 341 StructureType table<int,int>
+      Pointee: 357 StructureType table<int,int>
     - __kind: PointerType
-      ID: 1292
+      ID: 1308
       Name: '*table<int,interface {}>'
       ByteSize: 8
-      Pointee: 1293 StructureType table<int,interface {}>
+      Pointee: 1309 StructureType table<int,interface {}>
     - __kind: PointerType
       ID: 235
       Name: '*table<int,struct {}>'
       ByteSize: 8
-      Pointee: 449 StructureType table<int,struct {}>
+      Pointee: 465 StructureType table<int,struct {}>
     - __kind: PointerType
       ID: 205
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 400 StructureType table<int,uint8>
+      Pointee: 416 StructureType table<int,uint8>
     - __kind: PointerType
       ID: 195
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 382 StructureType table<string,[]main.structWithMap>
+      Pointee: 398 StructureType table<string,[]main.structWithMap>
     - __kind: PointerType
       ID: 183
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 365 StructureType table<string,[]string>
+      Pointee: 381 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 963
+      ID: 979
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 990 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 1006 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 178
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 357 StructureType table<string,int>
+      Pointee: 373 StructureType table<string,int>
     - __kind: PointerType
       ID: 173
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 349 StructureType table<string,main.nestedStruct>
+      Pointee: 365 StructureType table<string,main.nestedStruct>
     - __kind: PointerType
       ID: 230
       Name: '*table<struct {},int>'
       ByteSize: 8
-      Pointee: 441 StructureType table<struct {},int>
+      Pointee: 457 StructureType table<struct {},int>
     - __kind: PointerType
       ID: 288
       Name: '*table<struct {},main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 491 StructureType table<struct {},main.structWithCyclicMaps>
+      Pointee: 507 StructureType table<struct {},main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 293
       Name: '*table<struct {},map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 499 StructureType table<struct {},map[struct {}]main.structWithCyclicMaps>
+      Pointee: 515 StructureType table<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 298
       Name: '*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 507 StructureType table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 523 StructureType table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 303
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 515 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 531 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 308
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 523 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 539 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 313
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 531 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 547 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 240
       Name: '*table<struct {},struct {}>'
       ByteSize: 8
-      Pointee: 457 StructureType table<struct {},struct {}>
+      Pointee: 473 StructureType table<struct {},struct {}>
     - __kind: PointerType
       ID: 215
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 416 StructureType table<uint8,[4]int>
+      Pointee: 432 StructureType table<uint8,[4]int>
     - __kind: PointerType
       ID: 210
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 408 StructureType table<uint8,uint8>
+      Pointee: 424 StructureType table<uint8,uint8>
     - __kind: PointerType
-      ID: 1153
+      ID: 1169
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
       GoRuntimeType: 2.152576e+06
       GoKind: 22
-      Pointee: 1154 UnresolvedPointeeType text/tabwriter.Writer
+      Pointee: 1170 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
-      ID: 877
+      ID: 893
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1.084672e+06
       GoKind: 22
-      Pointee: 878 StructureType text/template.ExecError
+      Pointee: 894 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 952
+      ID: 968
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.618656e+06
       GoKind: 22
-      Pointee: 953 UnresolvedPointeeType time.Location
+      Pointee: 969 UnresolvedPointeeType time.Location
     - __kind: PointerType
-      ID: 620
+      ID: 636
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 897952
       GoKind: 22
-      Pointee: 621 UnresolvedPointeeType time.ParseError
+      Pointee: 637 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 619
+      ID: 635
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 897856
       GoKind: 22
-      Pointee: 541 GoStringHeaderType time.fileSizeError
+      Pointee: 557 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 543
+      ID: 559
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 542 GoStringDataType time.fileSizeError.str
+      Pointee: 558 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
       ID: 105
       Name: '*uint'
@@ -11492,52 +11598,88 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: PointerType
-      ID: 708
+      ID: 724
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 915904
       GoKind: 22
-      Pointee: 709 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 725 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 1145
+      ID: 1161
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.128032e+06
       GoKind: 22
-      Pointee: 1146 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1162 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 692
+      ID: 708
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 912064
       GoKind: 22
-      Pointee: 693 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 709 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 694
+      ID: 710
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 912160
       GoKind: 22
-      Pointee: 582 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 598 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 856
+      ID: 872
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1.043072e+06
       GoKind: 22
-      Pointee: 857 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 873 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 858
+      ID: 874
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1.0432e+06
       GoKind: 22
-      Pointee: 811 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 827 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1551
+      ID: 1568
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
     - __kind: EventRootType
-      ID: 1549
+      ID: 1552
+      Name: Probe[main.executeStructFuncs]Line
+      ByteSize: 66
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: sta.a
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 333 ArrayType [3]uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 10, name: sta}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: sta.b
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 10, name: sta}
+                  Offset: 24
+                  ByteSize: 1
+        - Name: sta.c
+          Offset: 26
+          Kind: template_segment
+          Expression:
+            Type: 334 ArrayType [5]int64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 10, name: sta}
+                  Offset: 32
+                  ByteSize: 40
+    - __kind: EventRootType
+      ID: 1566
       Name: Probe[main.firstBehavior.DoSomething]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11546,14 +11688,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 319 StructureType main.firstBehavior
+            Type: 335 StructureType main.firstBehavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 0, name: b}
+                  Variable: {subprogram: 165, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1550
+      ID: 1567
       Name: Probe[main.firstBehavior.DoSomething]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11565,14 +11707,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 1, name: ~r0}
+                  Variable: {subprogram: 165, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1507
+      ID: 1523
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1508
+      ID: 1524
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11588,7 +11730,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1374
+      ID: 1390
       Name: Probe[main.testAnyPtr]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11614,7 +11756,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1375
+      ID: 1391
       Name: Probe[main.testAnyPtr]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11630,7 +11772,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1371
+      ID: 1387
       Name: Probe[main.testAny]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11656,7 +11798,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1372
+      ID: 1388
       Name: Probe[main.testAny]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11672,7 +11814,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1478
+      ID: 1494
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11698,7 +11840,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1479
+      ID: 1495
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11714,7 +11856,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1322
+      ID: 1338
       Name: Probe[main.testArrayEmptyStructs]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11740,7 +11882,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1320
+      ID: 1336
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 129
       PresenceBitsetSize: 1
@@ -11766,7 +11908,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1318
+      ID: 1334
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -11792,7 +11934,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1383
+      ID: 1399
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11818,7 +11960,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1319
+      ID: 1335
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -11844,7 +11986,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1321
+      ID: 1337
       Name: Probe[main.testArrayOfStructs]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -11870,7 +12012,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1405
+      ID: 1421
       Name: Probe[main.testAtomicAdd]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11896,7 +12038,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1406
+      ID: 1422
       Name: Probe[main.testAtomicAdd]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11912,7 +12054,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1340
+      ID: 1356
       Name: Probe[main.testBigStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -11938,10 +12080,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1341
+      ID: 1357
       Name: Probe[main.testBigStruct]Return
     - __kind: EventRootType
-      ID: 1307
+      ID: 1323
       Name: Probe[main.testBoolArray]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -11967,7 +12109,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1304
+      ID: 1320
       Name: Probe[main.testByteArray]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -11993,7 +12135,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1407
+      ID: 1423
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -12019,7 +12161,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1401
+      ID: 1417
       Name: Probe[main.testCombinedByte]
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -12085,7 +12227,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1402
+      ID: 1418
       Name: Probe[main.testCombinedString]
       ByteSize: 18
       PresenceBitsetSize: 1
@@ -12111,7 +12253,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1403
+      ID: 1419
       Name: Probe[main.testCombinedString]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -12147,7 +12289,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1415
+      ID: 1431
       Name: Probe[main.testCycle]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12173,7 +12315,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1346
+      ID: 1362
       Name: Probe[main.testDeepMap1]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12199,7 +12341,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1347
+      ID: 1363
       Name: Probe[main.testDeepMap7]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12225,7 +12367,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1342
+      ID: 1358
       Name: Probe[main.testDeepPtr1]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12251,7 +12393,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1343
+      ID: 1359
       Name: Probe[main.testDeepPtr7]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12277,7 +12419,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1344
+      ID: 1360
       Name: Probe[main.testDeepSlice1]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12303,7 +12445,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1345
+      ID: 1361
       Name: Probe[main.testDeepSlice7]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12329,7 +12471,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1498
+      ID: 1514
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -12375,7 +12517,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1495
+      ID: 1511
       Name: Probe[main.testEmptySlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12401,7 +12543,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1521
+      ID: 1537
       Name: Probe[main.testEmptyString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12427,7 +12569,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1535
+      ID: 1551
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12453,7 +12595,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1534
+      ID: 1550
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -12479,7 +12621,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1373
+      ID: 1389
       Name: Probe[main.testError]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12505,7 +12647,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1355
+      ID: 1371
       Name: Probe[main.testEsotericHeap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12531,10 +12673,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1356
+      ID: 1372
       Name: Probe[main.testEsotericHeap]Return
     - __kind: EventRootType
-      ID: 1353
+      ID: 1369
       Name: Probe[main.testEsotericStack]
       ByteSize: 129
       PresenceBitsetSize: 1
@@ -12560,10 +12702,10 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1354
+      ID: 1370
       Name: Probe[main.testEsotericStack]Return
     - __kind: EventRootType
-      ID: 1367
+      ID: 1383
       Name: Probe[main.testFramelessArray]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12589,7 +12731,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1369
+      ID: 1385
       Name: Probe[main.testFramelessArray]Line
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -12625,7 +12767,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1368
+      ID: 1384
       Name: Probe[main.testFramelessArray]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12641,7 +12783,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1365
+      ID: 1381
       Name: Probe[main.testFrameless]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12667,7 +12809,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1366
+      ID: 1382
       Name: Probe[main.testFrameless]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12683,7 +12825,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1357
+      ID: 1373
       Name: Probe[main.testInlinedBA]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12709,10 +12851,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1358
+      ID: 1374
       Name: Probe[main.testInlinedBA]Return
     - __kind: EventRootType
-      ID: 1361
+      ID: 1377
       Name: Probe[main.testInlinedBBA]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12738,13 +12880,13 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1362
+      ID: 1378
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1541
+      ID: 1558
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 1359
+      ID: 1375
       Name: Probe[main.testInlinedBB]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12790,28 +12932,28 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1360
+      ID: 1376
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1542
+      ID: 1559
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1543
+      ID: 1560
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1544
+      ID: 1561
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1545
+      ID: 1562
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
-      ID: 1363
+      ID: 1379
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 1364
+      ID: 1380
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1538
+      ID: 1555
       Name: Probe[main.testInlinedPrint]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12823,7 +12965,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12833,11 +12975,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1536
+      ID: 1553
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12849,11 +12991,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1537
+      ID: 1554
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12865,7 +13007,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x_val
@@ -12875,11 +13017,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1540
+      ID: 1557
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12891,7 +13033,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12901,14 +13043,14 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1539
+      ID: 1556
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1546
+      ID: 1563
       Name: Probe[main.testInlinedSq]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12920,7 +13062,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12930,11 +13072,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1547
+      ID: 1564
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12946,7 +13088,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12956,11 +13098,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1548
+      ID: 1565
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12972,7 +13114,7 @@ Types:
             Type: 159 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: a}
+                  Variable: {subprogram: 164, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: a
@@ -12982,11 +13124,11 @@ Types:
             Type: 159 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: a}
+                  Variable: {subprogram: 164, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1310
+      ID: 1326
       Name: Probe[main.testInt16Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -13012,7 +13154,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1311
+      ID: 1327
       Name: Probe[main.testInt32Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13038,7 +13180,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1312
+      ID: 1328
       Name: Probe[main.testInt64Array]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13064,7 +13206,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1309
+      ID: 1325
       Name: Probe[main.testInt8Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -13090,7 +13232,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1308
+      ID: 1324
       Name: Probe[main.testIntArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13116,7 +13258,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1370
+      ID: 1386
       Name: Probe[main.testInterface]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13142,7 +13284,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1476
+      ID: 1492
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 161
       PresenceBitsetSize: 1
@@ -13168,7 +13310,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1477
+      ID: 1493
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13184,7 +13326,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1409
+      ID: 1425
       Name: Probe[main.testLinkedList]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13210,36 +13352,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1350
+      ID: 1366
       Name: Probe[main.testLongFunctionWithChangingState]Line
     - __kind: EventRootType
-      ID: 1351
-      Name: Probe[main.testLongFunctionWithChangingState]Line
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: aPerArch
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 1, name: aPerArch}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: b
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 2, name: b}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1352
+      ID: 1367
       Name: Probe[main.testLongFunctionWithChangingState]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13265,7 +13381,33 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1482
+      ID: 1368
+      Name: Probe[main.testLongFunctionWithChangingState]Line
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: aPerArch
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 1, name: aPerArch}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1498
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 147
       PresenceBitsetSize: 3
@@ -13451,7 +13593,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1483
+      ID: 1499
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13467,7 +13609,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1381
+      ID: 1397
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13493,7 +13635,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1388
+      ID: 1404
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13519,7 +13661,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1400
+      ID: 1416
       Name: Probe[main.testMapEmptyKeyAndValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13545,7 +13687,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1398
+      ID: 1414
       Name: Probe[main.testMapEmptyKey]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13571,7 +13713,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1399
+      ID: 1415
       Name: Probe[main.testMapEmptyValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13597,7 +13739,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1385
+      ID: 1401
       Name: Probe[main.testMapIntToInt]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13623,7 +13765,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1397
+      ID: 1413
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13649,7 +13791,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1396
+      ID: 1412
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13675,7 +13817,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1386
+      ID: 1402
       Name: Probe[main.testMapMassive]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13701,7 +13843,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1387
+      ID: 1403
       Name: Probe[main.testMapMassive]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13727,7 +13869,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1395
+      ID: 1411
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13753,7 +13895,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1394
+      ID: 1410
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13779,7 +13921,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1379
+      ID: 1395
       Name: Probe[main.testMapStringToInt]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13805,7 +13947,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1380
+      ID: 1396
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13831,7 +13973,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1378
+      ID: 1394
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13857,7 +13999,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1389
+      ID: 1405
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13883,7 +14025,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1393
+      ID: 1409
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13909,7 +14051,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1392
+      ID: 1408
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13935,7 +14077,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1391
+      ID: 1407
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13961,7 +14103,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1390
+      ID: 1406
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13987,7 +14129,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1518
+      ID: 1534
       Name: Probe[main.testMassiveString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14013,7 +14155,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1519
+      ID: 1535
       Name: Probe[main.testMassiveString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14039,7 +14181,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1484
+      ID: 1500
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 163
       PresenceBitsetSize: 3
@@ -14225,7 +14367,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1485
+      ID: 1501
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -14241,7 +14383,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1488
+      ID: 1504
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -14287,7 +14429,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1489
+      ID: 1505
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -14313,7 +14455,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1480
+      ID: 1496
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 321
       PresenceBitsetSize: 1
@@ -14359,7 +14501,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1481
+      ID: 1497
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -14375,7 +14517,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1434
+      ID: 1450
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14401,7 +14543,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1436
+      ID: 1452
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14447,7 +14589,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1438
+      ID: 1454
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14463,7 +14605,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1440
+      ID: 1456
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14479,7 +14621,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1442
+      ID: 1458
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14495,7 +14637,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1435
+      ID: 1451
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14521,7 +14663,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1437
+      ID: 1453
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -14587,7 +14729,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1439
+      ID: 1455
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14613,7 +14755,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1441
+      ID: 1457
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14639,7 +14781,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1443
+      ID: 1459
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14665,7 +14807,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1404
+      ID: 1420
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 62
       PresenceBitsetSize: 2
@@ -14771,7 +14913,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1430
+      ID: 1446
       Name: Probe[main.testNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14797,7 +14939,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1432
+      ID: 1448
       Name: Probe[main.testNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14823,7 +14965,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1431
+      ID: 1447
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14839,7 +14981,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1433
+      ID: 1449
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14865,7 +15007,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1530
+      ID: 1546
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14891,7 +15033,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1531
+      ID: 1547
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14913,10 +15055,10 @@ Types:
                   Bias: 8
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1532
+      ID: 1548
       Name: Probe[main.testNestedPointer]
     - __kind: EventRootType
-      ID: 1533
+      ID: 1549
       Name: Probe[main.testNestedPointer]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -14938,7 +15080,7 @@ Types:
                   Bias: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1414
+      ID: 1430
       Name: Probe[main.testNilPointer]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14984,7 +15126,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1499
+      ID: 1515
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -15030,7 +15172,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1501
+      ID: 1517
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 67
       PresenceBitsetSize: 1
@@ -15096,7 +15238,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1502
+      ID: 1518
       Name: Probe[main.testNilSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -15122,7 +15264,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1517
+      ID: 1533
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15148,7 +15290,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1410
+      ID: 1426
       Name: Probe[main.testPointerLoop]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15174,7 +15316,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1384
+      ID: 1400
       Name: Probe[main.testPointerToMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15200,7 +15342,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1408
+      ID: 1424
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15226,7 +15368,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1424
+      ID: 1440
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 35
       PresenceBitsetSize: 1
@@ -15272,7 +15414,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1425
+      ID: 1441
       Name: Probe[main.testReturnsAnyAndError]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15298,7 +15440,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1426
+      ID: 1442
       Name: Probe[main.testReturnsAny]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15324,7 +15466,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1427
+      ID: 1443
       Name: Probe[main.testReturnsAny]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15340,10 +15482,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1456
+      ID: 1472
       Name: Probe[main.testReturnsArrayOne]
     - __kind: EventRootType
-      ID: 1457
+      ID: 1473
       Name: Probe[main.testReturnsArrayOne]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15359,10 +15501,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1458
+      ID: 1474
       Name: Probe[main.testReturnsArrayZero]
     - __kind: EventRootType
-      ID: 1459
+      ID: 1475
       Name: Probe[main.testReturnsArrayZero]Return
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -15378,10 +15520,10 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1454
+      ID: 1470
       Name: Probe[main.testReturnsArray]
     - __kind: EventRootType
-      ID: 1455
+      ID: 1471
       Name: Probe[main.testReturnsArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15397,10 +15539,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1462
+      ID: 1478
       Name: Probe[main.testReturnsBacktrackInt]
     - __kind: EventRootType
-      ID: 1463
+      ID: 1479
       Name: Probe[main.testReturnsBacktrackInt]Return
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -15496,10 +15638,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1474
+      ID: 1490
       Name: Probe[main.testReturnsBoolAndUintptr]
     - __kind: EventRootType
-      ID: 1475
+      ID: 1491
       Name: Probe[main.testReturnsBoolAndUintptr]Return
       ByteSize: 10
       PresenceBitsetSize: 1
@@ -15525,10 +15667,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1450
+      ID: 1466
       Name: Probe[main.testReturnsComplex]
     - __kind: EventRootType
-      ID: 1451
+      ID: 1467
       Name: Probe[main.testReturnsComplex]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15554,7 +15696,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1422
+      ID: 1438
       Name: Probe[main.testReturnsError]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -15580,7 +15722,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1423
+      ID: 1439
       Name: Probe[main.testReturnsError]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15596,7 +15738,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1420
+      ID: 1436
       Name: Probe[main.testReturnsIntAndFloat]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15622,7 +15764,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1421
+      ID: 1437
       Name: Probe[main.testReturnsIntAndFloat]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15648,7 +15790,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1418
+      ID: 1434
       Name: Probe[main.testReturnsIntPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15674,7 +15816,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1419
+      ID: 1435
       Name: Probe[main.testReturnsIntPointer]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15690,7 +15832,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1416
+      ID: 1432
       Name: Probe[main.testReturnsInt]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15716,7 +15858,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1417
+      ID: 1433
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15732,7 +15874,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1428
+      ID: 1444
       Name: Probe[main.testReturnsInterface]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15758,7 +15900,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1429
+      ID: 1445
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15774,10 +15916,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1452
+      ID: 1468
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1453
+      ID: 1469
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -15793,10 +15935,10 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1448
+      ID: 1464
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1449
+      ID: 1465
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 139
       PresenceBitsetSize: 3
@@ -15972,10 +16114,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1460
+      ID: 1476
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1461
+      ID: 1477
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15991,10 +16133,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1466
+      ID: 1482
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1467
+      ID: 1483
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16050,10 +16192,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1472
+      ID: 1488
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1473
+      ID: 1489
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -16079,10 +16221,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1470
+      ID: 1486
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1471
+      ID: 1487
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -16098,10 +16240,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1446
+      ID: 1462
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1447
+      ID: 1463
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -16187,10 +16329,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1468
+      ID: 1484
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1469
+      ID: 1485
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16206,10 +16348,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1464
+      ID: 1480
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1465
+      ID: 1481
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -16225,7 +16367,7 @@ Types:
                   Offset: 0
                   ByteSize: 88
     - __kind: EventRootType
-      ID: 1305
+      ID: 1321
       Name: Probe[main.testRuneArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16251,7 +16393,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1326
+      ID: 1342
       Name: Probe[main.testSingleBool]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -16277,7 +16419,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1324
+      ID: 1340
       Name: Probe[main.testSingleByte]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -16303,7 +16445,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1337
+      ID: 1353
       Name: Probe[main.testSingleFloat32]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -16329,7 +16471,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1338
+      ID: 1354
       Name: Probe[main.testSingleFloat64]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16355,7 +16497,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1329
+      ID: 1345
       Name: Probe[main.testSingleInt16]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -16381,7 +16523,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1330
+      ID: 1346
       Name: Probe[main.testSingleInt32]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -16407,7 +16549,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1331
+      ID: 1347
       Name: Probe[main.testSingleInt64]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16433,7 +16575,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1328
+      ID: 1344
       Name: Probe[main.testSingleInt8]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -16479,7 +16621,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1327
+      ID: 1343
       Name: Probe[main.testSingleInt]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16505,7 +16647,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1325
+      ID: 1341
       Name: Probe[main.testSingleRune]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -16531,7 +16673,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1509
+      ID: 1525
       Name: Probe[main.testSingleString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16557,7 +16699,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1334
+      ID: 1350
       Name: Probe[main.testSingleUint16]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -16583,7 +16725,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1335
+      ID: 1351
       Name: Probe[main.testSingleUint32]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -16609,7 +16751,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1336
+      ID: 1352
       Name: Probe[main.testSingleUint64]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16635,7 +16777,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1333
+      ID: 1349
       Name: Probe[main.testSingleUint8]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -16661,7 +16803,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1332
+      ID: 1348
       Name: Probe[main.testSingleUint]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16687,7 +16829,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1505
+      ID: 1521
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16713,7 +16855,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1496
+      ID: 1512
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16739,7 +16881,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1382
+      ID: 1398
       Name: Probe[main.testSmallMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16765,7 +16907,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1444
+      ID: 1460
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16791,7 +16933,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1445
+      ID: 1461
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16827,7 +16969,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1486
+      ID: 1502
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -16853,7 +16995,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1487
+      ID: 1503
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16889,7 +17031,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1306
+      ID: 1322
       Name: Probe[main.testStringArray]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -16915,7 +17057,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1413
+      ID: 1429
       Name: Probe[main.testStringPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16941,7 +17083,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1500
+      ID: 1516
       Name: Probe[main.testStringSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16967,7 +17109,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1348
+      ID: 1364
       Name: Probe[main.testStringType1]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16993,7 +17135,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1349
+      ID: 1365
       Name: Probe[main.testStringType2]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17019,7 +17161,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1497
+      ID: 1513
       Name: Probe[main.testStructSlice]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -17065,7 +17207,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1376
+      ID: 1392
       Name: Probe[main.testStructWithAny]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17091,7 +17233,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1490
+      ID: 1506
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17117,7 +17259,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1491
+      ID: 1507
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17143,7 +17285,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1524
+      ID: 1540
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17169,10 +17311,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1525
+      ID: 1541
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1523
+      ID: 1539
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 289
       PresenceBitsetSize: 1
@@ -17198,7 +17340,7 @@ Types:
                   Offset: 0
                   ByteSize: 144
     - __kind: EventRootType
-      ID: 1377
+      ID: 1393
       Name: Probe[main.testStructWithMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17224,7 +17366,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1526
+      ID: 1542
       Name: Probe[main.testStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17240,7 +17382,7 @@ Types:
                   Offset: 8
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1528
+      ID: 1544
       Name: Probe[main.testStruct]
       ByteSize: 113
       PresenceBitsetSize: 1
@@ -17266,13 +17408,13 @@ Types:
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1527
+      ID: 1543
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1529
+      ID: 1545
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1506
+      ID: 1522
       Name: Probe[main.testSubslices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -17338,7 +17480,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1522
+      ID: 1538
       Name: Probe[main.testSubstrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17404,7 +17546,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1515
+      ID: 1531
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17430,7 +17572,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1516
+      ID: 1532
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17475,7 +17617,7 @@ Types:
                   Bias: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1511
+      ID: 1527
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17501,7 +17643,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1513
+      ID: 1529
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17537,13 +17679,13 @@ Types:
                   Offset: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1512
+      ID: 1528
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1514
+      ID: 1530
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1510
+      ID: 1526
       Name: Probe[main.testThreeStrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17609,7 +17751,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1339
+      ID: 1355
       Name: Probe[main.testTypeAlias]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -17635,7 +17777,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1315
+      ID: 1331
       Name: Probe[main.testUint16Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -17661,7 +17803,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1316
+      ID: 1332
       Name: Probe[main.testUint32Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17687,7 +17829,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1317
+      ID: 1333
       Name: Probe[main.testUint64Array]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17713,7 +17855,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1314
+      ID: 1330
       Name: Probe[main.testUint8Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -17739,7 +17881,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1313
+      ID: 1329
       Name: Probe[main.testUintArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17765,7 +17907,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1412
+      ID: 1428
       Name: Probe[main.testUintPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17791,7 +17933,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1494
+      ID: 1510
       Name: Probe[main.testUintSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17817,7 +17959,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1520
+      ID: 1536
       Name: Probe[main.testUnitializedString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17843,7 +17985,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1411
+      ID: 1427
       Name: Probe[main.testUnsafePointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17869,7 +18011,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1323
+      ID: 1339
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 1601
       PresenceBitsetSize: 1
@@ -17895,7 +18037,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1503
+      ID: 1519
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17921,7 +18063,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1504
+      ID: 1520
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17947,7 +18089,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1492
+      ID: 1508
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17993,7 +18135,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1493
+      ID: 1509
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -18261,7 +18403,15 @@ Types:
       HasCount: true
       Element: 32 StructureType internal/runtime/atomic.Uint32
     - __kind: ArrayType
-      ID: 422
+      ID: 333
+      Name: '[3]uint64'
+      ByteSize: 24
+      GoKind: 17
+      Count: 3
+      HasCount: true
+      Element: 8 BaseType uint64
+    - __kind: ArrayType
+      ID: 438
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 679648
@@ -18270,7 +18420,7 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 379
+      ID: 395
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 679936
@@ -18296,7 +18446,15 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 980
+      ID: 334
+      Name: '[5]int64'
+      ByteSize: 40
+      GoKind: 17
+      Count: 5
+      HasCount: true
+      Element: 13 BaseType int64
+    - __kind: ArrayType
+      ID: 996
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 681472
@@ -18338,15 +18496,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 329 GoSliceDataType []*main.deepSlice2.array
+      Data: 345 GoSliceDataType []*main.deepSlice2.array
     - __kind: GoSliceDataType
-      ID: 329
+      ID: 345
       Name: '[]*main.deepSlice2.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 138 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 1218
+      ID: 1234
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 475328
@@ -18354,22 +18512,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1219 PointerType **main.deepSlice3
+          Type: 1235 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1222 GoSliceDataType []*main.deepSlice3.array
+      Data: 1238 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 1222
+      ID: 1238
       Name: '[]*main.deepSlice3.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1220 PointerType *main.deepSlice3
+      Element: 1236 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 1243
+      ID: 1259
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 475008
@@ -18377,22 +18535,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1244 PointerType **main.deepSlice8
+          Type: 1260 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1247 GoSliceDataType []*main.deepSlice8.array
+      Data: 1263 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 1247
+      ID: 1263
       Name: '[]*main.deepSlice8.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1245 PointerType *main.deepSlice8
+      Element: 1261 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 1249
+      ID: 1265
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 474944
@@ -18400,20 +18558,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1250 PointerType **main.deepSlice9
+          Type: 1266 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1253 GoSliceDataType []*main.deepSlice9.array
+      Data: 1269 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 1253
+      ID: 1269
       Name: '[]*main.deepSlice9.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1251 PointerType *main.deepSlice9
+      Element: 1267 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 127
       Name: '[]*string'
@@ -18430,171 +18588,171 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 326 GoSliceDataType []*string.array
+      Data: 342 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 326
+      ID: 342
       Name: '[]*string.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 93 PointerType *string
     - __kind: GoSliceDataType
-      ID: 439
+      ID: 455
       Name: '[]*table<[4]int,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 225 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 431
+      ID: 447
       Name: '[]*table<[4]int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 220 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 380
+      ID: 396
       Name: '[]*table<[4]string,[2]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 188 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 398
+      ID: 414
       Name: '[]*table<bool,main.node>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 200 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 339
+      ID: 355
       Name: '[]*table<int,*main.deepMap2>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 146 PointerType *table<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 1237
+      ID: 1253
       Name: '[]*table<int,*main.deepMap3>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1228 PointerType *table<int,*main.deepMap3>
+      Element: 1244 PointerType *table<int,*main.deepMap3>
     - __kind: GoSliceDataType
-      ID: 1271
+      ID: 1287
       Name: '[]*table<int,*main.deepMap8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1262 PointerType *table<int,*main.deepMap8>
+      Element: 1278 PointerType *table<int,*main.deepMap8>
     - __kind: GoSliceDataType
-      ID: 1286
+      ID: 1302
       Name: '[]*table<int,*main.deepMap9>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1277 PointerType *table<int,*main.deepMap9>
+      Element: 1293 PointerType *table<int,*main.deepMap9>
     - __kind: GoSliceDataType
-      ID: 347
+      ID: 363
       Name: '[]*table<int,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 168 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 1299
+      ID: 1315
       Name: '[]*table<int,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1292 PointerType *table<int,interface {}>
+      Element: 1308 PointerType *table<int,interface {}>
     - __kind: GoSliceDataType
-      ID: 455
+      ID: 471
       Name: '[]*table<int,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 235 PointerType *table<int,struct {}>
     - __kind: GoSliceDataType
-      ID: 406
+      ID: 422
       Name: '[]*table<int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 205 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 390
+      ID: 406
       Name: '[]*table<string,[]main.structWithMap>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 195 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 371
+      ID: 387
       Name: '[]*table<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 183 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 996
+      ID: 1012
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 963 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 979 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 363
+      ID: 379
       Name: '[]*table<string,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 178 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 355
+      ID: 371
       Name: '[]*table<string,main.nestedStruct>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 173 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 447
+      ID: 463
       Name: '[]*table<struct {},int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 230 PointerType *table<struct {},int>
     - __kind: GoSliceDataType
-      ID: 497
+      ID: 513
       Name: '[]*table<struct {},main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 288 PointerType *table<struct {},main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 505
+      ID: 521
       Name: '[]*table<struct {},map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 293 PointerType *table<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 513
+      ID: 529
       Name: '[]*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 298 PointerType *table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 521
+      ID: 537
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 303 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 529
+      ID: 545
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 308 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 537
+      ID: 553
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 313 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 463
+      ID: 479
       Name: '[]*table<struct {},struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 240 PointerType *table<struct {},struct {}>
     - __kind: GoSliceDataType
-      ID: 423
+      ID: 439
       Name: '[]*table<uint8,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 215 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 414
+      ID: 430
       Name: '[]*table<uint8,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
@@ -18614,9 +18772,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 489 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Data: 505 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 489
+      ID: 505
       Name: '[][][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -18636,9 +18794,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 487 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Data: 503 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 487
+      ID: 503
       Name: '[][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -18658,9 +18816,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 485 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Data: 501 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 485
+      ID: 501
       Name: '[][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -18680,9 +18838,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 483 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Data: 499 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 483
+      ID: 499
       Name: '[][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -18702,9 +18860,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 481 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Data: 497 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 481
+      ID: 497
       Name: '[][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -18724,9 +18882,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 467 GoSliceDataType [][]uint.array
+      Data: 483 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 467
+      ID: 483
       Name: '[][]uint.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -18747,15 +18905,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 473 GoSliceDataType []bool.array
+      Data: 489 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 473
+      ID: 489
       Name: '[]bool.array'
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 975
+      ID: 991
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 484352
@@ -18770,15 +18928,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 998 GoSliceDataType []float64.array
+      Data: 1014 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 998
+      ID: 1014
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 18 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 1255
+      ID: 1271
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 484800
@@ -18793,9 +18951,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1256 GoSliceDataType []interface {}.array
+      Data: 1272 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 1256
+      ID: 1272
       Name: '[]interface {}.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -18815,15 +18973,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 479 GoSliceDataType []main.structWithCyclicSlices.array
+      Data: 495 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 479
+      ID: 495
       Name: '[]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 144
       Element: 270 StructureType main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 388
+      ID: 404
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 475648
@@ -18831,16 +18989,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 389 PointerType *main.structWithMap
+          Type: 405 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 539 GoSliceDataType []main.structWithMap.array
+      Data: 555 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 539
+      ID: 555
       Name: '[]main.structWithMap.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -18860,175 +19018,175 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 469 GoSliceDataType []main.structWithNoStrings.array
+      Data: 485 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 469
+      ID: 485
       Name: '[]main.structWithNoStrings.array'
       DynamicSizeClass: slice
       ByteSize: 2
       Element: 260 StructureType main.structWithNoStrings
     - __kind: GoSliceDataType
-      ID: 440
+      ID: 456
       Name: '[]noalg.map.group[[4]int][4]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 520
-      Element: 436 StructureType noalg.map.group[[4]int][4]int
+      Element: 452 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 432
+      ID: 448
       Name: '[]noalg.map.group[[4]int]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 428 StructureType noalg.map.group[[4]int]uint8
+      Element: 444 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 381
+      ID: 397
       Name: '[]noalg.map.group[[4]string][2]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 648
-      Element: 376 StructureType noalg.map.group[[4]string][2]int
+      Element: 392 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 399
+      ID: 415
       Name: '[]noalg.map.group[bool]main.node.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 395 StructureType noalg.map.group[bool]main.node
+      Element: 411 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
-      ID: 340
+      ID: 356
       Name: '[]noalg.map.group[int]*main.deepMap2.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 334 StructureType noalg.map.group[int]*main.deepMap2
+      Element: 350 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSliceDataType
-      ID: 1238
+      ID: 1254
       Name: '[]noalg.map.group[int]*main.deepMap3.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1232 StructureType noalg.map.group[int]*main.deepMap3
+      Element: 1248 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSliceDataType
-      ID: 1272
+      ID: 1288
       Name: '[]noalg.map.group[int]*main.deepMap8.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1266 StructureType noalg.map.group[int]*main.deepMap8
+      Element: 1282 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSliceDataType
-      ID: 1287
+      ID: 1303
       Name: '[]noalg.map.group[int]*main.deepMap9.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1281 StructureType noalg.map.group[int]*main.deepMap9
+      Element: 1297 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSliceDataType
-      ID: 348
+      ID: 364
       Name: '[]noalg.map.group[int]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 344 StructureType noalg.map.group[int]int
+      Element: 360 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 1300
+      ID: 1316
       Name: '[]noalg.map.group[int]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 1296 StructureType noalg.map.group[int]interface {}
+      Element: 1312 StructureType noalg.map.group[int]interface {}
     - __kind: GoSliceDataType
-      ID: 456
+      ID: 472
       Name: '[]noalg.map.group[int]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 452 StructureType noalg.map.group[int]struct {}
+      Element: 468 StructureType noalg.map.group[int]struct {}
     - __kind: GoSliceDataType
-      ID: 407
+      ID: 423
       Name: '[]noalg.map.group[int]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 403 StructureType noalg.map.group[int]uint8
+      Element: 419 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
-      ID: 391
+      ID: 407
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 385 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 401 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
-      ID: 372
+      ID: 388
       Name: '[]noalg.map.group[string][]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 368 StructureType noalg.map.group[string][]string
+      Element: 384 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 997
+      ID: 1013
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 993 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 1009 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
-      ID: 364
+      ID: 380
       Name: '[]noalg.map.group[string]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 360 StructureType noalg.map.group[string]int
+      Element: 376 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 356
+      ID: 372
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 352 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 368 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 448
+      ID: 464
       Name: '[]noalg.map.group[struct {}]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 444 StructureType noalg.map.group[struct {}]int
+      Element: 460 StructureType noalg.map.group[struct {}]int
     - __kind: GoSliceDataType
-      ID: 498
+      ID: 514
       Name: '[]noalg.map.group[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 392
-      Element: 494 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      Element: 510 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 506
+      ID: 522
       Name: '[]noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 502 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 518 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 514
+      ID: 530
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 510 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 526 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 522
+      ID: 538
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 518 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 534 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 530
+      ID: 546
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 526 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 542 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 538
+      ID: 554
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 534 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 550 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 464
+      ID: 480
       Name: '[]noalg.map.group[struct {}]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 16
-      Element: 460 StructureType noalg.map.group[struct {}]struct {}
+      Element: 476 StructureType noalg.map.group[struct {}]struct {}
     - __kind: GoSliceDataType
-      ID: 424
+      ID: 440
       Name: '[]noalg.map.group[uint8][4]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 419 StructureType noalg.map.group[uint8][4]int
+      Element: 435 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 415
+      ID: 431
       Name: '[]noalg.map.group[uint8]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 24
-      Element: 411 StructureType noalg.map.group[uint8]uint8
+      Element: 427 StructureType noalg.map.group[uint8]uint8
     - __kind: UnresolvedPointeeType
       ID: 40
       Name: '[]runtime.ancestorInfo'
@@ -19049,9 +19207,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 471 GoSliceDataType []string.array
+      Data: 487 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 471
+      ID: 487
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -19071,9 +19229,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 477 GoSliceDataType []struct {}.array
+      Data: 493 GoSliceDataType []struct {}.array
     - __kind: GoSliceDataType
-      ID: 477
+      ID: 493
       Name: '[]struct {}.array'
       DynamicSizeClass: slice
       Element: 123 StructureType struct {}
@@ -19093,9 +19251,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 465 GoSliceDataType []uint.array
+      Data: 481 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 465
+      ID: 481
       Name: '[]uint.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -19116,9 +19274,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 475 GoSliceDataType []uint16.array
+      Data: 491 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 475
+      ID: 491
       Name: '[]uint16.array'
       DynamicSizeClass: slice
       ByteSize: 2
@@ -19139,9 +19297,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 322 GoSliceDataType []uint8.array
+      Data: 338 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 322
+      ID: 338
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -19162,19 +19320,19 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 324 GoSliceDataType []uintptr.array
+      Data: 340 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 324
+      ID: 340
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 1 BaseType uintptr
     - __kind: UnresolvedPointeeType
-      ID: 1130
+      ID: 1146
       Name: archive/tar.Writer
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 771
+      ID: 787
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 927040
@@ -19189,33 +19347,33 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 772 GoSliceDataType archive/tar.headerError.array
+      Data: 788 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 772
+      ID: 788
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1065
+      ID: 1081
       Name: archive/tar.regFileWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1013
+      ID: 1029
       Name: archive/zip.countWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1015
+      ID: 1031
       Name: archive/zip.dirWriter
       GoRuntimeType: 1.115808e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1113
+      ID: 1129
       Name: archive/zip.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1041
+      ID: 1057
       Name: archive/zip.nopCloser
       ByteSize: 16
       GoRuntimeType: 1.561152e+06
@@ -19225,7 +19383,7 @@ Types:
           Offset: 0
           Type: 129 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1043
+      ID: 1059
       Name: archive/zip.pooledFlateWriter
       ByteSize: 8
     - __kind: BaseType
@@ -19235,15 +19393,15 @@ Types:
       GoRuntimeType: 581920
       GoKind: 1
     - __kind: UnresolvedPointeeType
-      ID: 1088
+      ID: 1104
       Name: bufio.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1117
+      ID: 1133
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1168
+      ID: 1184
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
@@ -19269,13 +19427,13 @@ Types:
       GoRuntimeType: 581664
       GoKind: 15
     - __kind: BaseType
-      ID: 574
+      ID: 590
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 831552
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 575
+      ID: 591
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 831648
@@ -19283,110 +19441,110 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 577 PointerType *compress/flate.InternalError.str
+          Type: 593 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 576 GoStringDataType compress/flate.InternalError.str
+      Data: 592 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 576
+      ID: 592
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1063
+      ID: 1079
       Name: compress/flate.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1009
+      ID: 1025
       Name: compress/flate.dictWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1085
+      ID: 1101
       Name: compress/gzip.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 915
+      ID: 931
       Name: context.deadlineExceededError
       GoRuntimeType: 1.475392e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 588
+      ID: 604
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 834144
       GoKind: 2
     - __kind: BaseType
-      ID: 589
+      ID: 605
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 834240
       GoKind: 2
     - __kind: BaseType
-      ID: 590
+      ID: 606
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 834336
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1075
+      ID: 1091
       Name: crypto/internal/fips140/hmac.HMAC
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1109
+      ID: 1125
       Name: crypto/internal/fips140/sha256.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1141
+      ID: 1157
       Name: crypto/internal/fips140/sha3.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1115
+      ID: 1131
       Name: crypto/internal/fips140/sha3.SHAKE
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1111
+      ID: 1127
       Name: crypto/internal/fips140/sha512.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1107
+      ID: 1123
       Name: crypto/md5.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 591
+      ID: 607
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 834432
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1125
+      ID: 1141
       Name: crypto/sha1.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1097
+      ID: 1113
       Name: crypto/sha3.SHA3
       ByteSize: 8
     - __kind: BaseType
-      ID: 578
+      ID: 594
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 832128
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 855
+      ID: 871
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1194
+      ID: 1210
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 687
+      ID: 703
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 685
+      ID: 701
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1.724576e+06
@@ -19397,34 +19555,34 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 980 ArrayType [5]uint8
+          Type: 996 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 981 GoInterfaceType net.Conn
+          Type: 997 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 810
+      ID: 826
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 989280
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1073
+      ID: 1089
       Name: crypto/tls.cthWrapper
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1080
+      ID: 1096
       Name: crypto/tls.finishedHash
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 950
+      ID: 966
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 965
+      ID: 981
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 759
+      ID: 775
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1.727456e+06
@@ -19432,21 +19590,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 964 PointerType *crypto/x509.Certificate
+          Type: 980 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 983 BaseType crypto/x509.InvalidReason
+          Type: 999 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 753
+      ID: 769
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1.113376e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 755
+      ID: 771
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1.595872e+06
@@ -19454,24 +19612,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 964 PointerType *crypto/x509.Certificate
+          Type: 980 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 587
+      ID: 603
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 833760
       GoKind: 2
     - __kind: BaseType
-      ID: 983
+      ID: 999
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 587104
       GoKind: 2
     - __kind: StructureType
-      ID: 860
+      ID: 876
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1.557152e+06
@@ -19481,13 +19639,13 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 761
+      ID: 777
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1.113632e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 757
+      ID: 773
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1.727264e+06
@@ -19495,15 +19653,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 964 PointerType *crypto/x509.Certificate
+          Type: 980 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 14 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 964 PointerType *crypto/x509.Certificate
+          Type: 980 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 775
+      ID: 791
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1.432832e+06
@@ -19513,7 +19671,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 779
+      ID: 795
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1.432992e+06
@@ -19523,55 +19681,55 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 777
+      ID: 793
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 572
+      ID: 588
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 831168
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 1031
+      ID: 1047
       Name: encoding/base64.encoder
       ByteSize: 8
     - __kind: BaseType
-      ID: 573
+      ID: 589
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 831360
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 644
+      ID: 660
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 846
+      ID: 862
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 636
+      ID: 652
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 642
+      ID: 658
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 640
+      ID: 656
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 638
+      ID: 654
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1174
+      ID: 1190
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 646
+      ID: 662
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1.416672e+06
@@ -19581,19 +19739,19 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1039
+      ID: 1055
       Name: encoding/pem.lineBreaker
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 747
+      ID: 763
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 745
+      ID: 761
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 584
+      ID: 600
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 833664
@@ -19601,22 +19759,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 586 PointerType *encoding/xml.UnmarshalError.str
+          Type: 602 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 585 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 601 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 585
+      ID: 601
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 750
+      ID: 766
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1152
+      ID: 1168
       Name: encoding/xml.printer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -19633,11 +19791,11 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 614
+      ID: 630
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 813
+      ID: 829
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -19653,15 +19811,15 @@ Types:
       GoRuntimeType: 581856
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 1162
+      ID: 1178
       Name: fmt.pp
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 815
+      ID: 831
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 817
+      ID: 833
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -19677,11 +19835,11 @@ Types:
       GoRuntimeType: 845280
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 674
+      ID: 690
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 655
+      ID: 671
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1.723424e+06
@@ -19689,7 +19847,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 973 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 989 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 7 BaseType int
@@ -19697,25 +19855,25 @@ Types:
           Offset: 200
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 657
+      ID: 673
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 977
+      ID: 993
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 661
+      ID: 677
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1.109664e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 979
+      ID: 995
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 566
+      ID: 582
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 830592
@@ -19723,18 +19881,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 568 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 584 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 567 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 583 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 567
+      ID: 583
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 973
+      ID: 989
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2.212384e+06
@@ -19742,7 +19900,7 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 974 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 990 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -19757,7 +19915,7 @@ Types:
           Type: 18 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 975 GoSliceHeaderType []float64
+          Type: 991 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 13 BaseType int64
@@ -19766,10 +19924,10 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 976 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 992 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 978 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 994 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
           Type: 261 GoSliceHeaderType []string
@@ -19783,13 +19941,13 @@ Types:
           Offset: 184
           Type: 13 BaseType int64
     - __kind: BaseType
-      ID: 974
+      ID: 990
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 583712
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 563
+      ID: 579
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 830496
@@ -19797,18 +19955,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 565 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 581 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 564 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 580 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 564
+      ID: 580
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 569
+      ID: 585
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 830688
@@ -19816,60 +19974,60 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 571 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 587 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 570 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 586 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 570
+      ID: 586
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1053
+      ID: 1069
       Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1138
+      ID: 1154
       Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 769
+      ID: 785
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 924
+      ID: 940
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1170
+      ID: 1186
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 696
+      ID: 712
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 703
+      ID: 719
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1.112608e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 583
+      ID: 599
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 832800
       GoKind: 2
     - __kind: StructureType
-      ID: 701
+      ID: 717
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1.11248e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 699
+      ID: 715
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1.593952e+06
@@ -19882,7 +20040,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 719
+      ID: 735
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1.594752e+06
@@ -19895,7 +20053,7 @@ Types:
           Offset: 16
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 723
+      ID: 739
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1.726688e+06
@@ -19911,7 +20069,7 @@ Types:
           Offset: 24
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 721
+      ID: 737
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1.426432e+06
@@ -19921,7 +20079,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 717
+      ID: 733
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1.426112e+06
@@ -19931,14 +20089,14 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 959
+      ID: 975
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1.496512e+06
       GoKind: 21
-      HeaderType: 961 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 977 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 982
+      ID: 998
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1.046656e+06
@@ -19953,15 +20111,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1000 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 1016 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 1000
+      ID: 1016
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 731
+      ID: 747
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1.595072e+06
@@ -19969,12 +20127,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 959 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 975 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 959 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 975 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 725
+      ID: 741
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1.426592e+06
@@ -19984,7 +20142,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 729
+      ID: 745
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1.72688e+06
@@ -19995,12 +20153,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 982 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 998 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 982 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 998 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 727
+      ID: 743
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1.594912e+06
@@ -20013,7 +20171,7 @@ Types:
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 733
+      ID: 749
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1.426752e+06
@@ -20021,9 +20179,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 951 StructureType time.Time
+          Type: 967 StructureType time.Time
     - __kind: StructureType
-      ID: 739
+      ID: 755
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1.595392e+06
@@ -20036,7 +20194,7 @@ Types:
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 741
+      ID: 757
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1.427072e+06
@@ -20046,7 +20204,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 737
+      ID: 753
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1.595232e+06
@@ -20059,7 +20217,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 735
+      ID: 751
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1.426912e+06
@@ -20069,7 +20227,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 743
+      ID: 759
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1.595552e+06
@@ -20082,7 +20240,7 @@ Types:
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 663
+      ID: 679
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1.418912e+06
@@ -20092,11 +20250,11 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1091
+      ID: 1107
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 665
+      ID: 681
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1.419072e+06
@@ -20104,21 +20262,21 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 663 StructureType github.com/cihub/seelog.baseError
+          Type: 679 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1071
+      ID: 1087
       Name: github.com/cihub/seelog.connWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1027
+      ID: 1043
       Name: github.com/cihub/seelog.consoleWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1061
+      ID: 1077
       Name: github.com/cihub/seelog.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 669
+      ID: 685
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1.419392e+06
@@ -20126,13 +20284,13 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 663 StructureType github.com/cihub/seelog.baseError
+          Type: 679 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1128
+      ID: 1144
       Name: github.com/cihub/seelog.rollingFileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1139
+      ID: 1155
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
       GoRuntimeType: 2.100768e+06
@@ -20140,12 +20298,12 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1127 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1143 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: maxFileSize
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 1142
+      ID: 1158
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
       GoRuntimeType: 2.124576e+06
@@ -20153,7 +20311,7 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1127 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1143 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: timePattern
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -20161,11 +20319,11 @@ Types:
           Offset: 24
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1029
+      ID: 1045
       Name: github.com/cihub/seelog.smtpWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 667
+      ID: 683
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1.419232e+06
@@ -20173,9 +20331,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 663 StructureType github.com/cihub/seelog.baseError
+          Type: 679 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 671
+      ID: 687
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1.419552e+06
@@ -20183,64 +20341,64 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 663 StructureType github.com/cihub/seelog.baseError
+          Type: 679 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1093
+      ID: 1109
       Name: github.com/cihub/seelog/archive/gzip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1134
+      ID: 1150
       Name: github.com/cihub/seelog/archive/tar.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1136
+      ID: 1152
       Name: github.com/cihub/seelog/archive/zip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 955
+      ID: 971
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 868
+      ID: 884
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 866
+      ID: 882
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 870
+      ID: 886
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 872
+      ID: 888
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1082
+      ID: 1098
       Name: github.com/gogo/protobuf/proto.textWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 862
+      ID: 878
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 677
+      ID: 693
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1.420512e+06
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 7 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 1186
+      ID: 1202
       Name: github.com/json-iterator/go.Stream
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 926
+      ID: 942
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 899
+      ID: 915
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1.834688e+06
@@ -20256,11 +20414,11 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 893
+      ID: 909
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 832
+      ID: 848
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1.697472e+06
@@ -20273,7 +20431,7 @@ Types:
           Offset: 1
           Type: 16 BaseType int8
     - __kind: StructureType
-      ID: 905
+      ID: 921
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1.835136e+06
@@ -20289,13 +20447,13 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 809
+      ID: 825
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 986592
       GoKind: 8
     - __kind: StructureType
-      ID: 897
+      ID: 913
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1.834464e+06
@@ -20311,13 +20469,13 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 984
+      ID: 1000
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 828768
       GoKind: 8
     - __kind: StructureType
-      ID: 895
+      ID: 911
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1.83424e+06
@@ -20325,15 +20483,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 984 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 1000 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 984 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 1000 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 903
+      ID: 919
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1.748928e+06
@@ -20346,7 +20504,7 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 901
+      ID: 917
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1.834912e+06
@@ -20362,11 +20520,11 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1190
+      ID: 1206
       Name: github.com/tinylib/msgp/msgp.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 909
+      ID: 925
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1.619616e+06
@@ -20376,19 +20534,19 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 836
+      ID: 852
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1.279456e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 834
+      ID: 850
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1.279328e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 907
+      ID: 923
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1.74912e+06
@@ -20401,7 +20559,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 596
+      ID: 612
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 836256
@@ -20409,22 +20567,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 598 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 614 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 597 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 613 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 597
+      ID: 613
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 968
+      ID: 984
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 876
+      ID: 892
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1.444672e+06
@@ -20434,7 +20592,7 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 1059
+      ID: 1075
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
       GoRuntimeType: 1.673568e+06
@@ -20442,13 +20600,13 @@ Types:
       RawFields:
         - Name: WriteSyncer
           Offset: 0
-          Type: 1083 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+          Type: 1099 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
     - __kind: UnresolvedPointeeType
-      ID: 1150
+      ID: 1166
       Name: go.uber.org/zap/buffer.Buffer
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1083
+      ID: 1099
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
       GoRuntimeType: 1.12336e+06
@@ -20461,7 +20619,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1045
+      ID: 1061
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
       GoRuntimeType: 1.566112e+06
@@ -20471,19 +20629,19 @@ Types:
           Offset: 0
           Type: 129 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 599
+      ID: 615
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 836832
       GoKind: 10
     - __kind: BaseType
-      ID: 966
+      ID: 982
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 999744
       GoKind: 10
     - __kind: StructureType
-      ID: 934
+      ID: 950
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1.873664e+06
@@ -20494,12 +20652,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 966 BaseType golang.org/x/net/http2.ErrCode
+          Type: 982 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 795
+      ID: 811
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1.602592e+06
@@ -20507,12 +20665,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 966 BaseType golang.org/x/net/http2.ErrCode
+          Type: 982 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 603
+      ID: 619
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 837024
@@ -20520,18 +20678,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 605 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 621 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 604 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 620 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 604
+      ID: 620
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 609
+      ID: 625
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 837216
@@ -20539,18 +20697,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 611 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 627 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 610 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 626 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 610
+      ID: 626
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 606
+      ID: 622
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 837120
@@ -20558,18 +20716,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 608 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 624 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 607 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 623 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 607
+      ID: 623
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 600
+      ID: 616
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 836928
@@ -20577,22 +20735,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 602 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 618 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 601 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 617 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 601
+      ID: 617
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1148
+      ID: 1164
       Name: golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 799
+      ID: 815
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.445312e+06
@@ -20602,13 +20760,13 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: BaseType
-      ID: 612
+      ID: 628
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 837312
       GoKind: 2
     - __kind: StructureType
-      ID: 787
+      ID: 803
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1.440352e+06
@@ -20618,11 +20776,11 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 932
+      ID: 948
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 957
+      ID: 973
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1.901568e+06
@@ -20638,7 +20796,7 @@ Types:
           Offset: 24
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 789
+      ID: 805
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1.602112e+06
@@ -20651,7 +20809,7 @@ Types:
           Offset: 16
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 1099
+      ID: 1115
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
       GoRuntimeType: 1.959136e+06
@@ -20659,16 +20817,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 981 GoInterfaceType net.Conn
+          Type: 997 GoInterfaceType net.Conn
         - Name: r
           Offset: 16
-          Type: 1126 GoInterfaceType io.Reader
+          Type: 1142 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 1057
+      ID: 1073
       Name: google.golang.org/grpc/internal/transport.bufWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 874
+      ID: 890
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1.563712e+06
@@ -20678,29 +20836,29 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1017
+      ID: 1033
       Name: google.golang.org/grpc/mem.writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 767
+      ID: 783
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 864
+      ID: 880
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 930
+      ID: 946
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 928
+      ID: 944
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1.507072e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 781
+      ID: 797
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1.433632e+06
@@ -20710,7 +20868,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 783
+      ID: 799
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1.433792e+06
@@ -20720,393 +20878,393 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 711
+      ID: 727
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 434
+      ID: 450
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 435 PointerType *noalg.map.group[[4]int][4]int
+          Type: 451 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 436 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 440 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      GroupType: 452 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 456 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 426
+      ID: 442
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 427 PointerType *noalg.map.group[[4]int]uint8
+          Type: 443 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 428 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 432 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 444 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 448 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 374
+      ID: 390
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 375 PointerType *noalg.map.group[[4]string][2]int
+          Type: 391 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 376 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 381 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 392 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 397 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 393
+      ID: 409
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 394 PointerType *noalg.map.group[bool]main.node
+          Type: 410 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 395 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 399 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 411 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 415 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 332
+      ID: 348
       Name: groupReference<int,*main.deepMap2>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 333 PointerType *noalg.map.group[int]*main.deepMap2
+          Type: 349 PointerType *noalg.map.group[int]*main.deepMap2
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 334 StructureType noalg.map.group[int]*main.deepMap2
-      GroupSliceType: 340 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
+      GroupType: 350 StructureType noalg.map.group[int]*main.deepMap2
+      GroupSliceType: 356 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
     - __kind: GoSwissMapGroupsType
-      ID: 1230
+      ID: 1246
       Name: groupReference<int,*main.deepMap3>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1231 PointerType *noalg.map.group[int]*main.deepMap3
+          Type: 1247 PointerType *noalg.map.group[int]*main.deepMap3
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1232 StructureType noalg.map.group[int]*main.deepMap3
-      GroupSliceType: 1238 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+      GroupType: 1248 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 1254 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
     - __kind: GoSwissMapGroupsType
-      ID: 1264
+      ID: 1280
       Name: groupReference<int,*main.deepMap8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1265 PointerType *noalg.map.group[int]*main.deepMap8
+          Type: 1281 PointerType *noalg.map.group[int]*main.deepMap8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1266 StructureType noalg.map.group[int]*main.deepMap8
-      GroupSliceType: 1272 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
+      GroupType: 1282 StructureType noalg.map.group[int]*main.deepMap8
+      GroupSliceType: 1288 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
     - __kind: GoSwissMapGroupsType
-      ID: 1279
+      ID: 1295
       Name: groupReference<int,*main.deepMap9>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1280 PointerType *noalg.map.group[int]*main.deepMap9
+          Type: 1296 PointerType *noalg.map.group[int]*main.deepMap9
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1281 StructureType noalg.map.group[int]*main.deepMap9
-      GroupSliceType: 1287 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
+      GroupType: 1297 StructureType noalg.map.group[int]*main.deepMap9
+      GroupSliceType: 1303 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
     - __kind: GoSwissMapGroupsType
-      ID: 342
+      ID: 358
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 343 PointerType *noalg.map.group[int]int
+          Type: 359 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 344 StructureType noalg.map.group[int]int
-      GroupSliceType: 348 GoSliceDataType []noalg.map.group[int]int.array
+      GroupType: 360 StructureType noalg.map.group[int]int
+      GroupSliceType: 364 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 1294
+      ID: 1310
       Name: groupReference<int,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1295 PointerType *noalg.map.group[int]interface {}
+          Type: 1311 PointerType *noalg.map.group[int]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1296 StructureType noalg.map.group[int]interface {}
-      GroupSliceType: 1300 GoSliceDataType []noalg.map.group[int]interface {}.array
+      GroupType: 1312 StructureType noalg.map.group[int]interface {}
+      GroupSliceType: 1316 GoSliceDataType []noalg.map.group[int]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 450
+      ID: 466
       Name: groupReference<int,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 451 PointerType *noalg.map.group[int]struct {}
+          Type: 467 PointerType *noalg.map.group[int]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 452 StructureType noalg.map.group[int]struct {}
-      GroupSliceType: 456 GoSliceDataType []noalg.map.group[int]struct {}.array
+      GroupType: 468 StructureType noalg.map.group[int]struct {}
+      GroupSliceType: 472 GoSliceDataType []noalg.map.group[int]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 401
+      ID: 417
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 402 PointerType *noalg.map.group[int]uint8
+          Type: 418 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 403 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 407 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 419 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 423 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 383
+      ID: 399
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 384 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 400 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 385 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 391 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 401 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 407 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 366
+      ID: 382
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 367 PointerType *noalg.map.group[string][]string
+          Type: 383 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 368 StructureType noalg.map.group[string][]string
-      GroupSliceType: 372 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 384 StructureType noalg.map.group[string][]string
+      GroupSliceType: 388 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 991
+      ID: 1007
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 992 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1008 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 993 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 997 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 1009 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 1013 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
-      ID: 358
+      ID: 374
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 359 PointerType *noalg.map.group[string]int
+          Type: 375 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 360 StructureType noalg.map.group[string]int
-      GroupSliceType: 364 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 376 StructureType noalg.map.group[string]int
+      GroupSliceType: 380 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 350
+      ID: 366
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 351 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 367 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 352 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 356 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+      GroupType: 368 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 372 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 442
+      ID: 458
       Name: groupReference<struct {},int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 443 PointerType *noalg.map.group[struct {}]int
+          Type: 459 PointerType *noalg.map.group[struct {}]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 444 StructureType noalg.map.group[struct {}]int
-      GroupSliceType: 448 GoSliceDataType []noalg.map.group[struct {}]int.array
+      GroupType: 460 StructureType noalg.map.group[struct {}]int
+      GroupSliceType: 464 GoSliceDataType []noalg.map.group[struct {}]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 492
+      ID: 508
       Name: groupReference<struct {},main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 493 PointerType *noalg.map.group[struct {}]main.structWithCyclicMaps
+          Type: 509 PointerType *noalg.map.group[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 494 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 498 GoSliceDataType []noalg.map.group[struct {}]main.structWithCyclicMaps.array
+      GroupType: 510 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 514 GoSliceDataType []noalg.map.group[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 500
+      ID: 516
       Name: groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 501 PointerType *noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 517 PointerType *noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 502 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 506 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 518 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 522 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 508
+      ID: 524
       Name: groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 509 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 525 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 510 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 514 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 526 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 530 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 516
+      ID: 532
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 517 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 533 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 518 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 522 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 534 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 538 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 524
+      ID: 540
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 525 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 541 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 526 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 530 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 542 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 546 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 532
+      ID: 548
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 533 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 549 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 534 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 538 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 550 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 554 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 458
+      ID: 474
       Name: groupReference<struct {},struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 459 PointerType *noalg.map.group[struct {}]struct {}
+          Type: 475 PointerType *noalg.map.group[struct {}]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 460 StructureType noalg.map.group[struct {}]struct {}
-      GroupSliceType: 464 GoSliceDataType []noalg.map.group[struct {}]struct {}.array
+      GroupType: 476 StructureType noalg.map.group[struct {}]struct {}
+      GroupSliceType: 480 GoSliceDataType []noalg.map.group[struct {}]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 417
+      ID: 433
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 418 PointerType *noalg.map.group[uint8][4]int
+          Type: 434 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 419 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 424 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 435 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 440 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 409
+      ID: 425
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 410 PointerType *noalg.map.group[uint8]uint8
+          Type: 426 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 411 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 415 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 427 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 431 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: UnresolvedPointeeType
-      ID: 1105
+      ID: 1121
       Name: hash/crc32.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 802
+      ID: 818
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -21153,7 +21311,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 681
+      ID: 697
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -21179,29 +21337,29 @@ Types:
           Offset: 296
           Type: 2 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 679
+      ID: 695
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1003
+      ID: 1019
       Name: internal/godebug.runtimeStderr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 891
+      ID: 907
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1192
+      ID: 1208
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 889
+      ID: 905
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1.472192e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 616
+      ID: 632
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -21282,7 +21440,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1204
+      ID: 1220
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.469632e+06
@@ -21295,11 +21453,11 @@ Types:
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 1049
+      ID: 1065
       Name: io.PipeWriter
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1089
+      ID: 1105
       Name: io.ReadWriteCloser
       ByteSize: 16
       GoRuntimeType: 1.18672e+06
@@ -21312,7 +21470,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1126
+      ID: 1142
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 1.020032e+06
@@ -21325,7 +21483,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1078
+      ID: 1094
       Name: io.WriteCloser
       ByteSize: 16
       GoRuntimeType: 1.105952e+06
@@ -21351,21 +21509,21 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1047
+      ID: 1063
       Name: io.discard
       GoRuntimeType: 1.460032e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1021
+      ID: 1037
       Name: io.multiWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 887
+      ID: 903
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1095
+      ID: 1111
       Name: log/slog/internal/buffer.Buffer
       ByteSize: 8
     - __kind: StructureType
@@ -21394,7 +21552,25 @@ Types:
       RawFields:
         - Name: nested
           Offset: 0
-          Type: 1301 PointerType *main.nestedStruct
+          Type: 1317 PointerType *main.nestedStruct
+    - __kind: StructureType
+      ID: 323
+      Name: main.bStruct
+      ByteSize: 72
+      GoKind: 25
+      RawFields:
+        - Name: aInt16
+          Offset: 0
+          Type: 94 BaseType int16
+        - Name: nested
+          Offset: 8
+          Type: 314 StructureType main.aStruct
+        - Name: aBool
+          Offset: 64
+          Type: 4 BaseType bool
+        - Name: aInt32
+          Offset: 68
+          Type: 12 BaseType int32
     - __kind: GoInterfaceType
       ID: 160
       Name: main.behavior
@@ -21424,6 +21600,21 @@ Types:
           Offset: 32
           Type: 129 GoInterfaceType io.Writer
     - __kind: StructureType
+      ID: 320
+      Name: main.cStruct
+      ByteSize: 24
+      GoKind: 25
+      RawFields:
+        - Name: aInt32
+          Offset: 0
+          Type: 12 BaseType int32
+        - Name: aUint
+          Offset: 8
+          Type: 10 BaseType uint
+        - Name: nested
+          Offset: 16
+          Type: 260 StructureType main.structWithNoStrings
+    - __kind: StructureType
       ID: 141
       Name: main.deepMap1
       ByteSize: 8
@@ -21434,7 +21625,7 @@ Types:
           Offset: 0
           Type: 142 GoMapType map[int]*main.deepMap2
     - __kind: StructureType
-      ID: 338
+      ID: 354
       Name: main.deepMap2
       ByteSize: 8
       GoRuntimeType: 1.183008e+06
@@ -21442,9 +21633,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1224 GoMapType map[int]*main.deepMap3
+          Type: 1240 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 1236
+      ID: 1252
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -21456,9 +21647,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1258 GoMapType map[int]*main.deepMap8
+          Type: 1274 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 1270
+      ID: 1286
       Name: main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.18224e+06
@@ -21466,9 +21657,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1273 GoMapType map[int]*main.deepMap9
+          Type: 1289 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 1285
+      ID: 1301
       Name: main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.182112e+06
@@ -21476,7 +21667,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1288 GoMapType map[int]interface {}
+          Type: 1304 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 130
       Name: main.deepPtr1
@@ -21496,9 +21687,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1195 PointerType *main.deepPtr3
+          Type: 1211 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 1196
+      ID: 1212
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -21510,9 +21701,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1239 PointerType *main.deepPtr8
+          Type: 1255 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 1240
+      ID: 1256
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1.183392e+06
@@ -21520,9 +21711,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1241 PointerType *main.deepPtr9
+          Type: 1257 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 1242
+      ID: 1258
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1.183264e+06
@@ -21542,7 +21733,7 @@ Types:
           Offset: 0
           Type: 136 GoSliceHeaderType []*main.deepSlice2
     - __kind: StructureType
-      ID: 328
+      ID: 344
       Name: main.deepSlice2
       ByteSize: 24
       GoRuntimeType: 1.185312e+06
@@ -21550,9 +21741,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1218 GoSliceHeaderType []*main.deepSlice3
+          Type: 1234 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 1221
+      ID: 1237
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -21564,9 +21755,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1243 GoSliceHeaderType []*main.deepSlice8
+          Type: 1259 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 1246
+      ID: 1262
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1.184544e+06
@@ -21574,9 +21765,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1249 GoSliceHeaderType []*main.deepSlice9
+          Type: 1265 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 1252
+      ID: 1268
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1.184416e+06
@@ -21584,7 +21775,73 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1255 GoSliceHeaderType []interface {}
+          Type: 1271 GoSliceHeaderType []interface {}
+    - __kind: StructureType
+      ID: 325
+      Name: main.deepStruct1
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: b
+          Offset: 8
+          Type: 326 StructureType main.deepStruct2
+    - __kind: StructureType
+      ID: 326
+      Name: main.deepStruct2
+      ByteSize: 40
+      GoKind: 25
+      RawFields:
+        - Name: c
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: d
+          Offset: 8
+          Type: 327 StructureType main.deepStruct3
+    - __kind: StructureType
+      ID: 327
+      Name: main.deepStruct3
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: e
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: f
+          Offset: 8
+          Type: 328 StructureType main.deepStruct4
+    - __kind: StructureType
+      ID: 328
+      Name: main.deepStruct4
+      ByteSize: 24
+      GoKind: 25
+      RawFields:
+        - Name: g
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: h
+          Offset: 8
+          Type: 329 StructureType main.deepStruct5
+    - __kind: StructureType
+      ID: 329
+      Name: main.deepStruct5
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: i
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: j
+          Offset: 8
+          Type: 330 StructureType main.deepStruct6
+    - __kind: StructureType
+      ID: 330
+      Name: main.deepStruct6
+      ByteSize: 8
+      GoKind: 25
+      RawFields: [{Name: k, Offset: 0, Type: 7 BaseType int}]
     - __kind: StructureType
       ID: 317
       Name: main.emptyStruct
@@ -21602,16 +21859,16 @@ Types:
           Type: 153 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 1202 StructureType sync.Mutex
+          Type: 1218 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 1205 StructureType sync.Once
+          Type: 1221 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 1208 StructureType sync.WaitGroup
+          Type: 1224 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 1211 StructureType sync/atomic.Int32
+          Type: 1227 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 153
       Name: main.esotericStack
@@ -21641,7 +21898,7 @@ Types:
           Offset: 56
           Type: 59 GoSubroutineType func()
     - __kind: StructureType
-      ID: 319
+      ID: 335
       Name: main.firstBehavior
       ByteSize: 16
       GoRuntimeType: 1.409792e+06
@@ -21687,6 +21944,90 @@ Types:
           Offset: 72
           Type: 7 BaseType int
     - __kind: StructureType
+      ID: 331
+      Name: main.lotsOfFields
+      ByteSize: 26
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 3 BaseType uint8
+        - Name: b
+          Offset: 1
+          Type: 3 BaseType uint8
+        - Name: c
+          Offset: 2
+          Type: 3 BaseType uint8
+        - Name: d
+          Offset: 3
+          Type: 3 BaseType uint8
+        - Name: e
+          Offset: 4
+          Type: 3 BaseType uint8
+        - Name: f
+          Offset: 5
+          Type: 3 BaseType uint8
+        - Name: g
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: h
+          Offset: 7
+          Type: 3 BaseType uint8
+        - Name: i
+          Offset: 8
+          Type: 3 BaseType uint8
+        - Name: j
+          Offset: 9
+          Type: 3 BaseType uint8
+        - Name: k
+          Offset: 10
+          Type: 3 BaseType uint8
+        - Name: l
+          Offset: 11
+          Type: 3 BaseType uint8
+        - Name: m
+          Offset: 12
+          Type: 3 BaseType uint8
+        - Name: n
+          Offset: 13
+          Type: 3 BaseType uint8
+        - Name: o
+          Offset: 14
+          Type: 3 BaseType uint8
+        - Name: p
+          Offset: 15
+          Type: 3 BaseType uint8
+        - Name: q
+          Offset: 16
+          Type: 3 BaseType uint8
+        - Name: r
+          Offset: 17
+          Type: 3 BaseType uint8
+        - Name: s
+          Offset: 18
+          Type: 3 BaseType uint8
+        - Name: t
+          Offset: 19
+          Type: 3 BaseType uint8
+        - Name: u
+          Offset: 20
+          Type: 3 BaseType uint8
+        - Name: v
+          Offset: 21
+          Type: 3 BaseType uint8
+        - Name: w
+          Offset: 22
+          Type: 3 BaseType uint8
+        - Name: x
+          Offset: 23
+          Type: 3 BaseType uint8
+        - Name: y
+          Offset: 24
+          Type: 3 BaseType uint8
+        - Name: z
+          Offset: 25
+          Type: 3 BaseType uint8
+    - __kind: StructureType
       ID: 252
       Name: main.mixedStruct
       ByteSize: 24
@@ -21701,6 +22042,21 @@ Types:
         - Name: c
           Offset: 16
           Type: 7 BaseType int
+    - __kind: StructureType
+      ID: 319
+      Name: main.nStruct
+      ByteSize: 24
+      GoKind: 25
+      RawFields:
+        - Name: aBool
+          Offset: 0
+          Type: 4 BaseType bool
+        - Name: aInt
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: aInt16
+          Offset: 16
+          Type: 94 BaseType int16
     - __kind: StructureType
       ID: 121
       Name: main.nestedStruct
@@ -21737,7 +22093,13 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1214
+      ID: 321
+      Name: main.receiver
+      ByteSize: 8
+      GoKind: 25
+      RawFields: [{Name: u, Offset: 0, Type: 10 BaseType uint}]
+    - __kind: StructureType
+      ID: 1230
       Name: main.secondBehavior
       ByteSize: 8
       GoRuntimeType: 1.409952e+06
@@ -21757,7 +22119,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1201
+      ID: 1217
       Name: main.somethingImpl
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -21768,31 +22130,31 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1198 PointerType *main.stringType1.str
+          Type: 1214 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 1197 GoStringDataType main.stringType1.str
+      Data: 1213 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 1197
+      ID: 1213
       Name: main.stringType1.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 1199
+      ID: 1215
       Name: main.stringType2
       ByteSize: 16
       GoKind: 24
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1303 PointerType *main.stringType2.str
+          Type: 1319 PointerType *main.stringType2.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 1302 GoStringDataType main.stringType2.str
+      Data: 1318 GoStringDataType main.stringType2.str
     - __kind: GoStringDataType
-      ID: 1302
+      ID: 1318
       Name: main.stringType2.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -21889,6 +22251,21 @@ Types:
           Offset: 1
           Type: 4 BaseType bool
     - __kind: StructureType
+      ID: 332
+      Name: main.structWithTwoArrays
+      ByteSize: 72
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 333 ArrayType [3]uint64
+        - Name: b
+          Offset: 24
+          Type: 3 BaseType uint8
+        - Name: c
+          Offset: 32
+          Type: 334 ArrayType [5]int64
+    - __kind: StructureType
       ID: 243
       Name: main.structWithTwoValues
       ByteSize: 16
@@ -21908,23 +22285,74 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1215 PointerType **main.t
+          Type: 1231 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1216 GoSliceDataType main.t.array
+      Data: 1232 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 1216
+      ID: 1232
       Name: main.t.array
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 246 PointerType *main.t
     - __kind: StructureType
+      ID: 324
+      Name: main.tenStrings
+      ByteSize: 160
+      GoKind: 25
+      RawFields:
+        - Name: first
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: second
+          Offset: 16
+          Type: 9 GoStringHeaderType string
+        - Name: third
+          Offset: 32
+          Type: 9 GoStringHeaderType string
+        - Name: fourth
+          Offset: 48
+          Type: 9 GoStringHeaderType string
+        - Name: fifth
+          Offset: 64
+          Type: 9 GoStringHeaderType string
+        - Name: sixth
+          Offset: 80
+          Type: 9 GoStringHeaderType string
+        - Name: seventh
+          Offset: 96
+          Type: 9 GoStringHeaderType string
+        - Name: eighth
+          Offset: 112
+          Type: 9 GoStringHeaderType string
+        - Name: ninth
+          Offset: 128
+          Type: 9 GoStringHeaderType string
+        - Name: tenth
+          Offset: 144
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
       ID: 266
       Name: main.threeStringStruct
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: b
+          Offset: 16
+          Type: 9 GoStringHeaderType string
+        - Name: c
+          Offset: 32
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 322
+      Name: main.threestrings
       ByteSize: 48
       GoKind: 25
       RawFields:
@@ -22011,8 +22439,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 439 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 436 StructureType noalg.map.group[[4]int][4]int
+      TablePtrSliceType: 455 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 452 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
       ID: 218
       Name: map<[4]int,uint8>
@@ -22043,8 +22471,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 431 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 428 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 447 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 444 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 186
       Name: map<[4]string,[2]int>
@@ -22075,8 +22503,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 380 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 376 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 396 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 392 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
       ID: 198
       Name: map<bool,main.node>
@@ -22107,8 +22535,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 398 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 395 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 414 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 411 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
       ID: 144
       Name: map<int,*main.deepMap2>
@@ -22139,10 +22567,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 339 GoSliceDataType []*table<int,*main.deepMap2>.array
-      GroupType: 334 StructureType noalg.map.group[int]*main.deepMap2
+      TablePtrSliceType: 355 GoSliceDataType []*table<int,*main.deepMap2>.array
+      GroupType: 350 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSwissMapHeaderType
-      ID: 1226
+      ID: 1242
       Name: map<int,*main.deepMap3>
       ByteSize: 48
       GoKind: 25
@@ -22155,7 +22583,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1227 PointerType **table<int,*main.deepMap3>
+          Type: 1243 PointerType **table<int,*main.deepMap3>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -22171,10 +22599,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1237 GoSliceDataType []*table<int,*main.deepMap3>.array
-      GroupType: 1232 StructureType noalg.map.group[int]*main.deepMap3
+      TablePtrSliceType: 1253 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 1248 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSwissMapHeaderType
-      ID: 1260
+      ID: 1276
       Name: map<int,*main.deepMap8>
       ByteSize: 48
       GoKind: 25
@@ -22187,7 +22615,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1261 PointerType **table<int,*main.deepMap8>
+          Type: 1277 PointerType **table<int,*main.deepMap8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -22203,10 +22631,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1271 GoSliceDataType []*table<int,*main.deepMap8>.array
-      GroupType: 1266 StructureType noalg.map.group[int]*main.deepMap8
+      TablePtrSliceType: 1287 GoSliceDataType []*table<int,*main.deepMap8>.array
+      GroupType: 1282 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSwissMapHeaderType
-      ID: 1275
+      ID: 1291
       Name: map<int,*main.deepMap9>
       ByteSize: 48
       GoKind: 25
@@ -22219,7 +22647,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1276 PointerType **table<int,*main.deepMap9>
+          Type: 1292 PointerType **table<int,*main.deepMap9>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -22235,8 +22663,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1286 GoSliceDataType []*table<int,*main.deepMap9>.array
-      GroupType: 1281 StructureType noalg.map.group[int]*main.deepMap9
+      TablePtrSliceType: 1302 GoSliceDataType []*table<int,*main.deepMap9>.array
+      GroupType: 1297 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSwissMapHeaderType
       ID: 166
       Name: map<int,int>
@@ -22267,10 +22695,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 347 GoSliceDataType []*table<int,int>.array
-      GroupType: 344 StructureType noalg.map.group[int]int
+      TablePtrSliceType: 363 GoSliceDataType []*table<int,int>.array
+      GroupType: 360 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
-      ID: 1290
+      ID: 1306
       Name: map<int,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -22283,7 +22711,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1291 PointerType **table<int,interface {}>
+          Type: 1307 PointerType **table<int,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -22299,8 +22727,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1299 GoSliceDataType []*table<int,interface {}>.array
-      GroupType: 1296 StructureType noalg.map.group[int]interface {}
+      TablePtrSliceType: 1315 GoSliceDataType []*table<int,interface {}>.array
+      GroupType: 1312 StructureType noalg.map.group[int]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 233
       Name: map<int,struct {}>
@@ -22331,8 +22759,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 455 GoSliceDataType []*table<int,struct {}>.array
-      GroupType: 452 StructureType noalg.map.group[int]struct {}
+      TablePtrSliceType: 471 GoSliceDataType []*table<int,struct {}>.array
+      GroupType: 468 StructureType noalg.map.group[int]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 203
       Name: map<int,uint8>
@@ -22363,8 +22791,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 406 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 403 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 422 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 419 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 193
       Name: map<string,[]main.structWithMap>
@@ -22395,8 +22823,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 390 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 385 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 406 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 401 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
       ID: 181
       Name: map<string,[]string>
@@ -22427,10 +22855,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 371 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 368 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 387 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 384 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 961
+      ID: 977
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -22443,7 +22871,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 962 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 978 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -22459,8 +22887,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 996 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 993 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 1012 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 1009 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
       ID: 176
       Name: map<string,int>
@@ -22491,8 +22919,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 363 GoSliceDataType []*table<string,int>.array
-      GroupType: 360 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 379 GoSliceDataType []*table<string,int>.array
+      GroupType: 376 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
       ID: 171
       Name: map<string,main.nestedStruct>
@@ -22523,8 +22951,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 355 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 352 StructureType noalg.map.group[string]main.nestedStruct
+      TablePtrSliceType: 371 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 368 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSwissMapHeaderType
       ID: 228
       Name: map<struct {},int>
@@ -22555,8 +22983,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 447 GoSliceDataType []*table<struct {},int>.array
-      GroupType: 444 StructureType noalg.map.group[struct {}]int
+      TablePtrSliceType: 463 GoSliceDataType []*table<struct {},int>.array
+      GroupType: 460 StructureType noalg.map.group[struct {}]int
     - __kind: GoSwissMapHeaderType
       ID: 286
       Name: map<struct {},main.structWithCyclicMaps>
@@ -22587,8 +23015,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 497 GoSliceDataType []*table<struct {},main.structWithCyclicMaps>.array
-      GroupType: 494 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 513 GoSliceDataType []*table<struct {},main.structWithCyclicMaps>.array
+      GroupType: 510 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 291
       Name: map<struct {},map[struct {}]main.structWithCyclicMaps>
@@ -22619,8 +23047,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 505 GoSliceDataType []*table<struct {},map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 502 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 521 GoSliceDataType []*table<struct {},map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 518 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 296
       Name: map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -22651,8 +23079,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 513 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 510 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 529 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 526 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 301
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -22683,8 +23111,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 521 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 518 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 537 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 534 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 306
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -22715,8 +23143,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 529 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 526 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 545 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 542 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 311
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -22747,8 +23175,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 537 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 534 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 553 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 550 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 238
       Name: map<struct {},struct {}>
@@ -22779,8 +23207,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 463 GoSliceDataType []*table<struct {},struct {}>.array
-      GroupType: 460 StructureType noalg.map.group[struct {}]struct {}
+      TablePtrSliceType: 479 GoSliceDataType []*table<struct {},struct {}>.array
+      GroupType: 476 StructureType noalg.map.group[struct {}]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 213
       Name: map<uint8,[4]int>
@@ -22811,8 +23239,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 423 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 419 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 439 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 435 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
       ID: 208
       Name: map<uint8,uint8>
@@ -22843,8 +23271,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 414 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 411 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 430 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 427 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
       ID: 221
       Name: map[[4]int][4]int
@@ -22881,26 +23309,26 @@ Types:
       GoKind: 21
       HeaderType: 144 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 1224
+      ID: 1240
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 1.125024e+06
       GoKind: 21
-      HeaderType: 1226 GoSwissMapHeaderType map<int,*main.deepMap3>
+      HeaderType: 1242 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 1258
+      ID: 1274
       Name: map[int]*main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.124384e+06
       GoKind: 21
-      HeaderType: 1260 GoSwissMapHeaderType map<int,*main.deepMap8>
+      HeaderType: 1276 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
-      ID: 1273
+      ID: 1289
       Name: map[int]*main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.124256e+06
       GoKind: 21
-      HeaderType: 1275 GoSwissMapHeaderType map<int,*main.deepMap9>
+      HeaderType: 1291 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 164
       Name: map[int]int
@@ -22909,12 +23337,12 @@ Types:
       GoKind: 21
       HeaderType: 166 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
-      ID: 1288
+      ID: 1304
       Name: map[int]interface {}
       ByteSize: 8
       GoRuntimeType: 1.124128e+06
       GoKind: 21
-      HeaderType: 1290 GoSwissMapHeaderType map<int,interface {}>
+      HeaderType: 1306 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
       ID: 231
       Name: map[int]struct {}
@@ -23022,7 +23450,7 @@ Types:
       GoKind: 21
       HeaderType: 208 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: StructureType
-      ID: 715
+      ID: 731
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1.425792e+06
@@ -23032,7 +23460,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1011
+      ID: 1027
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
       GoRuntimeType: 1.422592e+06
@@ -23042,11 +23470,11 @@ Types:
           Offset: 0
           Type: 129 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 918
+      ID: 934
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 981
+      ID: 997
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1.592672e+06
@@ -23059,35 +23487,35 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 944
+      ID: 960
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1156
+      ID: 1172
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 942
+      ID: 958
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 920
+      ID: 936
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1166
+      ID: 1182
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1176
+      ID: 1192
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1164
+      ID: 1180
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 879
+      ID: 895
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1.10928e+06
@@ -23095,28 +23523,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 881 PointerType *net.UnknownNetworkError.str
+          Type: 897 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 880 GoStringDataType net.UnknownNetworkError.str
+      Data: 896 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 880
+      ID: 896
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 848
+      ID: 864
       Name: net.canceledError
       GoRuntimeType: 1.28048e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1132
+      ID: 1148
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 986
+      ID: 1002
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2.100064e+06
@@ -23124,7 +23552,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 981 GoInterfaceType net.Conn
+          Type: 997 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 14 GoInterfaceType error
@@ -23135,27 +23563,27 @@ Types:
           Offset: 33
           Type: 4 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 1178
+      ID: 1194
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 1172
+      ID: 1188
       Name: net.noReadFrom
       GoRuntimeType: 1.109536e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1171
+      ID: 1187
       Name: net.noWriteTo
       GoRuntimeType: 1.109408e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 648
+      ID: 664
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
-      ID: 650
+      ID: 666
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1.723232e+06
@@ -23163,7 +23591,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 969 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 985 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 9 GoStringHeaderType string
@@ -23171,7 +23599,7 @@ Types:
           Offset: 96
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 1160
+      ID: 1176
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.2848e+06
@@ -23179,12 +23607,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1172 StructureType net.noReadFrom
+          Type: 1188 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 1165 PointerType *net.TCPConn
+          Type: 1181 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 1158
+      ID: 1174
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.284256e+06
@@ -23192,24 +23620,24 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1171 StructureType net.noWriteTo
+          Type: 1187 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 1165 PointerType *net.TCPConn
+          Type: 1181 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 922
+      ID: 938
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 946
+      ID: 962
       Name: net.timeoutError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 838
+      ID: 854
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1005
+      ID: 1021
       Name: net/http.bufioFlushWriter
       ByteSize: 16
       GoRuntimeType: 1.414112e+06
@@ -23219,19 +23647,19 @@ Types:
           Offset: 0
           Type: 129 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 544
+      ID: 560
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 829248
       GoKind: 10
     - __kind: BaseType
-      ID: 958
+      ID: 974
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 986688
       GoKind: 10
     - __kind: StructureType
-      ID: 626
+      ID: 642
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1.721504e+06
@@ -23242,12 +23670,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 958 BaseType net/http.http2ErrCode
+          Type: 974 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 938
+      ID: 954
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1.892864e+06
@@ -23258,12 +23686,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 958 BaseType net/http.http2ErrCode
+          Type: 974 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 630
+      ID: 646
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1.592192e+06
@@ -23271,16 +23699,16 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 958 BaseType net/http.http2ErrCode
+          Type: 974 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1067
+      ID: 1083
       Name: net/http.http2dataBuffer
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 548
+      ID: 564
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 829440
@@ -23288,18 +23716,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 550 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 566 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 549 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 565 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 549
+      ID: 565
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 554
+      ID: 570
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 829632
@@ -23307,18 +23735,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 556 PointerType *net/http.http2headerFieldNameError.str
+          Type: 572 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 555 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 571 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 555
+      ID: 571
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 551
+      ID: 567
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 829536
@@ -23326,32 +23754,32 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 553 PointerType *net/http.http2headerFieldValueError.str
+          Type: 569 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 552 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 568 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 552
+      ID: 568
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 913
+      ID: 929
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 844
+      ID: 860
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1.279712e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1121
+      ID: 1137
       Name: net/http.http2pipe
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 545
+      ID: 561
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 829344
@@ -23359,18 +23787,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 547 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 563 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 546 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 562 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 546
+      ID: 562
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1007
+      ID: 1023
       Name: net/http.http2stickyErrWriter
       ByteSize: 48
       GoRuntimeType: 1.817376e+06
@@ -23378,18 +23806,18 @@ Types:
       RawFields:
         - Name: group
           Offset: 0
-          Type: 1100 GoInterfaceType net/http.http2synctestGroupInterface
+          Type: 1116 GoInterfaceType net/http.http2synctestGroupInterface
         - Name: conn
           Offset: 16
-          Type: 981 GoInterfaceType net.Conn
+          Type: 997 GoInterfaceType net.Conn
         - Name: timeout
           Offset: 32
-          Type: 1101 BaseType time.Duration
+          Type: 1117 BaseType time.Duration
         - Name: err
           Offset: 40
           Type: 104 PointerType *error
     - __kind: GoInterfaceType
-      ID: 1100
+      ID: 1116
       Name: net/http.http2synctestGroupInterface
       ByteSize: 16
       GoRuntimeType: 1.413472e+06
@@ -23402,14 +23830,14 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: ArrayType
-      ID: 1086
+      ID: 1102
       Name: net/http.incomparable
       GoRuntimeType: 899200
       GoKind: 17
       HasCount: true
       Element: 59 GoSubroutineType func()
     - __kind: StructureType
-      ID: 840
+      ID: 856
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1.551232e+06
@@ -23419,11 +23847,11 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1069
+      ID: 1085
       Name: net/http.persistConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 1025
+      ID: 1041
       Name: net/http.persistConnWriter
       ByteSize: 8
       GoRuntimeType: 1.551072e+06
@@ -23431,9 +23859,9 @@ Types:
       RawFields:
         - Name: pc
           Offset: 0
-          Type: 1068 PointerType *net/http.persistConn
+          Type: 1084 PointerType *net/http.persistConn
     - __kind: StructureType
-      ID: 1051
+      ID: 1067
       Name: net/http.readWriteCloserBody
       ByteSize: 24
       GoRuntimeType: 1.793376e+06
@@ -23441,15 +23869,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1086 ArrayType net/http.incomparable
+          Type: 1102 ArrayType net/http.incomparable
         - Name: br
           Offset: 0
-          Type: 1087 PointerType *bufio.Reader
+          Type: 1103 PointerType *bufio.Reader
         - Name: ReadWriteCloser
           Offset: 8
-          Type: 1089 GoInterfaceType io.ReadWriteCloser
+          Type: 1105 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 634
+      ID: 650
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1.415072e+06
@@ -23459,17 +23887,17 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 940
+      ID: 956
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 911
+      ID: 927
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1.475072e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 842
+      ID: 858
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1.551392e+06
@@ -23479,7 +23907,7 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 1103
+      ID: 1119
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
       GoRuntimeType: 2.01904e+06
@@ -23487,16 +23915,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 981 GoInterfaceType net.Conn
+          Type: 997 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 981 GoInterfaceType net.Conn
+          Type: 997 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 623
+      ID: 639
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1123
+      ID: 1139
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
       GoRuntimeType: 2.035072e+06
@@ -23504,13 +23932,13 @@ Types:
       RawFields:
         - Name: Writer
           Offset: 0
-          Type: 1116 PointerType *bufio.Writer
+          Type: 1132 PointerType *bufio.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1035
+      ID: 1051
       Name: net/http/internal.chunkedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 707
+      ID: 723
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1.726304e+06
@@ -23526,7 +23954,7 @@ Types:
           Offset: 32
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 705
+      ID: 721
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1.594112e+06
@@ -23539,11 +23967,11 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1077
+      ID: 1093
       Name: net/smtp.Client
       ByteSize: 8
     - __kind: StructureType
-      ID: 1037
+      ID: 1053
       Name: net/smtp.dataCloser
       ByteSize: 24
       GoRuntimeType: 1.596032e+06
@@ -23551,16 +23979,16 @@ Types:
       RawFields:
         - Name: c
           Offset: 0
-          Type: 1076 PointerType *net/smtp.Client
+          Type: 1092 PointerType *net/smtp.Client
         - Name: WriteCloser
           Offset: 8
-          Type: 1078 GoInterfaceType io.WriteCloser
+          Type: 1094 GoInterfaceType io.WriteCloser
     - __kind: UnresolvedPointeeType
-      ID: 691
+      ID: 707
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 579
+      ID: 595
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 832224
@@ -23568,26 +23996,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 581 PointerType *net/textproto.ProtocolError.str
+          Type: 597 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 580 GoStringDataType net/textproto.ProtocolError.str
+      Data: 596 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 580
+      ID: 596
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1033
+      ID: 1049
       Name: net/textproto.dotWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 948
+      ID: 964
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 557
+      ID: 573
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 830208
@@ -23595,18 +24023,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 559 PointerType *net/url.EscapeError.str
+          Type: 575 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 558 GoStringDataType net/url.EscapeError.str
+      Data: 574 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 558
+      ID: 574
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 560
+      ID: 576
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 830304
@@ -23614,254 +24042,254 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 562 PointerType *net/url.InvalidHostError.str
+          Type: 578 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 561 GoStringDataType net/url.InvalidHostError.str
+      Data: 577 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 561
+      ID: 577
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: ArrayType
-      ID: 437
+      ID: 453
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
       GoRuntimeType: 679744
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 438 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 454 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 429
+      ID: 445
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
       GoRuntimeType: 679840
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 430 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 446 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 377
+      ID: 393
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
       GoRuntimeType: 680128
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 378 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 394 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 396
+      ID: 412
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
       GoRuntimeType: 680224
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 397 StructureType noalg.struct { key bool; elem main.node }
+      Element: 413 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 335
+      ID: 351
       Name: noalg.[8]struct { key int; elem *main.deepMap2 }
       ByteSize: 128
       GoRuntimeType: 679072
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 336 StructureType noalg.struct { key int; elem *main.deepMap2 }
+      Element: 352 StructureType noalg.struct { key int; elem *main.deepMap2 }
     - __kind: ArrayType
-      ID: 1233
+      ID: 1249
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
       GoRuntimeType: 678976
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1234 StructureType noalg.struct { key int; elem *main.deepMap3 }
+      Element: 1250 StructureType noalg.struct { key int; elem *main.deepMap3 }
     - __kind: ArrayType
-      ID: 1267
+      ID: 1283
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
       ByteSize: 128
       GoRuntimeType: 678496
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1268 StructureType noalg.struct { key int; elem *main.deepMap8 }
+      Element: 1284 StructureType noalg.struct { key int; elem *main.deepMap8 }
     - __kind: ArrayType
-      ID: 1282
+      ID: 1298
       Name: noalg.[8]struct { key int; elem *main.deepMap9 }
       ByteSize: 128
       GoRuntimeType: 678400
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1283 StructureType noalg.struct { key int; elem *main.deepMap9 }
+      Element: 1299 StructureType noalg.struct { key int; elem *main.deepMap9 }
     - __kind: ArrayType
-      ID: 345
+      ID: 361
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
       GoRuntimeType: 677248
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 346 StructureType noalg.struct { key int; elem int }
+      Element: 362 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 1297
+      ID: 1313
       Name: noalg.[8]struct { key int; elem interface {} }
       ByteSize: 192
       GoRuntimeType: 678304
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1298 StructureType noalg.struct { key int; elem interface {} }
+      Element: 1314 StructureType noalg.struct { key int; elem interface {} }
     - __kind: ArrayType
-      ID: 453
+      ID: 469
       Name: noalg.[8]struct { key int; elem struct {} }
       ByteSize: 128
       GoRuntimeType: 680320
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 454 StructureType noalg.struct { key int; elem struct {} }
+      Element: 470 StructureType noalg.struct { key int; elem struct {} }
     - __kind: ArrayType
-      ID: 404
+      ID: 420
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
       GoRuntimeType: 680416
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 405 StructureType noalg.struct { key int; elem uint8 }
+      Element: 421 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 386
+      ID: 402
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
       GoRuntimeType: 680512
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 387 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 403 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 369
+      ID: 385
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 680608
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 370 StructureType noalg.struct { key string; elem []string }
+      Element: 386 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 994
+      ID: 1010
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 755616
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 995 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 1011 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
-      ID: 361
+      ID: 377
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 680704
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 362 StructureType noalg.struct { key string; elem int }
+      Element: 378 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 353
+      ID: 369
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
       GoRuntimeType: 680800
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 354 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 370 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 445
+      ID: 461
       Name: noalg.[8]struct { key struct {}; elem int }
       ByteSize: 64
       GoRuntimeType: 680896
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 446 StructureType noalg.struct { key struct {}; elem int }
+      Element: 462 StructureType noalg.struct { key struct {}; elem int }
     - __kind: ArrayType
-      ID: 495
+      ID: 511
       Name: noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
       ByteSize: 384
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 496 StructureType noalg.struct { key struct {}; elem main.structWithCyclicMaps }
+      Element: 512 StructureType noalg.struct { key struct {}; elem main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 503
+      ID: 519
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 504 StructureType noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+      Element: 520 StructureType noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 511
+      ID: 527
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 512 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 528 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 519
+      ID: 535
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 520 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 536 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 527
+      ID: 543
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 528 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 544 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 535
+      ID: 551
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 536 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 552 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 461
+      ID: 477
       Name: noalg.[8]struct { key struct {}; elem struct {} }
       GoRuntimeType: 680992
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 462 StructureType noalg.struct { key struct {}; elem struct {} }
+      Element: 478 StructureType noalg.struct { key struct {}; elem struct {} }
     - __kind: ArrayType
-      ID: 420
+      ID: 436
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
       GoRuntimeType: 681088
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 421 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 437 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 412
+      ID: 428
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 681184
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 413 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 429 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 436
+      ID: 452
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
       GoRuntimeType: 1.291488e+06
@@ -23872,9 +24300,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 437 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 453 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 428
+      ID: 444
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
       GoRuntimeType: 1.291744e+06
@@ -23885,9 +24313,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 429 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 445 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 376
+      ID: 392
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
       GoRuntimeType: 1.292e+06
@@ -23898,9 +24326,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 377 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 393 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 395
+      ID: 411
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
       GoRuntimeType: 1.292256e+06
@@ -23911,9 +24339,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 396 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 412 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 334
+      ID: 350
       Name: noalg.map.group[int]*main.deepMap2
       ByteSize: 136
       GoRuntimeType: 1.291232e+06
@@ -23924,9 +24352,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 335 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
+          Type: 351 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
     - __kind: StructureType
-      ID: 1232
+      ID: 1248
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
       GoRuntimeType: 1.290976e+06
@@ -23937,9 +24365,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1233 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+          Type: 1249 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
     - __kind: StructureType
-      ID: 1266
+      ID: 1282
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
       GoRuntimeType: 1.289696e+06
@@ -23950,9 +24378,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1267 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
+          Type: 1283 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
     - __kind: StructureType
-      ID: 1281
+      ID: 1297
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
       GoRuntimeType: 1.28944e+06
@@ -23963,9 +24391,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1282 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
+          Type: 1298 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
     - __kind: StructureType
-      ID: 344
+      ID: 360
       Name: noalg.map.group[int]int
       ByteSize: 136
       GoRuntimeType: 1.288416e+06
@@ -23976,9 +24404,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 345 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 361 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 1296
+      ID: 1312
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
       GoRuntimeType: 1.289184e+06
@@ -23989,9 +24417,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1297 ArrayType noalg.[8]struct { key int; elem interface {} }
+          Type: 1313 ArrayType noalg.[8]struct { key int; elem interface {} }
     - __kind: StructureType
-      ID: 452
+      ID: 468
       Name: noalg.map.group[int]struct {}
       ByteSize: 136
       GoRuntimeType: 1.292512e+06
@@ -24002,9 +24430,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 453 ArrayType noalg.[8]struct { key int; elem struct {} }
+          Type: 469 ArrayType noalg.[8]struct { key int; elem struct {} }
     - __kind: StructureType
-      ID: 403
+      ID: 419
       Name: noalg.map.group[int]uint8
       ByteSize: 136
       GoRuntimeType: 1.292768e+06
@@ -24015,9 +24443,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 404 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 420 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 385
+      ID: 401
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
       GoRuntimeType: 1.293024e+06
@@ -24028,9 +24456,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 386 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 402 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 368
+      ID: 384
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.29328e+06
@@ -24041,9 +24469,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 369 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 385 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 993
+      ID: 1009
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1.354976e+06
@@ -24054,9 +24482,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 994 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 1010 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
-      ID: 360
+      ID: 376
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 1.293536e+06
@@ -24067,9 +24495,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 361 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 377 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 352
+      ID: 368
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
       GoRuntimeType: 1.293792e+06
@@ -24080,9 +24508,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 353 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 369 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 444
+      ID: 460
       Name: noalg.map.group[struct {}]int
       ByteSize: 72
       GoRuntimeType: 1.294048e+06
@@ -24093,9 +24521,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 445 ArrayType noalg.[8]struct { key struct {}; elem int }
+          Type: 461 ArrayType noalg.[8]struct { key struct {}; elem int }
     - __kind: StructureType
-      ID: 494
+      ID: 510
       Name: noalg.map.group[struct {}]main.structWithCyclicMaps
       ByteSize: 392
       GoKind: 25
@@ -24105,9 +24533,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 495 ArrayType noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
+          Type: 511 ArrayType noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 502
+      ID: 518
       Name: noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -24117,9 +24545,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 503 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+          Type: 519 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 510
+      ID: 526
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -24129,9 +24557,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 511 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 527 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 518
+      ID: 534
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -24141,9 +24569,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 519 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 535 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 526
+      ID: 542
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -24153,9 +24581,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 527 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 543 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 534
+      ID: 550
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -24165,9 +24593,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 535 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 551 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 460
+      ID: 476
       Name: noalg.map.group[struct {}]struct {}
       ByteSize: 16
       GoRuntimeType: 1.294304e+06
@@ -24178,9 +24606,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 461 ArrayType noalg.[8]struct { key struct {}; elem struct {} }
+          Type: 477 ArrayType noalg.[8]struct { key struct {}; elem struct {} }
     - __kind: StructureType
-      ID: 419
+      ID: 435
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
       GoRuntimeType: 1.29456e+06
@@ -24191,9 +24619,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 420 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 436 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 411
+      ID: 427
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
       GoRuntimeType: 1.294816e+06
@@ -24204,9 +24632,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 412 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 428 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 438
+      ID: 454
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
       GoRuntimeType: 1.29136e+06
@@ -24214,12 +24642,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 422 ArrayType [4]int
+          Type: 438 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 422 ArrayType [4]int
+          Type: 438 ArrayType [4]int
     - __kind: StructureType
-      ID: 430
+      ID: 446
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
       GoRuntimeType: 1.291616e+06
@@ -24227,12 +24655,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 422 ArrayType [4]int
+          Type: 438 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 378
+      ID: 394
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
       GoRuntimeType: 1.291872e+06
@@ -24240,12 +24668,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 379 ArrayType [4]string
+          Type: 395 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 111 ArrayType [2]int
     - __kind: StructureType
-      ID: 397
+      ID: 413
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
       GoRuntimeType: 1.292128e+06
@@ -24258,7 +24686,7 @@ Types:
           Offset: 8
           Type: 244 StructureType main.node
     - __kind: StructureType
-      ID: 336
+      ID: 352
       Name: noalg.struct { key int; elem *main.deepMap2 }
       ByteSize: 16
       GoRuntimeType: 1.291104e+06
@@ -24269,9 +24697,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 337 PointerType *main.deepMap2
+          Type: 353 PointerType *main.deepMap2
     - __kind: StructureType
-      ID: 1234
+      ID: 1250
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
       GoRuntimeType: 1.290848e+06
@@ -24282,9 +24710,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1235 PointerType *main.deepMap3
+          Type: 1251 PointerType *main.deepMap3
     - __kind: StructureType
-      ID: 1268
+      ID: 1284
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
       GoRuntimeType: 1.289568e+06
@@ -24295,9 +24723,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1269 PointerType *main.deepMap8
+          Type: 1285 PointerType *main.deepMap8
     - __kind: StructureType
-      ID: 1283
+      ID: 1299
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
       GoRuntimeType: 1.289312e+06
@@ -24308,9 +24736,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1284 PointerType *main.deepMap9
+          Type: 1300 PointerType *main.deepMap9
     - __kind: StructureType
-      ID: 346
+      ID: 362
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
       GoRuntimeType: 1.288288e+06
@@ -24323,7 +24751,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 1298
+      ID: 1314
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
       GoRuntimeType: 1.289056e+06
@@ -24336,7 +24764,7 @@ Types:
           Offset: 8
           Type: 155 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 454
+      ID: 470
       Name: noalg.struct { key int; elem struct {} }
       ByteSize: 16
       GoRuntimeType: 1.292384e+06
@@ -24349,7 +24777,7 @@ Types:
           Offset: 8
           Type: 123 StructureType struct {}
     - __kind: StructureType
-      ID: 405
+      ID: 421
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 1.29264e+06
@@ -24362,7 +24790,7 @@ Types:
           Offset: 8
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 387
+      ID: 403
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
       GoRuntimeType: 1.292896e+06
@@ -24373,9 +24801,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 388 GoSliceHeaderType []main.structWithMap
+          Type: 404 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 370
+      ID: 386
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.293152e+06
@@ -24388,7 +24816,7 @@ Types:
           Offset: 16
           Type: 261 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 995
+      ID: 1011
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1.354848e+06
@@ -24399,9 +24827,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 982 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 998 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 362
+      ID: 378
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 1.293408e+06
@@ -24414,7 +24842,7 @@ Types:
           Offset: 16
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 354
+      ID: 370
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
       GoRuntimeType: 1.293664e+06
@@ -24427,7 +24855,7 @@ Types:
           Offset: 16
           Type: 121 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 446
+      ID: 462
       Name: noalg.struct { key struct {}; elem int }
       ByteSize: 8
       GoRuntimeType: 1.29392e+06
@@ -24440,7 +24868,7 @@ Types:
           Offset: 0
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 496
+      ID: 512
       Name: noalg.struct { key struct {}; elem main.structWithCyclicMaps }
       ByteSize: 48
       GoKind: 25
@@ -24452,7 +24880,7 @@ Types:
           Offset: 0
           Type: 283 StructureType main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 504
+      ID: 520
       Name: noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -24464,7 +24892,7 @@ Types:
           Offset: 0
           Type: 284 GoMapType map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 512
+      ID: 528
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -24476,7 +24904,7 @@ Types:
           Offset: 0
           Type: 289 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 520
+      ID: 536
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -24488,7 +24916,7 @@ Types:
           Offset: 0
           Type: 294 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 528
+      ID: 544
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -24500,7 +24928,7 @@ Types:
           Offset: 0
           Type: 299 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 536
+      ID: 552
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -24512,7 +24940,7 @@ Types:
           Offset: 0
           Type: 304 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 462
+      ID: 478
       Name: noalg.struct { key struct {}; elem struct {} }
       GoRuntimeType: 1.294176e+06
       GoKind: 25
@@ -24524,7 +24952,7 @@ Types:
           Offset: 0
           Type: 123 StructureType struct {}
     - __kind: StructureType
-      ID: 421
+      ID: 437
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
       GoRuntimeType: 1.294432e+06
@@ -24535,9 +24963,9 @@ Types:
           Type: 3 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 422 ArrayType [4]int
+          Type: 438 ArrayType [4]int
     - __kind: StructureType
-      ID: 413
+      ID: 429
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
       GoRuntimeType: 1.294688e+06
@@ -24550,19 +24978,19 @@ Types:
           Offset: 1
           Type: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1184
+      ID: 1200
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 819
+      ID: 835
       Name: os.LinkError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 883
+      ID: 899
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1182
+      ID: 1198
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.353408e+06
@@ -24570,12 +24998,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1188 StructureType os.noReadFrom
+          Type: 1204 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 1183 PointerType *os.File
+          Type: 1199 PointerType *os.File
     - __kind: StructureType
-      ID: 1180
+      ID: 1196
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.352608e+06
@@ -24583,36 +25011,36 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1187 StructureType os.noWriteTo
+          Type: 1203 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 1183 PointerType *os.File
+          Type: 1199 PointerType *os.File
     - __kind: StructureType
-      ID: 1188
+      ID: 1204
       Name: os.noReadFrom
       GoRuntimeType: 1.106848e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1187
+      ID: 1203
       Name: os.noWriteTo
       GoRuntimeType: 1.10672e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 850
+      ID: 866
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 989
+      ID: 1005
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1055
+      ID: 1071
       Name: os/exec.prefixSuffixSaver
       ByteSize: 8
     - __kind: StructureType
-      ID: 852
+      ID: 868
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1.698048e+06
@@ -24625,7 +25053,7 @@ Types:
           Offset: 16
           Type: 14 GoInterfaceType error
     - __kind: GoStringHeaderType
-      ID: 593
+      ID: 609
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 835488
@@ -24633,36 +25061,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 595 PointerType *os/user.UnknownGroupIdError.str
+          Type: 611 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 594 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 610 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 594
+      ID: 610
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 592
+      ID: 608
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 835392
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 618
+      ID: 634
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 713
+      ID: 729
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 823
+      ID: 839
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 827
+      ID: 843
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -24674,7 +25102,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 825
+      ID: 841
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1.88128e+06
@@ -24691,9 +25119,9 @@ Types:
           Type: 4 BaseType bool
         - Name: code
           Offset: 17
-          Type: 987 BaseType runtime.boundsErrorCode
+          Type: 1003 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 987
+      ID: 1003
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 582048
@@ -24713,7 +25141,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 885
+      ID: 901
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1.745856e+06
@@ -24726,7 +25154,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 803
+      ID: 819
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 985344
@@ -24734,13 +25162,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 805 PointerType *runtime.errorString.str
+          Type: 821 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 804 GoStringDataType runtime.errorString.str
+      Data: 820 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 804
+      ID: 820
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -25396,7 +25824,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 806
+      ID: 822
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 985440
@@ -25404,13 +25832,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 808 PointerType *runtime.plainError.str
+          Type: 824 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 807 GoStringDataType runtime.plainError.str
+      Data: 823 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 807
+      ID: 823
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -25496,7 +25924,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 829
+      ID: 845
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -25508,26 +25936,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 321 PointerType *string.str
+          Type: 337 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 320 GoStringDataType string.str
+      Data: 336 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 320
+      ID: 336
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1119
+      ID: 1135
       Name: strings.Builder
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1023
+      ID: 1039
       Name: strings.appendSliceWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1019
+      ID: 1035
       Name: struct { io.Writer }
       ByteSize: 16
       GoRuntimeType: 1.451872e+06
@@ -25543,7 +25971,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1202
+      ID: 1218
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.460352e+06
@@ -25551,12 +25979,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1203 StructureType sync.noCopy
+          Type: 1219 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 1204 StructureType internal/sync.Mutex
+          Type: 1220 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 1205
+      ID: 1221
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.608864e+06
@@ -25564,15 +25992,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1203 StructureType sync.noCopy
+          Type: 1219 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 1206 StructureType sync/atomic.Uint32
+          Type: 1222 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 1202 StructureType sync.Mutex
+          Type: 1218 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 1208
+      ID: 1224
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.609056e+06
@@ -25580,21 +26008,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 1203 StructureType sync.noCopy
+          Type: 1219 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 1209 StructureType sync/atomic.Uint64
+          Type: 1225 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1203
+      ID: 1219
       Name: sync.noCopy
       GoRuntimeType: 984288
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1211
+      ID: 1227
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.461632e+06
@@ -25602,12 +26030,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1207 StructureType sync/atomic.noCopy
+          Type: 1223 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 1206
+      ID: 1222
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1.461792e+06
@@ -25615,12 +26043,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1207 StructureType sync/atomic.noCopy
+          Type: 1223 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1209
+      ID: 1225
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.60944e+06
@@ -25628,33 +26056,33 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1207 StructureType sync/atomic.noCopy
+          Type: 1223 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 1210 StructureType sync/atomic.align64
+          Type: 1226 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 8 BaseType uint64
     - __kind: StructureType
-      ID: 1210
+      ID: 1226
       Name: sync/atomic.align64
       GoRuntimeType: 984480
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1207
+      ID: 1223
       Name: sync/atomic.noCopy
       GoRuntimeType: 984384
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 935
+      ID: 951
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1.279072e+06
       GoKind: 12
     - __kind: StructureType
-      ID: 433
+      ID: 449
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -25676,9 +26104,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 434 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 450 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
-      ID: 425
+      ID: 441
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -25700,9 +26128,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 426 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 442 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
-      ID: 373
+      ID: 389
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
@@ -25724,9 +26152,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 374 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 390 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
-      ID: 392
+      ID: 408
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
@@ -25748,9 +26176,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 393 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 409 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
-      ID: 331
+      ID: 347
       Name: table<int,*main.deepMap2>
       ByteSize: 32
       GoKind: 25
@@ -25772,9 +26200,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 332 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
+          Type: 348 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
     - __kind: StructureType
-      ID: 1229
+      ID: 1245
       Name: table<int,*main.deepMap3>
       ByteSize: 32
       GoKind: 25
@@ -25796,9 +26224,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1230 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+          Type: 1246 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
     - __kind: StructureType
-      ID: 1263
+      ID: 1279
       Name: table<int,*main.deepMap8>
       ByteSize: 32
       GoKind: 25
@@ -25820,9 +26248,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1264 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
+          Type: 1280 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
     - __kind: StructureType
-      ID: 1278
+      ID: 1294
       Name: table<int,*main.deepMap9>
       ByteSize: 32
       GoKind: 25
@@ -25844,9 +26272,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1279 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
+          Type: 1295 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
     - __kind: StructureType
-      ID: 341
+      ID: 357
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
@@ -25868,9 +26296,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 342 GoSwissMapGroupsType groupReference<int,int>
+          Type: 358 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 1293
+      ID: 1309
       Name: table<int,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -25892,9 +26320,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1294 GoSwissMapGroupsType groupReference<int,interface {}>
+          Type: 1310 GoSwissMapGroupsType groupReference<int,interface {}>
     - __kind: StructureType
-      ID: 449
+      ID: 465
       Name: table<int,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -25916,9 +26344,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 450 GoSwissMapGroupsType groupReference<int,struct {}>
+          Type: 466 GoSwissMapGroupsType groupReference<int,struct {}>
     - __kind: StructureType
-      ID: 400
+      ID: 416
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -25940,9 +26368,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 401 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 417 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
-      ID: 382
+      ID: 398
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
@@ -25964,9 +26392,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 383 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 399 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 365
+      ID: 381
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -25988,9 +26416,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 366 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 382 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 990
+      ID: 1006
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -26012,9 +26440,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 991 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 1007 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
-      ID: 357
+      ID: 373
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -26036,9 +26464,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 358 GoSwissMapGroupsType groupReference<string,int>
+          Type: 374 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 349
+      ID: 365
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
@@ -26060,9 +26488,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 350 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 366 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 441
+      ID: 457
       Name: table<struct {},int>
       ByteSize: 32
       GoKind: 25
@@ -26084,9 +26512,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 442 GoSwissMapGroupsType groupReference<struct {},int>
+          Type: 458 GoSwissMapGroupsType groupReference<struct {},int>
     - __kind: StructureType
-      ID: 491
+      ID: 507
       Name: table<struct {},main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -26108,9 +26536,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 492 GoSwissMapGroupsType groupReference<struct {},main.structWithCyclicMaps>
+          Type: 508 GoSwissMapGroupsType groupReference<struct {},main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 499
+      ID: 515
       Name: table<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -26132,9 +26560,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 500 GoSwissMapGroupsType groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
+          Type: 516 GoSwissMapGroupsType groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 507
+      ID: 523
       Name: table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -26156,9 +26584,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 508 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 524 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 515
+      ID: 531
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -26180,9 +26608,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 516 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 532 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 523
+      ID: 539
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -26204,9 +26632,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 524 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 540 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 531
+      ID: 547
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -26228,9 +26656,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 532 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 548 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 457
+      ID: 473
       Name: table<struct {},struct {}>
       ByteSize: 32
       GoKind: 25
@@ -26252,9 +26680,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 458 GoSwissMapGroupsType groupReference<struct {},struct {}>
+          Type: 474 GoSwissMapGroupsType groupReference<struct {},struct {}>
     - __kind: StructureType
-      ID: 416
+      ID: 432
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -26276,9 +26704,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 417 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 433 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
-      ID: 408
+      ID: 424
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
@@ -26300,13 +26728,13 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 409 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 425 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: UnresolvedPointeeType
-      ID: 1154
+      ID: 1170
       Name: text/tabwriter.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 878
+      ID: 894
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1.702464e+06
@@ -26319,21 +26747,21 @@ Types:
           Offset: 16
           Type: 14 GoInterfaceType error
     - __kind: BaseType
-      ID: 1101
+      ID: 1117
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1.907424e+06
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 953
+      ID: 969
       Name: time.Location
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 621
+      ID: 637
       Name: time.ParseError
       ByteSize: 8
     - __kind: StructureType
-      ID: 951
+      ID: 967
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.368288e+06
@@ -26347,9 +26775,9 @@ Types:
           Type: 13 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 952 PointerType *time.Location
+          Type: 968 PointerType *time.Location
     - __kind: GoStringHeaderType
-      ID: 541
+      ID: 557
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 828384
@@ -26357,13 +26785,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 543 PointerType *time.fileSizeError.str
+          Type: 559 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 542 GoStringDataType time.fileSizeError.str
+      Data: 558 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 542
+      ID: 558
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -26410,7 +26838,7 @@ Types:
       GoRuntimeType: 581984
       GoKind: 26
     - __kind: StructureType
-      ID: 969
+      ID: 985
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2.05648e+06
@@ -26421,10 +26849,10 @@ Types:
           Type: 38 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 970 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 986 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 971 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 987 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: off
           Offset: 40
           Type: 7 BaseType int
@@ -26439,18 +26867,18 @@ Types:
           Type: 7 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 972 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 988 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 6 BaseType uint16
     - __kind: BaseType
-      ID: 972
+      ID: 988
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 990912
       GoKind: 9
     - __kind: StructureType
-      ID: 970
+      ID: 986
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1.918176e+06
@@ -26475,21 +26903,21 @@ Types:
           Offset: 10
           Type: 6 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 709
+      ID: 725
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 971
+      ID: 987
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 585632
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1146
+      ID: 1162
       Name: vendor/golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 693
+      ID: 709
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.422912e+06
@@ -26499,13 +26927,13 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: BaseType
-      ID: 582
+      ID: 598
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 832320
       GoKind: 2
     - __kind: StructureType
-      ID: 857
+      ID: 873
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1.69824e+06
@@ -26518,12 +26946,12 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 811
+      ID: 827
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 989760
       GoKind: 5
-MaxTypeID: 1551
+MaxTypeID: 1568
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x132d360", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -11,11 +11,11 @@ Probes:
       subprogram: {subprogram: 142}
       events:
         - Kind: Entry
-          Type: 1526 EventRootType Probe[main.stackC]
+          Type: 1542 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0x80c388", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1527 EventRootType Probe[main.stackC]Return
+          Type: 1543 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0x80c3b8", Frameless: false}]
           Condition: null
       probeTemplate: {TemplateString: stackC, Segments: [stackC]}
@@ -30,11 +30,11 @@ Probes:
       subprogram: {subprogram: 56}
       events:
         - Kind: Entry
-          Type: 1390 EventRootType Probe[main.testAny]
+          Type: 1406 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0x807c18", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1391 EventRootType Probe[main.testAny]Return
+          Type: 1407 EventRootType Probe[main.testAny]Return
           InjectionPoints: [{PC: "0x807c40", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -55,11 +55,11 @@ Probes:
       subprogram: {subprogram: 58}
       events:
         - Kind: Entry
-          Type: 1393 EventRootType Probe[main.testAnyPtr]
+          Type: 1409 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0x807c88", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1394 EventRootType Probe[main.testAnyPtr]Return
+          Type: 1410 EventRootType Probe[main.testAnyPtr]Return
           InjectionPoints: [{PC: "0x807cb0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -79,11 +79,11 @@ Probes:
       subprogram: {subprogram: 122}
       events:
         - Kind: Entry
-          Type: 1497 EventRootType Probe[main.testArrayArgAndReturn]
+          Type: 1513 EventRootType Probe[main.testArrayArgAndReturn]
           InjectionPoints: [{PC: "0x80b29c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1498 EventRootType Probe[main.testArrayArgAndReturn]Return
+          Type: 1514 EventRootType Probe[main.testArrayArgAndReturn]Return
           InjectionPoints: [{PC: "0x80b328", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -104,7 +104,7 @@ Probes:
       subprogram: {subprogram: 19}
       events:
         - Kind: Entry
-          Type: 1341 EventRootType Probe[main.testArrayEmptyStructs]
+          Type: 1357 EventRootType Probe[main.testArrayEmptyStructs]
           InjectionPoints: [{PC: "0x8063b0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -125,7 +125,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - Kind: Entry
-          Type: 1337 EventRootType Probe[main.testArrayOfArrays]
+          Type: 1353 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0x806370", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -146,7 +146,7 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - Kind: Entry
-          Type: 1339 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          Type: 1355 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0x806390", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -167,7 +167,7 @@ Probes:
       subprogram: {subprogram: 66}
       events:
         - Kind: Entry
-          Type: 1402 EventRootType Probe[main.testArrayOfMaps]
+          Type: 1418 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0x808280", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -188,7 +188,7 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - Kind: Entry
-          Type: 1338 EventRootType Probe[main.testArrayOfStrings]
+          Type: 1354 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0x806380", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -208,7 +208,7 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - Kind: Entry
-          Type: 1340 EventRootType Probe[main.testArrayOfStructs]
+          Type: 1356 EventRootType Probe[main.testArrayOfStructs]
           InjectionPoints: [{PC: "0x8063a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -229,11 +229,11 @@ Probes:
       subprogram: {subprogram: 86}
       events:
         - Kind: Entry
-          Type: 1424 EventRootType Probe[main.testAtomicAdd]
+          Type: 1440 EventRootType Probe[main.testAtomicAdd]
           InjectionPoints: [{PC: "0x8099d0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1425 EventRootType Probe[main.testAtomicAdd]Return
+          Type: 1441 EventRootType Probe[main.testAtomicAdd]Return
           InjectionPoints: [{PC: "0x809a0c", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -254,11 +254,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 1359 EventRootType Probe[main.testBigStruct]
+          Type: 1375 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0x8068f0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1360 EventRootType Probe[main.testBigStruct]Return
+          Type: 1376 EventRootType Probe[main.testBigStruct]Return
           InjectionPoints: [{PC: "0x8068fc", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -279,7 +279,7 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - Kind: Entry
-          Type: 1326 EventRootType Probe[main.testBoolArray]
+          Type: 1342 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0x8062c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -300,7 +300,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - Kind: Entry
-          Type: 1323 EventRootType Probe[main.testByteArray]
+          Type: 1339 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0x806290", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -326,11 +326,11 @@ Probes:
       subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1545 EventRootType Probe[main.testStruct]
+          Type: 1561 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0x80c670", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1546 EventRootType Probe[main.testStruct]Return
+          Type: 1562 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0x80c680", Frameless: true}]
           Condition: null
     - id: testCaptureExprLine
@@ -345,10 +345,10 @@ Probes:
       segments: []
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1555 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1572 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0x807538"
               Frameless: false
@@ -373,10 +373,10 @@ Probes:
       segments: [x=, {json: {ref: x}, dsl: x}]
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1556 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1573 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0x807538"
               Frameless: false
@@ -412,7 +412,7 @@ Probes:
       subprogram: {subprogram: 84}
       events:
         - Kind: Entry
-          Type: 1421 EventRootType Probe[main.testCombinedString]
+          Type: 1437 EventRootType Probe[main.testCombinedString]
           InjectionPoints: [{PC: "0x809770", Frameless: true}]
           Condition: null
     - id: testCaptureExprWithTemplate
@@ -430,7 +430,7 @@ Probes:
       subprogram: {subprogram: 84}
       events:
         - Kind: Entry
-          Type: 1422 EventRootType Probe[main.testCombinedString]
+          Type: 1438 EventRootType Probe[main.testCombinedString]
           InjectionPoints: [{PC: "0x809770", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -452,7 +452,7 @@ Probes:
       subprogram: {subprogram: 87}
       events:
         - Kind: Entry
-          Type: 1426 EventRootType Probe[main.testChannel]
+          Type: 1442 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0x809a10", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -481,7 +481,7 @@ Probes:
       subprogram: {subprogram: 83}
       events:
         - Kind: Entry
-          Type: 1420 EventRootType Probe[main.testCombinedByte]
+          Type: 1436 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0x809750", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -512,7 +512,7 @@ Probes:
       subprogram: {subprogram: 95}
       events:
         - Kind: Entry
-          Type: 1434 EventRootType Probe[main.testCycle]
+          Type: 1450 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0x809ca0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -533,7 +533,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - Kind: Entry
-          Type: 1365 EventRootType Probe[main.testDeepMap1]
+          Type: 1381 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0x806c90", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -554,7 +554,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - Kind: Entry
-          Type: 1366 EventRootType Probe[main.testDeepMap7]
+          Type: 1382 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0x806ca0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -575,7 +575,7 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - Kind: Entry
-          Type: 1361 EventRootType Probe[main.testDeepPtr1]
+          Type: 1377 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0x8069b0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -596,7 +596,7 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - Kind: Entry
-          Type: 1362 EventRootType Probe[main.testDeepPtr7]
+          Type: 1378 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0x8069c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -617,7 +617,7 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - Kind: Entry
-          Type: 1363 EventRootType Probe[main.testDeepSlice1]
+          Type: 1379 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0x806b30", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -638,7 +638,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - Kind: Entry
-          Type: 1364 EventRootType Probe[main.testDeepSlice7]
+          Type: 1380 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0x806b40", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -659,7 +659,7 @@ Probes:
       subprogram: {subprogram: 131}
       events:
         - Kind: Entry
-          Type: 1514 EventRootType Probe[main.testEmptySlice]
+          Type: 1530 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0x80bfe0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -685,7 +685,7 @@ Probes:
       subprogram: {subprogram: 134}
       events:
         - Kind: Entry
-          Type: 1517 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 1533 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0x80c010", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -712,7 +712,7 @@ Probes:
       subprogram: {subprogram: 150}
       events:
         - Kind: Entry
-          Type: 1540 EventRootType Probe[main.testEmptyString]
+          Type: 1556 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0x80c440", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -733,7 +733,7 @@ Probes:
       subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1553 EventRootType Probe[main.testEmptyStruct]
+          Type: 1569 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0x80c740", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -753,7 +753,7 @@ Probes:
       subprogram: {subprogram: 157}
       events:
         - Kind: Entry
-          Type: 1554 EventRootType Probe[main.testEmptyStructPointer]
+          Type: 1570 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0x80c750", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -774,7 +774,7 @@ Probes:
       subprogram: {subprogram: 57}
       events:
         - Kind: Entry
-          Type: 1392 EventRootType Probe[main.testError]
+          Type: 1408 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0x807c60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -795,11 +795,11 @@ Probes:
       subprogram: {subprogram: 48}
       events:
         - Kind: Entry
-          Type: 1374 EventRootType Probe[main.testEsotericHeap]
+          Type: 1390 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0x8072b8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1375 EventRootType Probe[main.testEsotericHeap]Return
+          Type: 1391 EventRootType Probe[main.testEsotericHeap]Return
           InjectionPoints: [{PC: "0x8072f0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -820,11 +820,11 @@ Probes:
       subprogram: {subprogram: 47}
       events:
         - Kind: Entry
-          Type: 1372 EventRootType Probe[main.testEsotericStack]
+          Type: 1388 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0x8071fc", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1373 EventRootType Probe[main.testEsotericStack]Return
+          Type: 1389 EventRootType Probe[main.testEsotericStack]Return
           InjectionPoints: [{PC: "0x807258", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -845,11 +845,11 @@ Probes:
       subprogram: {subprogram: 53}
       events:
         - Kind: Entry
-          Type: 1384 EventRootType Probe[main.testFrameless]
+          Type: 1400 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0x807980", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1385 EventRootType Probe[main.testFrameless]Return
+          Type: 1401 EventRootType Probe[main.testFrameless]Return
           InjectionPoints: [{PC: "0x807988", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -870,11 +870,11 @@ Probes:
       subprogram: {subprogram: 54}
       events:
         - Kind: Entry
-          Type: 1386 EventRootType Probe[main.testFramelessArray]
+          Type: 1402 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0x80799c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1387 EventRootType Probe[main.testFramelessArray]Return
+          Type: 1403 EventRootType Probe[main.testFramelessArray]Return
           InjectionPoints: [{PC: "0x8079d0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -898,7 +898,7 @@ Probes:
       subprogram: {subprogram: 54}
       events:
         - Kind: Line
-          Type: 1388 EventRootType Probe[main.testFramelessArray]Line
+          Type: 1404 EventRootType Probe[main.testFramelessArray]Line
           InjectionPoints: [{PC: "0x80799c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -919,11 +919,11 @@ Probes:
       subprogram: {subprogram: 49}
       events:
         - Kind: Entry
-          Type: 1376 EventRootType Probe[main.testInlinedBA]
+          Type: 1392 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0x8076c8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1377 EventRootType Probe[main.testInlinedBA]Return
+          Type: 1393 EventRootType Probe[main.testInlinedBA]Return
           InjectionPoints: [{PC: "0x80771c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -949,11 +949,11 @@ Probes:
       subprogram: {subprogram: 50}
       events:
         - Kind: Entry
-          Type: 1378 EventRootType Probe[main.testInlinedBB]
+          Type: 1394 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0x807758", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1379 EventRootType Probe[main.testInlinedBB]Return
+          Type: 1395 EventRootType Probe[main.testInlinedBB]Return
           InjectionPoints: [{PC: "0x8077d8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -979,11 +979,11 @@ Probes:
       subprogram: {subprogram: 51}
       events:
         - Kind: Entry
-          Type: 1380 EventRootType Probe[main.testInlinedBBA]
+          Type: 1396 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0x807818", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1381 EventRootType Probe[main.testInlinedBBA]Return
+          Type: 1397 EventRootType Probe[main.testInlinedBBA]Return
           InjectionPoints: [{PC: "0x807850", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1001,10 +1001,10 @@ Probes:
       template: testInlinedBBB
       segments: [testInlinedBBB]
       captureSnapshot: true
-      subprogram: {subprogram: 159}
+      subprogram: {subprogram: 160}
       events:
         - Kind: Entry
-          Type: 1560 EventRootType Probe[main.testInlinedBBB]
+          Type: 1577 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x8077a4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1021,11 +1021,11 @@ Probes:
       subprogram: {subprogram: 52}
       events:
         - Kind: Entry
-          Type: 1382 EventRootType Probe[main.testInlinedBC]
+          Type: 1398 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0x807888", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1383 EventRootType Probe[main.testInlinedBC]Return
+          Type: 1399 EventRootType Probe[main.testInlinedBC]Return
           InjectionPoints: [{PC: "0x807964", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1039,10 +1039,10 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Entry
-          Type: 1561 EventRootType Probe[main.testInlinedBCA]
+          Type: 1578 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x80788c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1059,10 +1059,10 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Line
-          Type: 1562 EventRootType Probe[main.testInlinedBCA]Line
+          Type: 1579 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0x80788c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1076,10 +1076,10 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Entry
-          Type: 1563 EventRootType Probe[main.testInlinedBCB]
+          Type: 1580 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x807930", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1096,10 +1096,10 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Line
-          Type: 1564 EventRootType Probe[main.testInlinedBCB]Line
+          Type: 1581 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0x807930", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1113,10 +1113,10 @@ Probes:
       template: testInlinedFuncFromOtherPackage
       segments: [testInlinedFuncFromOtherPackage]
       captureSnapshot: true
-      subprogram: {subprogram: 165}
+      subprogram: {subprogram: 166}
       events:
         - Kind: Entry
-          Type: 1570 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
+          Type: 1587 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
           InjectionPoints:
             - PC: "0x805df8"
               Frameless: true
@@ -1135,10 +1135,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Entry
-          Type: 1557 EventRootType Probe[main.testInlinedPrint]
+          Type: 1574 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x807538"
               Frameless: false
@@ -1152,7 +1152,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1558 EventRootType Probe[main.testInlinedPrint]Return
+          Type: 1575 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0x80756c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1173,10 +1173,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1559 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1576 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0x807538"
               Frameless: false
@@ -1204,10 +1204,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 162}
+      subprogram: {subprogram: 163}
       events:
         - Kind: Entry
-          Type: 1565 EventRootType Probe[main.testInlinedSq]
+          Type: 1582 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x807984", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1228,10 +1228,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 162}
+      subprogram: {subprogram: 163}
       events:
         - Kind: Line
-          Type: 1566 EventRootType Probe[main.testInlinedSq]Line
+          Type: 1583 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0x807984", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1250,10 +1250,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 163}
+      subprogram: {subprogram: 164}
       events:
         - Kind: Entry
-          Type: 1567 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1584 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0x8079b4"
               Frameless: false
@@ -1278,7 +1278,7 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - Kind: Entry
-          Type: 1329 EventRootType Probe[main.testInt16Array]
+          Type: 1345 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0x8062f0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1299,7 +1299,7 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - Kind: Entry
-          Type: 1330 EventRootType Probe[main.testInt32Array]
+          Type: 1346 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0x806300", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1320,7 +1320,7 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - Kind: Entry
-          Type: 1331 EventRootType Probe[main.testInt64Array]
+          Type: 1347 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0x806310", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1341,7 +1341,7 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - Kind: Entry
-          Type: 1328 EventRootType Probe[main.testInt8Array]
+          Type: 1344 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0x8062e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1362,7 +1362,7 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - Kind: Entry
-          Type: 1327 EventRootType Probe[main.testIntArray]
+          Type: 1343 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0x8062d0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1383,7 +1383,7 @@ Probes:
       subprogram: {subprogram: 55}
       events:
         - Kind: Entry
-          Type: 1389 EventRootType Probe[main.testInterface]
+          Type: 1405 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0x807bf0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1403,11 +1403,11 @@ Probes:
       subprogram: {subprogram: 121}
       events:
         - Kind: Entry
-          Type: 1495 EventRootType Probe[main.testLargeArgAndReturn]
+          Type: 1511 EventRootType Probe[main.testLargeArgAndReturn]
           InjectionPoints: [{PC: "0x80b110", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1496 EventRootType Probe[main.testLargeArgAndReturn]Return
+          Type: 1512 EventRootType Probe[main.testLargeArgAndReturn]Return
           InjectionPoints: [{PC: "0x80b238", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1417,6 +1417,49 @@ Probes:
               DSL: arg
               EventKind: Entry
               EventExpressionIndex: 1
+    - id: testLineProbeTemplateWithStructFields
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.executeStructFuncs
+        sourceFile: structs.go
+        lines: ["208"]
+      template: 'sta.a: {sta.a} sta.b: {sta.b} sta.c: {sta.c}'
+      segments:
+        - 'sta.a: '
+        - json: {getmember: [{ref: sta}, a]}
+          dsl: sta.a
+        - ' sta.b: '
+        - json: {getmember: [{ref: sta}, b]}
+          dsl: sta.b
+        - ' sta.c: '
+        - json: {getmember: [{ref: sta}, c]}
+          dsl: sta.c
+      captureSnapshot: false
+      subprogram: {subprogram: 158}
+      events:
+        - Kind: Line
+          Type: 1571 EventRootType Probe[main.executeStructFuncs]Line
+          InjectionPoints: [{PC: "0x80cb40", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: 'sta.a: {sta.a} sta.b: {sta.b} sta.c: {sta.c}'
+        Segments:
+            - 'sta.a: '
+            - JSON: {Base: {Ref: sta}, Member: a}
+              DSL: sta.a
+              EventKind: Line
+              EventExpressionIndex: 0
+            - ' sta.b: '
+            - JSON: {Base: {Ref: sta}, Member: b}
+              DSL: sta.b
+              EventKind: Line
+              EventExpressionIndex: 1
+            - ' sta.c: '
+            - JSON: {Base: {Ref: sta}, Member: c}
+              DSL: sta.c
+              EventKind: Line
+              EventExpressionIndex: 2
     - id: testLinkedList
       version: 0
       type: LOG_PROBE
@@ -1428,7 +1471,7 @@ Probes:
       subprogram: {subprogram: 89}
       events:
         - Kind: Entry
-          Type: 1428 EventRootType Probe[main.testLinkedList]
+          Type: 1444 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0x809bb0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1452,7 +1495,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - Kind: Line
-          Type: 1369 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          Type: 1385 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x806cec", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1473,7 +1516,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - Kind: Line
-          Type: 1370 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          Type: 1386 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x806d70", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1494,7 +1537,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - Kind: Line
-          Type: 1371 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          Type: 1387 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x806e0c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1536,11 +1579,11 @@ Probes:
       subprogram: {subprogram: 124}
       events:
         - Kind: Entry
-          Type: 1501 EventRootType Probe[main.testManyArgsArrayReturn]
+          Type: 1517 EventRootType Probe[main.testManyArgsArrayReturn]
           InjectionPoints: [{PC: "0x80b56c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1502 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          Type: 1518 EventRootType Probe[main.testManyArgsArrayReturn]Return
           InjectionPoints: [{PC: "0x80b6ac", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1601,7 +1644,7 @@ Probes:
       subprogram: {subprogram: 64}
       events:
         - Kind: Entry
-          Type: 1400 EventRootType Probe[main.testMapArrayToArray]
+          Type: 1416 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0x808260", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1622,7 +1665,7 @@ Probes:
       subprogram: {subprogram: 70}
       events:
         - Kind: Entry
-          Type: 1407 EventRootType Probe[main.testMapEmbeddedMaps]
+          Type: 1423 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0x8082c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1643,7 +1686,7 @@ Probes:
       subprogram: {subprogram: 80}
       events:
         - Kind: Entry
-          Type: 1417 EventRootType Probe[main.testMapEmptyKey]
+          Type: 1433 EventRootType Probe[main.testMapEmptyKey]
           InjectionPoints: [{PC: "0x808360", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1664,7 +1707,7 @@ Probes:
       subprogram: {subprogram: 82}
       events:
         - Kind: Entry
-          Type: 1419 EventRootType Probe[main.testMapEmptyKeyAndValue]
+          Type: 1435 EventRootType Probe[main.testMapEmptyKeyAndValue]
           InjectionPoints: [{PC: "0x808380", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1685,7 +1728,7 @@ Probes:
       subprogram: {subprogram: 81}
       events:
         - Kind: Entry
-          Type: 1418 EventRootType Probe[main.testMapEmptyValue]
+          Type: 1434 EventRootType Probe[main.testMapEmptyValue]
           InjectionPoints: [{PC: "0x808370", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1706,7 +1749,7 @@ Probes:
       subprogram: {subprogram: 68}
       events:
         - Kind: Entry
-          Type: 1404 EventRootType Probe[main.testMapIntToInt]
+          Type: 1420 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0x8082a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1727,7 +1770,7 @@ Probes:
       subprogram: {subprogram: 79}
       events:
         - Kind: Entry
-          Type: 1416 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          Type: 1432 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0x808350", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1748,7 +1791,7 @@ Probes:
       subprogram: {subprogram: 78}
       events:
         - Kind: Entry
-          Type: 1415 EventRootType Probe[main.testMapLargeKeySmallValue]
+          Type: 1431 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0x808340", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1771,7 +1814,7 @@ Probes:
       subprogram: {subprogram: 69}
       events:
         - Kind: Entry
-          Type: 1405 EventRootType Probe[main.testMapMassive]
+          Type: 1421 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0x8082b0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1794,7 +1837,7 @@ Probes:
       subprogram: {subprogram: 69}
       events:
         - Kind: Entry
-          Type: 1406 EventRootType Probe[main.testMapMassive]
+          Type: 1422 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0x8082b0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1815,7 +1858,7 @@ Probes:
       subprogram: {subprogram: 77}
       events:
         - Kind: Entry
-          Type: 1414 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          Type: 1430 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0x808330", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1836,7 +1879,7 @@ Probes:
       subprogram: {subprogram: 76}
       events:
         - Kind: Entry
-          Type: 1413 EventRootType Probe[main.testMapSmallKeySmallValue]
+          Type: 1429 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0x808320", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1857,7 +1900,7 @@ Probes:
       subprogram: {subprogram: 62}
       events:
         - Kind: Entry
-          Type: 1398 EventRootType Probe[main.testMapStringToInt]
+          Type: 1414 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0x808240", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1878,7 +1921,7 @@ Probes:
       subprogram: {subprogram: 63}
       events:
         - Kind: Entry
-          Type: 1399 EventRootType Probe[main.testMapStringToSlice]
+          Type: 1415 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0x808250", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1899,7 +1942,7 @@ Probes:
       subprogram: {subprogram: 61}
       events:
         - Kind: Entry
-          Type: 1397 EventRootType Probe[main.testMapStringToStruct]
+          Type: 1413 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0x808230", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1920,7 +1963,7 @@ Probes:
       subprogram: {subprogram: 71}
       events:
         - Kind: Entry
-          Type: 1408 EventRootType Probe[main.testMapWithLinkedList]
+          Type: 1424 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0x8082d0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1941,7 +1984,7 @@ Probes:
       subprogram: {subprogram: 74}
       events:
         - Kind: Entry
-          Type: 1411 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          Type: 1427 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0x808300", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1962,7 +2005,7 @@ Probes:
       subprogram: {subprogram: 75}
       events:
         - Kind: Entry
-          Type: 1412 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          Type: 1428 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0x808310", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1983,7 +2026,7 @@ Probes:
       subprogram: {subprogram: 72}
       events:
         - Kind: Entry
-          Type: 1409 EventRootType Probe[main.testMapWithSmallValue]
+          Type: 1425 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0x8082e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2006,7 +2049,7 @@ Probes:
       subprogram: {subprogram: 73}
       events:
         - Kind: Entry
-          Type: 1410 EventRootType Probe[main.testMapWithSmallValueMassive]
+          Type: 1426 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0x8082f0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2027,7 +2070,7 @@ Probes:
       subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1537 EventRootType Probe[main.testMassiveString]
+          Type: 1553 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x80c420", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2049,7 +2092,7 @@ Probes:
       subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1538 EventRootType Probe[main.testMassiveString]
+          Type: 1554 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x80c420", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2095,11 +2138,11 @@ Probes:
       subprogram: {subprogram: 125}
       events:
         - Kind: Entry
-          Type: 1503 EventRootType Probe[main.testMixedArgsStackReturn]
+          Type: 1519 EventRootType Probe[main.testMixedArgsStackReturn]
           InjectionPoints: [{PC: "0x80b710", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1504 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          Type: 1520 EventRootType Probe[main.testMixedArgsStackReturn]Return
           InjectionPoints: [{PC: "0x80b898", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2164,11 +2207,11 @@ Probes:
       subprogram: {subprogram: 127}
       events:
         - Kind: Entry
-          Type: 1507 EventRootType Probe[main.testMultipleArrayArgs]
+          Type: 1523 EventRootType Probe[main.testMultipleArrayArgs]
           InjectionPoints: [{PC: "0x80b98c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1508 EventRootType Probe[main.testMultipleArrayArgs]Return
+          Type: 1524 EventRootType Probe[main.testMultipleArrayArgs]Return
           InjectionPoints: [{PC: "0x80ba24", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2198,11 +2241,11 @@ Probes:
       subprogram: {subprogram: 123}
       events:
         - Kind: Entry
-          Type: 1499 EventRootType Probe[main.testMultipleLargeArgs]
+          Type: 1515 EventRootType Probe[main.testMultipleLargeArgs]
           InjectionPoints: [{PC: "0x80b360", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1500 EventRootType Probe[main.testMultipleLargeArgs]Return
+          Type: 1516 EventRootType Probe[main.testMultipleLargeArgs]Return
           InjectionPoints: [{PC: "0x80b504", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2227,11 +2270,11 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1453 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1469 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x80a768", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1454 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1470 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x80a7e8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2266,7 +2309,7 @@ Probes:
       subprogram: {subprogram: 85}
       events:
         - Kind: Entry
-          Type: 1423 EventRootType Probe[main.testMultipleSimpleParams]
+          Type: 1439 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0x809830", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2306,11 +2349,11 @@ Probes:
       subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1449 EventRootType Probe[main.testNamedReturn]
+          Type: 1465 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0x80a6d8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1450 EventRootType Probe[main.testNamedReturn]Return
+          Type: 1466 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0x80a730", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2336,11 +2379,11 @@ Probes:
       subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1451 EventRootType Probe[main.testNamedReturn]
+          Type: 1467 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0x80a6d8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1452 EventRootType Probe[main.testNamedReturn]Return
+          Type: 1468 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0x80a730", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2367,7 +2410,7 @@ Probes:
       subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1549 EventRootType Probe[main.testNestedPointer]
+          Type: 1565 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0x80c700", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2391,7 +2434,7 @@ Probes:
       subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1550 EventRootType Probe[main.testNestedPointer]
+          Type: 1566 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0x80c700", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2421,7 +2464,7 @@ Probes:
       subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1551 EventRootType Probe[main.testNestedPointer]
+          Type: 1567 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0x80c700", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2445,7 +2488,7 @@ Probes:
       subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1552 EventRootType Probe[main.testNestedPointer]
+          Type: 1568 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0x80c700", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2471,7 +2514,7 @@ Probes:
       subprogram: {subprogram: 94}
       events:
         - Kind: Entry
-          Type: 1433 EventRootType Probe[main.testNilPointer]
+          Type: 1449 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0x809c80", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2497,7 +2540,7 @@ Probes:
       subprogram: {subprogram: 138}
       events:
         - Kind: Entry
-          Type: 1521 EventRootType Probe[main.testNilSlice]
+          Type: 1537 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0x80c050", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2523,7 +2566,7 @@ Probes:
       subprogram: {subprogram: 135}
       events:
         - Kind: Entry
-          Type: 1518 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 1534 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0x80c020", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2557,7 +2600,7 @@ Probes:
       subprogram: {subprogram: 137}
       events:
         - Kind: Entry
-          Type: 1520 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 1536 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0x80c040", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2588,7 +2631,7 @@ Probes:
       subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1536 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 1552 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0x80c410", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2609,7 +2652,7 @@ Probes:
       subprogram: {subprogram: 90}
       events:
         - Kind: Entry
-          Type: 1429 EventRootType Probe[main.testPointerLoop]
+          Type: 1445 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0x809bc0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2630,7 +2673,7 @@ Probes:
       subprogram: {subprogram: 67}
       events:
         - Kind: Entry
-          Type: 1403 EventRootType Probe[main.testPointerToMap]
+          Type: 1419 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0x808290", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2651,7 +2694,7 @@ Probes:
       subprogram: {subprogram: 88}
       events:
         - Kind: Entry
-          Type: 1427 EventRootType Probe[main.testPointerToSimpleStruct]
+          Type: 1443 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0x809ba0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2672,11 +2715,11 @@ Probes:
       subprogram: {subprogram: 101}
       events:
         - Kind: Entry
-          Type: 1445 EventRootType Probe[main.testReturnsAny]
+          Type: 1461 EventRootType Probe[main.testReturnsAny]
           InjectionPoints: [{PC: "0x80a3a8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1446 EventRootType Probe[main.testReturnsAny]Return
+          Type: 1462 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints:
             - PC: "0x80a430"
               Frameless: false
@@ -2710,11 +2753,11 @@ Probes:
       subprogram: {subprogram: 100}
       events:
         - Kind: Entry
-          Type: 1443 EventRootType Probe[main.testReturnsAnyAndError]
+          Type: 1459 EventRootType Probe[main.testReturnsAnyAndError]
           InjectionPoints: [{PC: "0x80a238", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1444 EventRootType Probe[main.testReturnsAnyAndError]Return
+          Type: 1460 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
             - PC: "0x80a28c"
               Frameless: false
@@ -2747,11 +2790,11 @@ Probes:
       subprogram: {subprogram: 110}
       events:
         - Kind: Entry
-          Type: 1473 EventRootType Probe[main.testReturnsArray]
+          Type: 1489 EventRootType Probe[main.testReturnsArray]
           InjectionPoints: [{PC: "0x80ab6c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1474 EventRootType Probe[main.testReturnsArray]Return
+          Type: 1490 EventRootType Probe[main.testReturnsArray]Return
           InjectionPoints: [{PC: "0x80abb8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2767,11 +2810,11 @@ Probes:
       subprogram: {subprogram: 111}
       events:
         - Kind: Entry
-          Type: 1475 EventRootType Probe[main.testReturnsArrayOne]
+          Type: 1491 EventRootType Probe[main.testReturnsArrayOne]
           InjectionPoints: [{PC: "0x80abe8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1476 EventRootType Probe[main.testReturnsArrayOne]Return
+          Type: 1492 EventRootType Probe[main.testReturnsArrayOne]Return
           InjectionPoints: [{PC: "0x80ac20", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2787,11 +2830,11 @@ Probes:
       subprogram: {subprogram: 112}
       events:
         - Kind: Entry
-          Type: 1477 EventRootType Probe[main.testReturnsArrayZero]
+          Type: 1493 EventRootType Probe[main.testReturnsArrayZero]
           InjectionPoints: [{PC: "0x80ac58", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1478 EventRootType Probe[main.testReturnsArrayZero]Return
+          Type: 1494 EventRootType Probe[main.testReturnsArrayZero]Return
           InjectionPoints: [{PC: "0x80ac8c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2807,11 +2850,11 @@ Probes:
       subprogram: {subprogram: 114}
       events:
         - Kind: Entry
-          Type: 1481 EventRootType Probe[main.testReturnsBacktrackInt]
+          Type: 1497 EventRootType Probe[main.testReturnsBacktrackInt]
           InjectionPoints: [{PC: "0x80ad48", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1482 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          Type: 1498 EventRootType Probe[main.testReturnsBacktrackInt]Return
           InjectionPoints: [{PC: "0x80ada8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2827,11 +2870,11 @@ Probes:
       subprogram: {subprogram: 120}
       events:
         - Kind: Entry
-          Type: 1493 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          Type: 1509 EventRootType Probe[main.testReturnsBoolAndUintptr]
           InjectionPoints: [{PC: "0x80b098", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1494 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          Type: 1510 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
           InjectionPoints: [{PC: "0x80b0d4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2847,11 +2890,11 @@ Probes:
       subprogram: {subprogram: 108}
       events:
         - Kind: Entry
-          Type: 1469 EventRootType Probe[main.testReturnsComplex]
+          Type: 1485 EventRootType Probe[main.testReturnsComplex]
           InjectionPoints: [{PC: "0x80aa28", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1470 EventRootType Probe[main.testReturnsComplex]Return
+          Type: 1486 EventRootType Probe[main.testReturnsComplex]Return
           InjectionPoints: [{PC: "0x80aa70", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2868,11 +2911,11 @@ Probes:
       subprogram: {subprogram: 99}
       events:
         - Kind: Entry
-          Type: 1441 EventRootType Probe[main.testReturnsError]
+          Type: 1457 EventRootType Probe[main.testReturnsError]
           InjectionPoints: [{PC: "0x80a1b8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1442 EventRootType Probe[main.testReturnsError]Return
+          Type: 1458 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
             - PC: "0x80a1e4"
               Frameless: false
@@ -2896,11 +2939,11 @@ Probes:
       subprogram: {subprogram: 96}
       events:
         - Kind: Entry
-          Type: 1435 EventRootType Probe[main.testReturnsInt]
+          Type: 1451 EventRootType Probe[main.testReturnsInt]
           InjectionPoints: [{PC: "0x809fc8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1436 EventRootType Probe[main.testReturnsInt]Return
+          Type: 1452 EventRootType Probe[main.testReturnsInt]Return
           InjectionPoints: [{PC: "0x80a008", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2920,11 +2963,11 @@ Probes:
       subprogram: {subprogram: 98}
       events:
         - Kind: Entry
-          Type: 1439 EventRootType Probe[main.testReturnsIntAndFloat]
+          Type: 1455 EventRootType Probe[main.testReturnsIntAndFloat]
           InjectionPoints: [{PC: "0x80a0e8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1440 EventRootType Probe[main.testReturnsIntAndFloat]Return
+          Type: 1456 EventRootType Probe[main.testReturnsIntAndFloat]Return
           InjectionPoints: [{PC: "0x80a174", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2944,11 +2987,11 @@ Probes:
       subprogram: {subprogram: 97}
       events:
         - Kind: Entry
-          Type: 1437 EventRootType Probe[main.testReturnsIntPointer]
+          Type: 1453 EventRootType Probe[main.testReturnsIntPointer]
           InjectionPoints: [{PC: "0x80a048", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1438 EventRootType Probe[main.testReturnsIntPointer]Return
+          Type: 1454 EventRootType Probe[main.testReturnsIntPointer]Return
           InjectionPoints: [{PC: "0x80a0a4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2969,11 +3012,11 @@ Probes:
       subprogram: {subprogram: 102}
       events:
         - Kind: Entry
-          Type: 1447 EventRootType Probe[main.testReturnsInterface]
+          Type: 1463 EventRootType Probe[main.testReturnsInterface]
           InjectionPoints: [{PC: "0x80a588", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1448 EventRootType Probe[main.testReturnsInterface]Return
+          Type: 1464 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
             - PC: "0x80a640"
               Frameless: false
@@ -2997,11 +3040,11 @@ Probes:
       subprogram: {subprogram: 109}
       events:
         - Kind: Entry
-          Type: 1471 EventRootType Probe[main.testReturnsLargeStruct]
+          Type: 1487 EventRootType Probe[main.testReturnsLargeStruct]
           InjectionPoints: [{PC: "0x80aab0", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1472 EventRootType Probe[main.testReturnsLargeStruct]Return
+          Type: 1488 EventRootType Probe[main.testReturnsLargeStruct]Return
           InjectionPoints: [{PC: "0x80ab2c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3017,11 +3060,11 @@ Probes:
       subprogram: {subprogram: 107}
       events:
         - Kind: Entry
-          Type: 1467 EventRootType Probe[main.testReturnsManyFloats]
+          Type: 1483 EventRootType Probe[main.testReturnsManyFloats]
           InjectionPoints: [{PC: "0x80a978", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1468 EventRootType Probe[main.testReturnsManyFloats]Return
+          Type: 1484 EventRootType Probe[main.testReturnsManyFloats]Return
           InjectionPoints: [{PC: "0x80a9f8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3037,11 +3080,11 @@ Probes:
       subprogram: {subprogram: 116}
       events:
         - Kind: Entry
-          Type: 1485 EventRootType Probe[main.testReturnsMixed]
+          Type: 1501 EventRootType Probe[main.testReturnsMixed]
           InjectionPoints: [{PC: "0x80aea8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1486 EventRootType Probe[main.testReturnsMixed]Return
+          Type: 1502 EventRootType Probe[main.testReturnsMixed]Return
           InjectionPoints: [{PC: "0x80aefc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3057,11 +3100,11 @@ Probes:
       subprogram: {subprogram: 113}
       events:
         - Kind: Entry
-          Type: 1479 EventRootType Probe[main.testReturnsMixedStruct]
+          Type: 1495 EventRootType Probe[main.testReturnsMixedStruct]
           InjectionPoints: [{PC: "0x80acc8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1480 EventRootType Probe[main.testReturnsMixedStruct]Return
+          Type: 1496 EventRootType Probe[main.testReturnsMixedStruct]Return
           InjectionPoints: [{PC: "0x80ad0c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3077,11 +3120,11 @@ Probes:
       subprogram: {subprogram: 119}
       events:
         - Kind: Entry
-          Type: 1491 EventRootType Probe[main.testReturnsMultipleFloats]
+          Type: 1507 EventRootType Probe[main.testReturnsMultipleFloats]
           InjectionPoints: [{PC: "0x80b028", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1492 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          Type: 1508 EventRootType Probe[main.testReturnsMultipleFloats]Return
           InjectionPoints: [{PC: "0x80b068", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3097,11 +3140,11 @@ Probes:
       subprogram: {subprogram: 118}
       events:
         - Kind: Entry
-          Type: 1489 EventRootType Probe[main.testReturnsOnlyFloat]
+          Type: 1505 EventRootType Probe[main.testReturnsOnlyFloat]
           InjectionPoints: [{PC: "0x80afb8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1490 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          Type: 1506 EventRootType Probe[main.testReturnsOnlyFloat]Return
           InjectionPoints: [{PC: "0x80aff4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3117,11 +3160,11 @@ Probes:
       subprogram: {subprogram: 106}
       events:
         - Kind: Entry
-          Type: 1465 EventRootType Probe[main.testReturnsPrimitives]
+          Type: 1481 EventRootType Probe[main.testReturnsPrimitives]
           InjectionPoints: [{PC: "0x80a8e8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1466 EventRootType Probe[main.testReturnsPrimitives]Return
+          Type: 1482 EventRootType Probe[main.testReturnsPrimitives]Return
           InjectionPoints: [{PC: "0x80a93c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3137,11 +3180,11 @@ Probes:
       subprogram: {subprogram: 117}
       events:
         - Kind: Entry
-          Type: 1487 EventRootType Probe[main.testReturnsStructWithArray]
+          Type: 1503 EventRootType Probe[main.testReturnsStructWithArray]
           InjectionPoints: [{PC: "0x80af3c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1488 EventRootType Probe[main.testReturnsStructWithArray]Return
+          Type: 1504 EventRootType Probe[main.testReturnsStructWithArray]Return
           InjectionPoints: [{PC: "0x80af88", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3157,11 +3200,11 @@ Probes:
       subprogram: {subprogram: 115}
       events:
         - Kind: Entry
-          Type: 1483 EventRootType Probe[main.testReturnsWideStruct]
+          Type: 1499 EventRootType Probe[main.testReturnsWideStruct]
           InjectionPoints: [{PC: "0x80ade0", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1484 EventRootType Probe[main.testReturnsWideStruct]Return
+          Type: 1500 EventRootType Probe[main.testReturnsWideStruct]Return
           InjectionPoints: [{PC: "0x80ae6c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3178,7 +3221,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - Kind: Entry
-          Type: 1324 EventRootType Probe[main.testRuneArray]
+          Type: 1340 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0x8062a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3212,11 +3255,11 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1455 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1471 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x80a768", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1456 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1472 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x80a7e8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3261,7 +3304,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 1345 EventRootType Probe[main.testSingleBool]
+          Type: 1361 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0x806720", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3282,7 +3325,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - Kind: Entry
-          Type: 1343 EventRootType Probe[main.testSingleByte]
+          Type: 1359 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0x806700", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3303,7 +3346,7 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 1356 EventRootType Probe[main.testSingleFloat32]
+          Type: 1372 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0x8067d0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3324,7 +3367,7 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - Kind: Entry
-          Type: 1357 EventRootType Probe[main.testSingleFloat64]
+          Type: 1373 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0x8067e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3345,7 +3388,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 1346 EventRootType Probe[main.testSingleInt]
+          Type: 1362 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0x806730", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3366,7 +3409,7 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - Kind: Entry
-          Type: 1348 EventRootType Probe[main.testSingleInt16]
+          Type: 1364 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0x806750", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3388,7 +3431,7 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - Kind: Entry
-          Type: 1349 EventRootType Probe[main.testSingleInt32]
+          Type: 1365 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0x806760", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3409,7 +3452,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - Kind: Entry
-          Type: 1350 EventRootType Probe[main.testSingleInt64]
+          Type: 1366 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0x806770", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3437,7 +3480,7 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - Kind: Entry
-          Type: 1347 EventRootType Probe[main.testSingleInt8]
+          Type: 1363 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0x806740", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3467,7 +3510,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 1344 EventRootType Probe[main.testSingleRune]
+          Type: 1360 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0x806710", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3488,7 +3531,7 @@ Probes:
       subprogram: {subprogram: 143}
       events:
         - Kind: Entry
-          Type: 1528 EventRootType Probe[main.testSingleString]
+          Type: 1544 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0x80c3d0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3509,7 +3552,7 @@ Probes:
       subprogram: {subprogram: 29}
       events:
         - Kind: Entry
-          Type: 1351 EventRootType Probe[main.testSingleUint]
+          Type: 1367 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0x806780", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3530,7 +3573,7 @@ Probes:
       subprogram: {subprogram: 31}
       events:
         - Kind: Entry
-          Type: 1353 EventRootType Probe[main.testSingleUint16]
+          Type: 1369 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0x8067a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3551,7 +3594,7 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - Kind: Entry
-          Type: 1354 EventRootType Probe[main.testSingleUint32]
+          Type: 1370 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0x8067b0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3572,7 +3615,7 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 1355 EventRootType Probe[main.testSingleUint64]
+          Type: 1371 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0x8067c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3593,7 +3636,7 @@ Probes:
       subprogram: {subprogram: 30}
       events:
         - Kind: Entry
-          Type: 1352 EventRootType Probe[main.testSingleUint8]
+          Type: 1368 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0x806790", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3614,7 +3657,7 @@ Probes:
       subprogram: {subprogram: 140}
       events:
         - Kind: Entry
-          Type: 1524 EventRootType Probe[main.testSliceEmptyStructs]
+          Type: 1540 EventRootType Probe[main.testSliceEmptyStructs]
           InjectionPoints: [{PC: "0x80c070", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3635,7 +3678,7 @@ Probes:
       subprogram: {subprogram: 132}
       events:
         - Kind: Entry
-          Type: 1515 EventRootType Probe[main.testSliceOfSlices]
+          Type: 1531 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0x80bff0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3656,7 +3699,7 @@ Probes:
       subprogram: {subprogram: 65}
       events:
         - Kind: Entry
-          Type: 1401 EventRootType Probe[main.testSmallMap]
+          Type: 1417 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0x808270", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3676,11 +3719,11 @@ Probes:
       subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1463 EventRootType Probe[main.testSomeNamedReturn]
+          Type: 1479 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0x80a828", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1464 EventRootType Probe[main.testSomeNamedReturn]Return
+          Type: 1480 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0x80a8ac", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3700,11 +3743,11 @@ Probes:
       subprogram: {subprogram: 126}
       events:
         - Kind: Entry
-          Type: 1505 EventRootType Probe[main.testStackArgRegReturns]
+          Type: 1521 EventRootType Probe[main.testStackArgRegReturns]
           InjectionPoints: [{PC: "0x80b8f8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1506 EventRootType Probe[main.testStackArgRegReturns]Return
+          Type: 1522 EventRootType Probe[main.testStackArgRegReturns]Return
           InjectionPoints: [{PC: "0x80b950", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3725,7 +3768,7 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - Kind: Entry
-          Type: 1325 EventRootType Probe[main.testStringArray]
+          Type: 1341 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0x8062b0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3746,7 +3789,7 @@ Probes:
       subprogram: {subprogram: 93}
       events:
         - Kind: Entry
-          Type: 1432 EventRootType Probe[main.testStringPointer]
+          Type: 1448 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0x809c60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3767,7 +3810,7 @@ Probes:
       subprogram: {subprogram: 136}
       events:
         - Kind: Entry
-          Type: 1519 EventRootType Probe[main.testStringSlice]
+          Type: 1535 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0x80c030", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3788,7 +3831,7 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - Kind: Entry
-          Type: 1367 EventRootType Probe[main.testStringType1]
+          Type: 1383 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0x806cb0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3809,7 +3852,7 @@ Probes:
       subprogram: {subprogram: 45}
       events:
         - Kind: Entry
-          Type: 1368 EventRootType Probe[main.testStringType2]
+          Type: 1384 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0x806cc0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3830,11 +3873,11 @@ Probes:
       subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1547 EventRootType Probe[main.testStruct]
+          Type: 1563 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0x80c670", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1548 EventRootType Probe[main.testStruct]Return
+          Type: 1564 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0x80c680", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3860,7 +3903,7 @@ Probes:
       subprogram: {subprogram: 133}
       events:
         - Kind: Entry
-          Type: 1516 EventRootType Probe[main.testStructSlice]
+          Type: 1532 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0x80c000", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3886,7 +3929,7 @@ Probes:
       subprogram: {subprogram: 59}
       events:
         - Kind: Entry
-          Type: 1395 EventRootType Probe[main.testStructWithAny]
+          Type: 1411 EventRootType Probe[main.testStructWithAny]
           InjectionPoints: [{PC: "0x807cd0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3906,11 +3949,11 @@ Probes:
       subprogram: {subprogram: 128}
       events:
         - Kind: Entry
-          Type: 1509 EventRootType Probe[main.testStructWithArrayArg]
+          Type: 1525 EventRootType Probe[main.testStructWithArrayArg]
           InjectionPoints: [{PC: "0x80ba5c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1510 EventRootType Probe[main.testStructWithArrayArg]Return
+          Type: 1526 EventRootType Probe[main.testStructWithArrayArg]Return
           InjectionPoints: [{PC: "0x80bae0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3931,11 +3974,11 @@ Probes:
       subprogram: {subprogram: 153}
       events:
         - Kind: Entry
-          Type: 1543 EventRootType Probe[main.testStructWithCyclicMaps]
+          Type: 1559 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0x80c5c0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1544 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          Type: 1560 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0x80c5cc", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3955,7 +3998,7 @@ Probes:
       subprogram: {subprogram: 152}
       events:
         - Kind: Entry
-          Type: 1542 EventRootType Probe[main.testStructWithCyclicSlices]
+          Type: 1558 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0x80c5b0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3981,7 +4024,7 @@ Probes:
       subprogram: {subprogram: 60}
       events:
         - Kind: Entry
-          Type: 1396 EventRootType Probe[main.testStructWithMap]
+          Type: 1412 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0x808220", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4012,7 +4055,7 @@ Probes:
       subprogram: {subprogram: 141}
       events:
         - Kind: Entry
-          Type: 1525 EventRootType Probe[main.testSubslices]
+          Type: 1541 EventRootType Probe[main.testSubslices]
           InjectionPoints: [{PC: "0x80c080", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4051,7 +4094,7 @@ Probes:
       subprogram: {subprogram: 151}
       events:
         - Kind: Entry
-          Type: 1541 EventRootType Probe[main.testSubstrings]
+          Type: 1557 EventRootType Probe[main.testSubstrings]
           InjectionPoints: [{PC: "0x80c450", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4083,11 +4126,11 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1457 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1473 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x80a768", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1458 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1474 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x80a7e8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -4107,11 +4150,11 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1459 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1475 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x80a768", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1460 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1476 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x80a7e8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -4133,11 +4176,11 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1461 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1477 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x80a768", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1462 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1478 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x80a7e8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -4165,7 +4208,7 @@ Probes:
       subprogram: {subprogram: 144}
       events:
         - Kind: Entry
-          Type: 1529 EventRootType Probe[main.testThreeStrings]
+          Type: 1545 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0x80c3e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4196,11 +4239,11 @@ Probes:
       subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1530 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1546 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0x80c3f0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1531 EventRootType Probe[main.testThreeStringsInStruct]Return
+          Type: 1547 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0x80c3fc", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4229,11 +4272,11 @@ Probes:
       subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1532 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1548 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0x80c3f0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1533 EventRootType Probe[main.testThreeStringsInStruct]Return
+          Type: 1549 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0x80c3fc", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4264,7 +4307,7 @@ Probes:
       subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1534 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1550 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0x80c400", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4293,7 +4336,7 @@ Probes:
       subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1535 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1551 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0x80c400", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4324,7 +4367,7 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 1358 EventRootType Probe[main.testTypeAlias]
+          Type: 1374 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0x8067f0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4345,7 +4388,7 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - Kind: Entry
-          Type: 1334 EventRootType Probe[main.testUint16Array]
+          Type: 1350 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0x806340", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4366,7 +4409,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - Kind: Entry
-          Type: 1335 EventRootType Probe[main.testUint32Array]
+          Type: 1351 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0x806350", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4387,7 +4430,7 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - Kind: Entry
-          Type: 1336 EventRootType Probe[main.testUint64Array]
+          Type: 1352 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0x806360", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4408,7 +4451,7 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - Kind: Entry
-          Type: 1333 EventRootType Probe[main.testUint8Array]
+          Type: 1349 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0x806330", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4429,7 +4472,7 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - Kind: Entry
-          Type: 1332 EventRootType Probe[main.testUintArray]
+          Type: 1348 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0x806320", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4450,7 +4493,7 @@ Probes:
       subprogram: {subprogram: 92}
       events:
         - Kind: Entry
-          Type: 1431 EventRootType Probe[main.testUintPointer]
+          Type: 1447 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0x809bf0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4471,7 +4514,7 @@ Probes:
       subprogram: {subprogram: 130}
       events:
         - Kind: Entry
-          Type: 1513 EventRootType Probe[main.testUintSlice]
+          Type: 1529 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0x80bfd0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4492,7 +4535,7 @@ Probes:
       subprogram: {subprogram: 149}
       events:
         - Kind: Entry
-          Type: 1539 EventRootType Probe[main.testUnitializedString]
+          Type: 1555 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0x80c430", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4513,7 +4556,7 @@ Probes:
       subprogram: {subprogram: 91}
       events:
         - Kind: Entry
-          Type: 1430 EventRootType Probe[main.testUnsafePointer]
+          Type: 1446 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0x809bd0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4534,7 +4577,7 @@ Probes:
       subprogram: {subprogram: 20}
       events:
         - Kind: Entry
-          Type: 1342 EventRootType Probe[main.testVeryLargeArray]
+          Type: 1358 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0x8063d0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4555,7 +4598,7 @@ Probes:
       subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1522 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1538 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x80c060", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4576,7 +4619,7 @@ Probes:
       subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1523 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1539 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x80c060", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4593,10 +4636,10 @@ Probes:
       template: testWhollyInlinedSubroutine
       segments: [testWhollyInlinedSubroutine]
       captureSnapshot: true
-      subprogram: {subprogram: 164}
+      subprogram: {subprogram: 165}
       events:
         - Kind: Entry
-          Type: 1568 EventRootType Probe[main.firstBehavior.DoSomething]
+          Type: 1585 EventRootType Probe[main.firstBehavior.DoSomething]
           InjectionPoints:
             - PC: "0x807b38"
               Frameless: false
@@ -4604,7 +4647,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1569 EventRootType Probe[main.firstBehavior.DoSomething]Return
+          Type: 1586 EventRootType Probe[main.firstBehavior.DoSomething]Return
           InjectionPoints: [{PC: "0x807b60", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -4625,11 +4668,11 @@ Probes:
       subprogram: {subprogram: 129}
       events:
         - Kind: Entry
-          Type: 1511 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          Type: 1527 EventRootType Probe[main.testZeroSizeArgAndReturn]
           InjectionPoints: [{PC: "0x80bb18", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1512 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          Type: 1528 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
           InjectionPoints: [{PC: "0x80bb78", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -8185,6 +8228,77 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 158
+      Name: main.executeStructFuncs
+      OutOfLinePCRanges: [0x80c770..0x80d0e0]
+      InlinePCRanges: []
+      Variables:
+        - Name: n
+          Type: 321 StructureType main.nStruct
+          Locations:
+            - Range: 0x80c798..0x80c7dc
+              Pieces:
+                - Size: 1
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 2
+                  Op: null
+          Role: Local
+        - Name: ns
+          Type: 262 StructureType main.structWithNoStrings
+          Locations: [{Range: 0x80c770..0x80d0e0, Pieces: []}]
+          Role: Local
+        - Name: cs
+          Type: 322 StructureType main.cStruct
+          Locations: [{Range: 0x80c770..0x80d0e0, Pieces: []}]
+          Role: Local
+        - Name: rcvr
+          Type: 323 StructureType main.receiver
+          Locations: [{Range: 0x80c770..0x80d0e0, Pieces: []}]
+          Role: Local
+        - Name: ts
+          Type: 324 StructureType main.threestrings
+          Locations:
+            - Range: 0x80c798..0x80d0e0
+              Pieces: [{Size: 48, Op: {CfaOffset: -2072}}]
+          Role: Local
+        - Name: s
+          Type: 316 StructureType main.aStruct
+          Locations:
+            - Range: 0x80c7dc..0x80d0e0
+              Pieces: [{Size: 56, Op: {CfaOffset: -1912}}]
+          Role: Local
+        - Name: b
+          Type: 325 StructureType main.bStruct
+          Locations:
+            - Range: 0x80c828..0x80d0e0
+              Pieces: [{Size: 72, Op: {CfaOffset: -2072}}]
+          Role: Local
+        - Name: tenStr
+          Type: 326 StructureType main.tenStrings
+          Locations:
+            - Range: 0x80c9fc..0x80d0e0
+              Pieces: [{Size: 160, Op: {CfaOffset: -2072}}]
+          Role: Local
+        - Name: deep
+          Type: 327 StructureType main.deepStruct1
+          Locations:
+            - Range: 0x80ca3c..0x80d0e0
+              Pieces: [{Size: 48, Op: {CfaOffset: -2160}}]
+          Role: Local
+        - Name: fields
+          Type: 333 StructureType main.lotsOfFields
+          Locations:
+            - Range: 0x80ca90..0x80d0e0
+              Pieces: [{Size: 26, Op: {CfaOffset: -2160}}]
+          Role: Local
+        - Name: sta
+          Type: 334 StructureType main.structWithTwoArrays
+          Locations:
+            - Range: 0x80cae8..0x80d0e0
+              Pieces: [{Size: 72, Op: {CfaOffset: -2160}}]
+          Role: Local
+    - ID: 159
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0x807520..0x807590]
       InlinePCRanges:
@@ -8213,28 +8327,28 @@ Subprograms:
             - Range: 0x807800..0x807824
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 159
+    - ID: 160
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x8077a4..0x8077d8]
           RootRanges: [0x807740..0x807800]
       Variables: []
-    - ID: 160
+    - ID: 161
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x80788c..0x8078c0, 0x8078c8..0x8078cc]
           RootRanges: [0x807870..0x807980]
       Variables: []
-    - ID: 161
+    - ID: 162
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x807930..0x807964]
           RootRanges: [0x807870..0x807980]
       Variables: []
-    - ID: 162
+    - ID: 163
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -8247,7 +8361,7 @@ Subprograms:
             - Range: 0x807980..0x807988
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 163
+    - ID: 164
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -8264,7 +8378,7 @@ Subprograms:
             - Range: 0x807a28..0x807b20
               Pieces: [{Size: 40, Op: {CfaOffset: -120}}]
           Role: Parameter
-    - ID: 164
+    - ID: 165
       Name: main.firstBehavior.DoSomething
       OutOfLinePCRanges: [0x807b20..0x807b80]
       InlinePCRanges:
@@ -8272,7 +8386,7 @@ Subprograms:
           RootRanges: [0x80d2b0..0x80d340]
       Variables:
         - Name: b
-          Type: 321 StructureType main.firstBehavior
+          Type: 337 StructureType main.firstBehavior
           Locations:
             - Range: 0x807b20..0x807b44
               Pieces:
@@ -8295,7 +8409,7 @@ Subprograms:
             - Range: 0x807b61..0x807b80
               Pieces: []
           Role: Return
-    - ID: 165
+    - ID: 166
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -8311,20 +8425,20 @@ Types:
       ByteSize: 8
       Pointee: 140 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 1238
+      ID: 1254
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 1239 PointerType *main.deepSlice3
+      Pointee: 1255 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 1263
+      ID: 1279
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 1264 PointerType *main.deepSlice8
+      Pointee: 1280 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 1269
+      ID: 1285
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 1270 PointerType *main.deepSlice9
+      Pointee: 1286 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 153
       Name: '**main.stringType2'
@@ -8332,7 +8446,7 @@ Types:
       GoKind: 22
       Pointee: 154 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 1234
+      ID: 1250
       Name: '**main.t'
       ByteSize: 8
       Pointee: 248 PointerType *main.t
@@ -8375,30 +8489,30 @@ Types:
       ByteSize: 8
       Pointee: 148 PointerType *table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1246
+      ID: 1262
       Name: '**table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1247 PointerType *table<int,*main.deepMap3>
+      Pointee: 1263 PointerType *table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1280
+      ID: 1296
       Name: '**table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1281 PointerType *table<int,*main.deepMap8>
+      Pointee: 1297 PointerType *table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1295
+      ID: 1311
       Name: '**table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1296 PointerType *table<int,*main.deepMap9>
+      Pointee: 1312 PointerType *table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 169
       Name: '**table<int,int>'
       ByteSize: 8
       Pointee: 170 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 1310
+      ID: 1326
       Name: '**table<int,interface {}>'
       ByteSize: 8
-      Pointee: 1311 PointerType *table<int,interface {}>
+      Pointee: 1327 PointerType *table<int,interface {}>
     - __kind: PointerType
       ID: 236
       Name: '**table<int,struct {}>'
@@ -8420,10 +8534,10 @@ Types:
       ByteSize: 8
       Pointee: 185 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 981
+      ID: 997
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 982 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 998 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 179
       Name: '**table<string,int>'
@@ -8485,120 +8599,120 @@ Types:
       ByteSize: 8
       Pointee: 212 PointerType *table<uint8,uint8>
     - __kind: PointerType
-      ID: 335
+      ID: 351
       Name: '*[]*main.deepSlice2.array'
       ByteSize: 8
-      Pointee: 334 GoSliceDataType []*main.deepSlice2.array
+      Pointee: 350 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 1242
+      ID: 1258
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 1241 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 1257 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 1267
+      ID: 1283
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 1266 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 1282 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 1273
+      ID: 1289
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 1272 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 1288 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
-      ID: 330
+      ID: 346
       Name: '*[]*runtime.p.array'
       ByteSize: 8
-      Pointee: 329 GoSliceDataType []*runtime.p.array
+      Pointee: 345 GoSliceDataType []*runtime.p.array
     - __kind: PointerType
-      ID: 332
+      ID: 348
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 331 GoSliceDataType []*string.array
+      Pointee: 347 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 495
+      ID: 511
       Name: '*[][][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 494 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Pointee: 510 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 284
       Name: '*[][][][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 281 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 493
+      ID: 509
       Name: '*[][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 492 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Pointee: 508 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 282
       Name: '*[][][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 279 GoSliceHeaderType [][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 491
+      ID: 507
       Name: '*[][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 490 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Pointee: 506 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 280
       Name: '*[][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 277 GoSliceHeaderType [][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 489
+      ID: 505
       Name: '*[][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 488 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Pointee: 504 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 278
       Name: '*[][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 275 GoSliceHeaderType [][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 487
+      ID: 503
       Name: '*[][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 486 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Pointee: 502 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 473
+      ID: 489
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 472 GoSliceDataType [][]uint.array
+      Pointee: 488 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 479
+      ID: 495
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 478 GoSliceDataType []bool.array
+      Pointee: 494 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 1018
+      ID: 1034
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 1017 GoSliceDataType []float64.array
+      Pointee: 1033 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 1276
+      ID: 1292
       Name: '*[]interface {}.array'
       ByteSize: 8
-      Pointee: 1275 GoSliceDataType []interface {}.array
+      Pointee: 1291 GoSliceDataType []interface {}.array
     - __kind: PointerType
       ID: 276
       Name: '*[]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 273 GoSliceHeaderType []main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 485
+      ID: 501
       Name: '*[]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 484 GoSliceDataType []main.structWithCyclicSlices.array
+      Pointee: 500 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 545
+      ID: 561
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 544 GoSliceDataType []main.structWithMap.array
+      Pointee: 560 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 475
+      ID: 491
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 474 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 490 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
       ID: 39
       Name: '*[]runtime.ancestorInfo'
@@ -8607,101 +8721,101 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 477
+      ID: 493
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 476 GoSliceDataType []string.array
+      Pointee: 492 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 483
+      ID: 499
       Name: '*[]struct {}.array'
       ByteSize: 8
-      Pointee: 482 GoSliceDataType []struct {}.array
+      Pointee: 498 GoSliceDataType []struct {}.array
     - __kind: PointerType
       ID: 259
       Name: '*[]uint'
       ByteSize: 8
       Pointee: 257 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 471
+      ID: 487
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 470 GoSliceDataType []uint.array
+      Pointee: 486 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 481
+      ID: 497
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 480 GoSliceDataType []uint16.array
+      Pointee: 496 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 325
+      ID: 341
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 324 GoSliceDataType []uint8.array
+      Pointee: 340 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 327
+      ID: 343
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 326 GoSliceDataType []uintptr.array
+      Pointee: 342 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 1148
+      ID: 1164
       Name: '*archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1.987328e+06
       GoKind: 22
-      Pointee: 1149 UnresolvedPointeeType archive/tar.Writer
+      Pointee: 1165 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
-      ID: 783
+      ID: 799
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 931680
       GoKind: 22
-      Pointee: 784 GoSliceHeaderType archive/tar.headerError
+      Pointee: 800 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 786
+      ID: 802
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 785 GoSliceDataType archive/tar.headerError.array
+      Pointee: 801 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 1083
+      ID: 1099
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.436512e+06
       GoKind: 22
-      Pointee: 1084 UnresolvedPointeeType archive/tar.regFileWriter
+      Pointee: 1100 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
-      ID: 1031
+      ID: 1047
       Name: '*archive/zip.countWriter'
       ByteSize: 8
       GoRuntimeType: 931872
       GoKind: 22
-      Pointee: 1032 UnresolvedPointeeType archive/zip.countWriter
+      Pointee: 1048 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
-      ID: 1033
+      ID: 1049
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
       GoRuntimeType: 931968
       GoKind: 22
-      Pointee: 1034 StructureType archive/zip.dirWriter
+      Pointee: 1050 StructureType archive/zip.dirWriter
     - __kind: PointerType
-      ID: 1127
+      ID: 1143
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.905472e+06
       GoKind: 22
-      Pointee: 1128 UnresolvedPointeeType archive/zip.fileWriter
+      Pointee: 1144 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
-      ID: 1059
+      ID: 1075
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1.05808e+06
       GoKind: 22
-      Pointee: 1060 StructureType archive/zip.nopCloser
+      Pointee: 1076 StructureType archive/zip.nopCloser
     - __kind: PointerType
-      ID: 1061
+      ID: 1077
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
       GoRuntimeType: 1.058336e+06
       GoKind: 22
-      Pointee: 1062 UnresolvedPointeeType archive/zip.pooledFlateWriter
+      Pointee: 1078 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -8710,435 +8824,435 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 1106
+      ID: 1122
       Name: '*bufio.Reader'
       ByteSize: 8
       GoRuntimeType: 2.175424e+06
       GoKind: 22
-      Pointee: 1107 UnresolvedPointeeType bufio.Reader
+      Pointee: 1123 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
-      ID: 1135
+      ID: 1151
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1.950208e+06
       GoKind: 22
-      Pointee: 1136 UnresolvedPointeeType bufio.Writer
+      Pointee: 1152 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
-      ID: 1186
+      ID: 1202
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.268288e+06
       GoKind: 22
-      Pointee: 1187 UnresolvedPointeeType bytes.Buffer
+      Pointee: 1203 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 693
+      ID: 709
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 914208
       GoKind: 22
-      Pointee: 582 BaseType compress/flate.CorruptInputError
+      Pointee: 598 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 694
+      ID: 710
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 914304
       GoKind: 22
-      Pointee: 583 GoStringHeaderType compress/flate.InternalError
+      Pointee: 599 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 585
+      ID: 601
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 584 GoStringDataType compress/flate.InternalError.str
+      Pointee: 600 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 1081
+      ID: 1097
       Name: '*compress/flate.Writer'
       ByteSize: 8
       GoRuntimeType: 1.426112e+06
       GoKind: 22
-      Pointee: 1082 UnresolvedPointeeType compress/flate.Writer
+      Pointee: 1098 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
-      ID: 1027
+      ID: 1043
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
       GoRuntimeType: 914400
       GoKind: 22
-      Pointee: 1028 UnresolvedPointeeType compress/flate.dictWriter
+      Pointee: 1044 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
-      ID: 1103
+      ID: 1119
       Name: '*compress/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.726976e+06
       GoKind: 22
-      Pointee: 1104 UnresolvedPointeeType compress/gzip.Writer
+      Pointee: 1120 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
-      ID: 931
+      ID: 947
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.204e+06
       GoKind: 22
-      Pointee: 932 StructureType context.deadlineExceededError
+      Pointee: 948 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 775
+      ID: 791
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 926304
       GoKind: 22
-      Pointee: 596 BaseType crypto/aes.KeySizeError
+      Pointee: 612 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 776
+      ID: 792
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 926496
       GoKind: 22
-      Pointee: 597 BaseType crypto/des.KeySizeError
+      Pointee: 613 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 777
+      ID: 793
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 926784
       GoKind: 22
-      Pointee: 598 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 614 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 1098
+      ID: 1114
       Name: '*crypto/internal/fips140/hmac.HMAC'
       ByteSize: 8
       GoRuntimeType: 1.667712e+06
       GoKind: 22
-      Pointee: 1099 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
+      Pointee: 1115 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
     - __kind: PointerType
-      ID: 880
+      ID: 896
       Name: '*crypto/internal/fips140/hmac.errCloneUnsupported'
       ByteSize: 8
       GoRuntimeType: 1.065888e+06
       GoKind: 22
-      Pointee: 881 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
+      Pointee: 897 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
     - __kind: PointerType
-      ID: 1129
+      ID: 1145
       Name: '*crypto/internal/fips140/sha256.Digest'
       ByteSize: 8
       GoRuntimeType: 1.905984e+06
       GoKind: 22
-      Pointee: 1130 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
+      Pointee: 1146 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
     - __kind: PointerType
-      ID: 1159
+      ID: 1175
       Name: '*crypto/internal/fips140/sha3.Digest'
       ByteSize: 8
       GoRuntimeType: 2.120576e+06
       GoKind: 22
-      Pointee: 1160 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
+      Pointee: 1176 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
     - __kind: PointerType
-      ID: 1133
+      ID: 1149
       Name: '*crypto/internal/fips140/sha3.SHAKE'
       ByteSize: 8
       GoRuntimeType: 1.906496e+06
       GoKind: 22
-      Pointee: 1134 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
+      Pointee: 1150 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
     - __kind: PointerType
-      ID: 1131
+      ID: 1147
       Name: '*crypto/internal/fips140/sha512.Digest'
       ByteSize: 8
       GoRuntimeType: 1.90624e+06
       GoKind: 22
-      Pointee: 1132 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
+      Pointee: 1148 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
     - __kind: PointerType
-      ID: 1125
+      ID: 1141
       Name: '*crypto/md5.digest'
       ByteSize: 8
       GoRuntimeType: 1.90368e+06
       GoKind: 22
-      Pointee: 1126 UnresolvedPointeeType crypto/md5.digest
+      Pointee: 1142 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
-      ID: 778
+      ID: 794
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 927072
       GoKind: 22
-      Pointee: 599 BaseType crypto/rc4.KeySizeError
+      Pointee: 615 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 1146
+      ID: 1162
       Name: '*crypto/sha1.digest'
       ByteSize: 8
       GoRuntimeType: 1.984448e+06
       GoKind: 22
-      Pointee: 1147 UnresolvedPointeeType crypto/sha1.digest
+      Pointee: 1163 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
-      ID: 1121
+      ID: 1137
       Name: '*crypto/sha3.SHA3'
       ByteSize: 8
       GoRuntimeType: 1.873056e+06
       GoKind: 22
-      Pointee: 1122 UnresolvedPointeeType crypto/sha3.SHA3
+      Pointee: 1138 UnresolvedPointeeType crypto/sha3.SHA3
     - __kind: PointerType
-      ID: 701
+      ID: 717
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 915936
       GoKind: 22
-      Pointee: 586 BaseType crypto/tls.AlertError
+      Pointee: 602 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 869
+      ID: 885
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1.046688e+06
       GoKind: 22
-      Pointee: 870 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 886 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 1212
+      ID: 1228
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2.379808e+06
       GoKind: 22
-      Pointee: 1213 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 1229 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 697
+      ID: 713
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 915648
       GoKind: 22
-      Pointee: 698 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 714 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 695
+      ID: 711
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 915552
       GoKind: 22
-      Pointee: 696 StructureType crypto/tls.RecordHeaderError
+      Pointee: 712 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 868
+      ID: 884
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1.045024e+06
       GoKind: 22
-      Pointee: 823 BaseType crypto/tls.alert
+      Pointee: 839 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 1091
+      ID: 1107
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
       GoRuntimeType: 1.560576e+06
       GoKind: 22
-      Pointee: 1092 UnresolvedPointeeType crypto/tls.cthWrapper
+      Pointee: 1108 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
-      ID: 699
+      ID: 715
       Name: '*crypto/tls.echConfigErr'
       ByteSize: 8
       GoRuntimeType: 915744
       GoKind: 22
-      Pointee: 700 UnresolvedPointeeType crypto/tls.echConfigErr
+      Pointee: 716 UnresolvedPointeeType crypto/tls.echConfigErr
     - __kind: PointerType
-      ID: 1096
+      ID: 1112
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
       GoRuntimeType: 1.642752e+06
       GoKind: 22
-      Pointee: 1097 UnresolvedPointeeType crypto/tls.finishedHash
+      Pointee: 1113 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
-      ID: 966
+      ID: 982
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1.426592e+06
       GoKind: 22
-      Pointee: 967 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 983 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 983
+      ID: 999
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.043616e+06
       GoKind: 22
-      Pointee: 984 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 1000 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 771
+      ID: 787
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 925344
       GoKind: 22
-      Pointee: 772 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 788 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 765
+      ID: 781
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 924864
       GoKind: 22
-      Pointee: 766 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 782 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 767
+      ID: 783
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 924960
       GoKind: 22
-      Pointee: 768 StructureType crypto/x509.HostnameError
+      Pointee: 784 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 764
+      ID: 780
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 924768
       GoKind: 22
-      Pointee: 595 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 611 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 874
+      ID: 890
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1.052448e+06
       GoKind: 22
-      Pointee: 875 StructureType crypto/x509.SystemRootsError
+      Pointee: 891 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 773
+      ID: 789
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 925440
       GoKind: 22
-      Pointee: 774 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 790 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 769
+      ID: 785
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 925248
       GoKind: 22
-      Pointee: 770 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 786 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 787
+      ID: 803
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 932160
       GoKind: 22
-      Pointee: 788 StructureType encoding/asn1.StructuralError
+      Pointee: 804 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 791
+      ID: 807
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 932352
       GoKind: 22
-      Pointee: 792 StructureType encoding/asn1.SyntaxError
+      Pointee: 808 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 789
+      ID: 805
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 932256
       GoKind: 22
-      Pointee: 790 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 806 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 682
+      ID: 698
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 912192
       GoKind: 22
-      Pointee: 577 BaseType encoding/base64.CorruptInputError
+      Pointee: 593 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 1049
+      ID: 1065
       Name: '*encoding/base64.encoder'
       ByteSize: 8
       GoRuntimeType: 1.04208e+06
       GoKind: 22
-      Pointee: 1050 UnresolvedPointeeType encoding/base64.encoder
+      Pointee: 1066 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
-      ID: 685
+      ID: 701
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 913056
       GoKind: 22
-      Pointee: 578 BaseType encoding/hex.InvalidByteError
+      Pointee: 594 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 653
+      ID: 669
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 907008
       GoKind: 22
-      Pointee: 654 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 670 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 858
+      ID: 874
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1.03824e+06
       GoKind: 22
-      Pointee: 859 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 875 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 645
+      ID: 661
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 906624
       GoKind: 22
-      Pointee: 646 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 662 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 651
+      ID: 667
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 906912
       GoKind: 22
-      Pointee: 652 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 668 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 649
+      ID: 665
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 906816
       GoKind: 22
-      Pointee: 650 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 666 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 647
+      ID: 663
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 906720
       GoKind: 22
-      Pointee: 648 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 664 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 1192
+      ID: 1208
       Name: '*encoding/json.encodeState'
       ByteSize: 8
       GoRuntimeType: 2.293824e+06
       GoKind: 22
-      Pointee: 1193 UnresolvedPointeeType encoding/json.encodeState
+      Pointee: 1209 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 655
+      ID: 671
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 907392
       GoKind: 22
-      Pointee: 656 StructureType encoding/json.jsonError
+      Pointee: 672 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 1057
+      ID: 1073
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
       GoRuntimeType: 1.055008e+06
       GoKind: 22
-      Pointee: 1058 UnresolvedPointeeType encoding/pem.lineBreaker
+      Pointee: 1074 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
-      ID: 759
+      ID: 775
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 923808
       GoKind: 22
-      Pointee: 760 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 776 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 757
+      ID: 773
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 923712
       GoKind: 22
-      Pointee: 758 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 774 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 761
+      ID: 777
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 923904
       GoKind: 22
-      Pointee: 592 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 608 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 594
+      ID: 610
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 593 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 609 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 762
+      ID: 778
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 924000
       GoKind: 22
-      Pointee: 763 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 779 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
-      ID: 1170
+      ID: 1186
       Name: '*encoding/xml.printer'
       ByteSize: 8
       GoRuntimeType: 2.160416e+06
       GoKind: 22
-      Pointee: 1171 UnresolvedPointeeType encoding/xml.printer
+      Pointee: 1187 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
       ID: 106
       Name: '*error'
@@ -9147,19 +9261,19 @@ Types:
       GoKind: 22
       Pointee: 14 GoInterfaceType error
     - __kind: PointerType
-      ID: 621
+      ID: 637
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 897024
       GoKind: 22
-      Pointee: 622 UnresolvedPointeeType errors.errorString
+      Pointee: 638 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 825
+      ID: 841
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1.023136e+06
       GoKind: 22
-      Pointee: 826 UnresolvedPointeeType errors.joinError
+      Pointee: 842 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 108
       Name: '*float32'
@@ -9175,813 +9289,813 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType float64
     - __kind: PointerType
-      ID: 1180
+      ID: 1196
       Name: '*fmt.pp'
       ByteSize: 8
       GoRuntimeType: 2.260608e+06
       GoKind: 22
-      Pointee: 1181 UnresolvedPointeeType fmt.pp
+      Pointee: 1197 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
-      ID: 827
+      ID: 843
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.023264e+06
       GoKind: 22
-      Pointee: 828 UnresolvedPointeeType fmt.wrapError
+      Pointee: 844 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 829
+      ID: 845
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1.023392e+06
       GoKind: 22
-      Pointee: 830 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 846 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 683
+      ID: 699
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 912576
       GoKind: 22
-      Pointee: 684 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 700 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 664
+      ID: 680
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 909792
       GoKind: 22
-      Pointee: 665 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 681 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 666
+      ID: 682
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 909888
       GoKind: 22
-      Pointee: 667 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 683 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 995
+      ID: 1011
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 909600
       GoKind: 22
-      Pointee: 996 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 1012 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 670
+      ID: 686
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 910176
       GoKind: 22
-      Pointee: 671 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 687 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 997
+      ID: 1013
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 909696
       GoKind: 22
-      Pointee: 998 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 1014 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 668
+      ID: 684
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 909984
       GoKind: 22
-      Pointee: 571 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 587 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 573
+      ID: 589
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 572 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 588 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 663
+      ID: 679
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 909504
       GoKind: 22
-      Pointee: 568 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 584 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 570
+      ID: 586
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 569 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 585 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 669
+      ID: 685
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 910080
       GoKind: 22
-      Pointee: 574 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 590 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 576
+      ID: 592
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 575 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 591 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 1069
+      ID: 1085
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
       GoRuntimeType: 1.209504e+06
       GoKind: 22
-      Pointee: 1070 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      Pointee: 1086 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
-      ID: 1156
+      ID: 1172
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
       GoRuntimeType: 2.058624e+06
       GoKind: 22
-      Pointee: 1157 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      Pointee: 1173 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
-      ID: 781
+      ID: 797
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 930624
       GoKind: 22
-      Pointee: 782 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 798 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 940
+      ID: 956
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1.213088e+06
       GoKind: 22
-      Pointee: 941 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 957 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 1188
+      ID: 1204
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
       GoRuntimeType: 2.270336e+06
       GoKind: 22
-      Pointee: 1189 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      Pointee: 1205 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
-      ID: 708
+      ID: 724
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 919296
       GoKind: 22
-      Pointee: 709 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 725 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 715
+      ID: 731
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 920352
       GoKind: 22
-      Pointee: 716 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 732 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 710
+      ID: 726
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 920064
       GoKind: 22
-      Pointee: 591 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 607 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 713
+      ID: 729
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 920256
       GoKind: 22
-      Pointee: 714 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 730 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 711
+      ID: 727
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 920160
       GoKind: 22
-      Pointee: 712 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 728 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 731
+      ID: 747
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 922272
       GoKind: 22
-      Pointee: 732 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 748 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 735
+      ID: 751
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 922464
       GoKind: 22
-      Pointee: 736 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 752 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 733
+      ID: 749
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 922368
       GoKind: 22
-      Pointee: 734 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 750 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 729
+      ID: 745
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 922176
       GoKind: 22
-      Pointee: 730 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 746 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 1020
+      ID: 1036
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 1019 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 1035 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 743
+      ID: 759
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 922848
       GoKind: 22
-      Pointee: 744 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 760 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 737
+      ID: 753
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 922560
       GoKind: 22
-      Pointee: 738 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 754 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 741
+      ID: 757
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 922752
       GoKind: 22
-      Pointee: 742 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 758 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 739
+      ID: 755
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 922656
       GoKind: 22
-      Pointee: 740 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 756 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 745
+      ID: 761
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 922944
       GoKind: 22
-      Pointee: 746 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 762 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 751
+      ID: 767
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 923232
       GoKind: 22
-      Pointee: 752 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 768 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 753
+      ID: 769
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 923328
       GoKind: 22
-      Pointee: 754 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 770 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 749
+      ID: 765
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 923136
       GoKind: 22
-      Pointee: 750 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 766 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 747
+      ID: 763
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 923040
       GoKind: 22
-      Pointee: 748 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 764 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 755
+      ID: 771
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 923520
       GoKind: 22
-      Pointee: 756 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 772 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 672
+      ID: 688
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 911328
       GoKind: 22
-      Pointee: 673 StructureType github.com/cihub/seelog.baseError
+      Pointee: 689 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 1109
+      ID: 1125
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1.80384e+06
       GoKind: 22
-      Pointee: 1110 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 1126 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 674
+      ID: 690
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 911424
       GoKind: 22
-      Pointee: 675 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 691 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 1089
+      ID: 1105
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
       GoRuntimeType: 1.559296e+06
       GoKind: 22
-      Pointee: 1090 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+      Pointee: 1106 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
-      ID: 1045
+      ID: 1061
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
       GoRuntimeType: 1.040928e+06
       GoKind: 22
-      Pointee: 1046 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+      Pointee: 1062 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
-      ID: 1079
+      ID: 1095
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.424192e+06
       GoKind: 22
-      Pointee: 1080 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+      Pointee: 1096 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
-      ID: 678
+      ID: 694
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 911616
       GoKind: 22
-      Pointee: 679 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 695 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 1144
+      ID: 1160
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.976672e+06
       GoKind: 22
-      Pointee: 1145 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+      Pointee: 1161 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
-      ID: 1163
+      ID: 1179
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
       GoRuntimeType: 2.133216e+06
       GoKind: 22
-      Pointee: 1158 StructureType github.com/cihub/seelog.rollingFileWriterSize
+      Pointee: 1174 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
-      ID: 1162
+      ID: 1178
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
       GoRuntimeType: 2.132832e+06
       GoKind: 22
-      Pointee: 1161 StructureType github.com/cihub/seelog.rollingFileWriterTime
+      Pointee: 1177 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
-      ID: 1047
+      ID: 1063
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
       GoRuntimeType: 1.041056e+06
       GoKind: 22
-      Pointee: 1048 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+      Pointee: 1064 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
-      ID: 676
+      ID: 692
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 911520
       GoKind: 22
-      Pointee: 677 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 693 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 680
+      ID: 696
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 911712
       GoKind: 22
-      Pointee: 681 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 697 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 1111
+      ID: 1127
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.805632e+06
       GoKind: 22
-      Pointee: 1112 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+      Pointee: 1128 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
-      ID: 1152
+      ID: 1168
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 2.0128e+06
       GoKind: 22
-      Pointee: 1153 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+      Pointee: 1169 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
-      ID: 1154
+      ID: 1170
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
       GoRuntimeType: 2.043296e+06
       GoKind: 22
-      Pointee: 1155 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+      Pointee: 1171 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
-      ID: 971
+      ID: 987
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1.438912e+06
       GoKind: 22
-      Pointee: 972 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 988 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 884
+      ID: 900
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.066656e+06
       GoKind: 22
-      Pointee: 885 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 901 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 882
+      ID: 898
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1.066528e+06
       GoKind: 22
-      Pointee: 883 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 899 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 886
+      ID: 902
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.070624e+06
       GoKind: 22
-      Pointee: 887 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 903 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 888
+      ID: 904
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1.070752e+06
       GoKind: 22
-      Pointee: 889 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 905 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 1100
+      ID: 1116
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
       GoRuntimeType: 1.670016e+06
       GoKind: 22
-      Pointee: 1101 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+      Pointee: 1117 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
-      ID: 876
+      ID: 892
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.053088e+06
       GoKind: 22
-      Pointee: 877 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 893 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 686
+      ID: 702
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 913248
       GoKind: 22
-      Pointee: 687 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 703 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 1204
+      ID: 1220
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
       GoRuntimeType: 2.356256e+06
       GoKind: 22
-      Pointee: 1205 UnresolvedPointeeType github.com/json-iterator/go.Stream
+      Pointee: 1221 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
-      ID: 942
+      ID: 958
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1.221664e+06
       GoKind: 22
-      Pointee: 943 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 959 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 915
+      ID: 931
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1.200544e+06
       GoKind: 22
-      Pointee: 916 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 932 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 909
+      ID: 925
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1.20016e+06
       GoKind: 22
-      Pointee: 910 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 926 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 844
+      ID: 860
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1.032224e+06
       GoKind: 22
-      Pointee: 845 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 861 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 921
+      ID: 937
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1.200928e+06
       GoKind: 22
-      Pointee: 922 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 938 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 843
+      ID: 859
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1.032096e+06
       GoKind: 22
-      Pointee: 822 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 838 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 913
+      ID: 929
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1.200416e+06
       GoKind: 22
-      Pointee: 914 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 930 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 911
+      ID: 927
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1.200288e+06
       GoKind: 22
-      Pointee: 912 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 928 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 919
+      ID: 935
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1.2008e+06
       GoKind: 22
-      Pointee: 920 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 936 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 917
+      ID: 933
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1.200672e+06
       GoKind: 22
-      Pointee: 918 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 934 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 1208
+      ID: 1224
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
       GoRuntimeType: 2.368864e+06
       GoKind: 22
-      Pointee: 1209 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+      Pointee: 1225 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
-      ID: 925
+      ID: 941
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1.201312e+06
       GoKind: 22
-      Pointee: 926 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 942 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 848
+      ID: 864
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1.03248e+06
       GoKind: 22
-      Pointee: 849 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 865 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 846
+      ID: 862
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1.032352e+06
       GoKind: 22
-      Pointee: 847 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 863 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 923
+      ID: 939
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1.201184e+06
       GoKind: 22
-      Pointee: 924 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 940 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 803
+      ID: 819
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 945120
       GoKind: 22
-      Pointee: 604 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 620 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 606
+      ID: 622
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 605 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 621 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 986
+      ID: 1002
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1.66848e+06
       GoKind: 22
-      Pointee: 987 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 1003 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 892
+      ID: 908
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1.085472e+06
       GoKind: 22
-      Pointee: 893 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 909 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 1075
+      ID: 1091
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
       GoRuntimeType: 1.261472e+06
       GoKind: 22
-      Pointee: 1076 StructureType go.uber.org/zap.nopCloserSink
+      Pointee: 1092 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
-      ID: 1168
+      ID: 1184
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.148576e+06
       GoKind: 22
-      Pointee: 1169 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+      Pointee: 1185 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
-      ID: 1063
+      ID: 1079
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
       GoRuntimeType: 1.087776e+06
       GoKind: 22
-      Pointee: 1064 StructureType go.uber.org/zap/zapcore.writerWrapper
+      Pointee: 1080 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
-      ID: 804
+      ID: 820
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 946368
       GoKind: 22
-      Pointee: 607 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 623 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 950
+      ID: 966
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1.263136e+06
       GoKind: 22
-      Pointee: 951 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 967 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 807
+      ID: 823
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 946656
       GoKind: 22
-      Pointee: 808 StructureType golang.org/x/net/http2.connError
+      Pointee: 824 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 806
+      ID: 822
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 946560
       GoKind: 22
-      Pointee: 611 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 627 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 613
+      ID: 629
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 612 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 628 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 810
+      ID: 826
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 946848
       GoKind: 22
-      Pointee: 617 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 633 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 619
+      ID: 635
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 618 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 634 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 809
+      ID: 825
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 946752
       GoKind: 22
-      Pointee: 614 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 630 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 616
+      ID: 632
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 615 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 631 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 805
+      ID: 821
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 946464
       GoKind: 22
-      Pointee: 608 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 624 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 610
+      ID: 626
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 609 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 625 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1166
+      ID: 1182
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.146656e+06
       GoKind: 22
-      Pointee: 1167 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1183 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 811
+      ID: 827
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 946944
       GoKind: 22
-      Pointee: 812 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 828 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 813
+      ID: 829
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 947040
       GoKind: 22
-      Pointee: 620 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 636 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 799
+      ID: 815
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 940320
       GoKind: 22
-      Pointee: 800 StructureType google.golang.org/grpc.dropError
+      Pointee: 816 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 948
+      ID: 964
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1.260192e+06
       GoKind: 22
-      Pointee: 949 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 965 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 973
+      ID: 989
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1.446272e+06
       GoKind: 22
-      Pointee: 974 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 990 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 801
+      ID: 817
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 943392
       GoKind: 22
-      Pointee: 802 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 818 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 1115
+      ID: 1131
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1.811232e+06
       GoKind: 22
-      Pointee: 1116 StructureType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 1132 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 1073
+      ID: 1089
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
       GoRuntimeType: 1.256736e+06
       GoKind: 22
-      Pointee: 1074 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+      Pointee: 1090 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
-      ID: 890
+      ID: 906
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1.079712e+06
       GoKind: 22
-      Pointee: 891 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 907 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 1035
+      ID: 1051
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
       GoRuntimeType: 943488
       GoKind: 22
-      Pointee: 1036 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+      Pointee: 1052 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
-      ID: 779
+      ID: 795
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 928512
       GoKind: 22
-      Pointee: 780 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 796 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 878
+      ID: 894
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1.056416e+06
       GoKind: 22
-      Pointee: 879 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 895 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 946
+      ID: 962
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.228064e+06
       GoKind: 22
-      Pointee: 947 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 963 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 944
+      ID: 960
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1.227808e+06
       GoKind: 22
-      Pointee: 945 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 961 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 793
+      ID: 809
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 933216
       GoKind: 22
-      Pointee: 794 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 810 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 795
+      ID: 811
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 933312
       GoKind: 22
-      Pointee: 796 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 812 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 723
+      ID: 739
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 920736
       GoKind: 22
-      Pointee: 724 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 740 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 1123
+      ID: 1139
       Name: '*hash/crc32.digest'
       ByteSize: 8
       GoRuntimeType: 1.901632e+06
       GoKind: 22
-      Pointee: 1124 UnresolvedPointeeType hash/crc32.digest
+      Pointee: 1140 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
-      ID: 814
+      ID: 830
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 947808
       GoKind: 22
-      Pointee: 815 UnresolvedPointeeType html/template.Error
+      Pointee: 831 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 100
       Name: '*int'
@@ -10025,115 +10139,115 @@ Types:
       GoKind: 22
       Pointee: 157 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 975
+      ID: 991
       Name: '*internal/abi.Type'
       ByteSize: 8
       GoRuntimeType: 2.212928e+06
       GoKind: 22
-      Pointee: 976 UnresolvedPointeeType internal/abi.Type
+      Pointee: 992 UnresolvedPointeeType internal/abi.Type
     - __kind: PointerType
-      ID: 691
+      ID: 707
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 913920
       GoKind: 22
-      Pointee: 692 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 708 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 689
+      ID: 705
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 913824
       GoKind: 22
-      Pointee: 690 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 706 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 1021
+      ID: 1037
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
       GoRuntimeType: 901824
       GoKind: 22
-      Pointee: 1022 UnresolvedPointeeType internal/godebug.runtimeStderr
+      Pointee: 1038 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
-      ID: 907
+      ID: 923
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.199392e+06
       GoKind: 22
-      Pointee: 908 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 924 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 1210
+      ID: 1226
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2.374528e+06
       GoKind: 22
-      Pointee: 1211 UnresolvedPointeeType internal/poll.FD
+      Pointee: 1227 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 905
+      ID: 921
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1.199264e+06
       GoKind: 22
-      Pointee: 906 StructureType internal/poll.errNetClosing
+      Pointee: 922 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 625
+      ID: 641
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 901056
       GoKind: 22
-      Pointee: 626 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 642 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 688
+      ID: 704
       Name: '*internal/runtime/cgroup.stringError'
       ByteSize: 8
       GoRuntimeType: 913632
       GoKind: 22
-      Pointee: 579 GoStringHeaderType internal/runtime/cgroup.stringError
+      Pointee: 595 GoStringHeaderType internal/runtime/cgroup.stringError
     - __kind: PointerType
-      ID: 581
+      ID: 597
       Name: '*internal/runtime/cgroup.stringError.str'
       ByteSize: 8
-      Pointee: 580 GoStringDataType internal/runtime/cgroup.stringError.str
+      Pointee: 596 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: PointerType
-      ID: 862
+      ID: 878
       Name: '*internal/runtime/maps.unhashableTypeError'
       ByteSize: 8
       GoRuntimeType: 1.04336e+06
       GoKind: 22
-      Pointee: 863 StructureType internal/runtime/maps.unhashableTypeError
+      Pointee: 879 StructureType internal/runtime/maps.unhashableTypeError
     - __kind: PointerType
-      ID: 1067
+      ID: 1083
       Name: '*io.PipeWriter'
       ByteSize: 8
       GoRuntimeType: 1.190944e+06
       GoKind: 22
-      Pointee: 1068 UnresolvedPointeeType io.PipeWriter
+      Pointee: 1084 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
-      ID: 1065
+      ID: 1081
       Name: '*io.discard'
       ByteSize: 8
       GoRuntimeType: 1.19056e+06
       GoKind: 22
-      Pointee: 1066 StructureType io.discard
+      Pointee: 1082 StructureType io.discard
     - __kind: PointerType
-      ID: 1039
+      ID: 1055
       Name: '*io.multiWriter'
       ByteSize: 8
       GoRuntimeType: 1.02416e+06
       GoKind: 22
-      Pointee: 1040 UnresolvedPointeeType io.multiWriter
+      Pointee: 1056 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
-      ID: 903
+      ID: 919
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1.198752e+06
       GoKind: 22
-      Pointee: 904 UnresolvedPointeeType io/fs.PathError
+      Pointee: 920 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 1113
+      ID: 1129
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 1.805856e+06
       GoKind: 22
-      Pointee: 1114 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+      Pointee: 1130 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
       ID: 317
       Name: '*main.anotherStruct'
@@ -10141,19 +10255,19 @@ Types:
       GoKind: 22
       Pointee: 318 StructureType main.anotherStruct
     - __kind: PointerType
-      ID: 342
+      ID: 358
       Name: '*main.deepMap2'
       ByteSize: 8
       GoRuntimeType: 386464
       GoKind: 22
-      Pointee: 343 StructureType main.deepMap2
+      Pointee: 359 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 1254
+      ID: 1270
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 386400
       GoKind: 22
-      Pointee: 1255 UnresolvedPointeeType main.deepMap3
+      Pointee: 1271 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 149
       Name: '*main.deepMap7'
@@ -10162,19 +10276,19 @@ Types:
       GoKind: 22
       Pointee: 150 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 1288
+      ID: 1304
       Name: '*main.deepMap8'
       ByteSize: 8
       GoRuntimeType: 386080
       GoKind: 22
-      Pointee: 1289 StructureType main.deepMap8
+      Pointee: 1305 StructureType main.deepMap8
     - __kind: PointerType
-      ID: 1303
+      ID: 1319
       Name: '*main.deepMap9'
       ByteSize: 8
       GoRuntimeType: 386016
       GoKind: 22
-      Pointee: 1304 StructureType main.deepMap9
+      Pointee: 1320 StructureType main.deepMap9
     - __kind: PointerType
       ID: 133
       Name: '*main.deepPtr2'
@@ -10183,12 +10297,12 @@ Types:
       GoKind: 22
       Pointee: 134 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 1214
+      ID: 1230
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 386976
       GoKind: 22
-      Pointee: 1215 UnresolvedPointeeType main.deepPtr3
+      Pointee: 1231 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 135
       Name: '*main.deepPtr7'
@@ -10197,33 +10311,33 @@ Types:
       GoKind: 22
       Pointee: 136 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 1258
+      ID: 1274
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 386656
       GoKind: 22
-      Pointee: 1259 StructureType main.deepPtr8
+      Pointee: 1275 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 1260
+      ID: 1276
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 386592
       GoKind: 22
-      Pointee: 1261 StructureType main.deepPtr9
+      Pointee: 1277 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 140
       Name: '*main.deepSlice2'
       ByteSize: 8
       GoRuntimeType: 387616
       GoKind: 22
-      Pointee: 333 StructureType main.deepSlice2
+      Pointee: 349 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 1239
+      ID: 1255
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 387552
       GoKind: 22
-      Pointee: 1240 UnresolvedPointeeType main.deepSlice3
+      Pointee: 1256 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 141
       Name: '*main.deepSlice7'
@@ -10232,19 +10346,19 @@ Types:
       GoKind: 22
       Pointee: 142 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 1264
+      ID: 1280
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 387232
       GoKind: 22
-      Pointee: 1265 StructureType main.deepSlice8
+      Pointee: 1281 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 1270
+      ID: 1286
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 387168
       GoKind: 22
-      Pointee: 1271 StructureType main.deepSlice9
+      Pointee: 1287 StructureType main.deepSlice9
     - __kind: PointerType
       ID: 320
       Name: '*main.emptyStruct'
@@ -10259,14 +10373,14 @@ Types:
       GoKind: 22
       Pointee: 160 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 1231
+      ID: 1247
       Name: '*main.firstBehavior'
       ByteSize: 8
       GoRuntimeType: 896736
       GoKind: 22
-      Pointee: 321 StructureType main.firstBehavior
+      Pointee: 337 StructureType main.firstBehavior
     - __kind: PointerType
-      ID: 1320
+      ID: 1336
       Name: '*main.nestedStruct'
       ByteSize: 8
       GoRuntimeType: 387872
@@ -10286,19 +10400,19 @@ Types:
       GoKind: 22
       Pointee: 271 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 1232
+      ID: 1248
       Name: '*main.secondBehavior'
       ByteSize: 8
       GoRuntimeType: 896832
       GoKind: 22
-      Pointee: 1233 StructureType main.secondBehavior
+      Pointee: 1249 StructureType main.secondBehavior
     - __kind: PointerType
-      ID: 1219
+      ID: 1235
       Name: '*main.somethingImpl'
       ByteSize: 8
       GoRuntimeType: 896928
       GoKind: 22
-      Pointee: 1220 UnresolvedPointeeType main.somethingImpl
+      Pointee: 1236 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
       ID: 151
       Name: '*main.stringType1'
@@ -10306,28 +10420,28 @@ Types:
       GoKind: 22
       Pointee: 152 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 1217
+      ID: 1233
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 1216 GoStringDataType main.stringType1.str
+      Pointee: 1232 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 154
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 1218 GoStringHeaderType main.stringType2
+      Pointee: 1234 GoStringHeaderType main.stringType2
     - __kind: PointerType
-      ID: 1322
+      ID: 1338
       Name: '*main.stringType2.str'
       ByteSize: 8
-      Pointee: 1321 GoStringDataType main.stringType2.str
+      Pointee: 1337 GoStringDataType main.stringType2.str
     - __kind: PointerType
       ID: 274
       Name: '*main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 272 StructureType main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 394
+      ID: 410
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 385952
@@ -10351,10 +10465,10 @@ Types:
       GoKind: 22
       Pointee: 249 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 1236
+      ID: 1252
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 1235 GoSliceDataType main.t.array
+      Pointee: 1251 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 269
       Name: '*main.threeStringStruct'
@@ -10387,30 +10501,30 @@ Types:
       ByteSize: 8
       Pointee: 146 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1244
+      ID: 1260
       Name: '*map<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1245 GoSwissMapHeaderType map<int,*main.deepMap3>
+      Pointee: 1261 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1278
+      ID: 1294
       Name: '*map<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1279 GoSwissMapHeaderType map<int,*main.deepMap8>
+      Pointee: 1295 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1293
+      ID: 1309
       Name: '*map<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1294 GoSwissMapHeaderType map<int,*main.deepMap9>
+      Pointee: 1310 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: PointerType
       ID: 167
       Name: '*map<int,int>'
       ByteSize: 8
       Pointee: 168 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 1308
+      ID: 1324
       Name: '*map<int,interface {}>'
       ByteSize: 8
-      Pointee: 1309 GoSwissMapHeaderType map<int,interface {}>
+      Pointee: 1325 GoSwissMapHeaderType map<int,interface {}>
     - __kind: PointerType
       ID: 234
       Name: '*map<int,struct {}>'
@@ -10432,10 +10546,10 @@ Types:
       ByteSize: 8
       Pointee: 183 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 979
+      ID: 995
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 980 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 996 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 177
       Name: '*map<string,int>'
@@ -10503,696 +10617,696 @@ Types:
       GoKind: 22
       Pointee: 176 GoMapType map[string]int
     - __kind: PointerType
-      ID: 727
+      ID: 743
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 921600
       GoKind: 22
-      Pointee: 728 StructureType math/big.ErrNaN
+      Pointee: 744 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 1029
+      ID: 1045
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
       GoRuntimeType: 916416
       GoKind: 22
-      Pointee: 1030 StructureType mime/multipart.writerOnly·1
+      Pointee: 1046 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
-      ID: 934
+      ID: 950
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1.207328e+06
       GoKind: 22
-      Pointee: 935 UnresolvedPointeeType net.AddrError
+      Pointee: 951 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 960
+      ID: 976
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1.422432e+06
       GoKind: 22
-      Pointee: 961 UnresolvedPointeeType net.DNSError
+      Pointee: 977 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 1174
+      ID: 1190
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2.2328e+06
       GoKind: 22
-      Pointee: 1175 UnresolvedPointeeType net.IPConn
+      Pointee: 1191 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 958
+      ID: 974
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1.422112e+06
       GoKind: 22
-      Pointee: 959 UnresolvedPointeeType net.OpError
+      Pointee: 975 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 936
+      ID: 952
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.207456e+06
       GoKind: 22
-      Pointee: 937 UnresolvedPointeeType net.ParseError
+      Pointee: 953 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 1184
+      ID: 1200
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2.261632e+06
       GoKind: 22
-      Pointee: 1185 UnresolvedPointeeType net.TCPConn
+      Pointee: 1201 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 1194
+      ID: 1210
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2.307136e+06
       GoKind: 22
-      Pointee: 1195 UnresolvedPointeeType net.UDPConn
+      Pointee: 1211 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 1182
+      ID: 1198
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2.26112e+06
       GoKind: 22
-      Pointee: 1183 UnresolvedPointeeType net.UnixConn
+      Pointee: 1199 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 933
+      ID: 949
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1.20656e+06
       GoKind: 22
-      Pointee: 896 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 912 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 898
+      ID: 914
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 897 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 913 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 860
+      ID: 876
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1.039136e+06
       GoKind: 22
-      Pointee: 861 StructureType net.canceledError
+      Pointee: 877 StructureType net.canceledError
     - __kind: PointerType
-      ID: 1150
+      ID: 1166
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 2.010208e+06
       GoKind: 22
-      Pointee: 1151 UnresolvedPointeeType net.conn
+      Pointee: 1167 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 1004
+      ID: 1020
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1.84864e+06
       GoKind: 22
-      Pointee: 1005 StructureType net.dialResult·1
+      Pointee: 1021 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 1196
+      ID: 1212
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2.311392e+06
       GoKind: 22
-      Pointee: 1197 UnresolvedPointeeType net.netFD
+      Pointee: 1213 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 657
+      ID: 673
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 908352
       GoKind: 22
-      Pointee: 658 UnresolvedPointeeType net.notFoundError
+      Pointee: 674 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 659
+      ID: 675
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 909024
       GoKind: 22
-      Pointee: 660 StructureType net.result·2
+      Pointee: 676 StructureType net.result·2
     - __kind: PointerType
-      ID: 1178
+      ID: 1194
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.247168e+06
       GoKind: 22
-      Pointee: 1179 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 1195 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 1176
+      ID: 1192
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.246688e+06
       GoKind: 22
-      Pointee: 1177 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 1193 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 938
+      ID: 954
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1.208096e+06
       GoKind: 22
-      Pointee: 939 UnresolvedPointeeType net.temporaryError
+      Pointee: 955 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 962
+      ID: 978
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.422592e+06
       GoKind: 22
-      Pointee: 963 UnresolvedPointeeType net.timeoutError
+      Pointee: 979 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 850
+      ID: 866
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1.034912e+06
       GoKind: 22
-      Pointee: 851 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 867 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
-      ID: 1023
+      ID: 1039
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
       GoRuntimeType: 904128
       GoKind: 22
-      Pointee: 1024 StructureType net/http.bufioFlushWriter
+      Pointee: 1040 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
-      ID: 634
+      ID: 650
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 904800
       GoKind: 22
-      Pointee: 549 BaseType net/http.http2ConnectionError
+      Pointee: 565 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 635
+      ID: 651
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 904896
       GoKind: 22
-      Pointee: 636 StructureType net/http.http2GoAwayError
+      Pointee: 652 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 954
+      ID: 970
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1.418112e+06
       GoKind: 22
-      Pointee: 955 StructureType net/http.http2StreamError
+      Pointee: 971 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 639
+      ID: 655
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 905472
       GoKind: 22
-      Pointee: 640 StructureType net/http.http2connError
+      Pointee: 656 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 1085
+      ID: 1101
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
       GoRuntimeType: 1.555776e+06
       GoKind: 22
-      Pointee: 1086 UnresolvedPointeeType net/http.http2dataBuffer
+      Pointee: 1102 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 638
+      ID: 654
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 905376
       GoKind: 22
-      Pointee: 553 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 569 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 555
+      ID: 571
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 554 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 570 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 642
+      ID: 658
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 905664
       GoKind: 22
-      Pointee: 559 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 575 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 561
+      ID: 577
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 560 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 576 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 641
+      ID: 657
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 905568
       GoKind: 22
-      Pointee: 556 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 572 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 558
+      ID: 574
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 557 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 573 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 929
+      ID: 945
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1.203232e+06
       GoKind: 22
-      Pointee: 930 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 946 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 856
+      ID: 872
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1.035552e+06
       GoKind: 22
-      Pointee: 857 StructureType net/http.http2noCachedConnError
+      Pointee: 873 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 1139
+      ID: 1155
       Name: '*net/http.http2pipe'
       ByteSize: 8
       GoRuntimeType: 1.952512e+06
       GoKind: 22
-      Pointee: 1140 UnresolvedPointeeType net/http.http2pipe
+      Pointee: 1156 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 637
+      ID: 653
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 905280
       GoKind: 22
-      Pointee: 550 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 566 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 552
+      ID: 568
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 551 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 567 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1025
+      ID: 1041
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
       GoRuntimeType: 905760
       GoKind: 22
-      Pointee: 1026 StructureType net/http.http2stickyErrWriter
+      Pointee: 1042 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
-      ID: 852
+      ID: 868
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1.035168e+06
       GoKind: 22
-      Pointee: 853 StructureType net/http.nothingWrittenError
+      Pointee: 869 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 1087
+      ID: 1103
       Name: '*net/http.persistConn'
       ByteSize: 8
       GoRuntimeType: 2.176672e+06
       GoKind: 22
-      Pointee: 1088 UnresolvedPointeeType net/http.persistConn
+      Pointee: 1104 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
-      ID: 1043
+      ID: 1059
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
       GoRuntimeType: 1.03504e+06
       GoKind: 22
-      Pointee: 1044 StructureType net/http.persistConnWriter
+      Pointee: 1060 StructureType net/http.persistConnWriter
     - __kind: PointerType
-      ID: 1077
+      ID: 1093
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1.418272e+06
       GoKind: 22
-      Pointee: 1078 StructureType net/http.readWriteCloserBody
+      Pointee: 1094 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 643
+      ID: 659
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 905856
       GoKind: 22
-      Pointee: 644 StructureType net/http.requestBodyReadError
+      Pointee: 660 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 956
+      ID: 972
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.419392e+06
       GoKind: 22
-      Pointee: 957 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 973 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 927
+      ID: 943
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1.203104e+06
       GoKind: 22
-      Pointee: 928 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 944 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 854
+      ID: 870
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1.035296e+06
       GoKind: 22
-      Pointee: 855 StructureType net/http.transportReadFromServerError
+      Pointee: 871 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 1119
+      ID: 1135
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
       GoRuntimeType: 1.84528e+06
       GoKind: 22
-      Pointee: 1120 StructureType net/http.unencryptedNetConnInTLSConn
+      Pointee: 1136 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 632
+      ID: 648
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 904032
       GoKind: 22
-      Pointee: 633 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 649 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 1141
+      ID: 1157
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
       GoRuntimeType: 1.954304e+06
       GoKind: 22
-      Pointee: 1142 StructureType net/http/internal.FlushAfterChunkWriter
+      Pointee: 1158 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
-      ID: 1053
+      ID: 1069
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
       GoRuntimeType: 1.04784e+06
       GoKind: 22
-      Pointee: 1054 UnresolvedPointeeType net/http/internal.chunkedWriter
+      Pointee: 1070 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
-      ID: 719
+      ID: 735
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 920544
       GoKind: 22
-      Pointee: 720 StructureType net/netip.parseAddrError
+      Pointee: 736 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 717
+      ID: 733
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 920448
       GoKind: 22
-      Pointee: 718 StructureType net/netip.parsePrefixError
+      Pointee: 734 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 1093
+      ID: 1109
       Name: '*net/smtp.Client'
       ByteSize: 8
       GoRuntimeType: 2.119168e+06
       GoKind: 22
-      Pointee: 1094 UnresolvedPointeeType net/smtp.Client
+      Pointee: 1110 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
-      ID: 1055
+      ID: 1071
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
       GoRuntimeType: 1.052704e+06
       GoKind: 22
-      Pointee: 1056 StructureType net/smtp.dataCloser
+      Pointee: 1072 StructureType net/smtp.dataCloser
     - __kind: PointerType
-      ID: 703
+      ID: 719
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 916608
       GoKind: 22
-      Pointee: 704 UnresolvedPointeeType net/textproto.Error
+      Pointee: 720 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 702
+      ID: 718
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 916512
       GoKind: 22
-      Pointee: 587 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 603 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 589
+      ID: 605
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 588 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 604 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 1051
+      ID: 1067
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
       GoRuntimeType: 1.047072e+06
       GoKind: 22
-      Pointee: 1052 UnresolvedPointeeType net/textproto.dotWriter
+      Pointee: 1068 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
-      ID: 964
+      ID: 980
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1.422912e+06
       GoKind: 22
-      Pointee: 965 UnresolvedPointeeType net/url.Error
+      Pointee: 981 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 661
+      ID: 677
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 909120
       GoKind: 22
-      Pointee: 562 GoStringHeaderType net/url.EscapeError
+      Pointee: 578 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 564
+      ID: 580
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 563 GoStringDataType net/url.EscapeError.str
+      Pointee: 579 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 662
+      ID: 678
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 909216
       GoKind: 22
-      Pointee: 565 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 581 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 567
+      ID: 583
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 566 GoStringDataType net/url.InvalidHostError.str
-    - __kind: PointerType
-      ID: 440
-      Name: '*noalg.map.group[[4]int][4]int'
-      ByteSize: 8
-      Pointee: 441 StructureType noalg.map.group[[4]int][4]int
-    - __kind: PointerType
-      ID: 432
-      Name: '*noalg.map.group[[4]int]uint8'
-      ByteSize: 8
-      Pointee: 433 StructureType noalg.map.group[[4]int]uint8
-    - __kind: PointerType
-      ID: 380
-      Name: '*noalg.map.group[[4]string][2]int'
-      ByteSize: 8
-      Pointee: 381 StructureType noalg.map.group[[4]string][2]int
-    - __kind: PointerType
-      ID: 399
-      Name: '*noalg.map.group[bool]main.node'
-      ByteSize: 8
-      Pointee: 400 StructureType noalg.map.group[bool]main.node
-    - __kind: PointerType
-      ID: 338
-      Name: '*noalg.map.group[int]*main.deepMap2'
-      ByteSize: 8
-      Pointee: 339 StructureType noalg.map.group[int]*main.deepMap2
-    - __kind: PointerType
-      ID: 1250
-      Name: '*noalg.map.group[int]*main.deepMap3'
-      ByteSize: 8
-      Pointee: 1251 StructureType noalg.map.group[int]*main.deepMap3
-    - __kind: PointerType
-      ID: 1284
-      Name: '*noalg.map.group[int]*main.deepMap8'
-      ByteSize: 8
-      Pointee: 1285 StructureType noalg.map.group[int]*main.deepMap8
-    - __kind: PointerType
-      ID: 1299
-      Name: '*noalg.map.group[int]*main.deepMap9'
-      ByteSize: 8
-      Pointee: 1300 StructureType noalg.map.group[int]*main.deepMap9
-    - __kind: PointerType
-      ID: 348
-      Name: '*noalg.map.group[int]int'
-      ByteSize: 8
-      Pointee: 349 StructureType noalg.map.group[int]int
-    - __kind: PointerType
-      ID: 1314
-      Name: '*noalg.map.group[int]interface {}'
-      ByteSize: 8
-      Pointee: 1315 StructureType noalg.map.group[int]interface {}
+      Pointee: 582 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
       ID: 456
-      Name: '*noalg.map.group[int]struct {}'
+      Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 457 StructureType noalg.map.group[int]struct {}
-    - __kind: PointerType
-      ID: 407
-      Name: '*noalg.map.group[int]uint8'
-      ByteSize: 8
-      Pointee: 408 StructureType noalg.map.group[int]uint8
-    - __kind: PointerType
-      ID: 389
-      Name: '*noalg.map.group[string][]main.structWithMap'
-      ByteSize: 8
-      Pointee: 390 StructureType noalg.map.group[string][]main.structWithMap
-    - __kind: PointerType
-      ID: 372
-      Name: '*noalg.map.group[string][]string'
-      ByteSize: 8
-      Pointee: 373 StructureType noalg.map.group[string][]string
-    - __kind: PointerType
-      ID: 1011
-      Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
-      ByteSize: 8
-      Pointee: 1012 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-    - __kind: PointerType
-      ID: 364
-      Name: '*noalg.map.group[string]int'
-      ByteSize: 8
-      Pointee: 365 StructureType noalg.map.group[string]int
-    - __kind: PointerType
-      ID: 356
-      Name: '*noalg.map.group[string]main.nestedStruct'
-      ByteSize: 8
-      Pointee: 357 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 457 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
       ID: 448
-      Name: '*noalg.map.group[struct {}]int'
+      Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 449 StructureType noalg.map.group[struct {}]int
+      Pointee: 449 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 498
-      Name: '*noalg.map.group[struct {}]main.structWithCyclicMaps'
+      ID: 396
+      Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 499 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
-    - __kind: PointerType
-      ID: 506
-      Name: '*noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps'
-      ByteSize: 8
-      Pointee: 507 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
-    - __kind: PointerType
-      ID: 514
-      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
-      ByteSize: 8
-      Pointee: 515 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-    - __kind: PointerType
-      ID: 522
-      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
-      ByteSize: 8
-      Pointee: 523 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-    - __kind: PointerType
-      ID: 530
-      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
-      ByteSize: 8
-      Pointee: 531 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-    - __kind: PointerType
-      ID: 538
-      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
-      ByteSize: 8
-      Pointee: 539 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-    - __kind: PointerType
-      ID: 464
-      Name: '*noalg.map.group[struct {}]struct {}'
-      ByteSize: 8
-      Pointee: 465 StructureType noalg.map.group[struct {}]struct {}
-    - __kind: PointerType
-      ID: 423
-      Name: '*noalg.map.group[uint8][4]int'
-      ByteSize: 8
-      Pointee: 424 StructureType noalg.map.group[uint8][4]int
+      Pointee: 397 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
       ID: 415
+      Name: '*noalg.map.group[bool]main.node'
+      ByteSize: 8
+      Pointee: 416 StructureType noalg.map.group[bool]main.node
+    - __kind: PointerType
+      ID: 354
+      Name: '*noalg.map.group[int]*main.deepMap2'
+      ByteSize: 8
+      Pointee: 355 StructureType noalg.map.group[int]*main.deepMap2
+    - __kind: PointerType
+      ID: 1266
+      Name: '*noalg.map.group[int]*main.deepMap3'
+      ByteSize: 8
+      Pointee: 1267 StructureType noalg.map.group[int]*main.deepMap3
+    - __kind: PointerType
+      ID: 1300
+      Name: '*noalg.map.group[int]*main.deepMap8'
+      ByteSize: 8
+      Pointee: 1301 StructureType noalg.map.group[int]*main.deepMap8
+    - __kind: PointerType
+      ID: 1315
+      Name: '*noalg.map.group[int]*main.deepMap9'
+      ByteSize: 8
+      Pointee: 1316 StructureType noalg.map.group[int]*main.deepMap9
+    - __kind: PointerType
+      ID: 364
+      Name: '*noalg.map.group[int]int'
+      ByteSize: 8
+      Pointee: 365 StructureType noalg.map.group[int]int
+    - __kind: PointerType
+      ID: 1330
+      Name: '*noalg.map.group[int]interface {}'
+      ByteSize: 8
+      Pointee: 1331 StructureType noalg.map.group[int]interface {}
+    - __kind: PointerType
+      ID: 472
+      Name: '*noalg.map.group[int]struct {}'
+      ByteSize: 8
+      Pointee: 473 StructureType noalg.map.group[int]struct {}
+    - __kind: PointerType
+      ID: 423
+      Name: '*noalg.map.group[int]uint8'
+      ByteSize: 8
+      Pointee: 424 StructureType noalg.map.group[int]uint8
+    - __kind: PointerType
+      ID: 405
+      Name: '*noalg.map.group[string][]main.structWithMap'
+      ByteSize: 8
+      Pointee: 406 StructureType noalg.map.group[string][]main.structWithMap
+    - __kind: PointerType
+      ID: 388
+      Name: '*noalg.map.group[string][]string'
+      ByteSize: 8
+      Pointee: 389 StructureType noalg.map.group[string][]string
+    - __kind: PointerType
+      ID: 1027
+      Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
+      ByteSize: 8
+      Pointee: 1028 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+    - __kind: PointerType
+      ID: 380
+      Name: '*noalg.map.group[string]int'
+      ByteSize: 8
+      Pointee: 381 StructureType noalg.map.group[string]int
+    - __kind: PointerType
+      ID: 372
+      Name: '*noalg.map.group[string]main.nestedStruct'
+      ByteSize: 8
+      Pointee: 373 StructureType noalg.map.group[string]main.nestedStruct
+    - __kind: PointerType
+      ID: 464
+      Name: '*noalg.map.group[struct {}]int'
+      ByteSize: 8
+      Pointee: 465 StructureType noalg.map.group[struct {}]int
+    - __kind: PointerType
+      ID: 514
+      Name: '*noalg.map.group[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 515 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 522
+      Name: '*noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 523 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 530
+      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 531 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 538
+      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 539 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 546
+      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 547 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 554
+      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 555 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 480
+      Name: '*noalg.map.group[struct {}]struct {}'
+      ByteSize: 8
+      Pointee: 481 StructureType noalg.map.group[struct {}]struct {}
+    - __kind: PointerType
+      ID: 439
+      Name: '*noalg.map.group[uint8][4]int'
+      ByteSize: 8
+      Pointee: 440 StructureType noalg.map.group[uint8][4]int
+    - __kind: PointerType
+      ID: 431
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 416 StructureType noalg.map.group[uint8]uint8
+      Pointee: 432 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
-      ID: 1202
+      ID: 1218
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2.35088e+06
       GoKind: 22
-      Pointee: 1203 UnresolvedPointeeType os.File
+      Pointee: 1219 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 831
+      ID: 847
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1.026208e+06
       GoKind: 22
-      Pointee: 832 UnresolvedPointeeType os.LinkError
+      Pointee: 848 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 899
+      ID: 915
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1.192096e+06
       GoKind: 22
-      Pointee: 900 UnresolvedPointeeType os.SyscallError
+      Pointee: 916 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 1200
+      ID: 1216
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.349408e+06
       GoKind: 22
-      Pointee: 1201 StructureType os.fileWithoutReadFrom
+      Pointee: 1217 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 1198
+      ID: 1214
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.348672e+06
       GoKind: 22
-      Pointee: 1199 StructureType os.fileWithoutWriteTo
+      Pointee: 1215 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 864
+      ID: 880
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1.043744e+06
       GoKind: 22
-      Pointee: 865 UnresolvedPointeeType os/exec.Error
+      Pointee: 881 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 1007
+      ID: 1023
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2.090432e+06
       GoKind: 22
-      Pointee: 1008 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 1024 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 1071
+      ID: 1087
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
       GoRuntimeType: 1.214368e+06
       GoKind: 22
-      Pointee: 1072 UnresolvedPointeeType os/exec.prefixSuffixSaver
+      Pointee: 1088 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
-      ID: 866
+      ID: 882
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1.043872e+06
       GoKind: 22
-      Pointee: 867 StructureType os/exec.wrappedError
+      Pointee: 883 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 798
+      ID: 814
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 938400
       GoKind: 22
-      Pointee: 601 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 617 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 603
+      ID: 619
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 602 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 618 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 797
+      ID: 813
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 938304
       GoKind: 22
-      Pointee: 600 BaseType os/user.UnknownUserIdError
+      Pointee: 616 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 627
+      ID: 643
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 901728
       GoKind: 22
-      Pointee: 628 UnresolvedPointeeType reflect.ValueError
+      Pointee: 644 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 725
+      ID: 741
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 921216
       GoKind: 22
-      Pointee: 726 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 742 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 835
+      ID: 851
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1.027744e+06
       GoKind: 22
-      Pointee: 836 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 852 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 839
+      ID: 855
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1.029536e+06
       GoKind: 22
-      Pointee: 840 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 856 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
@@ -11208,12 +11322,12 @@ Types:
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 837
+      ID: 853
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1.027872e+06
       GoKind: 22
-      Pointee: 838 StructureType runtime.boundsError
+      Pointee: 854 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 65
       Name: '*runtime.cgoCallers'
@@ -11229,24 +11343,24 @@ Types:
       GoKind: 22
       Pointee: 48 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 901
+      ID: 917
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1.1976e+06
       GoKind: 22
-      Pointee: 902 StructureType runtime.errorAddressString
+      Pointee: 918 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 833
+      ID: 849
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1.02736e+06
       GoKind: 22
-      Pointee: 816 GoStringHeaderType runtime.errorString
+      Pointee: 832 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 818
+      ID: 834
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 817 GoStringDataType runtime.errorString.str
+      Pointee: 833 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 55
       Name: '*runtime.g'
@@ -11267,19 +11381,19 @@ Types:
       ByteSize: 8
       GoRuntimeType: 1.028896e+06
       GoKind: 22
-      Pointee: 328 UnresolvedPointeeType runtime.p
+      Pointee: 344 UnresolvedPointeeType runtime.p
     - __kind: PointerType
-      ID: 834
+      ID: 850
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1.027488e+06
       GoKind: 22
-      Pointee: 819 GoStringHeaderType runtime.plainError
+      Pointee: 835 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 821
+      ID: 837
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 820 GoStringDataType runtime.plainError.str
+      Pointee: 836 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
@@ -11295,12 +11409,12 @@ Types:
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
-      ID: 623
+      ID: 639
       Name: '*runtime.synctestDeadlockError'
       ByteSize: 8
       GoRuntimeType: 900384
       GoKind: 22
-      Pointee: 624 StructureType runtime.synctestDeadlockError
+      Pointee: 640 StructureType runtime.synctestDeadlockError
     - __kind: PointerType
       ID: 44
       Name: '*runtime.timer'
@@ -11316,12 +11430,12 @@ Types:
       GoKind: 22
       Pointee: 80 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 841
+      ID: 857
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1.029792e+06
       GoKind: 22
-      Pointee: 842 UnresolvedPointeeType strconv.NumError
+      Pointee: 858 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 95
       Name: '*string'
@@ -11330,31 +11444,31 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 323
+      ID: 339
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 322 GoStringDataType string.str
+      Pointee: 338 GoStringDataType string.str
     - __kind: PointerType
-      ID: 1137
+      ID: 1153
       Name: '*strings.Builder'
       ByteSize: 8
       GoRuntimeType: 1.951232e+06
       GoKind: 22
-      Pointee: 1138 UnresolvedPointeeType strings.Builder
+      Pointee: 1154 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
-      ID: 1041
+      ID: 1057
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
       GoRuntimeType: 1.02992e+06
       GoKind: 22
-      Pointee: 1042 UnresolvedPointeeType strings.appendSliceWriter
+      Pointee: 1058 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
-      ID: 1037
+      ID: 1053
       Name: '*struct { io.Writer }'
       ByteSize: 8
       GoRuntimeType: 971392
       GoKind: 22
-      Pointee: 1038 StructureType struct { io.Writer }
+      Pointee: 1054 StructureType struct { io.Writer }
     - __kind: PointerType
       ID: 267
       Name: '*struct {}'
@@ -11363,187 +11477,187 @@ Types:
       GoKind: 22
       Pointee: 125 StructureType struct {}
     - __kind: PointerType
-      ID: 953
+      ID: 969
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1.417472e+06
       GoKind: 22
-      Pointee: 952 BaseType syscall.Errno
+      Pointee: 968 BaseType syscall.Errno
     - __kind: PointerType
       ID: 227
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 438 StructureType table<[4]int,[4]int>
+      Pointee: 454 StructureType table<[4]int,[4]int>
     - __kind: PointerType
       ID: 222
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 430 StructureType table<[4]int,uint8>
+      Pointee: 446 StructureType table<[4]int,uint8>
     - __kind: PointerType
       ID: 190
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 378 StructureType table<[4]string,[2]int>
+      Pointee: 394 StructureType table<[4]string,[2]int>
     - __kind: PointerType
       ID: 202
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 397 StructureType table<bool,main.node>
+      Pointee: 413 StructureType table<bool,main.node>
     - __kind: PointerType
       ID: 148
       Name: '*table<int,*main.deepMap2>'
       ByteSize: 8
-      Pointee: 336 StructureType table<int,*main.deepMap2>
+      Pointee: 352 StructureType table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1247
+      ID: 1263
       Name: '*table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1248 StructureType table<int,*main.deepMap3>
+      Pointee: 1264 StructureType table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1281
+      ID: 1297
       Name: '*table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1282 StructureType table<int,*main.deepMap8>
+      Pointee: 1298 StructureType table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1296
+      ID: 1312
       Name: '*table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1297 StructureType table<int,*main.deepMap9>
+      Pointee: 1313 StructureType table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 170
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 346 StructureType table<int,int>
+      Pointee: 362 StructureType table<int,int>
     - __kind: PointerType
-      ID: 1311
+      ID: 1327
       Name: '*table<int,interface {}>'
       ByteSize: 8
-      Pointee: 1312 StructureType table<int,interface {}>
+      Pointee: 1328 StructureType table<int,interface {}>
     - __kind: PointerType
       ID: 237
       Name: '*table<int,struct {}>'
       ByteSize: 8
-      Pointee: 454 StructureType table<int,struct {}>
+      Pointee: 470 StructureType table<int,struct {}>
     - __kind: PointerType
       ID: 207
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 405 StructureType table<int,uint8>
+      Pointee: 421 StructureType table<int,uint8>
     - __kind: PointerType
       ID: 197
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 387 StructureType table<string,[]main.structWithMap>
+      Pointee: 403 StructureType table<string,[]main.structWithMap>
     - __kind: PointerType
       ID: 185
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 370 StructureType table<string,[]string>
+      Pointee: 386 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 982
+      ID: 998
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 1009 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 1025 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 180
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 362 StructureType table<string,int>
+      Pointee: 378 StructureType table<string,int>
     - __kind: PointerType
       ID: 175
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 354 StructureType table<string,main.nestedStruct>
+      Pointee: 370 StructureType table<string,main.nestedStruct>
     - __kind: PointerType
       ID: 232
       Name: '*table<struct {},int>'
       ByteSize: 8
-      Pointee: 446 StructureType table<struct {},int>
+      Pointee: 462 StructureType table<struct {},int>
     - __kind: PointerType
       ID: 290
       Name: '*table<struct {},main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 496 StructureType table<struct {},main.structWithCyclicMaps>
+      Pointee: 512 StructureType table<struct {},main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 295
       Name: '*table<struct {},map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 504 StructureType table<struct {},map[struct {}]main.structWithCyclicMaps>
+      Pointee: 520 StructureType table<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 300
       Name: '*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 512 StructureType table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 528 StructureType table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 305
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 520 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 536 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 310
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 528 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 544 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 315
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 536 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 552 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 242
       Name: '*table<struct {},struct {}>'
       ByteSize: 8
-      Pointee: 462 StructureType table<struct {},struct {}>
+      Pointee: 478 StructureType table<struct {},struct {}>
     - __kind: PointerType
       ID: 217
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 421 StructureType table<uint8,[4]int>
+      Pointee: 437 StructureType table<uint8,[4]int>
     - __kind: PointerType
       ID: 212
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 413 StructureType table<uint8,uint8>
+      Pointee: 429 StructureType table<uint8,uint8>
     - __kind: PointerType
-      ID: 1172
+      ID: 1188
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
       GoRuntimeType: 2.1608e+06
       GoKind: 22
-      Pointee: 1173 UnresolvedPointeeType text/tabwriter.Writer
+      Pointee: 1189 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
-      ID: 894
+      ID: 910
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1.089312e+06
       GoKind: 22
-      Pointee: 895 StructureType text/template.ExecError
+      Pointee: 911 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 969
+      ID: 985
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.623744e+06
       GoKind: 22
-      Pointee: 970 UnresolvedPointeeType time.Location
+      Pointee: 986 UnresolvedPointeeType time.Location
     - __kind: PointerType
-      ID: 630
+      ID: 646
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 902592
       GoKind: 22
-      Pointee: 631 UnresolvedPointeeType time.ParseError
+      Pointee: 647 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 629
+      ID: 645
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 902496
       GoKind: 22
-      Pointee: 546 GoStringHeaderType time.fileSizeError
+      Pointee: 562 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 548
+      ID: 564
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 547 GoStringDataType time.fileSizeError.str
+      Pointee: 563 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
       ID: 107
       Name: '*uint'
@@ -11587,52 +11701,88 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: PointerType
-      ID: 721
+      ID: 737
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 920640
       GoKind: 22
-      Pointee: 722 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 738 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 1164
+      ID: 1180
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.136288e+06
       GoKind: 22
-      Pointee: 1165 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1181 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 705
+      ID: 721
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 916800
       GoKind: 22
-      Pointee: 706 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 722 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 707
+      ID: 723
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 916896
       GoKind: 22
-      Pointee: 590 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 606 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 871
+      ID: 887
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1.047584e+06
       GoKind: 22
-      Pointee: 872 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 888 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 873
+      ID: 889
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1.047712e+06
       GoKind: 22
-      Pointee: 824 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 840 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1570
+      ID: 1587
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
     - __kind: EventRootType
-      ID: 1568
+      ID: 1571
+      Name: Probe[main.executeStructFuncs]Line
+      ByteSize: 66
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: sta.a
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 335 ArrayType [3]uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 10, name: sta}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: sta.b
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 10, name: sta}
+                  Offset: 24
+                  ByteSize: 1
+        - Name: sta.c
+          Offset: 26
+          Kind: template_segment
+          Expression:
+            Type: 336 ArrayType [5]int64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 10, name: sta}
+                  Offset: 32
+                  ByteSize: 40
+    - __kind: EventRootType
+      ID: 1585
       Name: Probe[main.firstBehavior.DoSomething]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11641,14 +11791,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 321 StructureType main.firstBehavior
+            Type: 337 StructureType main.firstBehavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 0, name: b}
+                  Variable: {subprogram: 165, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1569
+      ID: 1586
       Name: Probe[main.firstBehavior.DoSomething]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11660,14 +11810,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 1, name: ~r0}
+                  Variable: {subprogram: 165, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1526
+      ID: 1542
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1527
+      ID: 1543
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11683,7 +11833,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1393
+      ID: 1409
       Name: Probe[main.testAnyPtr]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11709,7 +11859,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1394
+      ID: 1410
       Name: Probe[main.testAnyPtr]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11725,7 +11875,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1390
+      ID: 1406
       Name: Probe[main.testAny]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11751,7 +11901,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1391
+      ID: 1407
       Name: Probe[main.testAny]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11767,7 +11917,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1497
+      ID: 1513
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11793,7 +11943,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1498
+      ID: 1514
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11809,7 +11959,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1341
+      ID: 1357
       Name: Probe[main.testArrayEmptyStructs]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11835,7 +11985,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1339
+      ID: 1355
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 129
       PresenceBitsetSize: 1
@@ -11861,7 +12011,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1337
+      ID: 1353
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -11887,7 +12037,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1402
+      ID: 1418
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11913,7 +12063,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1338
+      ID: 1354
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -11939,7 +12089,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1340
+      ID: 1356
       Name: Probe[main.testArrayOfStructs]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -11965,7 +12115,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1424
+      ID: 1440
       Name: Probe[main.testAtomicAdd]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11991,7 +12141,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1425
+      ID: 1441
       Name: Probe[main.testAtomicAdd]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12007,7 +12157,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1359
+      ID: 1375
       Name: Probe[main.testBigStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -12033,10 +12183,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1360
+      ID: 1376
       Name: Probe[main.testBigStruct]Return
     - __kind: EventRootType
-      ID: 1326
+      ID: 1342
       Name: Probe[main.testBoolArray]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -12062,7 +12212,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1323
+      ID: 1339
       Name: Probe[main.testByteArray]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -12088,7 +12238,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1426
+      ID: 1442
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -12114,7 +12264,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1420
+      ID: 1436
       Name: Probe[main.testCombinedByte]
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -12180,7 +12330,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1421
+      ID: 1437
       Name: Probe[main.testCombinedString]
       ByteSize: 18
       PresenceBitsetSize: 1
@@ -12206,7 +12356,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1422
+      ID: 1438
       Name: Probe[main.testCombinedString]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -12242,7 +12392,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1434
+      ID: 1450
       Name: Probe[main.testCycle]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12268,7 +12418,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1365
+      ID: 1381
       Name: Probe[main.testDeepMap1]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12294,7 +12444,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1366
+      ID: 1382
       Name: Probe[main.testDeepMap7]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12320,7 +12470,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1361
+      ID: 1377
       Name: Probe[main.testDeepPtr1]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12346,7 +12496,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1362
+      ID: 1378
       Name: Probe[main.testDeepPtr7]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12372,7 +12522,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1363
+      ID: 1379
       Name: Probe[main.testDeepSlice1]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12398,7 +12548,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1364
+      ID: 1380
       Name: Probe[main.testDeepSlice7]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12424,7 +12574,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1517
+      ID: 1533
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -12470,7 +12620,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1514
+      ID: 1530
       Name: Probe[main.testEmptySlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12496,7 +12646,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1540
+      ID: 1556
       Name: Probe[main.testEmptyString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12522,7 +12672,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1554
+      ID: 1570
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12548,7 +12698,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1553
+      ID: 1569
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -12574,7 +12724,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1392
+      ID: 1408
       Name: Probe[main.testError]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12600,7 +12750,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1374
+      ID: 1390
       Name: Probe[main.testEsotericHeap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12626,10 +12776,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1375
+      ID: 1391
       Name: Probe[main.testEsotericHeap]Return
     - __kind: EventRootType
-      ID: 1372
+      ID: 1388
       Name: Probe[main.testEsotericStack]
       ByteSize: 129
       PresenceBitsetSize: 1
@@ -12655,10 +12805,10 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1373
+      ID: 1389
       Name: Probe[main.testEsotericStack]Return
     - __kind: EventRootType
-      ID: 1386
+      ID: 1402
       Name: Probe[main.testFramelessArray]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12684,7 +12834,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1388
+      ID: 1404
       Name: Probe[main.testFramelessArray]Line
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -12720,7 +12870,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1387
+      ID: 1403
       Name: Probe[main.testFramelessArray]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12736,7 +12886,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1384
+      ID: 1400
       Name: Probe[main.testFrameless]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12762,7 +12912,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1385
+      ID: 1401
       Name: Probe[main.testFrameless]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12778,7 +12928,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1376
+      ID: 1392
       Name: Probe[main.testInlinedBA]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12804,10 +12954,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1377
+      ID: 1393
       Name: Probe[main.testInlinedBA]Return
     - __kind: EventRootType
-      ID: 1380
+      ID: 1396
       Name: Probe[main.testInlinedBBA]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12833,13 +12983,13 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1381
+      ID: 1397
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1560
+      ID: 1577
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 1378
+      ID: 1394
       Name: Probe[main.testInlinedBB]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12885,28 +13035,28 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1379
+      ID: 1395
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1561
+      ID: 1578
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1562
+      ID: 1579
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1563
+      ID: 1580
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1564
+      ID: 1581
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
-      ID: 1382
+      ID: 1398
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 1383
+      ID: 1399
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1557
+      ID: 1574
       Name: Probe[main.testInlinedPrint]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12918,7 +13068,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12928,11 +13078,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1555
+      ID: 1572
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12944,11 +13094,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1556
+      ID: 1573
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12960,7 +13110,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x_val
@@ -12970,11 +13120,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1559
+      ID: 1576
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12986,7 +13136,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12996,14 +13146,14 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1558
+      ID: 1575
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1565
+      ID: 1582
       Name: Probe[main.testInlinedSq]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13015,7 +13165,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -13025,11 +13175,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1566
+      ID: 1583
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13041,7 +13191,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -13051,11 +13201,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1567
+      ID: 1584
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13067,7 +13217,7 @@ Types:
             Type: 161 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: a}
+                  Variable: {subprogram: 164, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: a
@@ -13077,11 +13227,11 @@ Types:
             Type: 161 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: a}
+                  Variable: {subprogram: 164, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1329
+      ID: 1345
       Name: Probe[main.testInt16Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -13107,7 +13257,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1330
+      ID: 1346
       Name: Probe[main.testInt32Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13133,7 +13283,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1331
+      ID: 1347
       Name: Probe[main.testInt64Array]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13159,7 +13309,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1328
+      ID: 1344
       Name: Probe[main.testInt8Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -13185,7 +13335,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1327
+      ID: 1343
       Name: Probe[main.testIntArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13211,7 +13361,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1389
+      ID: 1405
       Name: Probe[main.testInterface]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13237,7 +13387,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1495
+      ID: 1511
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 161
       PresenceBitsetSize: 1
@@ -13263,7 +13413,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1496
+      ID: 1512
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13279,7 +13429,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1428
+      ID: 1444
       Name: Probe[main.testLinkedList]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13305,36 +13455,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1369
+      ID: 1385
       Name: Probe[main.testLongFunctionWithChangingState]Line
     - __kind: EventRootType
-      ID: 1370
-      Name: Probe[main.testLongFunctionWithChangingState]Line
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: aPerArch
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 1, name: aPerArch}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: b
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 2, name: b}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1371
+      ID: 1386
       Name: Probe[main.testLongFunctionWithChangingState]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13360,7 +13484,33 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1501
+      ID: 1387
+      Name: Probe[main.testLongFunctionWithChangingState]Line
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: aPerArch
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 1, name: aPerArch}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1517
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 147
       PresenceBitsetSize: 3
@@ -13546,7 +13696,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1502
+      ID: 1518
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13562,7 +13712,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1400
+      ID: 1416
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13588,7 +13738,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1407
+      ID: 1423
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13614,7 +13764,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1419
+      ID: 1435
       Name: Probe[main.testMapEmptyKeyAndValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13640,7 +13790,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1417
+      ID: 1433
       Name: Probe[main.testMapEmptyKey]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13666,7 +13816,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1418
+      ID: 1434
       Name: Probe[main.testMapEmptyValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13692,7 +13842,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1404
+      ID: 1420
       Name: Probe[main.testMapIntToInt]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13718,7 +13868,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1416
+      ID: 1432
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13744,7 +13894,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1415
+      ID: 1431
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13770,7 +13920,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1405
+      ID: 1421
       Name: Probe[main.testMapMassive]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13796,7 +13946,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1406
+      ID: 1422
       Name: Probe[main.testMapMassive]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13822,7 +13972,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1414
+      ID: 1430
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13848,7 +13998,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1413
+      ID: 1429
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13874,7 +14024,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1398
+      ID: 1414
       Name: Probe[main.testMapStringToInt]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13900,7 +14050,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1399
+      ID: 1415
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13926,7 +14076,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1397
+      ID: 1413
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13952,7 +14102,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1408
+      ID: 1424
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13978,7 +14128,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1412
+      ID: 1428
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14004,7 +14154,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1411
+      ID: 1427
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14030,7 +14180,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1410
+      ID: 1426
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14056,7 +14206,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1409
+      ID: 1425
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14082,7 +14232,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1537
+      ID: 1553
       Name: Probe[main.testMassiveString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14108,7 +14258,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1538
+      ID: 1554
       Name: Probe[main.testMassiveString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14134,7 +14284,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1503
+      ID: 1519
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 163
       PresenceBitsetSize: 3
@@ -14320,7 +14470,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1504
+      ID: 1520
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -14336,7 +14486,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1507
+      ID: 1523
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -14382,7 +14532,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1508
+      ID: 1524
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -14408,7 +14558,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1499
+      ID: 1515
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 321
       PresenceBitsetSize: 1
@@ -14454,7 +14604,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1500
+      ID: 1516
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -14470,7 +14620,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1453
+      ID: 1469
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14496,7 +14646,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1455
+      ID: 1471
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14542,7 +14692,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1457
+      ID: 1473
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14558,7 +14708,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1459
+      ID: 1475
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14574,7 +14724,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1461
+      ID: 1477
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14590,7 +14740,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1454
+      ID: 1470
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14616,7 +14766,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1456
+      ID: 1472
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -14682,7 +14832,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1458
+      ID: 1474
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14708,7 +14858,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1460
+      ID: 1476
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14734,7 +14884,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1462
+      ID: 1478
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14760,7 +14910,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1423
+      ID: 1439
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 62
       PresenceBitsetSize: 2
@@ -14866,7 +15016,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1449
+      ID: 1465
       Name: Probe[main.testNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14892,7 +15042,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1451
+      ID: 1467
       Name: Probe[main.testNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14918,7 +15068,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1450
+      ID: 1466
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14934,7 +15084,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1452
+      ID: 1468
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14960,7 +15110,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1549
+      ID: 1565
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14986,7 +15136,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1550
+      ID: 1566
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15008,10 +15158,10 @@ Types:
                   Bias: 8
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1551
+      ID: 1567
       Name: Probe[main.testNestedPointer]
     - __kind: EventRootType
-      ID: 1552
+      ID: 1568
       Name: Probe[main.testNestedPointer]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15033,7 +15183,7 @@ Types:
                   Bias: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1433
+      ID: 1449
       Name: Probe[main.testNilPointer]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15079,7 +15229,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1518
+      ID: 1534
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -15125,7 +15275,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1520
+      ID: 1536
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 67
       PresenceBitsetSize: 1
@@ -15191,7 +15341,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1521
+      ID: 1537
       Name: Probe[main.testNilSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -15217,7 +15367,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1536
+      ID: 1552
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15243,7 +15393,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1429
+      ID: 1445
       Name: Probe[main.testPointerLoop]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15269,7 +15419,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1403
+      ID: 1419
       Name: Probe[main.testPointerToMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15295,7 +15445,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1427
+      ID: 1443
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15321,7 +15471,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1443
+      ID: 1459
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 35
       PresenceBitsetSize: 1
@@ -15367,7 +15517,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1444
+      ID: 1460
       Name: Probe[main.testReturnsAnyAndError]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15393,7 +15543,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1445
+      ID: 1461
       Name: Probe[main.testReturnsAny]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15419,7 +15569,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1446
+      ID: 1462
       Name: Probe[main.testReturnsAny]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15435,10 +15585,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1475
+      ID: 1491
       Name: Probe[main.testReturnsArrayOne]
     - __kind: EventRootType
-      ID: 1476
+      ID: 1492
       Name: Probe[main.testReturnsArrayOne]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15454,10 +15604,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1477
+      ID: 1493
       Name: Probe[main.testReturnsArrayZero]
     - __kind: EventRootType
-      ID: 1478
+      ID: 1494
       Name: Probe[main.testReturnsArrayZero]Return
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -15473,10 +15623,10 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1473
+      ID: 1489
       Name: Probe[main.testReturnsArray]
     - __kind: EventRootType
-      ID: 1474
+      ID: 1490
       Name: Probe[main.testReturnsArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15492,10 +15642,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1481
+      ID: 1497
       Name: Probe[main.testReturnsBacktrackInt]
     - __kind: EventRootType
-      ID: 1482
+      ID: 1498
       Name: Probe[main.testReturnsBacktrackInt]Return
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -15591,10 +15741,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1493
+      ID: 1509
       Name: Probe[main.testReturnsBoolAndUintptr]
     - __kind: EventRootType
-      ID: 1494
+      ID: 1510
       Name: Probe[main.testReturnsBoolAndUintptr]Return
       ByteSize: 10
       PresenceBitsetSize: 1
@@ -15620,10 +15770,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1469
+      ID: 1485
       Name: Probe[main.testReturnsComplex]
     - __kind: EventRootType
-      ID: 1470
+      ID: 1486
       Name: Probe[main.testReturnsComplex]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15649,7 +15799,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1441
+      ID: 1457
       Name: Probe[main.testReturnsError]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -15675,7 +15825,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1442
+      ID: 1458
       Name: Probe[main.testReturnsError]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15691,7 +15841,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1439
+      ID: 1455
       Name: Probe[main.testReturnsIntAndFloat]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15717,7 +15867,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1440
+      ID: 1456
       Name: Probe[main.testReturnsIntAndFloat]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15743,7 +15893,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1437
+      ID: 1453
       Name: Probe[main.testReturnsIntPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15769,7 +15919,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1438
+      ID: 1454
       Name: Probe[main.testReturnsIntPointer]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15785,7 +15935,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1435
+      ID: 1451
       Name: Probe[main.testReturnsInt]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15811,7 +15961,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1436
+      ID: 1452
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15827,7 +15977,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1447
+      ID: 1463
       Name: Probe[main.testReturnsInterface]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15853,7 +16003,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1448
+      ID: 1464
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15869,10 +16019,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1471
+      ID: 1487
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1472
+      ID: 1488
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -15888,10 +16038,10 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1467
+      ID: 1483
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1468
+      ID: 1484
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 139
       PresenceBitsetSize: 3
@@ -16067,10 +16217,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1479
+      ID: 1495
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1480
+      ID: 1496
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16086,10 +16236,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1485
+      ID: 1501
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1486
+      ID: 1502
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16145,10 +16295,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1491
+      ID: 1507
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1492
+      ID: 1508
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -16174,10 +16324,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1489
+      ID: 1505
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1490
+      ID: 1506
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -16193,10 +16343,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1465
+      ID: 1481
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1466
+      ID: 1482
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -16282,10 +16432,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1487
+      ID: 1503
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1488
+      ID: 1504
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16301,10 +16451,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1483
+      ID: 1499
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1484
+      ID: 1500
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -16320,7 +16470,7 @@ Types:
                   Offset: 0
                   ByteSize: 88
     - __kind: EventRootType
-      ID: 1324
+      ID: 1340
       Name: Probe[main.testRuneArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16346,7 +16496,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1345
+      ID: 1361
       Name: Probe[main.testSingleBool]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -16372,7 +16522,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1343
+      ID: 1359
       Name: Probe[main.testSingleByte]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -16398,7 +16548,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1356
+      ID: 1372
       Name: Probe[main.testSingleFloat32]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -16424,7 +16574,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1357
+      ID: 1373
       Name: Probe[main.testSingleFloat64]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16450,7 +16600,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1348
+      ID: 1364
       Name: Probe[main.testSingleInt16]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -16476,7 +16626,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1349
+      ID: 1365
       Name: Probe[main.testSingleInt32]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -16502,7 +16652,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1350
+      ID: 1366
       Name: Probe[main.testSingleInt64]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16528,7 +16678,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1347
+      ID: 1363
       Name: Probe[main.testSingleInt8]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -16574,7 +16724,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1346
+      ID: 1362
       Name: Probe[main.testSingleInt]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16600,7 +16750,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1344
+      ID: 1360
       Name: Probe[main.testSingleRune]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -16626,7 +16776,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1528
+      ID: 1544
       Name: Probe[main.testSingleString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16652,7 +16802,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1353
+      ID: 1369
       Name: Probe[main.testSingleUint16]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -16678,7 +16828,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1354
+      ID: 1370
       Name: Probe[main.testSingleUint32]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -16704,7 +16854,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1355
+      ID: 1371
       Name: Probe[main.testSingleUint64]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16730,7 +16880,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1352
+      ID: 1368
       Name: Probe[main.testSingleUint8]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -16756,7 +16906,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1351
+      ID: 1367
       Name: Probe[main.testSingleUint]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16782,7 +16932,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1524
+      ID: 1540
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16808,7 +16958,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1515
+      ID: 1531
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16834,7 +16984,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1401
+      ID: 1417
       Name: Probe[main.testSmallMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16860,7 +17010,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1463
+      ID: 1479
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16886,7 +17036,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1464
+      ID: 1480
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16922,7 +17072,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1505
+      ID: 1521
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -16948,7 +17098,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1506
+      ID: 1522
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16984,7 +17134,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1325
+      ID: 1341
       Name: Probe[main.testStringArray]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -17010,7 +17160,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1432
+      ID: 1448
       Name: Probe[main.testStringPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17036,7 +17186,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1519
+      ID: 1535
       Name: Probe[main.testStringSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17062,7 +17212,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1367
+      ID: 1383
       Name: Probe[main.testStringType1]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17088,7 +17238,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1368
+      ID: 1384
       Name: Probe[main.testStringType2]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17114,7 +17264,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1516
+      ID: 1532
       Name: Probe[main.testStructSlice]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -17160,7 +17310,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1395
+      ID: 1411
       Name: Probe[main.testStructWithAny]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17186,7 +17336,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1509
+      ID: 1525
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17212,7 +17362,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1510
+      ID: 1526
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17238,7 +17388,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1543
+      ID: 1559
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17264,10 +17414,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1544
+      ID: 1560
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1542
+      ID: 1558
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 289
       PresenceBitsetSize: 1
@@ -17293,7 +17443,7 @@ Types:
                   Offset: 0
                   ByteSize: 144
     - __kind: EventRootType
-      ID: 1396
+      ID: 1412
       Name: Probe[main.testStructWithMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17319,7 +17469,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1545
+      ID: 1561
       Name: Probe[main.testStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17335,7 +17485,7 @@ Types:
                   Offset: 8
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1547
+      ID: 1563
       Name: Probe[main.testStruct]
       ByteSize: 113
       PresenceBitsetSize: 1
@@ -17361,13 +17511,13 @@ Types:
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1546
+      ID: 1562
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1548
+      ID: 1564
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1525
+      ID: 1541
       Name: Probe[main.testSubslices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -17433,7 +17583,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1541
+      ID: 1557
       Name: Probe[main.testSubstrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17499,7 +17649,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1534
+      ID: 1550
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17525,7 +17675,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1535
+      ID: 1551
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17570,7 +17720,7 @@ Types:
                   Bias: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1530
+      ID: 1546
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17596,7 +17746,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1532
+      ID: 1548
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17632,13 +17782,13 @@ Types:
                   Offset: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1531
+      ID: 1547
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1533
+      ID: 1549
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1529
+      ID: 1545
       Name: Probe[main.testThreeStrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17704,7 +17854,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1358
+      ID: 1374
       Name: Probe[main.testTypeAlias]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -17730,7 +17880,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1334
+      ID: 1350
       Name: Probe[main.testUint16Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -17756,7 +17906,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1335
+      ID: 1351
       Name: Probe[main.testUint32Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17782,7 +17932,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1336
+      ID: 1352
       Name: Probe[main.testUint64Array]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17808,7 +17958,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1333
+      ID: 1349
       Name: Probe[main.testUint8Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -17834,7 +17984,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1332
+      ID: 1348
       Name: Probe[main.testUintArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17860,7 +18010,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1431
+      ID: 1447
       Name: Probe[main.testUintPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17886,7 +18036,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1513
+      ID: 1529
       Name: Probe[main.testUintSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17912,7 +18062,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1539
+      ID: 1555
       Name: Probe[main.testUnitializedString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17938,7 +18088,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1430
+      ID: 1446
       Name: Probe[main.testUnsafePointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17964,7 +18114,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1342
+      ID: 1358
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 1601
       PresenceBitsetSize: 1
@@ -17990,7 +18140,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1522
+      ID: 1538
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -18016,7 +18166,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1523
+      ID: 1539
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -18042,7 +18192,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1511
+      ID: 1527
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -18088,7 +18238,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1512
+      ID: 1528
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -18349,7 +18499,15 @@ Types:
       HasCount: true
       Element: 32 StructureType internal/runtime/atomic.Uint32
     - __kind: ArrayType
-      ID: 427
+      ID: 335
+      Name: '[3]uint64'
+      ByteSize: 24
+      GoKind: 17
+      Count: 3
+      HasCount: true
+      Element: 8 BaseType uint64
+    - __kind: ArrayType
+      ID: 443
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 683360
@@ -18358,7 +18516,7 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 384
+      ID: 400
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 683648
@@ -18384,7 +18542,15 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 999
+      ID: 336
+      Name: '[5]int64'
+      ByteSize: 40
+      GoKind: 17
+      Count: 5
+      HasCount: true
+      Element: 13 BaseType int64
+    - __kind: ArrayType
+      ID: 1015
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 685184
@@ -18426,15 +18592,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 334 GoSliceDataType []*main.deepSlice2.array
+      Data: 350 GoSliceDataType []*main.deepSlice2.array
     - __kind: GoSliceDataType
-      ID: 334
+      ID: 350
       Name: '[]*main.deepSlice2.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 140 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 1237
+      ID: 1253
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 478176
@@ -18442,22 +18608,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1238 PointerType **main.deepSlice3
+          Type: 1254 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1241 GoSliceDataType []*main.deepSlice3.array
+      Data: 1257 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 1241
+      ID: 1257
       Name: '[]*main.deepSlice3.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1239 PointerType *main.deepSlice3
+      Element: 1255 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 1262
+      ID: 1278
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 477856
@@ -18465,22 +18631,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1263 PointerType **main.deepSlice8
+          Type: 1279 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1266 GoSliceDataType []*main.deepSlice8.array
+      Data: 1282 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 1266
+      ID: 1282
       Name: '[]*main.deepSlice8.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1264 PointerType *main.deepSlice8
+      Element: 1280 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 1268
+      ID: 1284
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 477792
@@ -18488,20 +18654,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1269 PointerType **main.deepSlice9
+          Type: 1285 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1272 GoSliceDataType []*main.deepSlice9.array
+      Data: 1288 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 1272
+      ID: 1288
       Name: '[]*main.deepSlice9.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1270 PointerType *main.deepSlice9
+      Element: 1286 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 62
       Name: '[]*runtime.p'
@@ -18518,9 +18684,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 329 GoSliceDataType []*runtime.p.array
+      Data: 345 GoSliceDataType []*runtime.p.array
     - __kind: GoSliceDataType
-      ID: 329
+      ID: 345
       Name: '[]*runtime.p.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -18541,171 +18707,171 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 331 GoSliceDataType []*string.array
+      Data: 347 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 331
+      ID: 347
       Name: '[]*string.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 95 PointerType *string
     - __kind: GoSliceDataType
-      ID: 444
+      ID: 460
       Name: '[]*table<[4]int,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 227 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 436
+      ID: 452
       Name: '[]*table<[4]int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 222 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 385
+      ID: 401
       Name: '[]*table<[4]string,[2]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 190 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 403
+      ID: 419
       Name: '[]*table<bool,main.node>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 202 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 344
+      ID: 360
       Name: '[]*table<int,*main.deepMap2>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 148 PointerType *table<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 1256
+      ID: 1272
       Name: '[]*table<int,*main.deepMap3>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1247 PointerType *table<int,*main.deepMap3>
+      Element: 1263 PointerType *table<int,*main.deepMap3>
     - __kind: GoSliceDataType
-      ID: 1290
+      ID: 1306
       Name: '[]*table<int,*main.deepMap8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1281 PointerType *table<int,*main.deepMap8>
+      Element: 1297 PointerType *table<int,*main.deepMap8>
     - __kind: GoSliceDataType
-      ID: 1305
+      ID: 1321
       Name: '[]*table<int,*main.deepMap9>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1296 PointerType *table<int,*main.deepMap9>
+      Element: 1312 PointerType *table<int,*main.deepMap9>
     - __kind: GoSliceDataType
-      ID: 352
+      ID: 368
       Name: '[]*table<int,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 170 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 1318
+      ID: 1334
       Name: '[]*table<int,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1311 PointerType *table<int,interface {}>
+      Element: 1327 PointerType *table<int,interface {}>
     - __kind: GoSliceDataType
-      ID: 460
+      ID: 476
       Name: '[]*table<int,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 237 PointerType *table<int,struct {}>
     - __kind: GoSliceDataType
-      ID: 411
+      ID: 427
       Name: '[]*table<int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 207 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 395
+      ID: 411
       Name: '[]*table<string,[]main.structWithMap>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 197 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 376
+      ID: 392
       Name: '[]*table<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 185 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 1015
+      ID: 1031
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 982 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 998 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 368
+      ID: 384
       Name: '[]*table<string,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 180 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 360
+      ID: 376
       Name: '[]*table<string,main.nestedStruct>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 175 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 452
+      ID: 468
       Name: '[]*table<struct {},int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 232 PointerType *table<struct {},int>
     - __kind: GoSliceDataType
-      ID: 502
+      ID: 518
       Name: '[]*table<struct {},main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 290 PointerType *table<struct {},main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 510
+      ID: 526
       Name: '[]*table<struct {},map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 295 PointerType *table<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 518
+      ID: 534
       Name: '[]*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 300 PointerType *table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 526
+      ID: 542
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 305 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 534
+      ID: 550
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 310 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 542
+      ID: 558
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 315 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 468
+      ID: 484
       Name: '[]*table<struct {},struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 242 PointerType *table<struct {},struct {}>
     - __kind: GoSliceDataType
-      ID: 428
+      ID: 444
       Name: '[]*table<uint8,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 217 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 419
+      ID: 435
       Name: '[]*table<uint8,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
@@ -18725,9 +18891,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 494 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Data: 510 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 494
+      ID: 510
       Name: '[][][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -18747,9 +18913,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 492 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Data: 508 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 492
+      ID: 508
       Name: '[][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -18769,9 +18935,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 490 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Data: 506 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 490
+      ID: 506
       Name: '[][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -18791,9 +18957,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 488 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Data: 504 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 488
+      ID: 504
       Name: '[][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -18813,9 +18979,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 486 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Data: 502 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 486
+      ID: 502
       Name: '[][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -18835,9 +19001,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 472 GoSliceDataType [][]uint.array
+      Data: 488 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 472
+      ID: 488
       Name: '[][]uint.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -18858,15 +19024,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 478 GoSliceDataType []bool.array
+      Data: 494 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 478
+      ID: 494
       Name: '[]bool.array'
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 994
+      ID: 1010
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 487648
@@ -18881,15 +19047,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1017 GoSliceDataType []float64.array
+      Data: 1033 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 1017
+      ID: 1033
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 16 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 1274
+      ID: 1290
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 488096
@@ -18904,9 +19070,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1275 GoSliceDataType []interface {}.array
+      Data: 1291 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 1275
+      ID: 1291
       Name: '[]interface {}.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -18926,15 +19092,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 484 GoSliceDataType []main.structWithCyclicSlices.array
+      Data: 500 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 484
+      ID: 500
       Name: '[]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 144
       Element: 272 StructureType main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 393
+      ID: 409
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 478496
@@ -18942,16 +19108,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 394 PointerType *main.structWithMap
+          Type: 410 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 544 GoSliceDataType []main.structWithMap.array
+      Data: 560 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 544
+      ID: 560
       Name: '[]main.structWithMap.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -18971,175 +19137,175 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 474 GoSliceDataType []main.structWithNoStrings.array
+      Data: 490 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 474
+      ID: 490
       Name: '[]main.structWithNoStrings.array'
       DynamicSizeClass: slice
       ByteSize: 2
       Element: 262 StructureType main.structWithNoStrings
     - __kind: GoSliceDataType
-      ID: 445
+      ID: 461
       Name: '[]noalg.map.group[[4]int][4]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 520
-      Element: 441 StructureType noalg.map.group[[4]int][4]int
+      Element: 457 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 437
+      ID: 453
       Name: '[]noalg.map.group[[4]int]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 433 StructureType noalg.map.group[[4]int]uint8
+      Element: 449 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 386
+      ID: 402
       Name: '[]noalg.map.group[[4]string][2]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 648
-      Element: 381 StructureType noalg.map.group[[4]string][2]int
+      Element: 397 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 404
+      ID: 420
       Name: '[]noalg.map.group[bool]main.node.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 400 StructureType noalg.map.group[bool]main.node
+      Element: 416 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
-      ID: 345
+      ID: 361
       Name: '[]noalg.map.group[int]*main.deepMap2.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 339 StructureType noalg.map.group[int]*main.deepMap2
+      Element: 355 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSliceDataType
-      ID: 1257
+      ID: 1273
       Name: '[]noalg.map.group[int]*main.deepMap3.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1251 StructureType noalg.map.group[int]*main.deepMap3
+      Element: 1267 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSliceDataType
-      ID: 1291
+      ID: 1307
       Name: '[]noalg.map.group[int]*main.deepMap8.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1285 StructureType noalg.map.group[int]*main.deepMap8
+      Element: 1301 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSliceDataType
-      ID: 1306
+      ID: 1322
       Name: '[]noalg.map.group[int]*main.deepMap9.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1300 StructureType noalg.map.group[int]*main.deepMap9
+      Element: 1316 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSliceDataType
-      ID: 353
+      ID: 369
       Name: '[]noalg.map.group[int]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 349 StructureType noalg.map.group[int]int
+      Element: 365 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 1319
+      ID: 1335
       Name: '[]noalg.map.group[int]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 1315 StructureType noalg.map.group[int]interface {}
+      Element: 1331 StructureType noalg.map.group[int]interface {}
     - __kind: GoSliceDataType
-      ID: 461
+      ID: 477
       Name: '[]noalg.map.group[int]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 457 StructureType noalg.map.group[int]struct {}
+      Element: 473 StructureType noalg.map.group[int]struct {}
     - __kind: GoSliceDataType
-      ID: 412
+      ID: 428
       Name: '[]noalg.map.group[int]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 408 StructureType noalg.map.group[int]uint8
+      Element: 424 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
-      ID: 396
+      ID: 412
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 390 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 406 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
-      ID: 377
+      ID: 393
       Name: '[]noalg.map.group[string][]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 373 StructureType noalg.map.group[string][]string
+      Element: 389 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 1016
+      ID: 1032
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 1012 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 1028 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
-      ID: 369
+      ID: 385
       Name: '[]noalg.map.group[string]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 365 StructureType noalg.map.group[string]int
+      Element: 381 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 361
+      ID: 377
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 357 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 373 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 453
+      ID: 469
       Name: '[]noalg.map.group[struct {}]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 449 StructureType noalg.map.group[struct {}]int
+      Element: 465 StructureType noalg.map.group[struct {}]int
     - __kind: GoSliceDataType
-      ID: 503
+      ID: 519
       Name: '[]noalg.map.group[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 392
-      Element: 499 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      Element: 515 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 511
+      ID: 527
       Name: '[]noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 507 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 523 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 519
+      ID: 535
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 515 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 531 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 527
+      ID: 543
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 523 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 539 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 535
+      ID: 551
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 531 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 547 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 543
+      ID: 559
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 539 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 555 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 469
+      ID: 485
       Name: '[]noalg.map.group[struct {}]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 16
-      Element: 465 StructureType noalg.map.group[struct {}]struct {}
+      Element: 481 StructureType noalg.map.group[struct {}]struct {}
     - __kind: GoSliceDataType
-      ID: 429
+      ID: 445
       Name: '[]noalg.map.group[uint8][4]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 424 StructureType noalg.map.group[uint8][4]int
+      Element: 440 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 420
+      ID: 436
       Name: '[]noalg.map.group[uint8]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 24
-      Element: 416 StructureType noalg.map.group[uint8]uint8
+      Element: 432 StructureType noalg.map.group[uint8]uint8
     - __kind: UnresolvedPointeeType
       ID: 40
       Name: '[]runtime.ancestorInfo'
@@ -19160,9 +19326,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 476 GoSliceDataType []string.array
+      Data: 492 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 476
+      ID: 492
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -19182,9 +19348,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 482 GoSliceDataType []struct {}.array
+      Data: 498 GoSliceDataType []struct {}.array
     - __kind: GoSliceDataType
-      ID: 482
+      ID: 498
       Name: '[]struct {}.array'
       DynamicSizeClass: slice
       Element: 125 StructureType struct {}
@@ -19204,9 +19370,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 470 GoSliceDataType []uint.array
+      Data: 486 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 470
+      ID: 486
       Name: '[]uint.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -19227,9 +19393,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 480 GoSliceDataType []uint16.array
+      Data: 496 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 480
+      ID: 496
       Name: '[]uint16.array'
       DynamicSizeClass: slice
       ByteSize: 2
@@ -19250,9 +19416,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 324 GoSliceDataType []uint8.array
+      Data: 340 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 324
+      ID: 340
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -19273,19 +19439,19 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 326 GoSliceDataType []uintptr.array
+      Data: 342 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 326
+      ID: 342
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 1 BaseType uintptr
     - __kind: UnresolvedPointeeType
-      ID: 1149
+      ID: 1165
       Name: archive/tar.Writer
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 784
+      ID: 800
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 931776
@@ -19300,33 +19466,33 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 785 GoSliceDataType archive/tar.headerError.array
+      Data: 801 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 785
+      ID: 801
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1084
+      ID: 1100
       Name: archive/tar.regFileWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1032
+      ID: 1048
       Name: archive/zip.countWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1034
+      ID: 1050
       Name: archive/zip.dirWriter
       GoRuntimeType: 1.120608e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1128
+      ID: 1144
       Name: archive/zip.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1060
+      ID: 1076
       Name: archive/zip.nopCloser
       ByteSize: 16
       GoRuntimeType: 1.566496e+06
@@ -19336,7 +19502,7 @@ Types:
           Offset: 0
           Type: 131 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1062
+      ID: 1078
       Name: archive/zip.pooledFlateWriter
       ByteSize: 8
     - __kind: BaseType
@@ -19346,15 +19512,15 @@ Types:
       GoRuntimeType: 585664
       GoKind: 1
     - __kind: UnresolvedPointeeType
-      ID: 1107
+      ID: 1123
       Name: bufio.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1136
+      ID: 1152
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1187
+      ID: 1203
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
@@ -19380,13 +19546,13 @@ Types:
       GoRuntimeType: 585408
       GoKind: 15
     - __kind: BaseType
-      ID: 582
+      ID: 598
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 835040
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 583
+      ID: 599
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 835136
@@ -19394,116 +19560,116 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 585 PointerType *compress/flate.InternalError.str
+          Type: 601 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 584 GoStringDataType compress/flate.InternalError.str
+      Data: 600 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 584
+      ID: 600
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1082
+      ID: 1098
       Name: compress/flate.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1028
+      ID: 1044
       Name: compress/flate.dictWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1104
+      ID: 1120
       Name: compress/gzip.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 932
+      ID: 948
       Name: context.deadlineExceededError
       GoRuntimeType: 1.480736e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 596
+      ID: 612
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 837632
       GoKind: 2
     - __kind: BaseType
-      ID: 597
+      ID: 613
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 837728
       GoKind: 2
     - __kind: BaseType
-      ID: 598
+      ID: 614
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 837824
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1099
+      ID: 1115
       Name: crypto/internal/fips140/hmac.HMAC
       ByteSize: 8
     - __kind: StructureType
-      ID: 881
+      ID: 897
       Name: crypto/internal/fips140/hmac.errCloneUnsupported
       GoRuntimeType: 1.289952e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1130
+      ID: 1146
       Name: crypto/internal/fips140/sha256.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1160
+      ID: 1176
       Name: crypto/internal/fips140/sha3.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1134
+      ID: 1150
       Name: crypto/internal/fips140/sha3.SHAKE
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1132
+      ID: 1148
       Name: crypto/internal/fips140/sha512.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1126
+      ID: 1142
       Name: crypto/md5.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 599
+      ID: 615
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 837920
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1147
+      ID: 1163
       Name: crypto/sha1.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1122
+      ID: 1138
       Name: crypto/sha3.SHA3
       ByteSize: 8
     - __kind: BaseType
-      ID: 586
+      ID: 602
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 835616
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 870
+      ID: 886
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1213
+      ID: 1229
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 698
+      ID: 714
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 696
+      ID: 712
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1.731584e+06
@@ -19514,38 +19680,38 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 999 ArrayType [5]uint8
+          Type: 1015 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 1000 GoInterfaceType net.Conn
+          Type: 1016 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 823
+      ID: 839
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 993760
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1092
+      ID: 1108
       Name: crypto/tls.cthWrapper
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 700
+      ID: 716
       Name: crypto/tls.echConfigErr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1097
+      ID: 1113
       Name: crypto/tls.finishedHash
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 967
+      ID: 983
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 984
+      ID: 1000
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 772
+      ID: 788
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1.734464e+06
@@ -19553,21 +19719,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 983 PointerType *crypto/x509.Certificate
+          Type: 999 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 1002 BaseType crypto/x509.InvalidReason
+          Type: 1018 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 766
+      ID: 782
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1.118176e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 768
+      ID: 784
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1.600608e+06
@@ -19575,24 +19741,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 983 PointerType *crypto/x509.Certificate
+          Type: 999 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 595
+      ID: 611
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 837248
       GoKind: 2
     - __kind: BaseType
-      ID: 1002
+      ID: 1018
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 590848
       GoKind: 2
     - __kind: StructureType
-      ID: 875
+      ID: 891
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1.562496e+06
@@ -19602,13 +19768,13 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 774
+      ID: 790
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1.118432e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 770
+      ID: 786
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1.734272e+06
@@ -19616,15 +19782,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 983 PointerType *crypto/x509.Certificate
+          Type: 999 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 14 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 983 PointerType *crypto/x509.Certificate
+          Type: 999 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 788
+      ID: 804
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1.437152e+06
@@ -19634,7 +19800,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 792
+      ID: 808
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1.437312e+06
@@ -19644,55 +19810,55 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 790
+      ID: 806
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 577
+      ID: 593
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 834560
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 1050
+      ID: 1066
       Name: encoding/base64.encoder
       ByteSize: 8
     - __kind: BaseType
-      ID: 578
+      ID: 594
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 834752
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 654
+      ID: 670
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 859
+      ID: 875
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 646
+      ID: 662
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 652
+      ID: 668
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 650
+      ID: 666
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 648
+      ID: 664
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1193
+      ID: 1209
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 656
+      ID: 672
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1.421152e+06
@@ -19702,19 +19868,19 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1058
+      ID: 1074
       Name: encoding/pem.lineBreaker
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 760
+      ID: 776
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 758
+      ID: 774
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 592
+      ID: 608
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 837152
@@ -19722,22 +19888,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 594 PointerType *encoding/xml.UnmarshalError.str
+          Type: 610 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 593 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 609 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 593
+      ID: 609
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 763
+      ID: 779
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1171
+      ID: 1187
       Name: encoding/xml.printer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -19754,11 +19920,11 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 622
+      ID: 638
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 826
+      ID: 842
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -19774,15 +19940,15 @@ Types:
       GoRuntimeType: 585600
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 1181
+      ID: 1197
       Name: fmt.pp
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 828
+      ID: 844
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 830
+      ID: 846
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -19798,11 +19964,11 @@ Types:
       GoRuntimeType: 848768
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 684
+      ID: 700
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 665
+      ID: 681
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1.730432e+06
@@ -19810,7 +19976,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 992 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 1008 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 7 BaseType int
@@ -19818,25 +19984,25 @@ Types:
           Offset: 200
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 667
+      ID: 683
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 996
+      ID: 1012
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 671
+      ID: 687
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1.114464e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 998
+      ID: 1014
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 571
+      ID: 587
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 833984
@@ -19844,18 +20010,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 573 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 589 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 572 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 588 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 572
+      ID: 588
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 992
+      ID: 1008
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2.220096e+06
@@ -19863,7 +20029,7 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 993 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 1009 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -19878,7 +20044,7 @@ Types:
           Type: 16 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 994 GoSliceHeaderType []float64
+          Type: 1010 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 13 BaseType int64
@@ -19887,10 +20053,10 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 995 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 1011 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 997 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 1013 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
           Type: 263 GoSliceHeaderType []string
@@ -19904,13 +20070,13 @@ Types:
           Offset: 184
           Type: 13 BaseType int64
     - __kind: BaseType
-      ID: 993
+      ID: 1009
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 587456
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 568
+      ID: 584
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 833888
@@ -19918,18 +20084,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 570 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 586 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 569 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 585 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 569
+      ID: 585
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 574
+      ID: 590
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 834080
@@ -19937,60 +20103,60 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 576 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 592 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 575 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 591 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 575
+      ID: 591
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1070
+      ID: 1086
       Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1157
+      ID: 1173
       Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 782
+      ID: 798
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 941
+      ID: 957
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1189
+      ID: 1205
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 709
+      ID: 725
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 716
+      ID: 732
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1.117408e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 591
+      ID: 607
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 836288
       GoKind: 2
     - __kind: StructureType
-      ID: 714
+      ID: 730
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1.11728e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 712
+      ID: 728
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1.598688e+06
@@ -20003,7 +20169,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 732
+      ID: 748
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1.599488e+06
@@ -20016,7 +20182,7 @@ Types:
           Offset: 16
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 736
+      ID: 752
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1.733696e+06
@@ -20032,7 +20198,7 @@ Types:
           Offset: 24
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 734
+      ID: 750
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1.431072e+06
@@ -20042,7 +20208,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 730
+      ID: 746
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1.430752e+06
@@ -20052,14 +20218,14 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 978
+      ID: 994
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1.501696e+06
       GoKind: 21
-      HeaderType: 980 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 996 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 1001
+      ID: 1017
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1.051168e+06
@@ -20074,15 +20240,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1019 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 1035 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 1019
+      ID: 1035
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 744
+      ID: 760
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1.599808e+06
@@ -20090,12 +20256,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 978 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 994 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 978 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 994 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 738
+      ID: 754
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1.431232e+06
@@ -20105,7 +20271,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 742
+      ID: 758
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1.733888e+06
@@ -20116,12 +20282,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 1001 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1017 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 1001 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1017 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 740
+      ID: 756
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1.599648e+06
@@ -20134,7 +20300,7 @@ Types:
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 746
+      ID: 762
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1.431392e+06
@@ -20142,9 +20308,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 968 StructureType time.Time
+          Type: 984 StructureType time.Time
     - __kind: StructureType
-      ID: 752
+      ID: 768
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1.600128e+06
@@ -20157,7 +20323,7 @@ Types:
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 754
+      ID: 770
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1.431712e+06
@@ -20167,7 +20333,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 750
+      ID: 766
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1.599968e+06
@@ -20180,7 +20346,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 748
+      ID: 764
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1.431552e+06
@@ -20190,7 +20356,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 756
+      ID: 772
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1.600288e+06
@@ -20203,7 +20369,7 @@ Types:
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 673
+      ID: 689
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1.423392e+06
@@ -20213,11 +20379,11 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1110
+      ID: 1126
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 675
+      ID: 691
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1.423552e+06
@@ -20225,21 +20391,21 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 673 StructureType github.com/cihub/seelog.baseError
+          Type: 689 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1090
+      ID: 1106
       Name: github.com/cihub/seelog.connWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1046
+      ID: 1062
       Name: github.com/cihub/seelog.consoleWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1080
+      ID: 1096
       Name: github.com/cihub/seelog.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 679
+      ID: 695
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1.423872e+06
@@ -20247,13 +20413,13 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 673 StructureType github.com/cihub/seelog.baseError
+          Type: 689 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1145
+      ID: 1161
       Name: github.com/cihub/seelog.rollingFileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1158
+      ID: 1174
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
       GoRuntimeType: 2.107584e+06
@@ -20261,12 +20427,12 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1144 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1160 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: maxFileSize
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 1161
+      ID: 1177
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
       GoRuntimeType: 2.132448e+06
@@ -20274,7 +20440,7 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1144 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1160 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: timePattern
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -20282,11 +20448,11 @@ Types:
           Offset: 24
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1048
+      ID: 1064
       Name: github.com/cihub/seelog.smtpWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 677
+      ID: 693
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1.423712e+06
@@ -20294,9 +20460,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 673 StructureType github.com/cihub/seelog.baseError
+          Type: 689 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 681
+      ID: 697
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1.424032e+06
@@ -20304,64 +20470,64 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 673 StructureType github.com/cihub/seelog.baseError
+          Type: 689 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1112
+      ID: 1128
       Name: github.com/cihub/seelog/archive/gzip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1153
+      ID: 1169
       Name: github.com/cihub/seelog/archive/tar.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1155
+      ID: 1171
       Name: github.com/cihub/seelog/archive/zip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 972
+      ID: 988
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 885
+      ID: 901
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 883
+      ID: 899
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 887
+      ID: 903
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 889
+      ID: 905
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1101
+      ID: 1117
       Name: github.com/gogo/protobuf/proto.textWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 877
+      ID: 893
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 687
+      ID: 703
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1.424992e+06
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 7 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 1205
+      ID: 1221
       Name: github.com/json-iterator/go.Stream
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 943
+      ID: 959
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 916
+      ID: 932
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1.843488e+06
@@ -20377,11 +20543,11 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 910
+      ID: 926
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 845
+      ID: 861
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1.703136e+06
@@ -20394,7 +20560,7 @@ Types:
           Offset: 1
           Type: 17 BaseType int8
     - __kind: StructureType
-      ID: 922
+      ID: 938
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1.843936e+06
@@ -20410,13 +20576,13 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 822
+      ID: 838
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 991072
       GoKind: 8
     - __kind: StructureType
-      ID: 914
+      ID: 930
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1.843264e+06
@@ -20432,13 +20598,13 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 1003
+      ID: 1019
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 832160
       GoKind: 8
     - __kind: StructureType
-      ID: 912
+      ID: 928
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1.84304e+06
@@ -20446,15 +20612,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 1003 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 1019 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 1003 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 1019 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 920
+      ID: 936
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1.757088e+06
@@ -20467,7 +20633,7 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 918
+      ID: 934
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1.843712e+06
@@ -20483,11 +20649,11 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1209
+      ID: 1225
       Name: github.com/tinylib/msgp/msgp.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 926
+      ID: 942
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1.624704e+06
@@ -20497,19 +20663,19 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 849
+      ID: 865
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1.283936e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 847
+      ID: 863
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1.283808e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 924
+      ID: 940
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1.75728e+06
@@ -20522,7 +20688,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 604
+      ID: 620
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 839744
@@ -20530,22 +20696,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 606 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 622 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 605 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 621 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 605
+      ID: 621
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 987
+      ID: 1003
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 893
+      ID: 909
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1.448992e+06
@@ -20555,7 +20721,7 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 1076
+      ID: 1092
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
       GoRuntimeType: 1.678848e+06
@@ -20563,13 +20729,13 @@ Types:
       RawFields:
         - Name: WriteSyncer
           Offset: 0
-          Type: 1102 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+          Type: 1118 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
     - __kind: UnresolvedPointeeType
-      ID: 1169
+      ID: 1185
       Name: go.uber.org/zap/buffer.Buffer
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1102
+      ID: 1118
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
       GoRuntimeType: 1.12816e+06
@@ -20582,7 +20748,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1064
+      ID: 1080
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
       GoRuntimeType: 1.571296e+06
@@ -20592,19 +20758,19 @@ Types:
           Offset: 0
           Type: 131 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 607
+      ID: 623
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 840320
       GoKind: 10
     - __kind: BaseType
-      ID: 985
+      ID: 1001
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 1.004224e+06
       GoKind: 10
     - __kind: StructureType
-      ID: 951
+      ID: 967
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1.881792e+06
@@ -20615,12 +20781,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 985 BaseType golang.org/x/net/http2.ErrCode
+          Type: 1001 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 808
+      ID: 824
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1.607328e+06
@@ -20628,12 +20794,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 985 BaseType golang.org/x/net/http2.ErrCode
+          Type: 1001 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 611
+      ID: 627
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 840512
@@ -20641,18 +20807,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 613 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 629 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 612 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 628 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 612
+      ID: 628
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 617
+      ID: 633
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 840704
@@ -20660,18 +20826,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 619 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 635 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 618 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 634 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 618
+      ID: 634
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 614
+      ID: 630
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 840608
@@ -20679,18 +20845,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 616 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 632 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 615 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 631 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 615
+      ID: 631
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 608
+      ID: 624
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 840416
@@ -20698,22 +20864,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 610 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 626 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 609 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 625 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 609
+      ID: 625
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1167
+      ID: 1183
       Name: golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 812
+      ID: 828
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.449632e+06
@@ -20723,13 +20889,13 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: BaseType
-      ID: 620
+      ID: 636
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 840800
       GoKind: 2
     - __kind: StructureType
-      ID: 800
+      ID: 816
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1.444672e+06
@@ -20739,11 +20905,11 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 949
+      ID: 965
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 974
+      ID: 990
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1.909568e+06
@@ -20759,7 +20925,7 @@ Types:
           Offset: 24
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 802
+      ID: 818
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1.606848e+06
@@ -20772,7 +20938,7 @@ Types:
           Offset: 16
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 1116
+      ID: 1132
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
       GoRuntimeType: 1.967616e+06
@@ -20780,16 +20946,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 1000 GoInterfaceType net.Conn
+          Type: 1016 GoInterfaceType net.Conn
         - Name: r
           Offset: 16
-          Type: 1143 GoInterfaceType io.Reader
+          Type: 1159 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 1074
+      ID: 1090
       Name: google.golang.org/grpc/internal/transport.bufWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 891
+      ID: 907
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1.568896e+06
@@ -20799,29 +20965,29 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1036
+      ID: 1052
       Name: google.golang.org/grpc/mem.writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 780
+      ID: 796
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 879
+      ID: 895
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 947
+      ID: 963
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 945
+      ID: 961
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1.512416e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 794
+      ID: 810
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1.437952e+06
@@ -20831,7 +20997,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 796
+      ID: 812
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1.438112e+06
@@ -20841,393 +21007,393 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 724
+      ID: 740
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 439
+      ID: 455
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 440 PointerType *noalg.map.group[[4]int][4]int
+          Type: 456 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 441 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 445 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      GroupType: 457 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 461 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 431
+      ID: 447
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 432 PointerType *noalg.map.group[[4]int]uint8
+          Type: 448 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 433 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 437 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 449 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 453 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 379
+      ID: 395
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 380 PointerType *noalg.map.group[[4]string][2]int
+          Type: 396 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 381 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 386 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 397 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 402 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 398
+      ID: 414
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 399 PointerType *noalg.map.group[bool]main.node
+          Type: 415 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 400 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 404 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 416 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 420 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 337
+      ID: 353
       Name: groupReference<int,*main.deepMap2>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 338 PointerType *noalg.map.group[int]*main.deepMap2
+          Type: 354 PointerType *noalg.map.group[int]*main.deepMap2
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 339 StructureType noalg.map.group[int]*main.deepMap2
-      GroupSliceType: 345 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
+      GroupType: 355 StructureType noalg.map.group[int]*main.deepMap2
+      GroupSliceType: 361 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
     - __kind: GoSwissMapGroupsType
-      ID: 1249
+      ID: 1265
       Name: groupReference<int,*main.deepMap3>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1250 PointerType *noalg.map.group[int]*main.deepMap3
+          Type: 1266 PointerType *noalg.map.group[int]*main.deepMap3
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1251 StructureType noalg.map.group[int]*main.deepMap3
-      GroupSliceType: 1257 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+      GroupType: 1267 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 1273 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
     - __kind: GoSwissMapGroupsType
-      ID: 1283
+      ID: 1299
       Name: groupReference<int,*main.deepMap8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1284 PointerType *noalg.map.group[int]*main.deepMap8
+          Type: 1300 PointerType *noalg.map.group[int]*main.deepMap8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1285 StructureType noalg.map.group[int]*main.deepMap8
-      GroupSliceType: 1291 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
+      GroupType: 1301 StructureType noalg.map.group[int]*main.deepMap8
+      GroupSliceType: 1307 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
     - __kind: GoSwissMapGroupsType
-      ID: 1298
+      ID: 1314
       Name: groupReference<int,*main.deepMap9>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1299 PointerType *noalg.map.group[int]*main.deepMap9
+          Type: 1315 PointerType *noalg.map.group[int]*main.deepMap9
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1300 StructureType noalg.map.group[int]*main.deepMap9
-      GroupSliceType: 1306 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
+      GroupType: 1316 StructureType noalg.map.group[int]*main.deepMap9
+      GroupSliceType: 1322 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
     - __kind: GoSwissMapGroupsType
-      ID: 347
+      ID: 363
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 348 PointerType *noalg.map.group[int]int
+          Type: 364 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 349 StructureType noalg.map.group[int]int
-      GroupSliceType: 353 GoSliceDataType []noalg.map.group[int]int.array
+      GroupType: 365 StructureType noalg.map.group[int]int
+      GroupSliceType: 369 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 1313
+      ID: 1329
       Name: groupReference<int,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1314 PointerType *noalg.map.group[int]interface {}
+          Type: 1330 PointerType *noalg.map.group[int]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1315 StructureType noalg.map.group[int]interface {}
-      GroupSliceType: 1319 GoSliceDataType []noalg.map.group[int]interface {}.array
+      GroupType: 1331 StructureType noalg.map.group[int]interface {}
+      GroupSliceType: 1335 GoSliceDataType []noalg.map.group[int]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 455
+      ID: 471
       Name: groupReference<int,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 456 PointerType *noalg.map.group[int]struct {}
+          Type: 472 PointerType *noalg.map.group[int]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 457 StructureType noalg.map.group[int]struct {}
-      GroupSliceType: 461 GoSliceDataType []noalg.map.group[int]struct {}.array
+      GroupType: 473 StructureType noalg.map.group[int]struct {}
+      GroupSliceType: 477 GoSliceDataType []noalg.map.group[int]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 406
+      ID: 422
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 407 PointerType *noalg.map.group[int]uint8
+          Type: 423 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 408 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 412 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 424 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 428 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 388
+      ID: 404
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 389 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 405 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 390 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 396 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 406 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 412 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 371
+      ID: 387
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 372 PointerType *noalg.map.group[string][]string
+          Type: 388 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 373 StructureType noalg.map.group[string][]string
-      GroupSliceType: 377 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 389 StructureType noalg.map.group[string][]string
+      GroupSliceType: 393 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 1010
+      ID: 1026
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1011 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1027 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1012 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 1016 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 1028 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 1032 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
-      ID: 363
+      ID: 379
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 364 PointerType *noalg.map.group[string]int
+          Type: 380 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 365 StructureType noalg.map.group[string]int
-      GroupSliceType: 369 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 381 StructureType noalg.map.group[string]int
+      GroupSliceType: 385 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 355
+      ID: 371
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 356 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 372 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 357 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 361 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+      GroupType: 373 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 377 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 447
+      ID: 463
       Name: groupReference<struct {},int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 448 PointerType *noalg.map.group[struct {}]int
+          Type: 464 PointerType *noalg.map.group[struct {}]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 449 StructureType noalg.map.group[struct {}]int
-      GroupSliceType: 453 GoSliceDataType []noalg.map.group[struct {}]int.array
+      GroupType: 465 StructureType noalg.map.group[struct {}]int
+      GroupSliceType: 469 GoSliceDataType []noalg.map.group[struct {}]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 497
+      ID: 513
       Name: groupReference<struct {},main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 498 PointerType *noalg.map.group[struct {}]main.structWithCyclicMaps
+          Type: 514 PointerType *noalg.map.group[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 499 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 503 GoSliceDataType []noalg.map.group[struct {}]main.structWithCyclicMaps.array
+      GroupType: 515 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 519 GoSliceDataType []noalg.map.group[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 505
+      ID: 521
       Name: groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 506 PointerType *noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 522 PointerType *noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 507 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 511 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 523 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 527 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 513
+      ID: 529
       Name: groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 514 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 530 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 515 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 519 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 531 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 535 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 521
+      ID: 537
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 522 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 538 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 523 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 527 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 539 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 543 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 529
+      ID: 545
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 530 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 546 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 531 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 535 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 547 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 551 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 537
+      ID: 553
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 538 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 554 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 539 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 543 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 555 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 559 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 463
+      ID: 479
       Name: groupReference<struct {},struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 464 PointerType *noalg.map.group[struct {}]struct {}
+          Type: 480 PointerType *noalg.map.group[struct {}]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 465 StructureType noalg.map.group[struct {}]struct {}
-      GroupSliceType: 469 GoSliceDataType []noalg.map.group[struct {}]struct {}.array
+      GroupType: 481 StructureType noalg.map.group[struct {}]struct {}
+      GroupSliceType: 485 GoSliceDataType []noalg.map.group[struct {}]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 422
+      ID: 438
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 423 PointerType *noalg.map.group[uint8][4]int
+          Type: 439 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 424 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 429 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 440 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 445 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 414
+      ID: 430
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 415 PointerType *noalg.map.group[uint8]uint8
+          Type: 431 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 416 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 420 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 432 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 436 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: UnresolvedPointeeType
-      ID: 1124
+      ID: 1140
       Name: hash/crc32.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 815
+      ID: 831
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -21274,11 +21440,11 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 976
+      ID: 992
       Name: internal/abi.Type
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 692
+      ID: 708
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -21304,29 +21470,29 @@ Types:
           Offset: 296
           Type: 2 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 690
+      ID: 706
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1022
+      ID: 1038
       Name: internal/godebug.runtimeStderr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 908
+      ID: 924
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1211
+      ID: 1227
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 906
+      ID: 922
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1.477536e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 626
+      ID: 642
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -21407,7 +21573,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 579
+      ID: 595
       Name: internal/runtime/cgroup.stringError
       ByteSize: 16
       GoRuntimeType: 834944
@@ -21415,18 +21581,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 581 PointerType *internal/runtime/cgroup.stringError.str
+          Type: 597 PointerType *internal/runtime/cgroup.stringError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 580 GoStringDataType internal/runtime/cgroup.stringError.str
+      Data: 596 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: GoStringDataType
-      ID: 580
+      ID: 596
       Name: internal/runtime/cgroup.stringError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 863
+      ID: 879
       Name: internal/runtime/maps.unhashableTypeError
       ByteSize: 8
       GoRuntimeType: 1.560256e+06
@@ -21434,9 +21600,9 @@ Types:
       RawFields:
         - Name: typ
           Offset: 0
-          Type: 975 PointerType *internal/abi.Type
+          Type: 991 PointerType *internal/abi.Type
     - __kind: StructureType
-      ID: 1223
+      ID: 1239
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.474976e+06
@@ -21449,11 +21615,11 @@ Types:
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 1068
+      ID: 1084
       Name: io.PipeWriter
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1108
+      ID: 1124
       Name: io.ReadWriteCloser
       ByteSize: 16
       GoRuntimeType: 1.190688e+06
@@ -21466,7 +21632,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1143
+      ID: 1159
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 1.024288e+06
@@ -21479,7 +21645,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1095
+      ID: 1111
       Name: io.WriteCloser
       ByteSize: 16
       GoRuntimeType: 1.110752e+06
@@ -21505,21 +21671,21 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1066
+      ID: 1082
       Name: io.discard
       GoRuntimeType: 1.464576e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1040
+      ID: 1056
       Name: io.multiWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 904
+      ID: 920
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1114
+      ID: 1130
       Name: log/slog/internal/buffer.Buffer
       ByteSize: 8
     - __kind: StructureType
@@ -21548,7 +21714,25 @@ Types:
       RawFields:
         - Name: nested
           Offset: 0
-          Type: 1320 PointerType *main.nestedStruct
+          Type: 1336 PointerType *main.nestedStruct
+    - __kind: StructureType
+      ID: 325
+      Name: main.bStruct
+      ByteSize: 72
+      GoKind: 25
+      RawFields:
+        - Name: aInt16
+          Offset: 0
+          Type: 96 BaseType int16
+        - Name: nested
+          Offset: 8
+          Type: 316 StructureType main.aStruct
+        - Name: aBool
+          Offset: 64
+          Type: 4 BaseType bool
+        - Name: aInt32
+          Offset: 68
+          Type: 12 BaseType int32
     - __kind: GoInterfaceType
       ID: 162
       Name: main.behavior
@@ -21578,6 +21762,21 @@ Types:
           Offset: 32
           Type: 131 GoInterfaceType io.Writer
     - __kind: StructureType
+      ID: 322
+      Name: main.cStruct
+      ByteSize: 24
+      GoKind: 25
+      RawFields:
+        - Name: aInt32
+          Offset: 0
+          Type: 12 BaseType int32
+        - Name: aUint
+          Offset: 8
+          Type: 10 BaseType uint
+        - Name: nested
+          Offset: 16
+          Type: 262 StructureType main.structWithNoStrings
+    - __kind: StructureType
       ID: 143
       Name: main.deepMap1
       ByteSize: 8
@@ -21588,7 +21787,7 @@ Types:
           Offset: 0
           Type: 144 GoMapType map[int]*main.deepMap2
     - __kind: StructureType
-      ID: 343
+      ID: 359
       Name: main.deepMap2
       ByteSize: 8
       GoRuntimeType: 1.186976e+06
@@ -21596,9 +21795,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1243 GoMapType map[int]*main.deepMap3
+          Type: 1259 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 1255
+      ID: 1271
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -21610,9 +21809,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1277 GoMapType map[int]*main.deepMap8
+          Type: 1293 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 1289
+      ID: 1305
       Name: main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.186208e+06
@@ -21620,9 +21819,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1292 GoMapType map[int]*main.deepMap9
+          Type: 1308 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 1304
+      ID: 1320
       Name: main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.18608e+06
@@ -21630,7 +21829,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1307 GoMapType map[int]interface {}
+          Type: 1323 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 132
       Name: main.deepPtr1
@@ -21650,9 +21849,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1214 PointerType *main.deepPtr3
+          Type: 1230 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 1215
+      ID: 1231
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -21664,9 +21863,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1258 PointerType *main.deepPtr8
+          Type: 1274 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 1259
+      ID: 1275
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1.18736e+06
@@ -21674,9 +21873,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1260 PointerType *main.deepPtr9
+          Type: 1276 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 1261
+      ID: 1277
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1.187232e+06
@@ -21696,7 +21895,7 @@ Types:
           Offset: 0
           Type: 138 GoSliceHeaderType []*main.deepSlice2
     - __kind: StructureType
-      ID: 333
+      ID: 349
       Name: main.deepSlice2
       ByteSize: 24
       GoRuntimeType: 1.18928e+06
@@ -21704,9 +21903,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1237 GoSliceHeaderType []*main.deepSlice3
+          Type: 1253 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 1240
+      ID: 1256
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -21718,9 +21917,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1262 GoSliceHeaderType []*main.deepSlice8
+          Type: 1278 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 1265
+      ID: 1281
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1.188512e+06
@@ -21728,9 +21927,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1268 GoSliceHeaderType []*main.deepSlice9
+          Type: 1284 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 1271
+      ID: 1287
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1.188384e+06
@@ -21738,7 +21937,73 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1274 GoSliceHeaderType []interface {}
+          Type: 1290 GoSliceHeaderType []interface {}
+    - __kind: StructureType
+      ID: 327
+      Name: main.deepStruct1
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: b
+          Offset: 8
+          Type: 328 StructureType main.deepStruct2
+    - __kind: StructureType
+      ID: 328
+      Name: main.deepStruct2
+      ByteSize: 40
+      GoKind: 25
+      RawFields:
+        - Name: c
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: d
+          Offset: 8
+          Type: 329 StructureType main.deepStruct3
+    - __kind: StructureType
+      ID: 329
+      Name: main.deepStruct3
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: e
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: f
+          Offset: 8
+          Type: 330 StructureType main.deepStruct4
+    - __kind: StructureType
+      ID: 330
+      Name: main.deepStruct4
+      ByteSize: 24
+      GoKind: 25
+      RawFields:
+        - Name: g
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: h
+          Offset: 8
+          Type: 331 StructureType main.deepStruct5
+    - __kind: StructureType
+      ID: 331
+      Name: main.deepStruct5
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: i
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: j
+          Offset: 8
+          Type: 332 StructureType main.deepStruct6
+    - __kind: StructureType
+      ID: 332
+      Name: main.deepStruct6
+      ByteSize: 8
+      GoKind: 25
+      RawFields: [{Name: k, Offset: 0, Type: 7 BaseType int}]
     - __kind: StructureType
       ID: 319
       Name: main.emptyStruct
@@ -21756,16 +22021,16 @@ Types:
           Type: 155 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 1221 StructureType sync.Mutex
+          Type: 1237 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 1224 StructureType sync.Once
+          Type: 1240 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 1227 StructureType sync.WaitGroup
+          Type: 1243 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 1230 StructureType sync/atomic.Int32
+          Type: 1246 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 155
       Name: main.esotericStack
@@ -21795,7 +22060,7 @@ Types:
           Offset: 56
           Type: 59 GoSubroutineType func()
     - __kind: StructureType
-      ID: 321
+      ID: 337
       Name: main.firstBehavior
       ByteSize: 16
       GoRuntimeType: 1.413632e+06
@@ -21841,6 +22106,90 @@ Types:
           Offset: 72
           Type: 7 BaseType int
     - __kind: StructureType
+      ID: 333
+      Name: main.lotsOfFields
+      ByteSize: 26
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 3 BaseType uint8
+        - Name: b
+          Offset: 1
+          Type: 3 BaseType uint8
+        - Name: c
+          Offset: 2
+          Type: 3 BaseType uint8
+        - Name: d
+          Offset: 3
+          Type: 3 BaseType uint8
+        - Name: e
+          Offset: 4
+          Type: 3 BaseType uint8
+        - Name: f
+          Offset: 5
+          Type: 3 BaseType uint8
+        - Name: g
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: h
+          Offset: 7
+          Type: 3 BaseType uint8
+        - Name: i
+          Offset: 8
+          Type: 3 BaseType uint8
+        - Name: j
+          Offset: 9
+          Type: 3 BaseType uint8
+        - Name: k
+          Offset: 10
+          Type: 3 BaseType uint8
+        - Name: l
+          Offset: 11
+          Type: 3 BaseType uint8
+        - Name: m
+          Offset: 12
+          Type: 3 BaseType uint8
+        - Name: n
+          Offset: 13
+          Type: 3 BaseType uint8
+        - Name: o
+          Offset: 14
+          Type: 3 BaseType uint8
+        - Name: p
+          Offset: 15
+          Type: 3 BaseType uint8
+        - Name: q
+          Offset: 16
+          Type: 3 BaseType uint8
+        - Name: r
+          Offset: 17
+          Type: 3 BaseType uint8
+        - Name: s
+          Offset: 18
+          Type: 3 BaseType uint8
+        - Name: t
+          Offset: 19
+          Type: 3 BaseType uint8
+        - Name: u
+          Offset: 20
+          Type: 3 BaseType uint8
+        - Name: v
+          Offset: 21
+          Type: 3 BaseType uint8
+        - Name: w
+          Offset: 22
+          Type: 3 BaseType uint8
+        - Name: x
+          Offset: 23
+          Type: 3 BaseType uint8
+        - Name: y
+          Offset: 24
+          Type: 3 BaseType uint8
+        - Name: z
+          Offset: 25
+          Type: 3 BaseType uint8
+    - __kind: StructureType
       ID: 254
       Name: main.mixedStruct
       ByteSize: 24
@@ -21855,6 +22204,21 @@ Types:
         - Name: c
           Offset: 16
           Type: 7 BaseType int
+    - __kind: StructureType
+      ID: 321
+      Name: main.nStruct
+      ByteSize: 24
+      GoKind: 25
+      RawFields:
+        - Name: aBool
+          Offset: 0
+          Type: 4 BaseType bool
+        - Name: aInt
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: aInt16
+          Offset: 16
+          Type: 96 BaseType int16
     - __kind: StructureType
       ID: 123
       Name: main.nestedStruct
@@ -21891,7 +22255,13 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1233
+      ID: 323
+      Name: main.receiver
+      ByteSize: 8
+      GoKind: 25
+      RawFields: [{Name: u, Offset: 0, Type: 10 BaseType uint}]
+    - __kind: StructureType
+      ID: 1249
       Name: main.secondBehavior
       ByteSize: 8
       GoRuntimeType: 1.413792e+06
@@ -21911,7 +22281,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1220
+      ID: 1236
       Name: main.somethingImpl
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -21922,31 +22292,31 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1217 PointerType *main.stringType1.str
+          Type: 1233 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 1216 GoStringDataType main.stringType1.str
+      Data: 1232 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 1216
+      ID: 1232
       Name: main.stringType1.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 1218
+      ID: 1234
       Name: main.stringType2
       ByteSize: 16
       GoKind: 24
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1322 PointerType *main.stringType2.str
+          Type: 1338 PointerType *main.stringType2.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 1321 GoStringDataType main.stringType2.str
+      Data: 1337 GoStringDataType main.stringType2.str
     - __kind: GoStringDataType
-      ID: 1321
+      ID: 1337
       Name: main.stringType2.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -22043,6 +22413,21 @@ Types:
           Offset: 1
           Type: 4 BaseType bool
     - __kind: StructureType
+      ID: 334
+      Name: main.structWithTwoArrays
+      ByteSize: 72
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 335 ArrayType [3]uint64
+        - Name: b
+          Offset: 24
+          Type: 3 BaseType uint8
+        - Name: c
+          Offset: 32
+          Type: 336 ArrayType [5]int64
+    - __kind: StructureType
       ID: 245
       Name: main.structWithTwoValues
       ByteSize: 16
@@ -22062,23 +22447,74 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1234 PointerType **main.t
+          Type: 1250 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1235 GoSliceDataType main.t.array
+      Data: 1251 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 1235
+      ID: 1251
       Name: main.t.array
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 248 PointerType *main.t
     - __kind: StructureType
+      ID: 326
+      Name: main.tenStrings
+      ByteSize: 160
+      GoKind: 25
+      RawFields:
+        - Name: first
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: second
+          Offset: 16
+          Type: 9 GoStringHeaderType string
+        - Name: third
+          Offset: 32
+          Type: 9 GoStringHeaderType string
+        - Name: fourth
+          Offset: 48
+          Type: 9 GoStringHeaderType string
+        - Name: fifth
+          Offset: 64
+          Type: 9 GoStringHeaderType string
+        - Name: sixth
+          Offset: 80
+          Type: 9 GoStringHeaderType string
+        - Name: seventh
+          Offset: 96
+          Type: 9 GoStringHeaderType string
+        - Name: eighth
+          Offset: 112
+          Type: 9 GoStringHeaderType string
+        - Name: ninth
+          Offset: 128
+          Type: 9 GoStringHeaderType string
+        - Name: tenth
+          Offset: 144
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
       ID: 268
       Name: main.threeStringStruct
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: b
+          Offset: 16
+          Type: 9 GoStringHeaderType string
+        - Name: c
+          Offset: 32
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 324
+      Name: main.threestrings
       ByteSize: 48
       GoKind: 25
       RawFields:
@@ -22168,8 +22604,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 444 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 441 StructureType noalg.map.group[[4]int][4]int
+      TablePtrSliceType: 460 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 457 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
       ID: 220
       Name: map<[4]int,uint8>
@@ -22203,8 +22639,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 436 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 433 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 452 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 449 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 188
       Name: map<[4]string,[2]int>
@@ -22238,8 +22674,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 385 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 381 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 401 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 397 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
       ID: 200
       Name: map<bool,main.node>
@@ -22273,8 +22709,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 403 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 400 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 419 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 416 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
       ID: 146
       Name: map<int,*main.deepMap2>
@@ -22308,10 +22744,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 344 GoSliceDataType []*table<int,*main.deepMap2>.array
-      GroupType: 339 StructureType noalg.map.group[int]*main.deepMap2
+      TablePtrSliceType: 360 GoSliceDataType []*table<int,*main.deepMap2>.array
+      GroupType: 355 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSwissMapHeaderType
-      ID: 1245
+      ID: 1261
       Name: map<int,*main.deepMap3>
       ByteSize: 48
       GoKind: 25
@@ -22324,7 +22760,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1246 PointerType **table<int,*main.deepMap3>
+          Type: 1262 PointerType **table<int,*main.deepMap3>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -22343,10 +22779,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1256 GoSliceDataType []*table<int,*main.deepMap3>.array
-      GroupType: 1251 StructureType noalg.map.group[int]*main.deepMap3
+      TablePtrSliceType: 1272 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 1267 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSwissMapHeaderType
-      ID: 1279
+      ID: 1295
       Name: map<int,*main.deepMap8>
       ByteSize: 48
       GoKind: 25
@@ -22359,7 +22795,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1280 PointerType **table<int,*main.deepMap8>
+          Type: 1296 PointerType **table<int,*main.deepMap8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -22378,10 +22814,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1290 GoSliceDataType []*table<int,*main.deepMap8>.array
-      GroupType: 1285 StructureType noalg.map.group[int]*main.deepMap8
+      TablePtrSliceType: 1306 GoSliceDataType []*table<int,*main.deepMap8>.array
+      GroupType: 1301 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSwissMapHeaderType
-      ID: 1294
+      ID: 1310
       Name: map<int,*main.deepMap9>
       ByteSize: 48
       GoKind: 25
@@ -22394,7 +22830,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1295 PointerType **table<int,*main.deepMap9>
+          Type: 1311 PointerType **table<int,*main.deepMap9>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -22413,8 +22849,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1305 GoSliceDataType []*table<int,*main.deepMap9>.array
-      GroupType: 1300 StructureType noalg.map.group[int]*main.deepMap9
+      TablePtrSliceType: 1321 GoSliceDataType []*table<int,*main.deepMap9>.array
+      GroupType: 1316 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSwissMapHeaderType
       ID: 168
       Name: map<int,int>
@@ -22448,10 +22884,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 352 GoSliceDataType []*table<int,int>.array
-      GroupType: 349 StructureType noalg.map.group[int]int
+      TablePtrSliceType: 368 GoSliceDataType []*table<int,int>.array
+      GroupType: 365 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
-      ID: 1309
+      ID: 1325
       Name: map<int,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -22464,7 +22900,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1310 PointerType **table<int,interface {}>
+          Type: 1326 PointerType **table<int,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -22483,8 +22919,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1318 GoSliceDataType []*table<int,interface {}>.array
-      GroupType: 1315 StructureType noalg.map.group[int]interface {}
+      TablePtrSliceType: 1334 GoSliceDataType []*table<int,interface {}>.array
+      GroupType: 1331 StructureType noalg.map.group[int]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 235
       Name: map<int,struct {}>
@@ -22518,8 +22954,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 460 GoSliceDataType []*table<int,struct {}>.array
-      GroupType: 457 StructureType noalg.map.group[int]struct {}
+      TablePtrSliceType: 476 GoSliceDataType []*table<int,struct {}>.array
+      GroupType: 473 StructureType noalg.map.group[int]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 205
       Name: map<int,uint8>
@@ -22553,8 +22989,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 411 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 408 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 427 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 424 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 195
       Name: map<string,[]main.structWithMap>
@@ -22588,8 +23024,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 395 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 390 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 411 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 406 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
       ID: 183
       Name: map<string,[]string>
@@ -22623,10 +23059,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 376 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 373 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 392 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 389 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 980
+      ID: 996
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -22639,7 +23075,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 981 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 997 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -22658,8 +23094,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1015 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 1012 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 1031 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 1028 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
       ID: 178
       Name: map<string,int>
@@ -22693,8 +23129,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 368 GoSliceDataType []*table<string,int>.array
-      GroupType: 365 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 384 GoSliceDataType []*table<string,int>.array
+      GroupType: 381 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
       ID: 173
       Name: map<string,main.nestedStruct>
@@ -22728,8 +23164,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 360 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 357 StructureType noalg.map.group[string]main.nestedStruct
+      TablePtrSliceType: 376 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 373 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSwissMapHeaderType
       ID: 230
       Name: map<struct {},int>
@@ -22763,8 +23199,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 452 GoSliceDataType []*table<struct {},int>.array
-      GroupType: 449 StructureType noalg.map.group[struct {}]int
+      TablePtrSliceType: 468 GoSliceDataType []*table<struct {},int>.array
+      GroupType: 465 StructureType noalg.map.group[struct {}]int
     - __kind: GoSwissMapHeaderType
       ID: 288
       Name: map<struct {},main.structWithCyclicMaps>
@@ -22798,8 +23234,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 502 GoSliceDataType []*table<struct {},main.structWithCyclicMaps>.array
-      GroupType: 499 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 518 GoSliceDataType []*table<struct {},main.structWithCyclicMaps>.array
+      GroupType: 515 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 293
       Name: map<struct {},map[struct {}]main.structWithCyclicMaps>
@@ -22833,8 +23269,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 510 GoSliceDataType []*table<struct {},map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 507 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 526 GoSliceDataType []*table<struct {},map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 523 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 298
       Name: map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -22868,8 +23304,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 518 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 515 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 534 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 531 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 303
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -22903,8 +23339,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 526 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 523 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 542 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 539 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 308
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -22938,8 +23374,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 534 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 531 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 550 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 547 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 313
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -22973,8 +23409,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 542 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 539 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 558 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 555 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 240
       Name: map<struct {},struct {}>
@@ -23008,8 +23444,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 468 GoSliceDataType []*table<struct {},struct {}>.array
-      GroupType: 465 StructureType noalg.map.group[struct {}]struct {}
+      TablePtrSliceType: 484 GoSliceDataType []*table<struct {},struct {}>.array
+      GroupType: 481 StructureType noalg.map.group[struct {}]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 215
       Name: map<uint8,[4]int>
@@ -23043,8 +23479,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 428 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 424 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 444 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 440 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
       ID: 210
       Name: map<uint8,uint8>
@@ -23078,8 +23514,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 419 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 416 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 435 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 432 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
       ID: 223
       Name: map[[4]int][4]int
@@ -23116,26 +23552,26 @@ Types:
       GoKind: 21
       HeaderType: 146 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 1243
+      ID: 1259
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 1.129824e+06
       GoKind: 21
-      HeaderType: 1245 GoSwissMapHeaderType map<int,*main.deepMap3>
+      HeaderType: 1261 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 1277
+      ID: 1293
       Name: map[int]*main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.129184e+06
       GoKind: 21
-      HeaderType: 1279 GoSwissMapHeaderType map<int,*main.deepMap8>
+      HeaderType: 1295 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
-      ID: 1292
+      ID: 1308
       Name: map[int]*main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.129056e+06
       GoKind: 21
-      HeaderType: 1294 GoSwissMapHeaderType map<int,*main.deepMap9>
+      HeaderType: 1310 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 166
       Name: map[int]int
@@ -23144,12 +23580,12 @@ Types:
       GoKind: 21
       HeaderType: 168 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
-      ID: 1307
+      ID: 1323
       Name: map[int]interface {}
       ByteSize: 8
       GoRuntimeType: 1.128928e+06
       GoKind: 21
-      HeaderType: 1309 GoSwissMapHeaderType map<int,interface {}>
+      HeaderType: 1325 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
       ID: 233
       Name: map[int]struct {}
@@ -23257,7 +23693,7 @@ Types:
       GoKind: 21
       HeaderType: 210 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: StructureType
-      ID: 728
+      ID: 744
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1.430272e+06
@@ -23267,7 +23703,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1030
+      ID: 1046
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
       GoRuntimeType: 1.427072e+06
@@ -23277,11 +23713,11 @@ Types:
           Offset: 0
           Type: 131 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 935
+      ID: 951
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1000
+      ID: 1016
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1.597408e+06
@@ -23294,35 +23730,35 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 961
+      ID: 977
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1175
+      ID: 1191
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 959
+      ID: 975
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 937
+      ID: 953
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1185
+      ID: 1201
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1195
+      ID: 1211
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1183
+      ID: 1199
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 896
+      ID: 912
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1.11408e+06
@@ -23330,28 +23766,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 898 PointerType *net.UnknownNetworkError.str
+          Type: 914 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 897 GoStringDataType net.UnknownNetworkError.str
+      Data: 913 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 897
+      ID: 913
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 861
+      ID: 877
       Name: net.canceledError
       GoRuntimeType: 1.28496e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1151
+      ID: 1167
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 1005
+      ID: 1021
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2.10688e+06
@@ -23359,7 +23795,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 1000 GoInterfaceType net.Conn
+          Type: 1016 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 14 GoInterfaceType error
@@ -23370,27 +23806,27 @@ Types:
           Offset: 33
           Type: 4 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 1197
+      ID: 1213
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 1191
+      ID: 1207
       Name: net.noReadFrom
       GoRuntimeType: 1.114336e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1190
+      ID: 1206
       Name: net.noWriteTo
       GoRuntimeType: 1.114208e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 658
+      ID: 674
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
-      ID: 660
+      ID: 676
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1.73024e+06
@@ -23398,7 +23834,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 988 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 1004 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 9 GoStringHeaderType string
@@ -23406,7 +23842,7 @@ Types:
           Offset: 96
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 1179
+      ID: 1195
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.289888e+06
@@ -23414,12 +23850,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1191 StructureType net.noReadFrom
+          Type: 1207 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 1184 PointerType *net.TCPConn
+          Type: 1200 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 1177
+      ID: 1193
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.289344e+06
@@ -23427,24 +23863,24 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1190 StructureType net.noWriteTo
+          Type: 1206 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 1184 PointerType *net.TCPConn
+          Type: 1200 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 939
+      ID: 955
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 963
+      ID: 979
       Name: net.timeoutError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 851
+      ID: 867
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1024
+      ID: 1040
       Name: net/http.bufioFlushWriter
       ByteSize: 16
       GoRuntimeType: 1.418592e+06
@@ -23454,19 +23890,19 @@ Types:
           Offset: 0
           Type: 131 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 549
+      ID: 565
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 832640
       GoKind: 10
     - __kind: BaseType
-      ID: 977
+      ID: 993
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 991168
       GoKind: 10
     - __kind: StructureType
-      ID: 636
+      ID: 652
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1.728512e+06
@@ -23477,12 +23913,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 977 BaseType net/http.http2ErrCode
+          Type: 993 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 955
+      ID: 971
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1.900096e+06
@@ -23493,12 +23929,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 977 BaseType net/http.http2ErrCode
+          Type: 993 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 640
+      ID: 656
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1.596928e+06
@@ -23506,16 +23942,16 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 977 BaseType net/http.http2ErrCode
+          Type: 993 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1086
+      ID: 1102
       Name: net/http.http2dataBuffer
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 553
+      ID: 569
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 832832
@@ -23523,18 +23959,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 555 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 571 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 554 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 570 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 554
+      ID: 570
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 559
+      ID: 575
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 833024
@@ -23542,18 +23978,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 561 PointerType *net/http.http2headerFieldNameError.str
+          Type: 577 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 560 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 576 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 560
+      ID: 576
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 556
+      ID: 572
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 832928
@@ -23561,32 +23997,32 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 558 PointerType *net/http.http2headerFieldValueError.str
+          Type: 574 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 557 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 573 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 557
+      ID: 573
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 930
+      ID: 946
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 857
+      ID: 873
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1.284192e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1140
+      ID: 1156
       Name: net/http.http2pipe
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 550
+      ID: 566
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 832736
@@ -23594,18 +24030,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 552 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 568 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 551 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 567 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 551
+      ID: 567
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1026
+      ID: 1042
       Name: net/http.http2stickyErrWriter
       ByteSize: 48
       GoRuntimeType: 1.826176e+06
@@ -23613,18 +24049,18 @@ Types:
       RawFields:
         - Name: group
           Offset: 0
-          Type: 1117 GoInterfaceType net/http.http2synctestGroupInterface
+          Type: 1133 GoInterfaceType net/http.http2synctestGroupInterface
         - Name: conn
           Offset: 16
-          Type: 1000 GoInterfaceType net.Conn
+          Type: 1016 GoInterfaceType net.Conn
         - Name: timeout
           Offset: 32
-          Type: 1118 BaseType time.Duration
+          Type: 1134 BaseType time.Duration
         - Name: err
           Offset: 40
           Type: 106 PointerType *error
     - __kind: GoInterfaceType
-      ID: 1117
+      ID: 1133
       Name: net/http.http2synctestGroupInterface
       ByteSize: 16
       GoRuntimeType: 1.417792e+06
@@ -23637,14 +24073,14 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: ArrayType
-      ID: 1105
+      ID: 1121
       Name: net/http.incomparable
       GoRuntimeType: 903840
       GoKind: 17
       HasCount: true
       Element: 59 GoSubroutineType func()
     - __kind: StructureType
-      ID: 853
+      ID: 869
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1.556416e+06
@@ -23654,11 +24090,11 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1088
+      ID: 1104
       Name: net/http.persistConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 1044
+      ID: 1060
       Name: net/http.persistConnWriter
       ByteSize: 8
       GoRuntimeType: 1.556256e+06
@@ -23666,9 +24102,9 @@ Types:
       RawFields:
         - Name: pc
           Offset: 0
-          Type: 1087 PointerType *net/http.persistConn
+          Type: 1103 PointerType *net/http.persistConn
     - __kind: StructureType
-      ID: 1078
+      ID: 1094
       Name: net/http.readWriteCloserBody
       ByteSize: 24
       GoRuntimeType: 1.801152e+06
@@ -23676,15 +24112,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1105 ArrayType net/http.incomparable
+          Type: 1121 ArrayType net/http.incomparable
         - Name: br
           Offset: 0
-          Type: 1106 PointerType *bufio.Reader
+          Type: 1122 PointerType *bufio.Reader
         - Name: ReadWriteCloser
           Offset: 8
-          Type: 1108 GoInterfaceType io.ReadWriteCloser
+          Type: 1124 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 644
+      ID: 660
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1.419552e+06
@@ -23694,17 +24130,17 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 957
+      ID: 973
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 928
+      ID: 944
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1.480416e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 855
+      ID: 871
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1.556576e+06
@@ -23714,7 +24150,7 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 1120
+      ID: 1136
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
       GoRuntimeType: 2.026592e+06
@@ -23722,16 +24158,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 1000 GoInterfaceType net.Conn
+          Type: 1016 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 1000 GoInterfaceType net.Conn
+          Type: 1016 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 633
+      ID: 649
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1142
+      ID: 1158
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
       GoRuntimeType: 2.042336e+06
@@ -23739,13 +24175,13 @@ Types:
       RawFields:
         - Name: Writer
           Offset: 0
-          Type: 1135 PointerType *bufio.Writer
+          Type: 1151 PointerType *bufio.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1054
+      ID: 1070
       Name: net/http/internal.chunkedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 720
+      ID: 736
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1.733312e+06
@@ -23761,7 +24197,7 @@ Types:
           Offset: 32
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 718
+      ID: 734
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1.598848e+06
@@ -23774,11 +24210,11 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1094
+      ID: 1110
       Name: net/smtp.Client
       ByteSize: 8
     - __kind: StructureType
-      ID: 1056
+      ID: 1072
       Name: net/smtp.dataCloser
       ByteSize: 24
       GoRuntimeType: 1.600768e+06
@@ -23786,16 +24222,16 @@ Types:
       RawFields:
         - Name: c
           Offset: 0
-          Type: 1093 PointerType *net/smtp.Client
+          Type: 1109 PointerType *net/smtp.Client
         - Name: WriteCloser
           Offset: 8
-          Type: 1095 GoInterfaceType io.WriteCloser
+          Type: 1111 GoInterfaceType io.WriteCloser
     - __kind: UnresolvedPointeeType
-      ID: 704
+      ID: 720
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 587
+      ID: 603
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 835712
@@ -23803,26 +24239,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 589 PointerType *net/textproto.ProtocolError.str
+          Type: 605 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 588 GoStringDataType net/textproto.ProtocolError.str
+      Data: 604 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 588
+      ID: 604
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1052
+      ID: 1068
       Name: net/textproto.dotWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 965
+      ID: 981
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 562
+      ID: 578
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 833600
@@ -23830,18 +24266,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 564 PointerType *net/url.EscapeError.str
+          Type: 580 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 563 GoStringDataType net/url.EscapeError.str
+      Data: 579 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 563
+      ID: 579
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 565
+      ID: 581
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 833696
@@ -23849,254 +24285,254 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 567 PointerType *net/url.InvalidHostError.str
+          Type: 583 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 566 GoStringDataType net/url.InvalidHostError.str
+      Data: 582 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 566
+      ID: 582
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: ArrayType
-      ID: 442
+      ID: 458
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
       GoRuntimeType: 683456
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 443 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 459 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 434
+      ID: 450
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
       GoRuntimeType: 683552
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 435 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 451 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 382
+      ID: 398
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
       GoRuntimeType: 683840
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 383 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 399 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 401
+      ID: 417
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
       GoRuntimeType: 683936
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 402 StructureType noalg.struct { key bool; elem main.node }
+      Element: 418 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 340
+      ID: 356
       Name: noalg.[8]struct { key int; elem *main.deepMap2 }
       ByteSize: 128
       GoRuntimeType: 682784
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 341 StructureType noalg.struct { key int; elem *main.deepMap2 }
+      Element: 357 StructureType noalg.struct { key int; elem *main.deepMap2 }
     - __kind: ArrayType
-      ID: 1252
+      ID: 1268
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
       GoRuntimeType: 682688
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1253 StructureType noalg.struct { key int; elem *main.deepMap3 }
+      Element: 1269 StructureType noalg.struct { key int; elem *main.deepMap3 }
     - __kind: ArrayType
-      ID: 1286
+      ID: 1302
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
       ByteSize: 128
       GoRuntimeType: 682208
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1287 StructureType noalg.struct { key int; elem *main.deepMap8 }
+      Element: 1303 StructureType noalg.struct { key int; elem *main.deepMap8 }
     - __kind: ArrayType
-      ID: 1301
+      ID: 1317
       Name: noalg.[8]struct { key int; elem *main.deepMap9 }
       ByteSize: 128
       GoRuntimeType: 682112
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1302 StructureType noalg.struct { key int; elem *main.deepMap9 }
+      Element: 1318 StructureType noalg.struct { key int; elem *main.deepMap9 }
     - __kind: ArrayType
-      ID: 350
+      ID: 366
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
       GoRuntimeType: 680960
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 351 StructureType noalg.struct { key int; elem int }
+      Element: 367 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 1316
+      ID: 1332
       Name: noalg.[8]struct { key int; elem interface {} }
       ByteSize: 192
       GoRuntimeType: 682016
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1317 StructureType noalg.struct { key int; elem interface {} }
+      Element: 1333 StructureType noalg.struct { key int; elem interface {} }
     - __kind: ArrayType
-      ID: 458
+      ID: 474
       Name: noalg.[8]struct { key int; elem struct {} }
       ByteSize: 128
       GoRuntimeType: 684032
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 459 StructureType noalg.struct { key int; elem struct {} }
+      Element: 475 StructureType noalg.struct { key int; elem struct {} }
     - __kind: ArrayType
-      ID: 409
+      ID: 425
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
       GoRuntimeType: 684128
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 410 StructureType noalg.struct { key int; elem uint8 }
+      Element: 426 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 391
+      ID: 407
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
       GoRuntimeType: 684224
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 392 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 408 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 374
+      ID: 390
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 684320
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 375 StructureType noalg.struct { key string; elem []string }
+      Element: 391 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 1013
+      ID: 1029
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 759968
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1014 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 1030 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
-      ID: 366
+      ID: 382
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 684416
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 367 StructureType noalg.struct { key string; elem int }
+      Element: 383 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 358
+      ID: 374
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
       GoRuntimeType: 684512
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 359 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 375 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 450
+      ID: 466
       Name: noalg.[8]struct { key struct {}; elem int }
       ByteSize: 64
       GoRuntimeType: 684608
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 451 StructureType noalg.struct { key struct {}; elem int }
+      Element: 467 StructureType noalg.struct { key struct {}; elem int }
     - __kind: ArrayType
-      ID: 500
+      ID: 516
       Name: noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
       ByteSize: 384
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 501 StructureType noalg.struct { key struct {}; elem main.structWithCyclicMaps }
+      Element: 517 StructureType noalg.struct { key struct {}; elem main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 508
+      ID: 524
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 509 StructureType noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+      Element: 525 StructureType noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 516
+      ID: 532
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 517 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 533 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 524
+      ID: 540
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 525 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 541 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 532
+      ID: 548
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 533 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 549 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 540
+      ID: 556
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 541 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 557 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 466
+      ID: 482
       Name: noalg.[8]struct { key struct {}; elem struct {} }
       GoRuntimeType: 684704
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 467 StructureType noalg.struct { key struct {}; elem struct {} }
+      Element: 483 StructureType noalg.struct { key struct {}; elem struct {} }
     - __kind: ArrayType
-      ID: 425
+      ID: 441
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
       GoRuntimeType: 684800
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 426 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 442 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 417
+      ID: 433
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 684896
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 418 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 434 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 441
+      ID: 457
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
       GoRuntimeType: 1.295968e+06
@@ -24107,9 +24543,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 442 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 458 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 433
+      ID: 449
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
       GoRuntimeType: 1.296224e+06
@@ -24120,9 +24556,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 434 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 450 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 381
+      ID: 397
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
       GoRuntimeType: 1.29648e+06
@@ -24133,9 +24569,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 382 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 398 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 400
+      ID: 416
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
       GoRuntimeType: 1.296736e+06
@@ -24146,9 +24582,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 401 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 417 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 339
+      ID: 355
       Name: noalg.map.group[int]*main.deepMap2
       ByteSize: 136
       GoRuntimeType: 1.295712e+06
@@ -24159,9 +24595,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 340 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
+          Type: 356 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
     - __kind: StructureType
-      ID: 1251
+      ID: 1267
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
       GoRuntimeType: 1.295456e+06
@@ -24172,9 +24608,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1252 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+          Type: 1268 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
     - __kind: StructureType
-      ID: 1285
+      ID: 1301
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
       GoRuntimeType: 1.294176e+06
@@ -24185,9 +24621,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1286 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
+          Type: 1302 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
     - __kind: StructureType
-      ID: 1300
+      ID: 1316
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
       GoRuntimeType: 1.29392e+06
@@ -24198,9 +24634,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1301 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
+          Type: 1317 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
     - __kind: StructureType
-      ID: 349
+      ID: 365
       Name: noalg.map.group[int]int
       ByteSize: 136
       GoRuntimeType: 1.292896e+06
@@ -24211,9 +24647,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 350 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 366 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 1315
+      ID: 1331
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
       GoRuntimeType: 1.293664e+06
@@ -24224,9 +24660,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1316 ArrayType noalg.[8]struct { key int; elem interface {} }
+          Type: 1332 ArrayType noalg.[8]struct { key int; elem interface {} }
     - __kind: StructureType
-      ID: 457
+      ID: 473
       Name: noalg.map.group[int]struct {}
       ByteSize: 136
       GoRuntimeType: 1.296992e+06
@@ -24237,9 +24673,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 458 ArrayType noalg.[8]struct { key int; elem struct {} }
+          Type: 474 ArrayType noalg.[8]struct { key int; elem struct {} }
     - __kind: StructureType
-      ID: 408
+      ID: 424
       Name: noalg.map.group[int]uint8
       ByteSize: 136
       GoRuntimeType: 1.297248e+06
@@ -24250,9 +24686,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 409 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 425 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 390
+      ID: 406
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
       GoRuntimeType: 1.297504e+06
@@ -24263,9 +24699,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 391 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 407 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 373
+      ID: 389
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.29776e+06
@@ -24276,9 +24712,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 374 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 390 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 1012
+      ID: 1028
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1.3592e+06
@@ -24289,9 +24725,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1013 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 1029 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
-      ID: 365
+      ID: 381
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 1.298016e+06
@@ -24302,9 +24738,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 366 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 382 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 357
+      ID: 373
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
       GoRuntimeType: 1.298272e+06
@@ -24315,9 +24751,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 358 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 374 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 449
+      ID: 465
       Name: noalg.map.group[struct {}]int
       ByteSize: 72
       GoRuntimeType: 1.298528e+06
@@ -24328,9 +24764,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 450 ArrayType noalg.[8]struct { key struct {}; elem int }
+          Type: 466 ArrayType noalg.[8]struct { key struct {}; elem int }
     - __kind: StructureType
-      ID: 499
+      ID: 515
       Name: noalg.map.group[struct {}]main.structWithCyclicMaps
       ByteSize: 392
       GoKind: 25
@@ -24340,9 +24776,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 500 ArrayType noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
+          Type: 516 ArrayType noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 507
+      ID: 523
       Name: noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -24352,9 +24788,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 508 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+          Type: 524 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 515
+      ID: 531
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -24364,9 +24800,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 516 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 532 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 523
+      ID: 539
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -24376,9 +24812,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 524 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 540 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 531
+      ID: 547
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -24388,9 +24824,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 532 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 548 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 539
+      ID: 555
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -24400,9 +24836,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 540 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 556 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 465
+      ID: 481
       Name: noalg.map.group[struct {}]struct {}
       ByteSize: 16
       GoRuntimeType: 1.298784e+06
@@ -24413,9 +24849,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 466 ArrayType noalg.[8]struct { key struct {}; elem struct {} }
+          Type: 482 ArrayType noalg.[8]struct { key struct {}; elem struct {} }
     - __kind: StructureType
-      ID: 424
+      ID: 440
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
       GoRuntimeType: 1.29904e+06
@@ -24426,9 +24862,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 425 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 441 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 416
+      ID: 432
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
       GoRuntimeType: 1.299296e+06
@@ -24439,9 +24875,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 417 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 433 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 443
+      ID: 459
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
       GoRuntimeType: 1.29584e+06
@@ -24449,12 +24885,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 427 ArrayType [4]int
+          Type: 443 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 427 ArrayType [4]int
+          Type: 443 ArrayType [4]int
     - __kind: StructureType
-      ID: 435
+      ID: 451
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
       GoRuntimeType: 1.296096e+06
@@ -24462,12 +24898,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 427 ArrayType [4]int
+          Type: 443 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 383
+      ID: 399
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
       GoRuntimeType: 1.296352e+06
@@ -24475,12 +24911,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 384 ArrayType [4]string
+          Type: 400 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 113 ArrayType [2]int
     - __kind: StructureType
-      ID: 402
+      ID: 418
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
       GoRuntimeType: 1.296608e+06
@@ -24493,7 +24929,7 @@ Types:
           Offset: 8
           Type: 246 StructureType main.node
     - __kind: StructureType
-      ID: 341
+      ID: 357
       Name: noalg.struct { key int; elem *main.deepMap2 }
       ByteSize: 16
       GoRuntimeType: 1.295584e+06
@@ -24504,9 +24940,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 342 PointerType *main.deepMap2
+          Type: 358 PointerType *main.deepMap2
     - __kind: StructureType
-      ID: 1253
+      ID: 1269
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
       GoRuntimeType: 1.295328e+06
@@ -24517,9 +24953,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1254 PointerType *main.deepMap3
+          Type: 1270 PointerType *main.deepMap3
     - __kind: StructureType
-      ID: 1287
+      ID: 1303
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
       GoRuntimeType: 1.294048e+06
@@ -24530,9 +24966,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1288 PointerType *main.deepMap8
+          Type: 1304 PointerType *main.deepMap8
     - __kind: StructureType
-      ID: 1302
+      ID: 1318
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
       GoRuntimeType: 1.293792e+06
@@ -24543,9 +24979,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1303 PointerType *main.deepMap9
+          Type: 1319 PointerType *main.deepMap9
     - __kind: StructureType
-      ID: 351
+      ID: 367
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
       GoRuntimeType: 1.292768e+06
@@ -24558,7 +24994,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 1317
+      ID: 1333
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
       GoRuntimeType: 1.293536e+06
@@ -24571,7 +25007,7 @@ Types:
           Offset: 8
           Type: 157 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 459
+      ID: 475
       Name: noalg.struct { key int; elem struct {} }
       ByteSize: 16
       GoRuntimeType: 1.296864e+06
@@ -24584,7 +25020,7 @@ Types:
           Offset: 8
           Type: 125 StructureType struct {}
     - __kind: StructureType
-      ID: 410
+      ID: 426
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 1.29712e+06
@@ -24597,7 +25033,7 @@ Types:
           Offset: 8
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 392
+      ID: 408
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
       GoRuntimeType: 1.297376e+06
@@ -24608,9 +25044,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 393 GoSliceHeaderType []main.structWithMap
+          Type: 409 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 375
+      ID: 391
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.297632e+06
@@ -24623,7 +25059,7 @@ Types:
           Offset: 16
           Type: 263 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 1014
+      ID: 1030
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1.359072e+06
@@ -24634,9 +25070,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 1001 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1017 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 367
+      ID: 383
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 1.297888e+06
@@ -24649,7 +25085,7 @@ Types:
           Offset: 16
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 359
+      ID: 375
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
       GoRuntimeType: 1.298144e+06
@@ -24662,7 +25098,7 @@ Types:
           Offset: 16
           Type: 123 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 451
+      ID: 467
       Name: noalg.struct { key struct {}; elem int }
       ByteSize: 8
       GoRuntimeType: 1.2984e+06
@@ -24675,7 +25111,7 @@ Types:
           Offset: 0
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 501
+      ID: 517
       Name: noalg.struct { key struct {}; elem main.structWithCyclicMaps }
       ByteSize: 48
       GoKind: 25
@@ -24687,7 +25123,7 @@ Types:
           Offset: 0
           Type: 285 StructureType main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 509
+      ID: 525
       Name: noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -24699,7 +25135,7 @@ Types:
           Offset: 0
           Type: 286 GoMapType map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 517
+      ID: 533
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -24711,7 +25147,7 @@ Types:
           Offset: 0
           Type: 291 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 525
+      ID: 541
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -24723,7 +25159,7 @@ Types:
           Offset: 0
           Type: 296 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 533
+      ID: 549
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -24735,7 +25171,7 @@ Types:
           Offset: 0
           Type: 301 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 541
+      ID: 557
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -24747,7 +25183,7 @@ Types:
           Offset: 0
           Type: 306 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 467
+      ID: 483
       Name: noalg.struct { key struct {}; elem struct {} }
       GoRuntimeType: 1.298656e+06
       GoKind: 25
@@ -24759,7 +25195,7 @@ Types:
           Offset: 0
           Type: 125 StructureType struct {}
     - __kind: StructureType
-      ID: 426
+      ID: 442
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
       GoRuntimeType: 1.298912e+06
@@ -24770,9 +25206,9 @@ Types:
           Type: 3 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 427 ArrayType [4]int
+          Type: 443 ArrayType [4]int
     - __kind: StructureType
-      ID: 418
+      ID: 434
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
       GoRuntimeType: 1.299168e+06
@@ -24785,19 +25221,19 @@ Types:
           Offset: 1
           Type: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1203
+      ID: 1219
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 832
+      ID: 848
       Name: os.LinkError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 900
+      ID: 916
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1201
+      ID: 1217
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.360256e+06
@@ -24805,12 +25241,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1207 StructureType os.noReadFrom
+          Type: 1223 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 1202 PointerType *os.File
+          Type: 1218 PointerType *os.File
     - __kind: StructureType
-      ID: 1199
+      ID: 1215
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.359456e+06
@@ -24818,36 +25254,36 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1206 StructureType os.noWriteTo
+          Type: 1222 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 1202 PointerType *os.File
+          Type: 1218 PointerType *os.File
     - __kind: StructureType
-      ID: 1207
+      ID: 1223
       Name: os.noReadFrom
       GoRuntimeType: 1.111648e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1206
+      ID: 1222
       Name: os.noWriteTo
       GoRuntimeType: 1.11152e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 865
+      ID: 881
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1008
+      ID: 1024
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1072
+      ID: 1088
       Name: os/exec.prefixSuffixSaver
       ByteSize: 8
     - __kind: StructureType
-      ID: 867
+      ID: 883
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1.703712e+06
@@ -24860,7 +25296,7 @@ Types:
           Offset: 16
           Type: 14 GoInterfaceType error
     - __kind: GoStringHeaderType
-      ID: 601
+      ID: 617
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 838976
@@ -24868,36 +25304,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 603 PointerType *os/user.UnknownGroupIdError.str
+          Type: 619 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 602 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 618 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 602
+      ID: 618
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 600
+      ID: 616
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 838880
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 628
+      ID: 644
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 726
+      ID: 742
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 836
+      ID: 852
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 840
+      ID: 856
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -24909,7 +25345,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 838
+      ID: 854
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1.88896e+06
@@ -24926,9 +25362,9 @@ Types:
           Type: 4 BaseType bool
         - Name: code
           Offset: 17
-          Type: 1006 BaseType runtime.boundsErrorCode
+          Type: 1022 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 1006
+      ID: 1022
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 585792
@@ -24948,7 +25384,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 902
+      ID: 918
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1.754016e+06
@@ -24961,7 +25397,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 816
+      ID: 832
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 989728
@@ -24969,13 +25405,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 818 PointerType *runtime.errorString.str
+          Type: 834 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 817 GoStringDataType runtime.errorString.str
+      Data: 833 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 817
+      ID: 833
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -25602,7 +26038,7 @@ Types:
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
-      ID: 328
+      ID: 344
       Name: runtime.p
       ByteSize: 8
     - __kind: StructureType
@@ -25638,7 +26074,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 819
+      ID: 835
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 989824
@@ -25646,13 +26082,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 821 PointerType *runtime.plainError.str
+          Type: 837 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 820 GoStringDataType runtime.plainError.str
+      Data: 836 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 820
+      ID: 836
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -25693,7 +26129,7 @@ Types:
       Name: runtime.synctestBubble
       ByteSize: 8
     - __kind: StructureType
-      ID: 624
+      ID: 640
       Name: runtime.synctestDeadlockError
       ByteSize: 24
       GoRuntimeType: 1.596608e+06
@@ -25751,7 +26187,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 842
+      ID: 858
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -25763,26 +26199,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 323 PointerType *string.str
+          Type: 339 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 322 GoStringDataType string.str
+      Data: 338 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 322
+      ID: 338
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1138
+      ID: 1154
       Name: strings.Builder
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1042
+      ID: 1058
       Name: strings.appendSliceWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1038
+      ID: 1054
       Name: struct { io.Writer }
       ByteSize: 16
       GoRuntimeType: 1.456352e+06
@@ -25798,7 +26234,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1221
+      ID: 1237
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.464896e+06
@@ -25806,12 +26242,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1222 StructureType sync.noCopy
+          Type: 1238 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 1223 StructureType internal/sync.Mutex
+          Type: 1239 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 1224
+      ID: 1240
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.613952e+06
@@ -25819,15 +26255,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1222 StructureType sync.noCopy
+          Type: 1238 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 1225 StructureType sync/atomic.Bool
+          Type: 1241 StructureType sync/atomic.Bool
         - Name: m
           Offset: 4
-          Type: 1221 StructureType sync.Mutex
+          Type: 1237 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 1227
+      ID: 1243
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.61376e+06
@@ -25835,21 +26271,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 1222 StructureType sync.noCopy
+          Type: 1238 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 1228 StructureType sync/atomic.Uint64
+          Type: 1244 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1222
+      ID: 1238
       Name: sync.noCopy
       GoRuntimeType: 988672
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1225
+      ID: 1241
       Name: sync/atomic.Bool
       ByteSize: 4
       GoRuntimeType: 1.466016e+06
@@ -25857,12 +26293,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1226 StructureType sync/atomic.noCopy
+          Type: 1242 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1230
+      ID: 1246
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.466176e+06
@@ -25870,12 +26306,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1226 StructureType sync/atomic.noCopy
+          Type: 1242 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 1228
+      ID: 1244
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.614336e+06
@@ -25883,33 +26319,33 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1226 StructureType sync/atomic.noCopy
+          Type: 1242 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 1229 StructureType sync/atomic.align64
+          Type: 1245 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 8 BaseType uint64
     - __kind: StructureType
-      ID: 1229
+      ID: 1245
       Name: sync/atomic.align64
       GoRuntimeType: 988864
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1226
+      ID: 1242
       Name: sync/atomic.noCopy
       GoRuntimeType: 988768
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 952
+      ID: 968
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1.283552e+06
       GoKind: 12
     - __kind: StructureType
-      ID: 438
+      ID: 454
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -25931,9 +26367,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 439 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 455 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
-      ID: 430
+      ID: 446
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -25955,9 +26391,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 431 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 447 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
-      ID: 378
+      ID: 394
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
@@ -25979,9 +26415,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 379 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 395 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
-      ID: 397
+      ID: 413
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
@@ -26003,9 +26439,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 398 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 414 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
-      ID: 336
+      ID: 352
       Name: table<int,*main.deepMap2>
       ByteSize: 32
       GoKind: 25
@@ -26027,9 +26463,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 337 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
+          Type: 353 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
     - __kind: StructureType
-      ID: 1248
+      ID: 1264
       Name: table<int,*main.deepMap3>
       ByteSize: 32
       GoKind: 25
@@ -26051,9 +26487,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1249 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+          Type: 1265 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
     - __kind: StructureType
-      ID: 1282
+      ID: 1298
       Name: table<int,*main.deepMap8>
       ByteSize: 32
       GoKind: 25
@@ -26075,9 +26511,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1283 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
+          Type: 1299 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
     - __kind: StructureType
-      ID: 1297
+      ID: 1313
       Name: table<int,*main.deepMap9>
       ByteSize: 32
       GoKind: 25
@@ -26099,9 +26535,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1298 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
+          Type: 1314 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
     - __kind: StructureType
-      ID: 346
+      ID: 362
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
@@ -26123,9 +26559,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 347 GoSwissMapGroupsType groupReference<int,int>
+          Type: 363 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 1312
+      ID: 1328
       Name: table<int,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -26147,9 +26583,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1313 GoSwissMapGroupsType groupReference<int,interface {}>
+          Type: 1329 GoSwissMapGroupsType groupReference<int,interface {}>
     - __kind: StructureType
-      ID: 454
+      ID: 470
       Name: table<int,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -26171,9 +26607,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 455 GoSwissMapGroupsType groupReference<int,struct {}>
+          Type: 471 GoSwissMapGroupsType groupReference<int,struct {}>
     - __kind: StructureType
-      ID: 405
+      ID: 421
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -26195,9 +26631,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 406 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 422 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
-      ID: 387
+      ID: 403
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
@@ -26219,9 +26655,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 388 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 404 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 370
+      ID: 386
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -26243,9 +26679,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 371 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 387 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 1009
+      ID: 1025
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -26267,9 +26703,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1010 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 1026 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
-      ID: 362
+      ID: 378
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -26291,9 +26727,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 363 GoSwissMapGroupsType groupReference<string,int>
+          Type: 379 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 354
+      ID: 370
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
@@ -26315,9 +26751,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 355 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 371 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 446
+      ID: 462
       Name: table<struct {},int>
       ByteSize: 32
       GoKind: 25
@@ -26339,9 +26775,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 447 GoSwissMapGroupsType groupReference<struct {},int>
+          Type: 463 GoSwissMapGroupsType groupReference<struct {},int>
     - __kind: StructureType
-      ID: 496
+      ID: 512
       Name: table<struct {},main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -26363,9 +26799,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 497 GoSwissMapGroupsType groupReference<struct {},main.structWithCyclicMaps>
+          Type: 513 GoSwissMapGroupsType groupReference<struct {},main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 504
+      ID: 520
       Name: table<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -26387,9 +26823,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 505 GoSwissMapGroupsType groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
+          Type: 521 GoSwissMapGroupsType groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 512
+      ID: 528
       Name: table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -26411,9 +26847,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 513 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 529 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 520
+      ID: 536
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -26435,9 +26871,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 521 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 537 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 528
+      ID: 544
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -26459,9 +26895,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 529 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 545 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 536
+      ID: 552
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -26483,9 +26919,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 537 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 553 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 462
+      ID: 478
       Name: table<struct {},struct {}>
       ByteSize: 32
       GoKind: 25
@@ -26507,9 +26943,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 463 GoSwissMapGroupsType groupReference<struct {},struct {}>
+          Type: 479 GoSwissMapGroupsType groupReference<struct {},struct {}>
     - __kind: StructureType
-      ID: 421
+      ID: 437
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -26531,9 +26967,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 422 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 438 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
-      ID: 413
+      ID: 429
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
@@ -26555,13 +26991,13 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 414 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 430 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: UnresolvedPointeeType
-      ID: 1173
+      ID: 1189
       Name: text/tabwriter.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 895
+      ID: 911
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1.708128e+06
@@ -26574,21 +27010,21 @@ Types:
           Offset: 16
           Type: 14 GoInterfaceType error
     - __kind: BaseType
-      ID: 1118
+      ID: 1134
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1.916416e+06
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 970
+      ID: 986
       Name: time.Location
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 631
+      ID: 647
       Name: time.ParseError
       ByteSize: 8
     - __kind: StructureType
-      ID: 968
+      ID: 984
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.373568e+06
@@ -26602,9 +27038,9 @@ Types:
           Type: 13 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 969 PointerType *time.Location
+          Type: 985 PointerType *time.Location
     - __kind: GoStringHeaderType
-      ID: 546
+      ID: 562
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 831776
@@ -26612,13 +27048,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 548 PointerType *time.fileSizeError.str
+          Type: 564 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 547 GoStringDataType time.fileSizeError.str
+      Data: 563 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 547
+      ID: 563
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -26665,7 +27101,7 @@ Types:
       GoRuntimeType: 585728
       GoKind: 26
     - __kind: StructureType
-      ID: 988
+      ID: 1004
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2.064064e+06
@@ -26676,10 +27112,10 @@ Types:
           Type: 38 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 989 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 1005 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 990 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 1006 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: off
           Offset: 40
           Type: 7 BaseType int
@@ -26694,18 +27130,18 @@ Types:
           Type: 7 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 991 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 1007 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 6 BaseType uint16
     - __kind: BaseType
-      ID: 991
+      ID: 1007
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 995392
       GoKind: 9
     - __kind: StructureType
-      ID: 989
+      ID: 1005
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1.927424e+06
@@ -26730,21 +27166,21 @@ Types:
           Offset: 10
           Type: 6 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 722
+      ID: 738
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 990
+      ID: 1006
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 589376
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1165
+      ID: 1181
       Name: vendor/golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 706
+      ID: 722
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.427392e+06
@@ -26754,13 +27190,13 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: BaseType
-      ID: 590
+      ID: 606
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 835808
       GoKind: 2
     - __kind: StructureType
-      ID: 872
+      ID: 888
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1.703904e+06
@@ -26773,12 +27209,12 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 824
+      ID: 840
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 994240
       GoKind: 5
-MaxTypeID: 1570
+MaxTypeID: 1587
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x12ed500", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.26rc1.yaml
@@ -11,11 +11,11 @@ Probes:
       subprogram: {subprogram: 142}
       events:
         - Kind: Entry
-          Type: 1526 EventRootType Probe[main.stackC]
+          Type: 1542 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0x808ad8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1527 EventRootType Probe[main.stackC]Return
+          Type: 1543 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0x808b08", Frameless: false}]
           Condition: null
       probeTemplate: {TemplateString: stackC, Segments: [stackC]}
@@ -30,11 +30,11 @@ Probes:
       subprogram: {subprogram: 56}
       events:
         - Kind: Entry
-          Type: 1390 EventRootType Probe[main.testAny]
+          Type: 1406 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0x804358", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1391 EventRootType Probe[main.testAny]Return
+          Type: 1407 EventRootType Probe[main.testAny]Return
           InjectionPoints: [{PC: "0x804380", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -55,11 +55,11 @@ Probes:
       subprogram: {subprogram: 58}
       events:
         - Kind: Entry
-          Type: 1393 EventRootType Probe[main.testAnyPtr]
+          Type: 1409 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0x8043c8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1394 EventRootType Probe[main.testAnyPtr]Return
+          Type: 1410 EventRootType Probe[main.testAnyPtr]Return
           InjectionPoints: [{PC: "0x8043f0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -79,11 +79,11 @@ Probes:
       subprogram: {subprogram: 122}
       events:
         - Kind: Entry
-          Type: 1497 EventRootType Probe[main.testArrayArgAndReturn]
+          Type: 1513 EventRootType Probe[main.testArrayArgAndReturn]
           InjectionPoints: [{PC: "0x8079dc", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1498 EventRootType Probe[main.testArrayArgAndReturn]Return
+          Type: 1514 EventRootType Probe[main.testArrayArgAndReturn]Return
           InjectionPoints: [{PC: "0x807a70", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -104,7 +104,7 @@ Probes:
       subprogram: {subprogram: 19}
       events:
         - Kind: Entry
-          Type: 1342 EventRootType Probe[main.testArrayEmptyStructs]
+          Type: 1358 EventRootType Probe[main.testArrayEmptyStructs]
           InjectionPoints: [{PC: "0x802b40", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -125,7 +125,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - Kind: Entry
-          Type: 1338 EventRootType Probe[main.testArrayOfArrays]
+          Type: 1354 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0x802b00", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -146,7 +146,7 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - Kind: Entry
-          Type: 1340 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          Type: 1356 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0x802b20", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -167,7 +167,7 @@ Probes:
       subprogram: {subprogram: 66}
       events:
         - Kind: Entry
-          Type: 1402 EventRootType Probe[main.testArrayOfMaps]
+          Type: 1418 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0x804a00", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -188,7 +188,7 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - Kind: Entry
-          Type: 1339 EventRootType Probe[main.testArrayOfStrings]
+          Type: 1355 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0x802b10", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -208,7 +208,7 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - Kind: Entry
-          Type: 1341 EventRootType Probe[main.testArrayOfStructs]
+          Type: 1357 EventRootType Probe[main.testArrayOfStructs]
           InjectionPoints: [{PC: "0x802b30", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -229,11 +229,11 @@ Probes:
       subprogram: {subprogram: 86}
       events:
         - Kind: Entry
-          Type: 1424 EventRootType Probe[main.testAtomicAdd]
+          Type: 1440 EventRootType Probe[main.testAtomicAdd]
           InjectionPoints: [{PC: "0x8060f0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1425 EventRootType Probe[main.testAtomicAdd]Return
+          Type: 1441 EventRootType Probe[main.testAtomicAdd]Return
           InjectionPoints: [{PC: "0x80612c", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -254,7 +254,7 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 1360 EventRootType Probe[main.testBigStruct]
+          Type: 1376 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0x803090", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -275,7 +275,7 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - Kind: Entry
-          Type: 1327 EventRootType Probe[main.testBoolArray]
+          Type: 1343 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0x802a50", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -296,7 +296,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - Kind: Entry
-          Type: 1324 EventRootType Probe[main.testByteArray]
+          Type: 1340 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0x802a20", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -322,7 +322,7 @@ Probes:
       subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1542 EventRootType Probe[main.testStruct]
+          Type: 1558 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0x808da0", Frameless: true}]
           Condition: null
     - id: testCaptureExprLine
@@ -337,10 +337,10 @@ Probes:
       segments: []
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1550 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1567 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0x803c78"
               Frameless: false
@@ -365,10 +365,10 @@ Probes:
       segments: [x=, {json: {ref: x}, dsl: x}]
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1551 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1568 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0x803c78"
               Frameless: false
@@ -404,7 +404,7 @@ Probes:
       subprogram: {subprogram: 84}
       events:
         - Kind: Entry
-          Type: 1421 EventRootType Probe[main.testCombinedString]
+          Type: 1437 EventRootType Probe[main.testCombinedString]
           InjectionPoints: [{PC: "0x805e90", Frameless: true}]
           Condition: null
     - id: testCaptureExprWithTemplate
@@ -422,7 +422,7 @@ Probes:
       subprogram: {subprogram: 84}
       events:
         - Kind: Entry
-          Type: 1422 EventRootType Probe[main.testCombinedString]
+          Type: 1438 EventRootType Probe[main.testCombinedString]
           InjectionPoints: [{PC: "0x805e90", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -444,7 +444,7 @@ Probes:
       subprogram: {subprogram: 87}
       events:
         - Kind: Entry
-          Type: 1426 EventRootType Probe[main.testChannel]
+          Type: 1442 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0x806130", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -473,7 +473,7 @@ Probes:
       subprogram: {subprogram: 83}
       events:
         - Kind: Entry
-          Type: 1420 EventRootType Probe[main.testCombinedByte]
+          Type: 1436 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0x805e70", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -504,7 +504,7 @@ Probes:
       subprogram: {subprogram: 95}
       events:
         - Kind: Entry
-          Type: 1434 EventRootType Probe[main.testCycle]
+          Type: 1450 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0x8063b0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -525,7 +525,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - Kind: Entry
-          Type: 1365 EventRootType Probe[main.testDeepMap1]
+          Type: 1381 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0x8033e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -546,7 +546,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - Kind: Entry
-          Type: 1366 EventRootType Probe[main.testDeepMap7]
+          Type: 1382 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0x8033f0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -567,7 +567,7 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - Kind: Entry
-          Type: 1361 EventRootType Probe[main.testDeepPtr1]
+          Type: 1377 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0x803150", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -588,7 +588,7 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - Kind: Entry
-          Type: 1362 EventRootType Probe[main.testDeepPtr7]
+          Type: 1378 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0x803160", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -609,7 +609,7 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - Kind: Entry
-          Type: 1363 EventRootType Probe[main.testDeepSlice1]
+          Type: 1379 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0x803280", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -630,7 +630,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - Kind: Entry
-          Type: 1364 EventRootType Probe[main.testDeepSlice7]
+          Type: 1380 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0x803290", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -651,7 +651,7 @@ Probes:
       subprogram: {subprogram: 131}
       events:
         - Kind: Entry
-          Type: 1514 EventRootType Probe[main.testEmptySlice]
+          Type: 1530 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0x808750", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -677,7 +677,7 @@ Probes:
       subprogram: {subprogram: 134}
       events:
         - Kind: Entry
-          Type: 1517 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 1533 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0x808780", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -704,7 +704,7 @@ Probes:
       subprogram: {subprogram: 150}
       events:
         - Kind: Entry
-          Type: 1538 EventRootType Probe[main.testEmptyString]
+          Type: 1554 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0x808b90", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -725,7 +725,7 @@ Probes:
       subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1548 EventRootType Probe[main.testEmptyStruct]
+          Type: 1564 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0x808e40", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -745,7 +745,7 @@ Probes:
       subprogram: {subprogram: 157}
       events:
         - Kind: Entry
-          Type: 1549 EventRootType Probe[main.testEmptyStructPointer]
+          Type: 1565 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0x808e50", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -766,7 +766,7 @@ Probes:
       subprogram: {subprogram: 57}
       events:
         - Kind: Entry
-          Type: 1392 EventRootType Probe[main.testError]
+          Type: 1408 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0x8043a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -787,11 +787,11 @@ Probes:
       subprogram: {subprogram: 48}
       events:
         - Kind: Entry
-          Type: 1374 EventRootType Probe[main.testEsotericHeap]
+          Type: 1390 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0x8039e8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1375 EventRootType Probe[main.testEsotericHeap]Return
+          Type: 1391 EventRootType Probe[main.testEsotericHeap]Return
           InjectionPoints: [{PC: "0x803a20", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -812,11 +812,11 @@ Probes:
       subprogram: {subprogram: 47}
       events:
         - Kind: Entry
-          Type: 1372 EventRootType Probe[main.testEsotericStack]
+          Type: 1388 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0x80392c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1373 EventRootType Probe[main.testEsotericStack]Return
+          Type: 1389 EventRootType Probe[main.testEsotericStack]Return
           InjectionPoints: [{PC: "0x803988", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -837,11 +837,11 @@ Probes:
       subprogram: {subprogram: 53}
       events:
         - Kind: Entry
-          Type: 1384 EventRootType Probe[main.testFrameless]
+          Type: 1400 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0x8040c0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1385 EventRootType Probe[main.testFrameless]Return
+          Type: 1401 EventRootType Probe[main.testFrameless]Return
           InjectionPoints: [{PC: "0x8040c8", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -862,11 +862,11 @@ Probes:
       subprogram: {subprogram: 54}
       events:
         - Kind: Entry
-          Type: 1386 EventRootType Probe[main.testFramelessArray]
+          Type: 1402 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0x8040dc", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1387 EventRootType Probe[main.testFramelessArray]Return
+          Type: 1403 EventRootType Probe[main.testFramelessArray]Return
           InjectionPoints: [{PC: "0x804110", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -890,7 +890,7 @@ Probes:
       subprogram: {subprogram: 54}
       events:
         - Kind: Line
-          Type: 1388 EventRootType Probe[main.testFramelessArray]Line
+          Type: 1404 EventRootType Probe[main.testFramelessArray]Line
           InjectionPoints: [{PC: "0x8040dc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -911,11 +911,11 @@ Probes:
       subprogram: {subprogram: 49}
       events:
         - Kind: Entry
-          Type: 1376 EventRootType Probe[main.testInlinedBA]
+          Type: 1392 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0x803e08", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1377 EventRootType Probe[main.testInlinedBA]Return
+          Type: 1393 EventRootType Probe[main.testInlinedBA]Return
           InjectionPoints: [{PC: "0x803e54", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -941,11 +941,11 @@ Probes:
       subprogram: {subprogram: 50}
       events:
         - Kind: Entry
-          Type: 1378 EventRootType Probe[main.testInlinedBB]
+          Type: 1394 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0x803e98", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1379 EventRootType Probe[main.testInlinedBB]Return
+          Type: 1395 EventRootType Probe[main.testInlinedBB]Return
           InjectionPoints: [{PC: "0x803f18", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -971,11 +971,11 @@ Probes:
       subprogram: {subprogram: 51}
       events:
         - Kind: Entry
-          Type: 1380 EventRootType Probe[main.testInlinedBBA]
+          Type: 1396 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0x803f58", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1381 EventRootType Probe[main.testInlinedBBA]Return
+          Type: 1397 EventRootType Probe[main.testInlinedBBA]Return
           InjectionPoints: [{PC: "0x803f90", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -993,10 +993,10 @@ Probes:
       template: testInlinedBBB
       segments: [testInlinedBBB]
       captureSnapshot: true
-      subprogram: {subprogram: 159}
+      subprogram: {subprogram: 160}
       events:
         - Kind: Entry
-          Type: 1555 EventRootType Probe[main.testInlinedBBB]
+          Type: 1572 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x803ee4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1013,11 +1013,11 @@ Probes:
       subprogram: {subprogram: 52}
       events:
         - Kind: Entry
-          Type: 1382 EventRootType Probe[main.testInlinedBC]
+          Type: 1398 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0x803fc8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1383 EventRootType Probe[main.testInlinedBC]Return
+          Type: 1399 EventRootType Probe[main.testInlinedBC]Return
           InjectionPoints: [{PC: "0x8040a4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1031,10 +1031,10 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Entry
-          Type: 1556 EventRootType Probe[main.testInlinedBCA]
+          Type: 1573 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x803fcc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1051,10 +1051,10 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Line
-          Type: 1557 EventRootType Probe[main.testInlinedBCA]Line
+          Type: 1574 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0x803fcc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1068,10 +1068,10 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Entry
-          Type: 1558 EventRootType Probe[main.testInlinedBCB]
+          Type: 1575 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x804070", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1088,10 +1088,10 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Line
-          Type: 1559 EventRootType Probe[main.testInlinedBCB]Line
+          Type: 1576 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0x804070", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1105,10 +1105,10 @@ Probes:
       template: testInlinedFuncFromOtherPackage
       segments: [testInlinedFuncFromOtherPackage]
       captureSnapshot: true
-      subprogram: {subprogram: 165}
+      subprogram: {subprogram: 166}
       events:
         - Kind: Entry
-          Type: 1565 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
+          Type: 1582 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
           InjectionPoints:
             - PC: "0x802568"
               Frameless: true
@@ -1127,10 +1127,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Entry
-          Type: 1552 EventRootType Probe[main.testInlinedPrint]
+          Type: 1569 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x803c78"
               Frameless: false
@@ -1144,7 +1144,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1553 EventRootType Probe[main.testInlinedPrint]Return
+          Type: 1570 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0x803cac", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1165,10 +1165,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1554 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1571 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0x803c78"
               Frameless: false
@@ -1196,10 +1196,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 162}
+      subprogram: {subprogram: 163}
       events:
         - Kind: Entry
-          Type: 1560 EventRootType Probe[main.testInlinedSq]
+          Type: 1577 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x8040c4", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1220,10 +1220,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 162}
+      subprogram: {subprogram: 163}
       events:
         - Kind: Line
-          Type: 1561 EventRootType Probe[main.testInlinedSq]Line
+          Type: 1578 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0x8040c4", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1242,10 +1242,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 163}
+      subprogram: {subprogram: 164}
       events:
         - Kind: Entry
-          Type: 1562 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1579 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0x8040f4"
               Frameless: false
@@ -1270,7 +1270,7 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - Kind: Entry
-          Type: 1330 EventRootType Probe[main.testInt16Array]
+          Type: 1346 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0x802a80", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1291,7 +1291,7 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - Kind: Entry
-          Type: 1331 EventRootType Probe[main.testInt32Array]
+          Type: 1347 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0x802a90", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1312,7 +1312,7 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - Kind: Entry
-          Type: 1332 EventRootType Probe[main.testInt64Array]
+          Type: 1348 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0x802aa0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1333,7 +1333,7 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - Kind: Entry
-          Type: 1329 EventRootType Probe[main.testInt8Array]
+          Type: 1345 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0x802a70", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1354,7 +1354,7 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - Kind: Entry
-          Type: 1328 EventRootType Probe[main.testIntArray]
+          Type: 1344 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0x802a60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1375,7 +1375,7 @@ Probes:
       subprogram: {subprogram: 55}
       events:
         - Kind: Entry
-          Type: 1389 EventRootType Probe[main.testInterface]
+          Type: 1405 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0x804330", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1395,11 +1395,11 @@ Probes:
       subprogram: {subprogram: 121}
       events:
         - Kind: Entry
-          Type: 1495 EventRootType Probe[main.testLargeArgAndReturn]
+          Type: 1511 EventRootType Probe[main.testLargeArgAndReturn]
           InjectionPoints: [{PC: "0x807850", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1496 EventRootType Probe[main.testLargeArgAndReturn]Return
+          Type: 1512 EventRootType Probe[main.testLargeArgAndReturn]Return
           InjectionPoints: [{PC: "0x807980", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1409,6 +1409,49 @@ Probes:
               DSL: arg
               EventKind: Entry
               EventExpressionIndex: 1
+    - id: testLineProbeTemplateWithStructFields
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.executeStructFuncs
+        sourceFile: structs.go
+        lines: ["208"]
+      template: 'sta.a: {sta.a} sta.b: {sta.b} sta.c: {sta.c}'
+      segments:
+        - 'sta.a: '
+        - json: {getmember: [{ref: sta}, a]}
+          dsl: sta.a
+        - ' sta.b: '
+        - json: {getmember: [{ref: sta}, b]}
+          dsl: sta.b
+        - ' sta.c: '
+        - json: {getmember: [{ref: sta}, c]}
+          dsl: sta.c
+      captureSnapshot: false
+      subprogram: {subprogram: 158}
+      events:
+        - Kind: Line
+          Type: 1566 EventRootType Probe[main.executeStructFuncs]Line
+          InjectionPoints: [{PC: "0x809270", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: 'sta.a: {sta.a} sta.b: {sta.b} sta.c: {sta.c}'
+        Segments:
+            - 'sta.a: '
+            - JSON: {Base: {Ref: sta}, Member: a}
+              DSL: sta.a
+              EventKind: Line
+              EventExpressionIndex: 0
+            - ' sta.b: '
+            - JSON: {Base: {Ref: sta}, Member: b}
+              DSL: sta.b
+              EventKind: Line
+              EventExpressionIndex: 1
+            - ' sta.c: '
+            - JSON: {Base: {Ref: sta}, Member: c}
+              DSL: sta.c
+              EventKind: Line
+              EventExpressionIndex: 2
     - id: testLinkedList
       version: 0
       type: LOG_PROBE
@@ -1420,7 +1463,7 @@ Probes:
       subprogram: {subprogram: 89}
       events:
         - Kind: Entry
-          Type: 1428 EventRootType Probe[main.testLinkedList]
+          Type: 1444 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0x8062c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1444,7 +1487,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - Kind: Line
-          Type: 1369 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          Type: 1385 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x80343c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1465,7 +1508,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - Kind: Line
-          Type: 1370 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          Type: 1386 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x8034dc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1486,7 +1529,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - Kind: Line
-          Type: 1371 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          Type: 1387 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x803580", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1528,11 +1571,11 @@ Probes:
       subprogram: {subprogram: 124}
       events:
         - Kind: Entry
-          Type: 1501 EventRootType Probe[main.testManyArgsArrayReturn]
+          Type: 1517 EventRootType Probe[main.testManyArgsArrayReturn]
           InjectionPoints: [{PC: "0x807cbc", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1502 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          Type: 1518 EventRootType Probe[main.testManyArgsArrayReturn]Return
           InjectionPoints: [{PC: "0x807e10", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1593,7 +1636,7 @@ Probes:
       subprogram: {subprogram: 64}
       events:
         - Kind: Entry
-          Type: 1400 EventRootType Probe[main.testMapArrayToArray]
+          Type: 1416 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0x8049e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1614,7 +1657,7 @@ Probes:
       subprogram: {subprogram: 70}
       events:
         - Kind: Entry
-          Type: 1407 EventRootType Probe[main.testMapEmbeddedMaps]
+          Type: 1423 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0x804a40", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1635,7 +1678,7 @@ Probes:
       subprogram: {subprogram: 80}
       events:
         - Kind: Entry
-          Type: 1417 EventRootType Probe[main.testMapEmptyKey]
+          Type: 1433 EventRootType Probe[main.testMapEmptyKey]
           InjectionPoints: [{PC: "0x804ae0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1656,7 +1699,7 @@ Probes:
       subprogram: {subprogram: 82}
       events:
         - Kind: Entry
-          Type: 1419 EventRootType Probe[main.testMapEmptyKeyAndValue]
+          Type: 1435 EventRootType Probe[main.testMapEmptyKeyAndValue]
           InjectionPoints: [{PC: "0x804b00", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1677,7 +1720,7 @@ Probes:
       subprogram: {subprogram: 81}
       events:
         - Kind: Entry
-          Type: 1418 EventRootType Probe[main.testMapEmptyValue]
+          Type: 1434 EventRootType Probe[main.testMapEmptyValue]
           InjectionPoints: [{PC: "0x804af0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1698,7 +1741,7 @@ Probes:
       subprogram: {subprogram: 68}
       events:
         - Kind: Entry
-          Type: 1404 EventRootType Probe[main.testMapIntToInt]
+          Type: 1420 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0x804a20", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1719,7 +1762,7 @@ Probes:
       subprogram: {subprogram: 79}
       events:
         - Kind: Entry
-          Type: 1416 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          Type: 1432 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0x804ad0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1740,7 +1783,7 @@ Probes:
       subprogram: {subprogram: 78}
       events:
         - Kind: Entry
-          Type: 1415 EventRootType Probe[main.testMapLargeKeySmallValue]
+          Type: 1431 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0x804ac0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1763,7 +1806,7 @@ Probes:
       subprogram: {subprogram: 69}
       events:
         - Kind: Entry
-          Type: 1405 EventRootType Probe[main.testMapMassive]
+          Type: 1421 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0x804a30", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1786,7 +1829,7 @@ Probes:
       subprogram: {subprogram: 69}
       events:
         - Kind: Entry
-          Type: 1406 EventRootType Probe[main.testMapMassive]
+          Type: 1422 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0x804a30", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1807,7 +1850,7 @@ Probes:
       subprogram: {subprogram: 77}
       events:
         - Kind: Entry
-          Type: 1414 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          Type: 1430 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0x804ab0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1828,7 +1871,7 @@ Probes:
       subprogram: {subprogram: 76}
       events:
         - Kind: Entry
-          Type: 1413 EventRootType Probe[main.testMapSmallKeySmallValue]
+          Type: 1429 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0x804aa0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1849,7 +1892,7 @@ Probes:
       subprogram: {subprogram: 62}
       events:
         - Kind: Entry
-          Type: 1398 EventRootType Probe[main.testMapStringToInt]
+          Type: 1414 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0x8049c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1870,7 +1913,7 @@ Probes:
       subprogram: {subprogram: 63}
       events:
         - Kind: Entry
-          Type: 1399 EventRootType Probe[main.testMapStringToSlice]
+          Type: 1415 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0x8049d0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1891,7 +1934,7 @@ Probes:
       subprogram: {subprogram: 61}
       events:
         - Kind: Entry
-          Type: 1397 EventRootType Probe[main.testMapStringToStruct]
+          Type: 1413 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0x8049b0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1912,7 +1955,7 @@ Probes:
       subprogram: {subprogram: 71}
       events:
         - Kind: Entry
-          Type: 1408 EventRootType Probe[main.testMapWithLinkedList]
+          Type: 1424 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0x804a50", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1933,7 +1976,7 @@ Probes:
       subprogram: {subprogram: 74}
       events:
         - Kind: Entry
-          Type: 1411 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          Type: 1427 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0x804a80", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1954,7 +1997,7 @@ Probes:
       subprogram: {subprogram: 75}
       events:
         - Kind: Entry
-          Type: 1412 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          Type: 1428 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0x804a90", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1975,7 +2018,7 @@ Probes:
       subprogram: {subprogram: 72}
       events:
         - Kind: Entry
-          Type: 1409 EventRootType Probe[main.testMapWithSmallValue]
+          Type: 1425 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0x804a60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1998,7 +2041,7 @@ Probes:
       subprogram: {subprogram: 73}
       events:
         - Kind: Entry
-          Type: 1410 EventRootType Probe[main.testMapWithSmallValueMassive]
+          Type: 1426 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0x804a70", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2019,7 +2062,7 @@ Probes:
       subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1535 EventRootType Probe[main.testMassiveString]
+          Type: 1551 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x808b70", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2041,7 +2084,7 @@ Probes:
       subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1536 EventRootType Probe[main.testMassiveString]
+          Type: 1552 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x808b70", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2087,11 +2130,11 @@ Probes:
       subprogram: {subprogram: 125}
       events:
         - Kind: Entry
-          Type: 1503 EventRootType Probe[main.testMixedArgsStackReturn]
+          Type: 1519 EventRootType Probe[main.testMixedArgsStackReturn]
           InjectionPoints: [{PC: "0x807e70", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1504 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          Type: 1520 EventRootType Probe[main.testMixedArgsStackReturn]Return
           InjectionPoints: [{PC: "0x807ffc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2156,11 +2199,11 @@ Probes:
       subprogram: {subprogram: 127}
       events:
         - Kind: Entry
-          Type: 1507 EventRootType Probe[main.testMultipleArrayArgs]
+          Type: 1523 EventRootType Probe[main.testMultipleArrayArgs]
           InjectionPoints: [{PC: "0x8080ec", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1508 EventRootType Probe[main.testMultipleArrayArgs]Return
+          Type: 1524 EventRootType Probe[main.testMultipleArrayArgs]Return
           InjectionPoints: [{PC: "0x808188", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2190,11 +2233,11 @@ Probes:
       subprogram: {subprogram: 123}
       events:
         - Kind: Entry
-          Type: 1499 EventRootType Probe[main.testMultipleLargeArgs]
+          Type: 1515 EventRootType Probe[main.testMultipleLargeArgs]
           InjectionPoints: [{PC: "0x807ab0", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1500 EventRootType Probe[main.testMultipleLargeArgs]Return
+          Type: 1516 EventRootType Probe[main.testMultipleLargeArgs]Return
           InjectionPoints: [{PC: "0x807c58", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2219,11 +2262,11 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1453 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1469 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x806e88", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1454 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1470 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x806f0c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2258,7 +2301,7 @@ Probes:
       subprogram: {subprogram: 85}
       events:
         - Kind: Entry
-          Type: 1423 EventRootType Probe[main.testMultipleSimpleParams]
+          Type: 1439 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0x805f50", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2298,11 +2341,11 @@ Probes:
       subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1449 EventRootType Probe[main.testNamedReturn]
+          Type: 1465 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0x806de8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1450 EventRootType Probe[main.testNamedReturn]Return
+          Type: 1466 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0x806e44", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2328,11 +2371,11 @@ Probes:
       subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1451 EventRootType Probe[main.testNamedReturn]
+          Type: 1467 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0x806de8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1452 EventRootType Probe[main.testNamedReturn]Return
+          Type: 1468 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0x806e44", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2359,7 +2402,7 @@ Probes:
       subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1544 EventRootType Probe[main.testNestedPointer]
+          Type: 1560 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0x808e00", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2383,7 +2426,7 @@ Probes:
       subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1545 EventRootType Probe[main.testNestedPointer]
+          Type: 1561 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0x808e00", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2413,7 +2456,7 @@ Probes:
       subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1546 EventRootType Probe[main.testNestedPointer]
+          Type: 1562 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0x808e00", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2437,7 +2480,7 @@ Probes:
       subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1547 EventRootType Probe[main.testNestedPointer]
+          Type: 1563 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0x808e00", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2463,7 +2506,7 @@ Probes:
       subprogram: {subprogram: 94}
       events:
         - Kind: Entry
-          Type: 1433 EventRootType Probe[main.testNilPointer]
+          Type: 1449 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0x806390", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2489,7 +2532,7 @@ Probes:
       subprogram: {subprogram: 138}
       events:
         - Kind: Entry
-          Type: 1521 EventRootType Probe[main.testNilSlice]
+          Type: 1537 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0x8087c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2515,7 +2558,7 @@ Probes:
       subprogram: {subprogram: 135}
       events:
         - Kind: Entry
-          Type: 1518 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 1534 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0x808790", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2549,7 +2592,7 @@ Probes:
       subprogram: {subprogram: 137}
       events:
         - Kind: Entry
-          Type: 1520 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 1536 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0x8087b0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2580,7 +2623,7 @@ Probes:
       subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1534 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 1550 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0x808b60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2601,7 +2644,7 @@ Probes:
       subprogram: {subprogram: 90}
       events:
         - Kind: Entry
-          Type: 1429 EventRootType Probe[main.testPointerLoop]
+          Type: 1445 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0x8062d0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2622,7 +2665,7 @@ Probes:
       subprogram: {subprogram: 67}
       events:
         - Kind: Entry
-          Type: 1403 EventRootType Probe[main.testPointerToMap]
+          Type: 1419 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0x804a10", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2643,7 +2686,7 @@ Probes:
       subprogram: {subprogram: 88}
       events:
         - Kind: Entry
-          Type: 1427 EventRootType Probe[main.testPointerToSimpleStruct]
+          Type: 1443 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0x8062b0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2664,11 +2707,11 @@ Probes:
       subprogram: {subprogram: 101}
       events:
         - Kind: Entry
-          Type: 1445 EventRootType Probe[main.testReturnsAny]
+          Type: 1461 EventRootType Probe[main.testReturnsAny]
           InjectionPoints: [{PC: "0x806ab8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1446 EventRootType Probe[main.testReturnsAny]Return
+          Type: 1462 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints:
             - PC: "0x806b40"
               Frameless: false
@@ -2702,11 +2745,11 @@ Probes:
       subprogram: {subprogram: 100}
       events:
         - Kind: Entry
-          Type: 1443 EventRootType Probe[main.testReturnsAnyAndError]
+          Type: 1459 EventRootType Probe[main.testReturnsAnyAndError]
           InjectionPoints: [{PC: "0x806938", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1444 EventRootType Probe[main.testReturnsAnyAndError]Return
+          Type: 1460 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
             - PC: "0x80698c"
               Frameless: false
@@ -2739,11 +2782,11 @@ Probes:
       subprogram: {subprogram: 110}
       events:
         - Kind: Entry
-          Type: 1473 EventRootType Probe[main.testReturnsArray]
+          Type: 1489 EventRootType Probe[main.testReturnsArray]
           InjectionPoints: [{PC: "0x80728c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1474 EventRootType Probe[main.testReturnsArray]Return
+          Type: 1490 EventRootType Probe[main.testReturnsArray]Return
           InjectionPoints: [{PC: "0x8072dc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2759,11 +2802,11 @@ Probes:
       subprogram: {subprogram: 111}
       events:
         - Kind: Entry
-          Type: 1475 EventRootType Probe[main.testReturnsArrayOne]
+          Type: 1491 EventRootType Probe[main.testReturnsArrayOne]
           InjectionPoints: [{PC: "0x807318", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1476 EventRootType Probe[main.testReturnsArrayOne]Return
+          Type: 1492 EventRootType Probe[main.testReturnsArrayOne]Return
           InjectionPoints: [{PC: "0x807350", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2779,11 +2822,11 @@ Probes:
       subprogram: {subprogram: 112}
       events:
         - Kind: Entry
-          Type: 1477 EventRootType Probe[main.testReturnsArrayZero]
+          Type: 1493 EventRootType Probe[main.testReturnsArrayZero]
           InjectionPoints: [{PC: "0x807388", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1478 EventRootType Probe[main.testReturnsArrayZero]Return
+          Type: 1494 EventRootType Probe[main.testReturnsArrayZero]Return
           InjectionPoints: [{PC: "0x8073bc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2799,11 +2842,11 @@ Probes:
       subprogram: {subprogram: 114}
       events:
         - Kind: Entry
-          Type: 1481 EventRootType Probe[main.testReturnsBacktrackInt]
+          Type: 1497 EventRootType Probe[main.testReturnsBacktrackInt]
           InjectionPoints: [{PC: "0x807478", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1482 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          Type: 1498 EventRootType Probe[main.testReturnsBacktrackInt]Return
           InjectionPoints: [{PC: "0x8074d8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2819,11 +2862,11 @@ Probes:
       subprogram: {subprogram: 120}
       events:
         - Kind: Entry
-          Type: 1493 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          Type: 1509 EventRootType Probe[main.testReturnsBoolAndUintptr]
           InjectionPoints: [{PC: "0x8077d8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1494 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          Type: 1510 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
           InjectionPoints: [{PC: "0x807814", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2839,11 +2882,11 @@ Probes:
       subprogram: {subprogram: 108}
       events:
         - Kind: Entry
-          Type: 1469 EventRootType Probe[main.testReturnsComplex]
+          Type: 1485 EventRootType Probe[main.testReturnsComplex]
           InjectionPoints: [{PC: "0x807148", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1470 EventRootType Probe[main.testReturnsComplex]Return
+          Type: 1486 EventRootType Probe[main.testReturnsComplex]Return
           InjectionPoints: [{PC: "0x807190", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2860,11 +2903,11 @@ Probes:
       subprogram: {subprogram: 99}
       events:
         - Kind: Entry
-          Type: 1441 EventRootType Probe[main.testReturnsError]
+          Type: 1457 EventRootType Probe[main.testReturnsError]
           InjectionPoints: [{PC: "0x8068b8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1442 EventRootType Probe[main.testReturnsError]Return
+          Type: 1458 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
             - PC: "0x8068ec"
               Frameless: false
@@ -2888,11 +2931,11 @@ Probes:
       subprogram: {subprogram: 96}
       events:
         - Kind: Entry
-          Type: 1435 EventRootType Probe[main.testReturnsInt]
+          Type: 1451 EventRootType Probe[main.testReturnsInt]
           InjectionPoints: [{PC: "0x8066c8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1436 EventRootType Probe[main.testReturnsInt]Return
+          Type: 1452 EventRootType Probe[main.testReturnsInt]Return
           InjectionPoints: [{PC: "0x806708", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2912,11 +2955,11 @@ Probes:
       subprogram: {subprogram: 98}
       events:
         - Kind: Entry
-          Type: 1439 EventRootType Probe[main.testReturnsIntAndFloat]
+          Type: 1455 EventRootType Probe[main.testReturnsIntAndFloat]
           InjectionPoints: [{PC: "0x8067e8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1440 EventRootType Probe[main.testReturnsIntAndFloat]Return
+          Type: 1456 EventRootType Probe[main.testReturnsIntAndFloat]Return
           InjectionPoints: [{PC: "0x806878", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2936,11 +2979,11 @@ Probes:
       subprogram: {subprogram: 97}
       events:
         - Kind: Entry
-          Type: 1437 EventRootType Probe[main.testReturnsIntPointer]
+          Type: 1453 EventRootType Probe[main.testReturnsIntPointer]
           InjectionPoints: [{PC: "0x806748", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1438 EventRootType Probe[main.testReturnsIntPointer]Return
+          Type: 1454 EventRootType Probe[main.testReturnsIntPointer]Return
           InjectionPoints: [{PC: "0x8067a4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2961,11 +3004,11 @@ Probes:
       subprogram: {subprogram: 102}
       events:
         - Kind: Entry
-          Type: 1447 EventRootType Probe[main.testReturnsInterface]
+          Type: 1463 EventRootType Probe[main.testReturnsInterface]
           InjectionPoints: [{PC: "0x806c98", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1448 EventRootType Probe[main.testReturnsInterface]Return
+          Type: 1464 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
             - PC: "0x806d50"
               Frameless: false
@@ -2989,11 +3032,11 @@ Probes:
       subprogram: {subprogram: 109}
       events:
         - Kind: Entry
-          Type: 1471 EventRootType Probe[main.testReturnsLargeStruct]
+          Type: 1487 EventRootType Probe[main.testReturnsLargeStruct]
           InjectionPoints: [{PC: "0x8071d0", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1472 EventRootType Probe[main.testReturnsLargeStruct]Return
+          Type: 1488 EventRootType Probe[main.testReturnsLargeStruct]Return
           InjectionPoints: [{PC: "0x807250", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3009,11 +3052,11 @@ Probes:
       subprogram: {subprogram: 107}
       events:
         - Kind: Entry
-          Type: 1467 EventRootType Probe[main.testReturnsManyFloats]
+          Type: 1483 EventRootType Probe[main.testReturnsManyFloats]
           InjectionPoints: [{PC: "0x807098", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1468 EventRootType Probe[main.testReturnsManyFloats]Return
+          Type: 1484 EventRootType Probe[main.testReturnsManyFloats]Return
           InjectionPoints: [{PC: "0x807118", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3029,11 +3072,11 @@ Probes:
       subprogram: {subprogram: 116}
       events:
         - Kind: Entry
-          Type: 1485 EventRootType Probe[main.testReturnsMixed]
+          Type: 1501 EventRootType Probe[main.testReturnsMixed]
           InjectionPoints: [{PC: "0x8075d8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1486 EventRootType Probe[main.testReturnsMixed]Return
+          Type: 1502 EventRootType Probe[main.testReturnsMixed]Return
           InjectionPoints: [{PC: "0x80762c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3049,11 +3092,11 @@ Probes:
       subprogram: {subprogram: 113}
       events:
         - Kind: Entry
-          Type: 1479 EventRootType Probe[main.testReturnsMixedStruct]
+          Type: 1495 EventRootType Probe[main.testReturnsMixedStruct]
           InjectionPoints: [{PC: "0x8073f8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1480 EventRootType Probe[main.testReturnsMixedStruct]Return
+          Type: 1496 EventRootType Probe[main.testReturnsMixedStruct]Return
           InjectionPoints: [{PC: "0x80743c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3069,11 +3112,11 @@ Probes:
       subprogram: {subprogram: 119}
       events:
         - Kind: Entry
-          Type: 1491 EventRootType Probe[main.testReturnsMultipleFloats]
+          Type: 1507 EventRootType Probe[main.testReturnsMultipleFloats]
           InjectionPoints: [{PC: "0x807768", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1492 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          Type: 1508 EventRootType Probe[main.testReturnsMultipleFloats]Return
           InjectionPoints: [{PC: "0x8077a8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3089,11 +3132,11 @@ Probes:
       subprogram: {subprogram: 118}
       events:
         - Kind: Entry
-          Type: 1489 EventRootType Probe[main.testReturnsOnlyFloat]
+          Type: 1505 EventRootType Probe[main.testReturnsOnlyFloat]
           InjectionPoints: [{PC: "0x8076f8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1490 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          Type: 1506 EventRootType Probe[main.testReturnsOnlyFloat]Return
           InjectionPoints: [{PC: "0x807734", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3109,11 +3152,11 @@ Probes:
       subprogram: {subprogram: 106}
       events:
         - Kind: Entry
-          Type: 1465 EventRootType Probe[main.testReturnsPrimitives]
+          Type: 1481 EventRootType Probe[main.testReturnsPrimitives]
           InjectionPoints: [{PC: "0x807008", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1466 EventRootType Probe[main.testReturnsPrimitives]Return
+          Type: 1482 EventRootType Probe[main.testReturnsPrimitives]Return
           InjectionPoints: [{PC: "0x80705c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3129,11 +3172,11 @@ Probes:
       subprogram: {subprogram: 117}
       events:
         - Kind: Entry
-          Type: 1487 EventRootType Probe[main.testReturnsStructWithArray]
+          Type: 1503 EventRootType Probe[main.testReturnsStructWithArray]
           InjectionPoints: [{PC: "0x80766c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1488 EventRootType Probe[main.testReturnsStructWithArray]Return
+          Type: 1504 EventRootType Probe[main.testReturnsStructWithArray]Return
           InjectionPoints: [{PC: "0x8076bc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3149,11 +3192,11 @@ Probes:
       subprogram: {subprogram: 115}
       events:
         - Kind: Entry
-          Type: 1483 EventRootType Probe[main.testReturnsWideStruct]
+          Type: 1499 EventRootType Probe[main.testReturnsWideStruct]
           InjectionPoints: [{PC: "0x807510", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1484 EventRootType Probe[main.testReturnsWideStruct]Return
+          Type: 1500 EventRootType Probe[main.testReturnsWideStruct]Return
           InjectionPoints: [{PC: "0x8075a0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3170,7 +3213,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - Kind: Entry
-          Type: 1325 EventRootType Probe[main.testRuneArray]
+          Type: 1341 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0x802a30", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3204,11 +3247,11 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1455 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1471 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x806e88", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1456 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1472 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x806f0c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3253,7 +3296,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 1346 EventRootType Probe[main.testSingleBool]
+          Type: 1362 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0x802ec0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3274,7 +3317,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - Kind: Entry
-          Type: 1344 EventRootType Probe[main.testSingleByte]
+          Type: 1360 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0x802ea0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3295,7 +3338,7 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 1357 EventRootType Probe[main.testSingleFloat32]
+          Type: 1373 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0x802f70", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3316,7 +3359,7 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - Kind: Entry
-          Type: 1358 EventRootType Probe[main.testSingleFloat64]
+          Type: 1374 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0x802f80", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3337,7 +3380,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 1347 EventRootType Probe[main.testSingleInt]
+          Type: 1363 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0x802ed0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3358,7 +3401,7 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - Kind: Entry
-          Type: 1349 EventRootType Probe[main.testSingleInt16]
+          Type: 1365 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0x802ef0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3380,7 +3423,7 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - Kind: Entry
-          Type: 1350 EventRootType Probe[main.testSingleInt32]
+          Type: 1366 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0x802f00", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3401,7 +3444,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - Kind: Entry
-          Type: 1351 EventRootType Probe[main.testSingleInt64]
+          Type: 1367 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0x802f10", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3429,7 +3472,7 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - Kind: Entry
-          Type: 1348 EventRootType Probe[main.testSingleInt8]
+          Type: 1364 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0x802ee0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3459,7 +3502,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 1345 EventRootType Probe[main.testSingleRune]
+          Type: 1361 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0x802eb0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3480,7 +3523,7 @@ Probes:
       subprogram: {subprogram: 143}
       events:
         - Kind: Entry
-          Type: 1528 EventRootType Probe[main.testSingleString]
+          Type: 1544 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0x808b20", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3501,7 +3544,7 @@ Probes:
       subprogram: {subprogram: 29}
       events:
         - Kind: Entry
-          Type: 1352 EventRootType Probe[main.testSingleUint]
+          Type: 1368 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0x802f20", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3522,7 +3565,7 @@ Probes:
       subprogram: {subprogram: 31}
       events:
         - Kind: Entry
-          Type: 1354 EventRootType Probe[main.testSingleUint16]
+          Type: 1370 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0x802f40", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3543,7 +3586,7 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - Kind: Entry
-          Type: 1355 EventRootType Probe[main.testSingleUint32]
+          Type: 1371 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0x802f50", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3564,7 +3607,7 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 1356 EventRootType Probe[main.testSingleUint64]
+          Type: 1372 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0x802f60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3585,7 +3628,7 @@ Probes:
       subprogram: {subprogram: 30}
       events:
         - Kind: Entry
-          Type: 1353 EventRootType Probe[main.testSingleUint8]
+          Type: 1369 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0x802f30", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3606,7 +3649,7 @@ Probes:
       subprogram: {subprogram: 140}
       events:
         - Kind: Entry
-          Type: 1524 EventRootType Probe[main.testSliceEmptyStructs]
+          Type: 1540 EventRootType Probe[main.testSliceEmptyStructs]
           InjectionPoints: [{PC: "0x8087e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3627,7 +3670,7 @@ Probes:
       subprogram: {subprogram: 132}
       events:
         - Kind: Entry
-          Type: 1515 EventRootType Probe[main.testSliceOfSlices]
+          Type: 1531 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0x808760", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3648,7 +3691,7 @@ Probes:
       subprogram: {subprogram: 65}
       events:
         - Kind: Entry
-          Type: 1401 EventRootType Probe[main.testSmallMap]
+          Type: 1417 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0x8049f0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3668,11 +3711,11 @@ Probes:
       subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1463 EventRootType Probe[main.testSomeNamedReturn]
+          Type: 1479 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0x806f48", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1464 EventRootType Probe[main.testSomeNamedReturn]Return
+          Type: 1480 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0x806fd0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3692,11 +3735,11 @@ Probes:
       subprogram: {subprogram: 126}
       events:
         - Kind: Entry
-          Type: 1505 EventRootType Probe[main.testStackArgRegReturns]
+          Type: 1521 EventRootType Probe[main.testStackArgRegReturns]
           InjectionPoints: [{PC: "0x808058", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1506 EventRootType Probe[main.testStackArgRegReturns]Return
+          Type: 1522 EventRootType Probe[main.testStackArgRegReturns]Return
           InjectionPoints: [{PC: "0x8080b4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3717,7 +3760,7 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - Kind: Entry
-          Type: 1326 EventRootType Probe[main.testStringArray]
+          Type: 1342 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0x802a40", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3738,7 +3781,7 @@ Probes:
       subprogram: {subprogram: 93}
       events:
         - Kind: Entry
-          Type: 1432 EventRootType Probe[main.testStringPointer]
+          Type: 1448 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0x806370", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3759,7 +3802,7 @@ Probes:
       subprogram: {subprogram: 136}
       events:
         - Kind: Entry
-          Type: 1519 EventRootType Probe[main.testStringSlice]
+          Type: 1535 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0x8087a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3780,7 +3823,7 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - Kind: Entry
-          Type: 1367 EventRootType Probe[main.testStringType1]
+          Type: 1383 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0x803400", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3801,7 +3844,7 @@ Probes:
       subprogram: {subprogram: 45}
       events:
         - Kind: Entry
-          Type: 1368 EventRootType Probe[main.testStringType2]
+          Type: 1384 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0x803410", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3822,7 +3865,7 @@ Probes:
       subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1543 EventRootType Probe[main.testStruct]
+          Type: 1559 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0x808da0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3848,7 +3891,7 @@ Probes:
       subprogram: {subprogram: 133}
       events:
         - Kind: Entry
-          Type: 1516 EventRootType Probe[main.testStructSlice]
+          Type: 1532 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0x808770", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3874,7 +3917,7 @@ Probes:
       subprogram: {subprogram: 59}
       events:
         - Kind: Entry
-          Type: 1395 EventRootType Probe[main.testStructWithAny]
+          Type: 1411 EventRootType Probe[main.testStructWithAny]
           InjectionPoints: [{PC: "0x804410", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3894,11 +3937,11 @@ Probes:
       subprogram: {subprogram: 128}
       events:
         - Kind: Entry
-          Type: 1509 EventRootType Probe[main.testStructWithArrayArg]
+          Type: 1525 EventRootType Probe[main.testStructWithArrayArg]
           InjectionPoints: [{PC: "0x8081bc", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1510 EventRootType Probe[main.testStructWithArrayArg]Return
+          Type: 1526 EventRootType Probe[main.testStructWithArrayArg]Return
           InjectionPoints: [{PC: "0x808244", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3919,7 +3962,7 @@ Probes:
       subprogram: {subprogram: 153}
       events:
         - Kind: Entry
-          Type: 1541 EventRootType Probe[main.testStructWithCyclicMaps]
+          Type: 1557 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0x808d00", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3939,7 +3982,7 @@ Probes:
       subprogram: {subprogram: 152}
       events:
         - Kind: Entry
-          Type: 1540 EventRootType Probe[main.testStructWithCyclicSlices]
+          Type: 1556 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0x808cf0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3965,7 +4008,7 @@ Probes:
       subprogram: {subprogram: 60}
       events:
         - Kind: Entry
-          Type: 1396 EventRootType Probe[main.testStructWithMap]
+          Type: 1412 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0x8049a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3996,7 +4039,7 @@ Probes:
       subprogram: {subprogram: 141}
       events:
         - Kind: Entry
-          Type: 1525 EventRootType Probe[main.testSubslices]
+          Type: 1541 EventRootType Probe[main.testSubslices]
           InjectionPoints: [{PC: "0x8087f0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4035,7 +4078,7 @@ Probes:
       subprogram: {subprogram: 151}
       events:
         - Kind: Entry
-          Type: 1539 EventRootType Probe[main.testSubstrings]
+          Type: 1555 EventRootType Probe[main.testSubstrings]
           InjectionPoints: [{PC: "0x808ba0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4067,11 +4110,11 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1457 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1473 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x806e88", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1458 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1474 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x806f0c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -4091,11 +4134,11 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1459 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1475 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x806e88", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1460 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1476 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x806f0c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -4117,11 +4160,11 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1461 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1477 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x806e88", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1462 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1478 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x806f0c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -4149,7 +4192,7 @@ Probes:
       subprogram: {subprogram: 144}
       events:
         - Kind: Entry
-          Type: 1529 EventRootType Probe[main.testThreeStrings]
+          Type: 1545 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0x808b30", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4180,7 +4223,7 @@ Probes:
       subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1530 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1546 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0x808b40", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4209,7 +4252,7 @@ Probes:
       subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1531 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1547 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0x808b40", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4240,7 +4283,7 @@ Probes:
       subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1532 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1548 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0x808b50", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4269,7 +4312,7 @@ Probes:
       subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1533 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1549 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0x808b50", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4300,7 +4343,7 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 1359 EventRootType Probe[main.testTypeAlias]
+          Type: 1375 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0x802f90", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4321,7 +4364,7 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - Kind: Entry
-          Type: 1335 EventRootType Probe[main.testUint16Array]
+          Type: 1351 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0x802ad0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4342,7 +4385,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - Kind: Entry
-          Type: 1336 EventRootType Probe[main.testUint32Array]
+          Type: 1352 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0x802ae0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4363,7 +4406,7 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - Kind: Entry
-          Type: 1337 EventRootType Probe[main.testUint64Array]
+          Type: 1353 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0x802af0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4384,7 +4427,7 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - Kind: Entry
-          Type: 1334 EventRootType Probe[main.testUint8Array]
+          Type: 1350 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0x802ac0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4405,7 +4448,7 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - Kind: Entry
-          Type: 1333 EventRootType Probe[main.testUintArray]
+          Type: 1349 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0x802ab0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4426,7 +4469,7 @@ Probes:
       subprogram: {subprogram: 92}
       events:
         - Kind: Entry
-          Type: 1431 EventRootType Probe[main.testUintPointer]
+          Type: 1447 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0x806300", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4447,7 +4490,7 @@ Probes:
       subprogram: {subprogram: 130}
       events:
         - Kind: Entry
-          Type: 1513 EventRootType Probe[main.testUintSlice]
+          Type: 1529 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0x808740", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4468,7 +4511,7 @@ Probes:
       subprogram: {subprogram: 149}
       events:
         - Kind: Entry
-          Type: 1537 EventRootType Probe[main.testUnitializedString]
+          Type: 1553 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0x808b80", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4489,7 +4532,7 @@ Probes:
       subprogram: {subprogram: 91}
       events:
         - Kind: Entry
-          Type: 1430 EventRootType Probe[main.testUnsafePointer]
+          Type: 1446 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0x8062e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4510,7 +4553,7 @@ Probes:
       subprogram: {subprogram: 20}
       events:
         - Kind: Entry
-          Type: 1343 EventRootType Probe[main.testVeryLargeArray]
+          Type: 1359 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0x802b60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4531,7 +4574,7 @@ Probes:
       subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1522 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1538 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x8087d0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4552,7 +4595,7 @@ Probes:
       subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1523 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1539 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x8087d0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4569,10 +4612,10 @@ Probes:
       template: testWhollyInlinedSubroutine
       segments: [testWhollyInlinedSubroutine]
       captureSnapshot: true
-      subprogram: {subprogram: 164}
+      subprogram: {subprogram: 165}
       events:
         - Kind: Entry
-          Type: 1563 EventRootType Probe[main.firstBehavior.DoSomething]
+          Type: 1580 EventRootType Probe[main.firstBehavior.DoSomething]
           InjectionPoints:
             - PC: "0x804278"
               Frameless: false
@@ -4580,7 +4623,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1564 EventRootType Probe[main.firstBehavior.DoSomething]Return
+          Type: 1581 EventRootType Probe[main.firstBehavior.DoSomething]Return
           InjectionPoints: [{PC: "0x8042a0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -4601,11 +4644,11 @@ Probes:
       subprogram: {subprogram: 129}
       events:
         - Kind: Entry
-          Type: 1511 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          Type: 1527 EventRootType Probe[main.testZeroSizeArgAndReturn]
           InjectionPoints: [{PC: "0x808278", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1512 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          Type: 1528 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
           InjectionPoints: [{PC: "0x8082dc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -8153,6 +8196,77 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 158
+      Name: main.executeStructFuncs
+      OutOfLinePCRanges: [0x808e70..0x8097c0]
+      InlinePCRanges: []
+      Variables:
+        - Name: n
+          Type: 327 StructureType main.nStruct
+          Locations:
+            - Range: 0x808e98..0x80908c
+              Pieces:
+                - Size: 1
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 2
+                  Op: null
+          Role: Local
+        - Name: ns
+          Type: 268 StructureType main.structWithNoStrings
+          Locations: [{Range: 0x808e70..0x8097c0, Pieces: []}]
+          Role: Local
+        - Name: cs
+          Type: 328 StructureType main.cStruct
+          Locations: [{Range: 0x808e70..0x8097c0, Pieces: []}]
+          Role: Local
+        - Name: rcvr
+          Type: 329 StructureType main.receiver
+          Locations: [{Range: 0x808e70..0x8097c0, Pieces: []}]
+          Role: Local
+        - Name: ts
+          Type: 330 StructureType main.threestrings
+          Locations:
+            - Range: 0x808e98..0x8097c0
+              Pieces: [{Size: 48, Op: {CfaOffset: -2072}}]
+          Role: Local
+        - Name: s
+          Type: 322 StructureType main.aStruct
+          Locations:
+            - Range: 0x808edc..0x8097c0
+              Pieces: [{Size: 56, Op: {CfaOffset: -1912}}]
+          Role: Local
+        - Name: b
+          Type: 331 StructureType main.bStruct
+          Locations:
+            - Range: 0x808f2c..0x8097c0
+              Pieces: [{Size: 72, Op: {CfaOffset: -2072}}]
+          Role: Local
+        - Name: tenStr
+          Type: 332 StructureType main.tenStrings
+          Locations:
+            - Range: 0x809104..0x8097c0
+              Pieces: [{Size: 160, Op: {CfaOffset: -2072}}]
+          Role: Local
+        - Name: deep
+          Type: 333 StructureType main.deepStruct1
+          Locations:
+            - Range: 0x809168..0x8097c0
+              Pieces: [{Size: 48, Op: {CfaOffset: -2160}}]
+          Role: Local
+        - Name: fields
+          Type: 339 StructureType main.lotsOfFields
+          Locations:
+            - Range: 0x8091bc..0x8097c0
+              Pieces: [{Size: 26, Op: {CfaOffset: -2160}}]
+          Role: Local
+        - Name: sta
+          Type: 340 StructureType main.structWithTwoArrays
+          Locations:
+            - Range: 0x809214..0x8097c0
+              Pieces: [{Size: 72, Op: {CfaOffset: -2160}}]
+          Role: Local
+    - ID: 159
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0x803c60..0x803cd0]
       InlinePCRanges:
@@ -8181,28 +8295,28 @@ Subprograms:
             - Range: 0x803f40..0x803f64
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 159
+    - ID: 160
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x803ee4..0x803f18]
           RootRanges: [0x803e80..0x803f40]
       Variables: []
-    - ID: 160
+    - ID: 161
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x803fcc..0x804000, 0x804008..0x80400c]
           RootRanges: [0x803fb0..0x8040c0]
       Variables: []
-    - ID: 161
+    - ID: 162
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x804070..0x8040a4]
           RootRanges: [0x803fb0..0x8040c0]
       Variables: []
-    - ID: 162
+    - ID: 163
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -8215,7 +8329,7 @@ Subprograms:
             - Range: 0x8040c0..0x8040c8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 163
+    - ID: 164
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -8232,7 +8346,7 @@ Subprograms:
             - Range: 0x804168..0x804260
               Pieces: [{Size: 40, Op: {CfaOffset: -120}}]
           Role: Parameter
-    - ID: 164
+    - ID: 165
       Name: main.firstBehavior.DoSomething
       OutOfLinePCRanges: [0x804260..0x8042c0]
       InlinePCRanges:
@@ -8240,7 +8354,7 @@ Subprograms:
           RootRanges: [0x809930..0x8099a0]
       Variables:
         - Name: b
-          Type: 327 StructureType main.firstBehavior
+          Type: 343 StructureType main.firstBehavior
           Locations:
             - Range: 0x804260..0x804284
               Pieces:
@@ -8263,7 +8377,7 @@ Subprograms:
             - Range: 0x8042a1..0x8042c0
               Pieces: []
           Role: Return
-    - ID: 165
+    - ID: 166
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -8279,20 +8393,20 @@ Types:
       ByteSize: 8
       Pointee: 146 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 1239
+      ID: 1255
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 1240 PointerType *main.deepSlice3
+      Pointee: 1256 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 1264
+      ID: 1280
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 1265 PointerType *main.deepSlice8
+      Pointee: 1281 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 1270
+      ID: 1286
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 1271 PointerType *main.deepSlice9
+      Pointee: 1287 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 159
       Name: '**main.stringType2'
@@ -8300,7 +8414,7 @@ Types:
       GoKind: 22
       Pointee: 160 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 1235
+      ID: 1251
       Name: '**main.t'
       ByteSize: 8
       Pointee: 254 PointerType *main.t
@@ -8343,30 +8457,30 @@ Types:
       ByteSize: 8
       Pointee: 154 PointerType *table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1247
+      ID: 1263
       Name: '**table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1248 PointerType *table<int,*main.deepMap3>
+      Pointee: 1264 PointerType *table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1281
+      ID: 1297
       Name: '**table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1282 PointerType *table<int,*main.deepMap8>
+      Pointee: 1298 PointerType *table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1296
+      ID: 1312
       Name: '**table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1297 PointerType *table<int,*main.deepMap9>
+      Pointee: 1313 PointerType *table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 175
       Name: '**table<int,int>'
       ByteSize: 8
       Pointee: 176 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 1311
+      ID: 1327
       Name: '**table<int,interface {}>'
       ByteSize: 8
-      Pointee: 1312 PointerType *table<int,interface {}>
+      Pointee: 1328 PointerType *table<int,interface {}>
     - __kind: PointerType
       ID: 242
       Name: '**table<int,struct {}>'
@@ -8388,10 +8502,10 @@ Types:
       ByteSize: 8
       Pointee: 191 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 983
+      ID: 999
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 984 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 1000 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 185
       Name: '**table<string,int>'
@@ -8453,120 +8567,120 @@ Types:
       ByteSize: 8
       Pointee: 218 PointerType *table<uint8,uint8>
     - __kind: PointerType
-      ID: 341
+      ID: 357
       Name: '*[]*main.deepSlice2.array'
       ByteSize: 8
-      Pointee: 340 GoSliceDataType []*main.deepSlice2.array
+      Pointee: 356 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 1243
+      ID: 1259
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 1242 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 1258 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 1268
+      ID: 1284
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 1267 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 1283 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 1274
+      ID: 1290
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 1273 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 1289 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
-      ID: 336
+      ID: 352
       Name: '*[]*runtime.p.array'
       ByteSize: 8
-      Pointee: 335 GoSliceDataType []*runtime.p.array
+      Pointee: 351 GoSliceDataType []*runtime.p.array
     - __kind: PointerType
-      ID: 338
+      ID: 354
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 337 GoSliceDataType []*string.array
+      Pointee: 353 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 501
+      ID: 517
       Name: '*[][][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 500 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Pointee: 516 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 290
       Name: '*[][][][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 287 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 499
+      ID: 515
       Name: '*[][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 498 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Pointee: 514 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 288
       Name: '*[][][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 285 GoSliceHeaderType [][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 497
+      ID: 513
       Name: '*[][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 496 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Pointee: 512 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 286
       Name: '*[][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 283 GoSliceHeaderType [][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 495
+      ID: 511
       Name: '*[][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 494 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Pointee: 510 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 284
       Name: '*[][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 281 GoSliceHeaderType [][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 493
+      ID: 509
       Name: '*[][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 492 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Pointee: 508 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 479
+      ID: 495
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 478 GoSliceDataType [][]uint.array
+      Pointee: 494 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 485
+      ID: 501
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 484 GoSliceDataType []bool.array
+      Pointee: 500 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 1020
+      ID: 1036
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 1019 GoSliceDataType []float64.array
+      Pointee: 1035 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 1277
+      ID: 1293
       Name: '*[]interface {}.array'
       ByteSize: 8
-      Pointee: 1276 GoSliceDataType []interface {}.array
+      Pointee: 1292 GoSliceDataType []interface {}.array
     - __kind: PointerType
       ID: 282
       Name: '*[]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 279 GoSliceHeaderType []main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 491
+      ID: 507
       Name: '*[]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 490 GoSliceDataType []main.structWithCyclicSlices.array
+      Pointee: 506 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 551
+      ID: 567
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 550 GoSliceDataType []main.structWithMap.array
+      Pointee: 566 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 481
+      ID: 497
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 480 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 496 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
       ID: 40
       Name: '*[]runtime.ancestorInfo'
@@ -8575,101 +8689,101 @@ Types:
       GoKind: 22
       Pointee: 41 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 483
+      ID: 499
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 482 GoSliceDataType []string.array
+      Pointee: 498 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 489
+      ID: 505
       Name: '*[]struct {}.array'
       ByteSize: 8
-      Pointee: 488 GoSliceDataType []struct {}.array
+      Pointee: 504 GoSliceDataType []struct {}.array
     - __kind: PointerType
       ID: 265
       Name: '*[]uint'
       ByteSize: 8
       Pointee: 263 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 477
+      ID: 493
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 476 GoSliceDataType []uint.array
+      Pointee: 492 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 487
+      ID: 503
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 486 GoSliceDataType []uint16.array
+      Pointee: 502 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 331
+      ID: 347
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 330 GoSliceDataType []uint8.array
+      Pointee: 346 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 333
+      ID: 349
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 332 GoSliceDataType []uintptr.array
+      Pointee: 348 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 1151
+      ID: 1167
       Name: '*archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 2.008256e+06
       GoKind: 22
-      Pointee: 1152 UnresolvedPointeeType archive/tar.Writer
+      Pointee: 1168 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
-      ID: 785
+      ID: 801
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 940576
       GoKind: 22
-      Pointee: 786 GoSliceHeaderType archive/tar.headerError
+      Pointee: 802 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 788
+      ID: 804
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 787 GoSliceDataType archive/tar.headerError.array
+      Pointee: 803 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 1085
+      ID: 1101
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.447584e+06
       GoKind: 22
-      Pointee: 1086 UnresolvedPointeeType archive/tar.regFileWriter
+      Pointee: 1102 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
-      ID: 1033
+      ID: 1049
       Name: '*archive/zip.countWriter'
       ByteSize: 8
       GoRuntimeType: 940768
       GoKind: 22
-      Pointee: 1034 UnresolvedPointeeType archive/zip.countWriter
+      Pointee: 1050 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
-      ID: 1035
+      ID: 1051
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
       GoRuntimeType: 940864
       GoKind: 22
-      Pointee: 1036 StructureType archive/zip.dirWriter
+      Pointee: 1052 StructureType archive/zip.dirWriter
     - __kind: PointerType
-      ID: 1128
+      ID: 1144
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.924288e+06
       GoKind: 22
-      Pointee: 1129 UnresolvedPointeeType archive/zip.fileWriter
+      Pointee: 1145 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
-      ID: 1061
+      ID: 1077
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1.066496e+06
       GoKind: 22
-      Pointee: 1062 StructureType archive/zip.nopCloser
+      Pointee: 1078 StructureType archive/zip.nopCloser
     - __kind: PointerType
-      ID: 1063
+      ID: 1079
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
       GoRuntimeType: 1.066752e+06
       GoKind: 22
-      Pointee: 1064 UnresolvedPointeeType archive/zip.pooledFlateWriter
+      Pointee: 1080 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 10
       Name: '*bool'
@@ -8678,26 +8792,26 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 1109
+      ID: 1125
       Name: '*bufio.Reader'
       ByteSize: 8
       GoRuntimeType: 2.197632e+06
       GoKind: 22
-      Pointee: 1110 UnresolvedPointeeType bufio.Reader
+      Pointee: 1126 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
-      ID: 1138
+      ID: 1154
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1.970304e+06
       GoKind: 22
-      Pointee: 1139 UnresolvedPointeeType bufio.Writer
+      Pointee: 1155 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
-      ID: 1187
+      ID: 1203
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.299616e+06
       GoKind: 22
-      Pointee: 1188 UnresolvedPointeeType bytes.Buffer
+      Pointee: 1204 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
       ID: 114
       Name: '*complex128'
@@ -8706,388 +8820,388 @@ Types:
       GoKind: 22
       Pointee: 18 BaseType complex128
     - __kind: PointerType
-      ID: 700
+      ID: 716
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 922816
       GoKind: 22
-      Pointee: 589 BaseType compress/flate.CorruptInputError
+      Pointee: 605 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 701
+      ID: 717
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 922912
       GoKind: 22
-      Pointee: 590 GoStringHeaderType compress/flate.InternalError
+      Pointee: 606 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 592
+      ID: 608
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 591 GoStringDataType compress/flate.InternalError.str
+      Pointee: 607 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 1083
+      ID: 1099
       Name: '*compress/flate.Writer'
       ByteSize: 8
       GoRuntimeType: 1.436384e+06
       GoKind: 22
-      Pointee: 1084 UnresolvedPointeeType compress/flate.Writer
+      Pointee: 1100 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
-      ID: 1029
+      ID: 1045
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
       GoRuntimeType: 923008
       GoKind: 22
-      Pointee: 1030 UnresolvedPointeeType compress/flate.dictWriter
+      Pointee: 1046 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
-      ID: 1105
+      ID: 1121
       Name: '*compress/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.743648e+06
       GoKind: 22
-      Pointee: 1106 UnresolvedPointeeType compress/gzip.Writer
+      Pointee: 1122 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
-      ID: 933
+      ID: 949
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.21216e+06
       GoKind: 22
-      Pointee: 934 StructureType context.deadlineExceededError
+      Pointee: 950 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 777
+      ID: 793
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 935200
       GoKind: 22
-      Pointee: 600 BaseType crypto/aes.KeySizeError
+      Pointee: 616 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 778
+      ID: 794
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 935392
       GoKind: 22
-      Pointee: 601 BaseType crypto/des.KeySizeError
+      Pointee: 617 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 779
+      ID: 795
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 935680
       GoKind: 22
-      Pointee: 602 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 618 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 1100
+      ID: 1116
       Name: '*crypto/internal/fips140/hmac.HMAC'
       ByteSize: 8
       GoRuntimeType: 1.684192e+06
       GoKind: 22
-      Pointee: 1101 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
+      Pointee: 1117 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
     - __kind: PointerType
-      ID: 882
+      ID: 898
       Name: '*crypto/internal/fips140/hmac.errCloneUnsupported'
       ByteSize: 8
       GoRuntimeType: 1.074304e+06
       GoKind: 22
-      Pointee: 883 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
+      Pointee: 899 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
     - __kind: PointerType
-      ID: 1130
+      ID: 1146
       Name: '*crypto/internal/fips140/sha256.Digest'
       ByteSize: 8
       GoRuntimeType: 1.9248e+06
       GoKind: 22
-      Pointee: 1131 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
+      Pointee: 1147 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
     - __kind: PointerType
-      ID: 1162
+      ID: 1178
       Name: '*crypto/internal/fips140/sha3.Digest'
       ByteSize: 8
       GoRuntimeType: 2.141632e+06
       GoKind: 22
-      Pointee: 1163 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
+      Pointee: 1179 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
     - __kind: PointerType
-      ID: 1136
+      ID: 1152
       Name: '*crypto/internal/fips140/sha3.SHAKE'
       ByteSize: 8
       GoRuntimeType: 1.925568e+06
       GoKind: 22
-      Pointee: 1137 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
+      Pointee: 1153 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
     - __kind: PointerType
-      ID: 1132
+      ID: 1148
       Name: '*crypto/internal/fips140/sha512.Digest'
       ByteSize: 8
       GoRuntimeType: 1.925056e+06
       GoKind: 22
-      Pointee: 1133 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
+      Pointee: 1149 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
     - __kind: PointerType
-      ID: 1126
+      ID: 1142
       Name: '*crypto/md5.digest'
       ByteSize: 8
       GoRuntimeType: 1.92224e+06
       GoKind: 22
-      Pointee: 1127 UnresolvedPointeeType crypto/md5.digest
+      Pointee: 1143 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
-      ID: 780
+      ID: 796
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 935968
       GoKind: 22
-      Pointee: 603 BaseType crypto/rc4.KeySizeError
+      Pointee: 619 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 1149
+      ID: 1165
       Name: '*crypto/sha1.digest'
       ByteSize: 8
       GoRuntimeType: 2.005952e+06
       GoKind: 22
-      Pointee: 1150 UnresolvedPointeeType crypto/sha1.digest
+      Pointee: 1166 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
-      ID: 1134
+      ID: 1150
       Name: '*crypto/sha3.SHA3'
       ByteSize: 8
       GoRuntimeType: 1.925312e+06
       GoKind: 22
-      Pointee: 1135 UnresolvedPointeeType crypto/sha3.SHA3
+      Pointee: 1151 UnresolvedPointeeType crypto/sha3.SHA3
     - __kind: PointerType
-      ID: 1118
+      ID: 1134
       Name: '*crypto/sha3.SHAKE'
       ByteSize: 8
       GoRuntimeType: 1.8272e+06
       GoKind: 22
-      Pointee: 1119 UnresolvedPointeeType crypto/sha3.SHAKE
+      Pointee: 1135 UnresolvedPointeeType crypto/sha3.SHAKE
     - __kind: PointerType
-      ID: 704
+      ID: 720
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 924256
       GoKind: 22
-      Pointee: 593 BaseType crypto/tls.AlertError
+      Pointee: 609 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 871
+      ID: 887
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1.055744e+06
       GoKind: 22
-      Pointee: 872 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 888 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 1213
+      ID: 1229
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2.402144e+06
       GoKind: 22
-      Pointee: 1214 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 1230 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 705
+      ID: 721
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 924352
       GoKind: 22
-      Pointee: 706 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 722 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 702
+      ID: 718
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 924160
       GoKind: 22
-      Pointee: 703 StructureType crypto/tls.RecordHeaderError
+      Pointee: 719 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 870
+      ID: 886
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1.05408e+06
       GoKind: 22
-      Pointee: 825 BaseType crypto/tls.alert
+      Pointee: 841 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 1093
+      ID: 1109
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
       GoRuntimeType: 1.574496e+06
       GoKind: 22
-      Pointee: 1094 UnresolvedPointeeType crypto/tls.cthWrapper
+      Pointee: 1110 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
-      ID: 707
+      ID: 723
       Name: '*crypto/tls.echConfigErr'
       ByteSize: 8
       GoRuntimeType: 924448
       GoKind: 22
-      Pointee: 708 UnresolvedPointeeType crypto/tls.echConfigErr
+      Pointee: 724 UnresolvedPointeeType crypto/tls.echConfigErr
     - __kind: PointerType
-      ID: 1098
+      ID: 1114
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
       GoRuntimeType: 1.658272e+06
       GoKind: 22
-      Pointee: 1099 UnresolvedPointeeType crypto/tls.finishedHash
+      Pointee: 1115 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
-      ID: 968
+      ID: 984
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1.436864e+06
       GoKind: 22
-      Pointee: 969 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 985 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 985
+      ID: 1001
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.034592e+06
       GoKind: 22
-      Pointee: 986 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 1002 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 773
+      ID: 789
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 934048
       GoKind: 22
-      Pointee: 774 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 790 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 767
+      ID: 783
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 933088
       GoKind: 22
-      Pointee: 768 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 784 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 769
+      ID: 785
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 933568
       GoKind: 22
-      Pointee: 770 StructureType crypto/x509.HostnameError
+      Pointee: 786 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 766
+      ID: 782
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 932992
       GoKind: 22
-      Pointee: 599 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 615 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 876
+      ID: 892
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1.060992e+06
       GoKind: 22
-      Pointee: 877 StructureType crypto/x509.SystemRootsError
+      Pointee: 893 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 775
+      ID: 791
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 934144
       GoKind: 22
-      Pointee: 776 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 792 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 771
+      ID: 787
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 933952
       GoKind: 22
-      Pointee: 772 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 788 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 789
+      ID: 805
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 941056
       GoKind: 22
-      Pointee: 790 StructureType encoding/asn1.StructuralError
+      Pointee: 806 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 793
+      ID: 809
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 941248
       GoKind: 22
-      Pointee: 794 StructureType encoding/asn1.SyntaxError
+      Pointee: 810 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 791
+      ID: 807
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 941152
       GoKind: 22
-      Pointee: 792 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 808 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 689
+      ID: 705
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 920800
       GoKind: 22
-      Pointee: 584 BaseType encoding/base64.CorruptInputError
+      Pointee: 600 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 1051
+      ID: 1067
       Name: '*encoding/base64.encoder'
       ByteSize: 8
       GoRuntimeType: 1.051136e+06
       GoKind: 22
-      Pointee: 1052 UnresolvedPointeeType encoding/base64.encoder
+      Pointee: 1068 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
-      ID: 692
+      ID: 708
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 921664
       GoKind: 22
-      Pointee: 585 BaseType encoding/hex.InvalidByteError
+      Pointee: 601 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 660
+      ID: 676
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 915616
       GoKind: 22
-      Pointee: 661 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 677 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 860
+      ID: 876
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1.047296e+06
       GoKind: 22
-      Pointee: 861 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 877 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 652
+      ID: 668
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 915232
       GoKind: 22
-      Pointee: 653 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 669 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 658
+      ID: 674
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 915520
       GoKind: 22
-      Pointee: 659 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 675 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 656
+      ID: 672
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 915424
       GoKind: 22
-      Pointee: 657 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 673 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 654
+      ID: 670
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 915328
       GoKind: 22
-      Pointee: 655 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 671 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 1193
+      ID: 1209
       Name: '*encoding/json.encodeState'
       ByteSize: 8
       GoRuntimeType: 2.320736e+06
       GoKind: 22
-      Pointee: 1194 UnresolvedPointeeType encoding/json.encodeState
+      Pointee: 1210 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 662
+      ID: 678
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 916000
       GoKind: 22
-      Pointee: 663 StructureType encoding/json.jsonError
+      Pointee: 679 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 1059
+      ID: 1075
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
       GoRuntimeType: 1.063296e+06
       GoKind: 22
-      Pointee: 1060 UnresolvedPointeeType encoding/pem.lineBreaker
+      Pointee: 1076 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
-      ID: 764
+      ID: 780
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 932224
       GoKind: 22
-      Pointee: 765 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 781 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
       ID: 111
       Name: '*error'
@@ -9096,19 +9210,19 @@ Types:
       GoKind: 22
       Pointee: 15 GoInterfaceType error
     - __kind: PointerType
-      ID: 625
+      ID: 641
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 905248
       GoKind: 22
-      Pointee: 626 UnresolvedPointeeType errors.errorString
+      Pointee: 642 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 827
+      ID: 843
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1.031936e+06
       GoKind: 22
-      Pointee: 828 UnresolvedPointeeType errors.joinError
+      Pointee: 844 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 113
       Name: '*float32'
@@ -9124,813 +9238,813 @@ Types:
       GoKind: 22
       Pointee: 14 BaseType float64
     - __kind: PointerType
-      ID: 1181
+      ID: 1197
       Name: '*fmt.pp'
       ByteSize: 8
       GoRuntimeType: 2.282176e+06
       GoKind: 22
-      Pointee: 1182 UnresolvedPointeeType fmt.pp
+      Pointee: 1198 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
-      ID: 829
+      ID: 845
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.032064e+06
       GoKind: 22
-      Pointee: 830 UnresolvedPointeeType fmt.wrapError
+      Pointee: 846 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 831
+      ID: 847
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1.032192e+06
       GoKind: 22
-      Pointee: 832 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 848 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 690
+      ID: 706
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 921184
       GoKind: 22
-      Pointee: 691 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 707 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 671
+      ID: 687
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 918400
       GoKind: 22
-      Pointee: 672 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 688 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 673
+      ID: 689
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 918496
       GoKind: 22
-      Pointee: 674 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 690 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 997
+      ID: 1013
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 918208
       GoKind: 22
-      Pointee: 998 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 1014 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 677
+      ID: 693
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 918784
       GoKind: 22
-      Pointee: 678 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 694 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 999
+      ID: 1015
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 918304
       GoKind: 22
-      Pointee: 1000 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 1016 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 675
+      ID: 691
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 918592
       GoKind: 22
-      Pointee: 578 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 594 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 580
+      ID: 596
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 579 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 595 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 670
+      ID: 686
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 918112
       GoKind: 22
-      Pointee: 575 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 591 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 577
+      ID: 593
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 576 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 592 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 676
+      ID: 692
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 918688
       GoKind: 22
-      Pointee: 581 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 597 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 583
+      ID: 599
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 582 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 598 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 1071
+      ID: 1087
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
       GoRuntimeType: 1.217664e+06
       GoKind: 22
-      Pointee: 1072 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      Pointee: 1088 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
-      ID: 1159
+      ID: 1175
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
       GoRuntimeType: 2.079744e+06
       GoKind: 22
-      Pointee: 1160 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      Pointee: 1176 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
-      ID: 783
+      ID: 799
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 939520
       GoKind: 22
-      Pointee: 784 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 800 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 942
+      ID: 958
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1.22112e+06
       GoKind: 22
-      Pointee: 943 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 959 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 1189
+      ID: 1205
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
       GoRuntimeType: 2.30016e+06
       GoKind: 22
-      Pointee: 1190 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      Pointee: 1206 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
-      ID: 715
+      ID: 731
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 927904
       GoKind: 22
-      Pointee: 716 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 732 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 722
+      ID: 738
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 928960
       GoKind: 22
-      Pointee: 723 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 739 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 717
+      ID: 733
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 928672
       GoKind: 22
-      Pointee: 598 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 614 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 720
+      ID: 736
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 928864
       GoKind: 22
-      Pointee: 721 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 737 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 718
+      ID: 734
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 928768
       GoKind: 22
-      Pointee: 719 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 735 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 738
+      ID: 754
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 930880
       GoKind: 22
-      Pointee: 739 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 755 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 742
+      ID: 758
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 931072
       GoKind: 22
-      Pointee: 743 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 759 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 740
+      ID: 756
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 930976
       GoKind: 22
-      Pointee: 741 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 757 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 736
+      ID: 752
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 930784
       GoKind: 22
-      Pointee: 737 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 753 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 1022
+      ID: 1038
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 1021 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 1037 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 750
+      ID: 766
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 931456
       GoKind: 22
-      Pointee: 751 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 767 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 744
+      ID: 760
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 931168
       GoKind: 22
-      Pointee: 745 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 761 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 748
+      ID: 764
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 931360
       GoKind: 22
-      Pointee: 749 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 765 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 746
+      ID: 762
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 931264
       GoKind: 22
-      Pointee: 747 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 763 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 752
+      ID: 768
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 931552
       GoKind: 22
-      Pointee: 753 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 769 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 758
+      ID: 774
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 931840
       GoKind: 22
-      Pointee: 759 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 775 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 760
+      ID: 776
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 931936
       GoKind: 22
-      Pointee: 761 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 777 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 756
+      ID: 772
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 931744
       GoKind: 22
-      Pointee: 757 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 773 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 754
+      ID: 770
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 931648
       GoKind: 22
-      Pointee: 755 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 771 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 762
+      ID: 778
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 932128
       GoKind: 22
-      Pointee: 763 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 779 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 679
+      ID: 695
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 919936
       GoKind: 22
-      Pointee: 680 StructureType github.com/cihub/seelog.baseError
+      Pointee: 696 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 1112
+      ID: 1128
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1.821824e+06
       GoKind: 22
-      Pointee: 1113 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 1129 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 681
+      ID: 697
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 920032
       GoKind: 22
-      Pointee: 682 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 698 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 1091
+      ID: 1107
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
       GoRuntimeType: 1.573216e+06
       GoKind: 22
-      Pointee: 1092 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+      Pointee: 1108 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
-      ID: 1047
+      ID: 1063
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
       GoRuntimeType: 1.049984e+06
       GoKind: 22
-      Pointee: 1048 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+      Pointee: 1064 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
-      ID: 1081
+      ID: 1097
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.434464e+06
       GoKind: 22
-      Pointee: 1082 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+      Pointee: 1098 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
-      ID: 685
+      ID: 701
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 920224
       GoKind: 22
-      Pointee: 686 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 702 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 1147
+      ID: 1163
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.997888e+06
       GoKind: 22
-      Pointee: 1148 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+      Pointee: 1164 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
-      ID: 1166
+      ID: 1182
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
       GoRuntimeType: 2.155424e+06
       GoKind: 22
-      Pointee: 1161 StructureType github.com/cihub/seelog.rollingFileWriterSize
+      Pointee: 1177 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
-      ID: 1165
+      ID: 1181
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
       GoRuntimeType: 2.15504e+06
       GoKind: 22
-      Pointee: 1164 StructureType github.com/cihub/seelog.rollingFileWriterTime
+      Pointee: 1180 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
-      ID: 1049
+      ID: 1065
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
       GoRuntimeType: 1.050112e+06
       GoKind: 22
-      Pointee: 1050 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+      Pointee: 1066 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
-      ID: 683
+      ID: 699
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 920128
       GoKind: 22
-      Pointee: 684 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 700 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 687
+      ID: 703
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 920320
       GoKind: 22
-      Pointee: 688 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 704 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 1114
+      ID: 1130
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.823616e+06
       GoKind: 22
-      Pointee: 1115 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+      Pointee: 1131 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
-      ID: 1155
+      ID: 1171
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 2.034304e+06
       GoKind: 22
-      Pointee: 1156 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+      Pointee: 1172 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
-      ID: 1157
+      ID: 1173
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
       GoRuntimeType: 2.065376e+06
       GoKind: 22
-      Pointee: 1158 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+      Pointee: 1174 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
-      ID: 973
+      ID: 989
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1.449984e+06
       GoKind: 22
-      Pointee: 974 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 990 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 886
+      ID: 902
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.075072e+06
       GoKind: 22
-      Pointee: 887 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 903 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 884
+      ID: 900
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1.074944e+06
       GoKind: 22
-      Pointee: 885 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 901 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 888
+      ID: 904
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.07904e+06
       GoKind: 22
-      Pointee: 889 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 905 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 890
+      ID: 906
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1.079168e+06
       GoKind: 22
-      Pointee: 891 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 907 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 1102
+      ID: 1118
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
       GoRuntimeType: 1.687072e+06
       GoKind: 22
-      Pointee: 1103 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+      Pointee: 1119 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
-      ID: 878
+      ID: 894
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.061504e+06
       GoKind: 22
-      Pointee: 879 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 895 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 693
+      ID: 709
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 921856
       GoKind: 22
-      Pointee: 694 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 710 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 1205
+      ID: 1221
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
       GoRuntimeType: 2.376064e+06
       GoKind: 22
-      Pointee: 1206 UnresolvedPointeeType github.com/json-iterator/go.Stream
+      Pointee: 1222 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
-      ID: 944
+      ID: 960
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1.230208e+06
       GoKind: 22
-      Pointee: 945 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 961 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 917
+      ID: 933
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1.208704e+06
       GoKind: 22
-      Pointee: 918 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 934 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 911
+      ID: 927
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1.20832e+06
       GoKind: 22
-      Pointee: 912 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 928 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 846
+      ID: 862
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1.041152e+06
       GoKind: 22
-      Pointee: 847 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 863 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 923
+      ID: 939
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1.209088e+06
       GoKind: 22
-      Pointee: 924 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 940 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 845
+      ID: 861
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1.041024e+06
       GoKind: 22
-      Pointee: 824 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 840 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 915
+      ID: 931
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1.208576e+06
       GoKind: 22
-      Pointee: 916 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 932 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 913
+      ID: 929
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1.208448e+06
       GoKind: 22
-      Pointee: 914 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 930 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 921
+      ID: 937
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1.20896e+06
       GoKind: 22
-      Pointee: 922 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 938 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 919
+      ID: 935
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1.208832e+06
       GoKind: 22
-      Pointee: 920 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 936 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 1209
+      ID: 1225
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
       GoRuntimeType: 2.391168e+06
       GoKind: 22
-      Pointee: 1210 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+      Pointee: 1226 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
-      ID: 927
+      ID: 943
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1.209472e+06
       GoKind: 22
-      Pointee: 928 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 944 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 850
+      ID: 866
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1.041408e+06
       GoKind: 22
-      Pointee: 851 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 867 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 848
+      ID: 864
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1.04128e+06
       GoKind: 22
-      Pointee: 849 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 865 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 925
+      ID: 941
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1.209344e+06
       GoKind: 22
-      Pointee: 926 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 942 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 805
+      ID: 821
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 954304
       GoKind: 22
-      Pointee: 608 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 624 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 610
+      ID: 626
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 609 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 625 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 988
+      ID: 1004
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1.685536e+06
       GoKind: 22
-      Pointee: 989 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 1005 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 894
+      ID: 910
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1.093888e+06
       GoKind: 22
-      Pointee: 895 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 911 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 1077
+      ID: 1093
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
       GoRuntimeType: 1.27104e+06
       GoKind: 22
-      Pointee: 1078 StructureType go.uber.org/zap.nopCloserSink
+      Pointee: 1094 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
-      ID: 1171
+      ID: 1187
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.1704e+06
       GoKind: 22
-      Pointee: 1172 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+      Pointee: 1188 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
-      ID: 1065
+      ID: 1081
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
       GoRuntimeType: 1.096192e+06
       GoKind: 22
-      Pointee: 1066 StructureType go.uber.org/zap/zapcore.writerWrapper
+      Pointee: 1082 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
-      ID: 806
+      ID: 822
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 955552
       GoKind: 22
-      Pointee: 611 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 627 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 952
+      ID: 968
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1.272704e+06
       GoKind: 22
-      Pointee: 953 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 969 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 809
+      ID: 825
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 955840
       GoKind: 22
-      Pointee: 810 StructureType golang.org/x/net/http2.connError
+      Pointee: 826 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 808
+      ID: 824
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 955744
       GoKind: 22
-      Pointee: 615 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 631 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 617
+      ID: 633
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 616 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 632 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 812
+      ID: 828
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 956032
       GoKind: 22
-      Pointee: 621 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 637 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 623
+      ID: 639
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 622 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 638 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 811
+      ID: 827
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 955936
       GoKind: 22
-      Pointee: 618 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 634 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 620
+      ID: 636
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 619 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 635 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 807
+      ID: 823
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 955648
       GoKind: 22
-      Pointee: 612 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 628 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 614
+      ID: 630
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 613 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 629 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1169
+      ID: 1185
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.16848e+06
       GoKind: 22
-      Pointee: 1170 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1186 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 813
+      ID: 829
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 956128
       GoKind: 22
-      Pointee: 814 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 830 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 815
+      ID: 831
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 956224
       GoKind: 22
-      Pointee: 624 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 640 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 801
+      ID: 817
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 949504
       GoKind: 22
-      Pointee: 802 StructureType google.golang.org/grpc.dropError
+      Pointee: 818 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 950
+      ID: 966
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1.26976e+06
       GoKind: 22
-      Pointee: 951 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 967 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 975
+      ID: 991
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1.457344e+06
       GoKind: 22
-      Pointee: 976 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 992 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 803
+      ID: 819
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 952576
       GoKind: 22
-      Pointee: 804 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 820 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 1120
+      ID: 1136
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1.82944e+06
       GoKind: 22
-      Pointee: 1121 StructureType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 1137 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 1075
+      ID: 1091
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
       GoRuntimeType: 1.266304e+06
       GoKind: 22
-      Pointee: 1076 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+      Pointee: 1092 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
-      ID: 892
+      ID: 908
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1.088128e+06
       GoKind: 22
-      Pointee: 893 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 909 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 1037
+      ID: 1053
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
       GoRuntimeType: 952672
       GoKind: 22
-      Pointee: 1038 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+      Pointee: 1054 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
-      ID: 781
+      ID: 797
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 937408
       GoKind: 22
-      Pointee: 782 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 798 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 880
+      ID: 896
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1.064832e+06
       GoKind: 22
-      Pointee: 881 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 897 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 948
+      ID: 964
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.236992e+06
       GoKind: 22
-      Pointee: 949 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 965 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 946
+      ID: 962
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1.236736e+06
       GoKind: 22
-      Pointee: 947 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 963 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 795
+      ID: 811
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 942112
       GoKind: 22
-      Pointee: 796 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 812 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 797
+      ID: 813
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 942208
       GoKind: 22
-      Pointee: 798 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 814 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 730
+      ID: 746
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 929344
       GoKind: 22
-      Pointee: 731 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 747 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 1124
+      ID: 1140
       Name: '*hash/crc32.digest'
       ByteSize: 8
       GoRuntimeType: 1.920192e+06
       GoKind: 22
-      Pointee: 1125 UnresolvedPointeeType hash/crc32.digest
+      Pointee: 1141 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
-      ID: 816
+      ID: 832
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 956992
       GoKind: 22
-      Pointee: 817 UnresolvedPointeeType html/template.Error
+      Pointee: 833 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 105
       Name: '*int'
@@ -9974,61 +10088,61 @@ Types:
       GoKind: 22
       Pointee: 163 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 977
+      ID: 993
       Name: '*internal/abi.Type'
       ByteSize: 8
       GoRuntimeType: 2.220896e+06
       GoKind: 22
-      Pointee: 978 UnresolvedPointeeType internal/abi.Type
+      Pointee: 994 UnresolvedPointeeType internal/abi.Type
     - __kind: PointerType
-      ID: 698
+      ID: 714
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 922528
       GoKind: 22
-      Pointee: 699 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 715 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 696
+      ID: 712
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 922432
       GoKind: 22
-      Pointee: 697 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 713 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 1023
+      ID: 1039
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
       GoRuntimeType: 910240
       GoKind: 22
-      Pointee: 1024 UnresolvedPointeeType internal/godebug.runtimeStderr
+      Pointee: 1040 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
-      ID: 909
+      ID: 925
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.207552e+06
       GoKind: 22
-      Pointee: 910 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 926 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 1211
+      ID: 1227
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2.396832e+06
       GoKind: 22
-      Pointee: 1212 UnresolvedPointeeType internal/poll.FD
+      Pointee: 1228 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 907
+      ID: 923
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1.207424e+06
       GoKind: 22
-      Pointee: 908 StructureType internal/poll.errNetClosing
+      Pointee: 924 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 629
+      ID: 645
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 909472
       GoKind: 22
-      Pointee: 630 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 646 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
       ID: 99
       Name: '*internal/runtime/atomic.Pointer[runtime.m]'
@@ -10037,66 +10151,66 @@ Types:
       GoKind: 22
       Pointee: 100 UnresolvedPointeeType internal/runtime/atomic.Pointer[runtime.m]
     - __kind: PointerType
-      ID: 695
+      ID: 711
       Name: '*internal/runtime/cgroup.stringError'
       ByteSize: 8
       GoRuntimeType: 922240
       GoKind: 22
-      Pointee: 586 GoStringHeaderType internal/runtime/cgroup.stringError
+      Pointee: 602 GoStringHeaderType internal/runtime/cgroup.stringError
     - __kind: PointerType
-      ID: 588
+      ID: 604
       Name: '*internal/runtime/cgroup.stringError.str'
       ByteSize: 8
-      Pointee: 587 GoStringDataType internal/runtime/cgroup.stringError.str
+      Pointee: 603 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: PointerType
-      ID: 864
+      ID: 880
       Name: '*internal/runtime/maps.unhashableTypeError'
       ByteSize: 8
       GoRuntimeType: 1.052416e+06
       GoKind: 22
-      Pointee: 865 StructureType internal/runtime/maps.unhashableTypeError
+      Pointee: 881 StructureType internal/runtime/maps.unhashableTypeError
     - __kind: PointerType
-      ID: 638
+      ID: 654
       Name: '*internal/strconv.Error'
       ByteSize: 8
       GoRuntimeType: 911392
       GoKind: 22
-      Pointee: 555 BaseType internal/strconv.Error
+      Pointee: 571 BaseType internal/strconv.Error
     - __kind: PointerType
-      ID: 1069
+      ID: 1085
       Name: '*io.PipeWriter'
       ByteSize: 8
       GoRuntimeType: 1.19872e+06
       GoKind: 22
-      Pointee: 1070 UnresolvedPointeeType io.PipeWriter
+      Pointee: 1086 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
-      ID: 1067
+      ID: 1083
       Name: '*io.discard'
       ByteSize: 8
       GoRuntimeType: 1.198336e+06
       GoKind: 22
-      Pointee: 1068 StructureType io.discard
+      Pointee: 1084 StructureType io.discard
     - __kind: PointerType
-      ID: 1041
+      ID: 1057
       Name: '*io.multiWriter'
       ByteSize: 8
       GoRuntimeType: 1.03296e+06
       GoKind: 22
-      Pointee: 1042 UnresolvedPointeeType io.multiWriter
+      Pointee: 1058 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
-      ID: 905
+      ID: 921
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1.206912e+06
       GoKind: 22
-      Pointee: 906 UnresolvedPointeeType io/fs.PathError
+      Pointee: 922 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 1116
+      ID: 1132
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 1.82384e+06
       GoKind: 22
-      Pointee: 1117 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+      Pointee: 1133 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
       ID: 323
       Name: '*main.anotherStruct'
@@ -10104,19 +10218,19 @@ Types:
       GoKind: 22
       Pointee: 324 StructureType main.anotherStruct
     - __kind: PointerType
-      ID: 348
+      ID: 364
       Name: '*main.deepMap2'
       ByteSize: 8
       GoRuntimeType: 391424
       GoKind: 22
-      Pointee: 349 StructureType main.deepMap2
+      Pointee: 365 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 1255
+      ID: 1271
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 391360
       GoKind: 22
-      Pointee: 1256 UnresolvedPointeeType main.deepMap3
+      Pointee: 1272 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 155
       Name: '*main.deepMap7'
@@ -10125,19 +10239,19 @@ Types:
       GoKind: 22
       Pointee: 156 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 1289
+      ID: 1305
       Name: '*main.deepMap8'
       ByteSize: 8
       GoRuntimeType: 391040
       GoKind: 22
-      Pointee: 1290 StructureType main.deepMap8
+      Pointee: 1306 StructureType main.deepMap8
     - __kind: PointerType
-      ID: 1304
+      ID: 1320
       Name: '*main.deepMap9'
       ByteSize: 8
       GoRuntimeType: 390976
       GoKind: 22
-      Pointee: 1305 StructureType main.deepMap9
+      Pointee: 1321 StructureType main.deepMap9
     - __kind: PointerType
       ID: 139
       Name: '*main.deepPtr2'
@@ -10146,12 +10260,12 @@ Types:
       GoKind: 22
       Pointee: 140 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 1215
+      ID: 1231
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 391936
       GoKind: 22
-      Pointee: 1216 UnresolvedPointeeType main.deepPtr3
+      Pointee: 1232 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 141
       Name: '*main.deepPtr7'
@@ -10160,33 +10274,33 @@ Types:
       GoKind: 22
       Pointee: 142 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 1259
+      ID: 1275
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 391616
       GoKind: 22
-      Pointee: 1260 StructureType main.deepPtr8
+      Pointee: 1276 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 1261
+      ID: 1277
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 391552
       GoKind: 22
-      Pointee: 1262 StructureType main.deepPtr9
+      Pointee: 1278 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 146
       Name: '*main.deepSlice2'
       ByteSize: 8
       GoRuntimeType: 392576
       GoKind: 22
-      Pointee: 339 StructureType main.deepSlice2
+      Pointee: 355 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 1240
+      ID: 1256
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 392512
       GoKind: 22
-      Pointee: 1241 UnresolvedPointeeType main.deepSlice3
+      Pointee: 1257 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 147
       Name: '*main.deepSlice7'
@@ -10195,19 +10309,19 @@ Types:
       GoKind: 22
       Pointee: 148 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 1265
+      ID: 1281
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 392192
       GoKind: 22
-      Pointee: 1266 StructureType main.deepSlice8
+      Pointee: 1282 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 1271
+      ID: 1287
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 392128
       GoKind: 22
-      Pointee: 1272 StructureType main.deepSlice9
+      Pointee: 1288 StructureType main.deepSlice9
     - __kind: PointerType
       ID: 326
       Name: '*main.emptyStruct'
@@ -10222,14 +10336,14 @@ Types:
       GoKind: 22
       Pointee: 166 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 1232
+      ID: 1248
       Name: '*main.firstBehavior'
       ByteSize: 8
       GoRuntimeType: 904960
       GoKind: 22
-      Pointee: 327 StructureType main.firstBehavior
+      Pointee: 343 StructureType main.firstBehavior
     - __kind: PointerType
-      ID: 1321
+      ID: 1337
       Name: '*main.nestedStruct'
       ByteSize: 8
       GoRuntimeType: 392832
@@ -10249,19 +10363,19 @@ Types:
       GoKind: 22
       Pointee: 277 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 1233
+      ID: 1249
       Name: '*main.secondBehavior'
       ByteSize: 8
       GoRuntimeType: 905056
       GoKind: 22
-      Pointee: 1234 StructureType main.secondBehavior
+      Pointee: 1250 StructureType main.secondBehavior
     - __kind: PointerType
-      ID: 1220
+      ID: 1236
       Name: '*main.somethingImpl'
       ByteSize: 8
       GoRuntimeType: 905152
       GoKind: 22
-      Pointee: 1221 UnresolvedPointeeType main.somethingImpl
+      Pointee: 1237 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
       ID: 157
       Name: '*main.stringType1'
@@ -10269,28 +10383,28 @@ Types:
       GoKind: 22
       Pointee: 158 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 1218
+      ID: 1234
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 1217 GoStringDataType main.stringType1.str
+      Pointee: 1233 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 160
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 1219 GoStringHeaderType main.stringType2
+      Pointee: 1235 GoStringHeaderType main.stringType2
     - __kind: PointerType
-      ID: 1323
+      ID: 1339
       Name: '*main.stringType2.str'
       ByteSize: 8
-      Pointee: 1322 GoStringDataType main.stringType2.str
+      Pointee: 1338 GoStringDataType main.stringType2.str
     - __kind: PointerType
       ID: 280
       Name: '*main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 278 StructureType main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 400
+      ID: 416
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 390912
@@ -10314,10 +10428,10 @@ Types:
       GoKind: 22
       Pointee: 255 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 1237
+      ID: 1253
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 1236 GoSliceDataType main.t.array
+      Pointee: 1252 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 275
       Name: '*main.threeStringStruct'
@@ -10350,30 +10464,30 @@ Types:
       ByteSize: 8
       Pointee: 152 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1245
+      ID: 1261
       Name: '*map<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1246 GoSwissMapHeaderType map<int,*main.deepMap3>
+      Pointee: 1262 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1279
+      ID: 1295
       Name: '*map<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1280 GoSwissMapHeaderType map<int,*main.deepMap8>
+      Pointee: 1296 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1294
+      ID: 1310
       Name: '*map<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1295 GoSwissMapHeaderType map<int,*main.deepMap9>
+      Pointee: 1311 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: PointerType
       ID: 173
       Name: '*map<int,int>'
       ByteSize: 8
       Pointee: 174 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 1309
+      ID: 1325
       Name: '*map<int,interface {}>'
       ByteSize: 8
-      Pointee: 1310 GoSwissMapHeaderType map<int,interface {}>
+      Pointee: 1326 GoSwissMapHeaderType map<int,interface {}>
     - __kind: PointerType
       ID: 240
       Name: '*map<int,struct {}>'
@@ -10395,10 +10509,10 @@ Types:
       ByteSize: 8
       Pointee: 189 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 981
+      ID: 997
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 982 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 998 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 183
       Name: '*map<string,int>'
@@ -10466,696 +10580,696 @@ Types:
       GoKind: 22
       Pointee: 182 GoMapType map[string]int
     - __kind: PointerType
-      ID: 734
+      ID: 750
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 930208
       GoKind: 22
-      Pointee: 735 StructureType math/big.ErrNaN
+      Pointee: 751 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 1031
+      ID: 1047
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
       GoRuntimeType: 925024
       GoKind: 22
-      Pointee: 1032 StructureType mime/multipart.writerOnly·1
+      Pointee: 1048 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
-      ID: 936
+      ID: 952
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1.215488e+06
       GoKind: 22
-      Pointee: 937 UnresolvedPointeeType net.AddrError
+      Pointee: 953 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 962
+      ID: 978
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1.432704e+06
       GoKind: 22
-      Pointee: 963 UnresolvedPointeeType net.DNSError
+      Pointee: 979 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 1175
+      ID: 1191
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2.255808e+06
       GoKind: 22
-      Pointee: 1176 UnresolvedPointeeType net.IPConn
+      Pointee: 1192 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 960
+      ID: 976
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1.432384e+06
       GoKind: 22
-      Pointee: 961 UnresolvedPointeeType net.OpError
+      Pointee: 977 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 938
+      ID: 954
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.215616e+06
       GoKind: 22
-      Pointee: 939 UnresolvedPointeeType net.ParseError
+      Pointee: 955 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 1185
+      ID: 1201
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2.2832e+06
       GoKind: 22
-      Pointee: 1186 UnresolvedPointeeType net.TCPConn
+      Pointee: 1202 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 1195
+      ID: 1211
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2.32832e+06
       GoKind: 22
-      Pointee: 1196 UnresolvedPointeeType net.UDPConn
+      Pointee: 1212 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 1183
+      ID: 1199
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2.282688e+06
       GoKind: 22
-      Pointee: 1184 UnresolvedPointeeType net.UnixConn
+      Pointee: 1200 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 935
+      ID: 951
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1.21472e+06
       GoKind: 22
-      Pointee: 898 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 914 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 900
+      ID: 916
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 899 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 915 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 862
+      ID: 878
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1.048192e+06
       GoKind: 22
-      Pointee: 863 StructureType net.canceledError
+      Pointee: 879 StructureType net.canceledError
     - __kind: PointerType
-      ID: 1153
+      ID: 1169
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 2.031424e+06
       GoKind: 22
-      Pointee: 1154 UnresolvedPointeeType net.conn
+      Pointee: 1170 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 1006
+      ID: 1022
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1.867072e+06
       GoKind: 22
-      Pointee: 1007 StructureType net.dialResult·1
+      Pointee: 1023 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 1197
+      ID: 1213
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2.332576e+06
       GoKind: 22
-      Pointee: 1198 UnresolvedPointeeType net.netFD
+      Pointee: 1214 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 664
+      ID: 680
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 916960
       GoKind: 22
-      Pointee: 665 UnresolvedPointeeType net.notFoundError
+      Pointee: 681 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 666
+      ID: 682
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 917632
       GoKind: 22
-      Pointee: 667 StructureType net.result·2
+      Pointee: 683 StructureType net.result·2
     - __kind: PointerType
-      ID: 1179
+      ID: 1195
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.268736e+06
       GoKind: 22
-      Pointee: 1180 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 1196 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 1177
+      ID: 1193
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.268256e+06
       GoKind: 22
-      Pointee: 1178 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 1194 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 940
+      ID: 956
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1.216256e+06
       GoKind: 22
-      Pointee: 941 UnresolvedPointeeType net.temporaryError
+      Pointee: 957 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 964
+      ID: 980
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.432864e+06
       GoKind: 22
-      Pointee: 965 UnresolvedPointeeType net.timeoutError
+      Pointee: 981 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 852
+      ID: 868
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1.043968e+06
       GoKind: 22
-      Pointee: 853 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 869 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
-      ID: 1025
+      ID: 1041
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
       GoRuntimeType: 912736
       GoKind: 22
-      Pointee: 1026 StructureType net/http.bufioFlushWriter
+      Pointee: 1042 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
-      ID: 641
+      ID: 657
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 913408
       GoKind: 22
-      Pointee: 556 BaseType net/http.http2ConnectionError
+      Pointee: 572 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 642
+      ID: 658
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 913504
       GoKind: 22
-      Pointee: 643 StructureType net/http.http2GoAwayError
+      Pointee: 659 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 956
+      ID: 972
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1.428384e+06
       GoKind: 22
-      Pointee: 957 StructureType net/http.http2StreamError
+      Pointee: 973 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 646
+      ID: 662
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 914080
       GoKind: 22
-      Pointee: 647 StructureType net/http.http2connError
+      Pointee: 663 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 1087
+      ID: 1103
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
       GoRuntimeType: 1.569376e+06
       GoKind: 22
-      Pointee: 1088 UnresolvedPointeeType net/http.http2dataBuffer
+      Pointee: 1104 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 645
+      ID: 661
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 913984
       GoKind: 22
-      Pointee: 560 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 576 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 562
+      ID: 578
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 561 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 577 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 649
+      ID: 665
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 914272
       GoKind: 22
-      Pointee: 566 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 582 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 568
+      ID: 584
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 567 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 583 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 648
+      ID: 664
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 914176
       GoKind: 22
-      Pointee: 563 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 579 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 565
+      ID: 581
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 564 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 580 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 931
+      ID: 947
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1.211392e+06
       GoKind: 22
-      Pointee: 932 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 948 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 858
+      ID: 874
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1.04448e+06
       GoKind: 22
-      Pointee: 859 StructureType net/http.http2noCachedConnError
+      Pointee: 875 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 1142
+      ID: 1158
       Name: '*net/http.http2pipe'
       ByteSize: 8
       GoRuntimeType: 1.972608e+06
       GoKind: 22
-      Pointee: 1143 UnresolvedPointeeType net/http.http2pipe
+      Pointee: 1159 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 644
+      ID: 660
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 913888
       GoKind: 22
-      Pointee: 557 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 573 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 559
+      ID: 575
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 558 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 574 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1027
+      ID: 1043
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
       GoRuntimeType: 914368
       GoKind: 22
-      Pointee: 1028 StructureType net/http.http2stickyErrWriter
+      Pointee: 1044 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
-      ID: 854
+      ID: 870
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1.044224e+06
       GoKind: 22
-      Pointee: 855 StructureType net/http.nothingWrittenError
+      Pointee: 871 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 1089
+      ID: 1105
       Name: '*net/http.persistConn'
       ByteSize: 8
       GoRuntimeType: 2.217152e+06
       GoKind: 22
-      Pointee: 1090 UnresolvedPointeeType net/http.persistConn
+      Pointee: 1106 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
-      ID: 1045
+      ID: 1061
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
       GoRuntimeType: 1.044096e+06
       GoKind: 22
-      Pointee: 1046 StructureType net/http.persistConnWriter
+      Pointee: 1062 StructureType net/http.persistConnWriter
     - __kind: PointerType
-      ID: 1079
+      ID: 1095
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1.428544e+06
       GoKind: 22
-      Pointee: 1080 StructureType net/http.readWriteCloserBody
+      Pointee: 1096 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 650
+      ID: 666
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 914464
       GoKind: 22
-      Pointee: 651 StructureType net/http.requestBodyReadError
+      Pointee: 667 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 958
+      ID: 974
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.429664e+06
       GoKind: 22
-      Pointee: 959 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 975 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 929
+      ID: 945
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1.211264e+06
       GoKind: 22
-      Pointee: 930 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 946 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 856
+      ID: 872
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1.044352e+06
       GoKind: 22
-      Pointee: 857 StructureType net/http.transportReadFromServerError
+      Pointee: 873 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 1122
+      ID: 1138
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
       GoRuntimeType: 1.863264e+06
       GoKind: 22
-      Pointee: 1123 StructureType net/http.unencryptedNetConnInTLSConn
+      Pointee: 1139 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 639
+      ID: 655
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 912640
       GoKind: 22
-      Pointee: 640 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 656 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 1144
+      ID: 1160
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
       GoRuntimeType: 1.9744e+06
       GoKind: 22
-      Pointee: 1145 StructureType net/http/internal.FlushAfterChunkWriter
+      Pointee: 1161 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
-      ID: 1055
+      ID: 1071
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
       GoRuntimeType: 1.056768e+06
       GoKind: 22
-      Pointee: 1056 UnresolvedPointeeType net/http/internal.chunkedWriter
+      Pointee: 1072 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
-      ID: 726
+      ID: 742
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 929152
       GoKind: 22
-      Pointee: 727 StructureType net/netip.parseAddrError
+      Pointee: 743 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 724
+      ID: 740
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 929056
       GoKind: 22
-      Pointee: 725 StructureType net/netip.parsePrefixError
+      Pointee: 741 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 1095
+      ID: 1111
       Name: '*net/smtp.Client'
       ByteSize: 8
       GoRuntimeType: 2.140224e+06
       GoKind: 22
-      Pointee: 1096 UnresolvedPointeeType net/smtp.Client
+      Pointee: 1112 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
-      ID: 1057
+      ID: 1073
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
       GoRuntimeType: 1.06112e+06
       GoKind: 22
-      Pointee: 1058 StructureType net/smtp.dataCloser
+      Pointee: 1074 StructureType net/smtp.dataCloser
     - __kind: PointerType
-      ID: 710
+      ID: 726
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 925216
       GoKind: 22
-      Pointee: 711 UnresolvedPointeeType net/textproto.Error
+      Pointee: 727 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 709
+      ID: 725
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 925120
       GoKind: 22
-      Pointee: 594 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 610 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 596
+      ID: 612
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 595 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 611 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 1053
+      ID: 1069
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
       GoRuntimeType: 1.056256e+06
       GoKind: 22
-      Pointee: 1054 UnresolvedPointeeType net/textproto.dotWriter
+      Pointee: 1070 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
-      ID: 966
+      ID: 982
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1.433184e+06
       GoKind: 22
-      Pointee: 967 UnresolvedPointeeType net/url.Error
+      Pointee: 983 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 668
+      ID: 684
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 917728
       GoKind: 22
-      Pointee: 569 GoStringHeaderType net/url.EscapeError
+      Pointee: 585 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 571
+      ID: 587
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 570 GoStringDataType net/url.EscapeError.str
+      Pointee: 586 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 669
+      ID: 685
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 917824
       GoKind: 22
-      Pointee: 572 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 588 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 574
+      ID: 590
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 573 GoStringDataType net/url.InvalidHostError.str
-    - __kind: PointerType
-      ID: 446
-      Name: '*noalg.map.group[[4]int][4]int'
-      ByteSize: 8
-      Pointee: 447 StructureType noalg.map.group[[4]int][4]int
-    - __kind: PointerType
-      ID: 438
-      Name: '*noalg.map.group[[4]int]uint8'
-      ByteSize: 8
-      Pointee: 439 StructureType noalg.map.group[[4]int]uint8
-    - __kind: PointerType
-      ID: 386
-      Name: '*noalg.map.group[[4]string][2]int'
-      ByteSize: 8
-      Pointee: 387 StructureType noalg.map.group[[4]string][2]int
-    - __kind: PointerType
-      ID: 405
-      Name: '*noalg.map.group[bool]main.node'
-      ByteSize: 8
-      Pointee: 406 StructureType noalg.map.group[bool]main.node
-    - __kind: PointerType
-      ID: 344
-      Name: '*noalg.map.group[int]*main.deepMap2'
-      ByteSize: 8
-      Pointee: 345 StructureType noalg.map.group[int]*main.deepMap2
-    - __kind: PointerType
-      ID: 1251
-      Name: '*noalg.map.group[int]*main.deepMap3'
-      ByteSize: 8
-      Pointee: 1252 StructureType noalg.map.group[int]*main.deepMap3
-    - __kind: PointerType
-      ID: 1285
-      Name: '*noalg.map.group[int]*main.deepMap8'
-      ByteSize: 8
-      Pointee: 1286 StructureType noalg.map.group[int]*main.deepMap8
-    - __kind: PointerType
-      ID: 1300
-      Name: '*noalg.map.group[int]*main.deepMap9'
-      ByteSize: 8
-      Pointee: 1301 StructureType noalg.map.group[int]*main.deepMap9
-    - __kind: PointerType
-      ID: 354
-      Name: '*noalg.map.group[int]int'
-      ByteSize: 8
-      Pointee: 355 StructureType noalg.map.group[int]int
-    - __kind: PointerType
-      ID: 1315
-      Name: '*noalg.map.group[int]interface {}'
-      ByteSize: 8
-      Pointee: 1316 StructureType noalg.map.group[int]interface {}
+      Pointee: 589 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
       ID: 462
-      Name: '*noalg.map.group[int]struct {}'
+      Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 463 StructureType noalg.map.group[int]struct {}
-    - __kind: PointerType
-      ID: 413
-      Name: '*noalg.map.group[int]uint8'
-      ByteSize: 8
-      Pointee: 414 StructureType noalg.map.group[int]uint8
-    - __kind: PointerType
-      ID: 395
-      Name: '*noalg.map.group[string][]main.structWithMap'
-      ByteSize: 8
-      Pointee: 396 StructureType noalg.map.group[string][]main.structWithMap
-    - __kind: PointerType
-      ID: 378
-      Name: '*noalg.map.group[string][]string'
-      ByteSize: 8
-      Pointee: 379 StructureType noalg.map.group[string][]string
-    - __kind: PointerType
-      ID: 1013
-      Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
-      ByteSize: 8
-      Pointee: 1014 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-    - __kind: PointerType
-      ID: 370
-      Name: '*noalg.map.group[string]int'
-      ByteSize: 8
-      Pointee: 371 StructureType noalg.map.group[string]int
-    - __kind: PointerType
-      ID: 362
-      Name: '*noalg.map.group[string]main.nestedStruct'
-      ByteSize: 8
-      Pointee: 363 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 463 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
       ID: 454
-      Name: '*noalg.map.group[struct {}]int'
+      Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 455 StructureType noalg.map.group[struct {}]int
+      Pointee: 455 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 504
-      Name: '*noalg.map.group[struct {}]main.structWithCyclicMaps'
+      ID: 402
+      Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 505 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
-    - __kind: PointerType
-      ID: 512
-      Name: '*noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps'
-      ByteSize: 8
-      Pointee: 513 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
-    - __kind: PointerType
-      ID: 520
-      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
-      ByteSize: 8
-      Pointee: 521 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-    - __kind: PointerType
-      ID: 528
-      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
-      ByteSize: 8
-      Pointee: 529 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-    - __kind: PointerType
-      ID: 536
-      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
-      ByteSize: 8
-      Pointee: 537 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-    - __kind: PointerType
-      ID: 544
-      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
-      ByteSize: 8
-      Pointee: 545 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-    - __kind: PointerType
-      ID: 470
-      Name: '*noalg.map.group[struct {}]struct {}'
-      ByteSize: 8
-      Pointee: 471 StructureType noalg.map.group[struct {}]struct {}
-    - __kind: PointerType
-      ID: 429
-      Name: '*noalg.map.group[uint8][4]int'
-      ByteSize: 8
-      Pointee: 430 StructureType noalg.map.group[uint8][4]int
+      Pointee: 403 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
       ID: 421
+      Name: '*noalg.map.group[bool]main.node'
+      ByteSize: 8
+      Pointee: 422 StructureType noalg.map.group[bool]main.node
+    - __kind: PointerType
+      ID: 360
+      Name: '*noalg.map.group[int]*main.deepMap2'
+      ByteSize: 8
+      Pointee: 361 StructureType noalg.map.group[int]*main.deepMap2
+    - __kind: PointerType
+      ID: 1267
+      Name: '*noalg.map.group[int]*main.deepMap3'
+      ByteSize: 8
+      Pointee: 1268 StructureType noalg.map.group[int]*main.deepMap3
+    - __kind: PointerType
+      ID: 1301
+      Name: '*noalg.map.group[int]*main.deepMap8'
+      ByteSize: 8
+      Pointee: 1302 StructureType noalg.map.group[int]*main.deepMap8
+    - __kind: PointerType
+      ID: 1316
+      Name: '*noalg.map.group[int]*main.deepMap9'
+      ByteSize: 8
+      Pointee: 1317 StructureType noalg.map.group[int]*main.deepMap9
+    - __kind: PointerType
+      ID: 370
+      Name: '*noalg.map.group[int]int'
+      ByteSize: 8
+      Pointee: 371 StructureType noalg.map.group[int]int
+    - __kind: PointerType
+      ID: 1331
+      Name: '*noalg.map.group[int]interface {}'
+      ByteSize: 8
+      Pointee: 1332 StructureType noalg.map.group[int]interface {}
+    - __kind: PointerType
+      ID: 478
+      Name: '*noalg.map.group[int]struct {}'
+      ByteSize: 8
+      Pointee: 479 StructureType noalg.map.group[int]struct {}
+    - __kind: PointerType
+      ID: 429
+      Name: '*noalg.map.group[int]uint8'
+      ByteSize: 8
+      Pointee: 430 StructureType noalg.map.group[int]uint8
+    - __kind: PointerType
+      ID: 411
+      Name: '*noalg.map.group[string][]main.structWithMap'
+      ByteSize: 8
+      Pointee: 412 StructureType noalg.map.group[string][]main.structWithMap
+    - __kind: PointerType
+      ID: 394
+      Name: '*noalg.map.group[string][]string'
+      ByteSize: 8
+      Pointee: 395 StructureType noalg.map.group[string][]string
+    - __kind: PointerType
+      ID: 1029
+      Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
+      ByteSize: 8
+      Pointee: 1030 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+    - __kind: PointerType
+      ID: 386
+      Name: '*noalg.map.group[string]int'
+      ByteSize: 8
+      Pointee: 387 StructureType noalg.map.group[string]int
+    - __kind: PointerType
+      ID: 378
+      Name: '*noalg.map.group[string]main.nestedStruct'
+      ByteSize: 8
+      Pointee: 379 StructureType noalg.map.group[string]main.nestedStruct
+    - __kind: PointerType
+      ID: 470
+      Name: '*noalg.map.group[struct {}]int'
+      ByteSize: 8
+      Pointee: 471 StructureType noalg.map.group[struct {}]int
+    - __kind: PointerType
+      ID: 520
+      Name: '*noalg.map.group[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 521 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 528
+      Name: '*noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 529 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 536
+      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 537 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 544
+      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 545 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 552
+      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 553 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 560
+      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 561 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 486
+      Name: '*noalg.map.group[struct {}]struct {}'
+      ByteSize: 8
+      Pointee: 487 StructureType noalg.map.group[struct {}]struct {}
+    - __kind: PointerType
+      ID: 445
+      Name: '*noalg.map.group[uint8][4]int'
+      ByteSize: 8
+      Pointee: 446 StructureType noalg.map.group[uint8][4]int
+    - __kind: PointerType
+      ID: 437
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 422 StructureType noalg.map.group[uint8]uint8
+      Pointee: 438 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
-      ID: 1203
+      ID: 1219
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2.370688e+06
       GoKind: 22
-      Pointee: 1204 UnresolvedPointeeType os.File
+      Pointee: 1220 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 833
+      ID: 849
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1.035008e+06
       GoKind: 22
-      Pointee: 834 UnresolvedPointeeType os.LinkError
+      Pointee: 850 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 901
+      ID: 917
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1.199872e+06
       GoKind: 22
-      Pointee: 902 UnresolvedPointeeType os.SyscallError
+      Pointee: 918 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 1201
+      ID: 1217
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.369952e+06
       GoKind: 22
-      Pointee: 1202 StructureType os.fileWithoutReadFrom
+      Pointee: 1218 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 1199
+      ID: 1215
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.369216e+06
       GoKind: 22
-      Pointee: 1200 StructureType os.fileWithoutWriteTo
+      Pointee: 1216 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 866
+      ID: 882
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1.0528e+06
       GoKind: 22
-      Pointee: 867 UnresolvedPointeeType os/exec.Error
+      Pointee: 883 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 1009
+      ID: 1025
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2.11184e+06
       GoKind: 22
-      Pointee: 1010 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 1026 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 1073
+      ID: 1089
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
       GoRuntimeType: 1.222528e+06
       GoKind: 22
-      Pointee: 1074 UnresolvedPointeeType os/exec.prefixSuffixSaver
+      Pointee: 1090 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
-      ID: 868
+      ID: 884
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1.052928e+06
       GoKind: 22
-      Pointee: 869 StructureType os/exec.wrappedError
+      Pointee: 885 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 800
+      ID: 816
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 947584
       GoKind: 22
-      Pointee: 605 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 621 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 607
+      ID: 623
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 606 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 622 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 799
+      ID: 815
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 947488
       GoKind: 22
-      Pointee: 604 BaseType os/user.UnknownUserIdError
+      Pointee: 620 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 631
+      ID: 647
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 910144
       GoKind: 22
-      Pointee: 632 UnresolvedPointeeType reflect.ValueError
+      Pointee: 648 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 732
+      ID: 748
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 929824
       GoKind: 22
-      Pointee: 733 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 749 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 837
+      ID: 853
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1.037824e+06
       GoKind: 22
-      Pointee: 838 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 854 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 841
+      ID: 857
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1.038464e+06
       GoKind: 22
-      Pointee: 842 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 858 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 27
       Name: '*runtime._defer'
@@ -11171,12 +11285,12 @@ Types:
       GoKind: 22
       Pointee: 26 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 839
+      ID: 855
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1.037952e+06
       GoKind: 22
-      Pointee: 840 StructureType runtime.boundsError
+      Pointee: 856 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 69
       Name: '*runtime.cgoCallers'
@@ -11192,24 +11306,24 @@ Types:
       GoKind: 22
       Pointee: 49 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 903
+      ID: 919
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1.20576e+06
       GoKind: 22
-      Pointee: 904 StructureType runtime.errorAddressString
+      Pointee: 920 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 835
+      ID: 851
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1.03616e+06
       GoKind: 22
-      Pointee: 818 GoStringHeaderType runtime.errorString
+      Pointee: 834 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 820
+      ID: 836
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 819 GoStringDataType runtime.errorString.str
+      Pointee: 835 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 59
       Name: '*runtime.g'
@@ -11230,19 +11344,19 @@ Types:
       ByteSize: 8
       GoRuntimeType: 1.037568e+06
       GoKind: 22
-      Pointee: 334 UnresolvedPointeeType runtime.p
+      Pointee: 350 UnresolvedPointeeType runtime.p
     - __kind: PointerType
-      ID: 836
+      ID: 852
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1.036288e+06
       GoKind: 22
-      Pointee: 821 GoStringHeaderType runtime.plainError
+      Pointee: 837 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 823
+      ID: 839
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 822 GoStringDataType runtime.plainError.str
+      Pointee: 838 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 42
       Name: '*runtime.sudog'
@@ -11258,12 +11372,12 @@ Types:
       GoKind: 22
       Pointee: 51 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
-      ID: 627
+      ID: 643
       Name: '*runtime.synctestDeadlockError'
       ByteSize: 8
       GoRuntimeType: 908800
       GoKind: 22
-      Pointee: 628 StructureType runtime.synctestDeadlockError
+      Pointee: 644 StructureType runtime.synctestDeadlockError
     - __kind: PointerType
       ID: 45
       Name: '*runtime.timer'
@@ -11286,12 +11400,12 @@ Types:
       GoKind: 22
       Pointee: 54 UnresolvedPointeeType runtime.xRegState
     - __kind: PointerType
-      ID: 843
+      ID: 859
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1.03872e+06
       GoKind: 22
-      Pointee: 844 UnresolvedPointeeType strconv.NumError
+      Pointee: 860 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 101
       Name: '*string'
@@ -11300,31 +11414,31 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 329
+      ID: 345
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 328 GoStringDataType string.str
+      Pointee: 344 GoStringDataType string.str
     - __kind: PointerType
-      ID: 1140
+      ID: 1156
       Name: '*strings.Builder'
       ByteSize: 8
       GoRuntimeType: 1.971328e+06
       GoKind: 22
-      Pointee: 1141 UnresolvedPointeeType strings.Builder
+      Pointee: 1157 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
-      ID: 1043
+      ID: 1059
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
       GoRuntimeType: 1.038848e+06
       GoKind: 22
-      Pointee: 1044 UnresolvedPointeeType strings.appendSliceWriter
+      Pointee: 1060 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
-      ID: 1039
+      ID: 1055
       Name: '*struct { io.Writer }'
       ByteSize: 8
       GoRuntimeType: 981056
       GoKind: 22
-      Pointee: 1040 StructureType struct { io.Writer }
+      Pointee: 1056 StructureType struct { io.Writer }
     - __kind: PointerType
       ID: 273
       Name: '*struct {}'
@@ -11333,194 +11447,194 @@ Types:
       GoKind: 22
       Pointee: 131 StructureType struct {}
     - __kind: PointerType
-      ID: 955
+      ID: 971
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1.427904e+06
       GoKind: 22
-      Pointee: 954 BaseType syscall.Errno
+      Pointee: 970 BaseType syscall.Errno
     - __kind: PointerType
       ID: 233
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 444 StructureType table<[4]int,[4]int>
+      Pointee: 460 StructureType table<[4]int,[4]int>
     - __kind: PointerType
       ID: 228
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 436 StructureType table<[4]int,uint8>
+      Pointee: 452 StructureType table<[4]int,uint8>
     - __kind: PointerType
       ID: 196
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 384 StructureType table<[4]string,[2]int>
+      Pointee: 400 StructureType table<[4]string,[2]int>
     - __kind: PointerType
       ID: 208
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 403 StructureType table<bool,main.node>
+      Pointee: 419 StructureType table<bool,main.node>
     - __kind: PointerType
       ID: 154
       Name: '*table<int,*main.deepMap2>'
       ByteSize: 8
-      Pointee: 342 StructureType table<int,*main.deepMap2>
+      Pointee: 358 StructureType table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1248
+      ID: 1264
       Name: '*table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1249 StructureType table<int,*main.deepMap3>
+      Pointee: 1265 StructureType table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1282
+      ID: 1298
       Name: '*table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1283 StructureType table<int,*main.deepMap8>
+      Pointee: 1299 StructureType table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1297
+      ID: 1313
       Name: '*table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1298 StructureType table<int,*main.deepMap9>
+      Pointee: 1314 StructureType table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 176
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 352 StructureType table<int,int>
+      Pointee: 368 StructureType table<int,int>
     - __kind: PointerType
-      ID: 1312
+      ID: 1328
       Name: '*table<int,interface {}>'
       ByteSize: 8
-      Pointee: 1313 StructureType table<int,interface {}>
+      Pointee: 1329 StructureType table<int,interface {}>
     - __kind: PointerType
       ID: 243
       Name: '*table<int,struct {}>'
       ByteSize: 8
-      Pointee: 460 StructureType table<int,struct {}>
+      Pointee: 476 StructureType table<int,struct {}>
     - __kind: PointerType
       ID: 213
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 411 StructureType table<int,uint8>
+      Pointee: 427 StructureType table<int,uint8>
     - __kind: PointerType
       ID: 203
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 393 StructureType table<string,[]main.structWithMap>
+      Pointee: 409 StructureType table<string,[]main.structWithMap>
     - __kind: PointerType
       ID: 191
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 376 StructureType table<string,[]string>
+      Pointee: 392 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 984
+      ID: 1000
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 1011 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 1027 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 186
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 368 StructureType table<string,int>
+      Pointee: 384 StructureType table<string,int>
     - __kind: PointerType
       ID: 181
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 360 StructureType table<string,main.nestedStruct>
+      Pointee: 376 StructureType table<string,main.nestedStruct>
     - __kind: PointerType
       ID: 238
       Name: '*table<struct {},int>'
       ByteSize: 8
-      Pointee: 452 StructureType table<struct {},int>
+      Pointee: 468 StructureType table<struct {},int>
     - __kind: PointerType
       ID: 296
       Name: '*table<struct {},main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 502 StructureType table<struct {},main.structWithCyclicMaps>
+      Pointee: 518 StructureType table<struct {},main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 301
       Name: '*table<struct {},map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 510 StructureType table<struct {},map[struct {}]main.structWithCyclicMaps>
+      Pointee: 526 StructureType table<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 306
       Name: '*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 518 StructureType table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 534 StructureType table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 311
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 526 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 542 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 316
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 534 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 550 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 321
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 542 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 558 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 248
       Name: '*table<struct {},struct {}>'
       ByteSize: 8
-      Pointee: 468 StructureType table<struct {},struct {}>
+      Pointee: 484 StructureType table<struct {},struct {}>
     - __kind: PointerType
       ID: 223
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 427 StructureType table<uint8,[4]int>
+      Pointee: 443 StructureType table<uint8,[4]int>
     - __kind: PointerType
       ID: 218
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 419 StructureType table<uint8,uint8>
+      Pointee: 435 StructureType table<uint8,uint8>
     - __kind: PointerType
-      ID: 1173
+      ID: 1189
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
       GoRuntimeType: 2.182624e+06
       GoKind: 22
-      Pointee: 1174 UnresolvedPointeeType text/tabwriter.Writer
+      Pointee: 1190 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
-      ID: 896
+      ID: 912
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1.097728e+06
       GoKind: 22
-      Pointee: 897 StructureType text/template.ExecError
+      Pointee: 913 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 971
+      ID: 987
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.639648e+06
       GoKind: 22
-      Pointee: 972 UnresolvedPointeeType time.Location
+      Pointee: 988 UnresolvedPointeeType time.Location
     - __kind: PointerType
-      ID: 636
+      ID: 652
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 911104
       GoKind: 22
-      Pointee: 637 UnresolvedPointeeType time.ParseError
+      Pointee: 653 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 633
+      ID: 649
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 910912
       GoKind: 22
-      Pointee: 552 GoStringHeaderType time.fileSizeError
+      Pointee: 568 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 554
+      ID: 570
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 553 GoStringDataType time.fileSizeError.str
+      Pointee: 569 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 634
+      ID: 650
       Name: '*time.parseDurationError'
       ByteSize: 8
       GoRuntimeType: 911008
       GoKind: 22
-      Pointee: 635 UnresolvedPointeeType time.parseDurationError
+      Pointee: 651 UnresolvedPointeeType time.parseDurationError
     - __kind: PointerType
       ID: 112
       Name: '*uint'
@@ -11564,52 +11678,88 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: PointerType
-      ID: 728
+      ID: 744
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 929248
       GoKind: 22
-      Pointee: 729 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 745 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 1167
+      ID: 1183
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.158112e+06
       GoKind: 22
-      Pointee: 1168 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1184 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 712
+      ID: 728
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 925408
       GoKind: 22
-      Pointee: 713 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 729 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 714
+      ID: 730
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 925504
       GoKind: 22
-      Pointee: 597 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 613 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 873
+      ID: 889
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1.056512e+06
       GoKind: 22
-      Pointee: 874 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 890 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 875
+      ID: 891
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1.05664e+06
       GoKind: 22
-      Pointee: 826 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 842 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1565
+      ID: 1582
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
     - __kind: EventRootType
-      ID: 1563
+      ID: 1566
+      Name: Probe[main.executeStructFuncs]Line
+      ByteSize: 66
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: sta.a
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 341 ArrayType [3]uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 10, name: sta}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: sta.b
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 10, name: sta}
+                  Offset: 24
+                  ByteSize: 1
+        - Name: sta.c
+          Offset: 26
+          Kind: template_segment
+          Expression:
+            Type: 342 ArrayType [5]int64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 10, name: sta}
+                  Offset: 32
+                  ByteSize: 40
+    - __kind: EventRootType
+      ID: 1580
       Name: Probe[main.firstBehavior.DoSomething]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11618,14 +11768,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 327 StructureType main.firstBehavior
+            Type: 343 StructureType main.firstBehavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 0, name: b}
+                  Variable: {subprogram: 165, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1564
+      ID: 1581
       Name: Probe[main.firstBehavior.DoSomething]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11637,14 +11787,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 1, name: ~r0}
+                  Variable: {subprogram: 165, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1526
+      ID: 1542
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1527
+      ID: 1543
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11660,7 +11810,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1393
+      ID: 1409
       Name: Probe[main.testAnyPtr]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11686,7 +11836,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1394
+      ID: 1410
       Name: Probe[main.testAnyPtr]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11702,7 +11852,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1390
+      ID: 1406
       Name: Probe[main.testAny]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11728,7 +11878,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1391
+      ID: 1407
       Name: Probe[main.testAny]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11744,7 +11894,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1497
+      ID: 1513
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11770,7 +11920,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1498
+      ID: 1514
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11786,7 +11936,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1342
+      ID: 1358
       Name: Probe[main.testArrayEmptyStructs]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11812,7 +11962,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1340
+      ID: 1356
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 129
       PresenceBitsetSize: 1
@@ -11838,7 +11988,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1338
+      ID: 1354
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -11864,7 +12014,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1402
+      ID: 1418
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11890,7 +12040,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1339
+      ID: 1355
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -11916,7 +12066,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1341
+      ID: 1357
       Name: Probe[main.testArrayOfStructs]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -11942,7 +12092,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1424
+      ID: 1440
       Name: Probe[main.testAtomicAdd]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11968,7 +12118,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1425
+      ID: 1441
       Name: Probe[main.testAtomicAdd]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11984,7 +12134,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1360
+      ID: 1376
       Name: Probe[main.testBigStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -12010,7 +12160,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1327
+      ID: 1343
       Name: Probe[main.testBoolArray]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -12036,7 +12186,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1324
+      ID: 1340
       Name: Probe[main.testByteArray]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -12062,7 +12212,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1426
+      ID: 1442
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -12088,7 +12238,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1420
+      ID: 1436
       Name: Probe[main.testCombinedByte]
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -12154,7 +12304,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1421
+      ID: 1437
       Name: Probe[main.testCombinedString]
       ByteSize: 18
       PresenceBitsetSize: 1
@@ -12180,7 +12330,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1422
+      ID: 1438
       Name: Probe[main.testCombinedString]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -12216,7 +12366,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1434
+      ID: 1450
       Name: Probe[main.testCycle]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12242,7 +12392,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1365
+      ID: 1381
       Name: Probe[main.testDeepMap1]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12268,7 +12418,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1366
+      ID: 1382
       Name: Probe[main.testDeepMap7]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12294,7 +12444,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1361
+      ID: 1377
       Name: Probe[main.testDeepPtr1]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12320,7 +12470,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1362
+      ID: 1378
       Name: Probe[main.testDeepPtr7]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12346,7 +12496,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1363
+      ID: 1379
       Name: Probe[main.testDeepSlice1]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12372,7 +12522,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1364
+      ID: 1380
       Name: Probe[main.testDeepSlice7]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12398,7 +12548,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1517
+      ID: 1533
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -12444,7 +12594,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1514
+      ID: 1530
       Name: Probe[main.testEmptySlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12470,7 +12620,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1538
+      ID: 1554
       Name: Probe[main.testEmptyString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12496,7 +12646,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1549
+      ID: 1565
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12522,7 +12672,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1548
+      ID: 1564
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -12548,7 +12698,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1392
+      ID: 1408
       Name: Probe[main.testError]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12574,7 +12724,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1374
+      ID: 1390
       Name: Probe[main.testEsotericHeap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12600,10 +12750,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1375
+      ID: 1391
       Name: Probe[main.testEsotericHeap]Return
     - __kind: EventRootType
-      ID: 1372
+      ID: 1388
       Name: Probe[main.testEsotericStack]
       ByteSize: 129
       PresenceBitsetSize: 1
@@ -12629,10 +12779,10 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1373
+      ID: 1389
       Name: Probe[main.testEsotericStack]Return
     - __kind: EventRootType
-      ID: 1386
+      ID: 1402
       Name: Probe[main.testFramelessArray]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12658,7 +12808,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1388
+      ID: 1404
       Name: Probe[main.testFramelessArray]Line
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -12694,7 +12844,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1387
+      ID: 1403
       Name: Probe[main.testFramelessArray]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12710,7 +12860,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1384
+      ID: 1400
       Name: Probe[main.testFrameless]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12736,7 +12886,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1385
+      ID: 1401
       Name: Probe[main.testFrameless]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12752,7 +12902,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1376
+      ID: 1392
       Name: Probe[main.testInlinedBA]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12778,10 +12928,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1377
+      ID: 1393
       Name: Probe[main.testInlinedBA]Return
     - __kind: EventRootType
-      ID: 1380
+      ID: 1396
       Name: Probe[main.testInlinedBBA]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12807,13 +12957,13 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1381
+      ID: 1397
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1555
+      ID: 1572
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 1378
+      ID: 1394
       Name: Probe[main.testInlinedBB]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12859,28 +13009,28 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1379
+      ID: 1395
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1556
+      ID: 1573
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1557
+      ID: 1574
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1558
+      ID: 1575
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1559
+      ID: 1576
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
-      ID: 1382
+      ID: 1398
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 1383
+      ID: 1399
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1552
+      ID: 1569
       Name: Probe[main.testInlinedPrint]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12892,7 +13042,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12902,11 +13052,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1550
+      ID: 1567
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12918,11 +13068,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1551
+      ID: 1568
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12934,7 +13084,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x_val
@@ -12944,11 +13094,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1554
+      ID: 1571
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12960,7 +13110,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12970,14 +13120,14 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1553
+      ID: 1570
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1560
+      ID: 1577
       Name: Probe[main.testInlinedSq]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12989,7 +13139,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12999,11 +13149,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1561
+      ID: 1578
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13015,7 +13165,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -13025,11 +13175,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: x}
+                  Variable: {subprogram: 163, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1562
+      ID: 1579
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13041,7 +13191,7 @@ Types:
             Type: 167 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: a}
+                  Variable: {subprogram: 164, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: a
@@ -13051,11 +13201,11 @@ Types:
             Type: 167 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: a}
+                  Variable: {subprogram: 164, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1330
+      ID: 1346
       Name: Probe[main.testInt16Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -13081,7 +13231,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1331
+      ID: 1347
       Name: Probe[main.testInt32Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13107,7 +13257,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1332
+      ID: 1348
       Name: Probe[main.testInt64Array]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13133,7 +13283,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1329
+      ID: 1345
       Name: Probe[main.testInt8Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -13159,7 +13309,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1328
+      ID: 1344
       Name: Probe[main.testIntArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13185,7 +13335,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1389
+      ID: 1405
       Name: Probe[main.testInterface]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13211,7 +13361,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1495
+      ID: 1511
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 161
       PresenceBitsetSize: 1
@@ -13237,7 +13387,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1496
+      ID: 1512
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13253,7 +13403,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1428
+      ID: 1444
       Name: Probe[main.testLinkedList]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13279,46 +13429,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1369
+      ID: 1385
       Name: Probe[main.testLongFunctionWithChangingState]Line
     - __kind: EventRootType
-      ID: 1370
-      Name: Probe[main.testLongFunctionWithChangingState]Line
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: aPerArch
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 1, name: aPerArch}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: b
-          Offset: 17
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 2, name: b}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1371
+      ID: 1386
       Name: Probe[main.testLongFunctionWithChangingState]Line
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13354,7 +13468,43 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1501
+      ID: 1387
+      Name: Probe[main.testLongFunctionWithChangingState]Line
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: aPerArch
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 1, name: aPerArch}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 17
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1517
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 147
       PresenceBitsetSize: 3
@@ -13540,7 +13690,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1502
+      ID: 1518
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13556,7 +13706,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1400
+      ID: 1416
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13582,7 +13732,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1407
+      ID: 1423
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13608,7 +13758,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1419
+      ID: 1435
       Name: Probe[main.testMapEmptyKeyAndValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13634,7 +13784,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1417
+      ID: 1433
       Name: Probe[main.testMapEmptyKey]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13660,7 +13810,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1418
+      ID: 1434
       Name: Probe[main.testMapEmptyValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13686,7 +13836,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1404
+      ID: 1420
       Name: Probe[main.testMapIntToInt]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13712,7 +13862,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1416
+      ID: 1432
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13738,7 +13888,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1415
+      ID: 1431
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13764,7 +13914,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1405
+      ID: 1421
       Name: Probe[main.testMapMassive]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13790,7 +13940,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1406
+      ID: 1422
       Name: Probe[main.testMapMassive]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13816,7 +13966,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1414
+      ID: 1430
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13842,7 +13992,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1413
+      ID: 1429
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13868,7 +14018,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1398
+      ID: 1414
       Name: Probe[main.testMapStringToInt]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13894,7 +14044,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1399
+      ID: 1415
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13920,7 +14070,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1397
+      ID: 1413
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13946,7 +14096,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1408
+      ID: 1424
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13972,7 +14122,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1412
+      ID: 1428
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13998,7 +14148,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1411
+      ID: 1427
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14024,7 +14174,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1410
+      ID: 1426
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14050,7 +14200,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1409
+      ID: 1425
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14076,7 +14226,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1535
+      ID: 1551
       Name: Probe[main.testMassiveString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14102,7 +14252,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1536
+      ID: 1552
       Name: Probe[main.testMassiveString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14128,7 +14278,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1503
+      ID: 1519
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 163
       PresenceBitsetSize: 3
@@ -14314,7 +14464,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1504
+      ID: 1520
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -14330,7 +14480,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1507
+      ID: 1523
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -14376,7 +14526,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1508
+      ID: 1524
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -14402,7 +14552,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1499
+      ID: 1515
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 321
       PresenceBitsetSize: 1
@@ -14448,7 +14598,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1500
+      ID: 1516
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -14464,7 +14614,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1453
+      ID: 1469
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14490,7 +14640,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1455
+      ID: 1471
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14536,7 +14686,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1457
+      ID: 1473
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14552,7 +14702,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1459
+      ID: 1475
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14568,7 +14718,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1461
+      ID: 1477
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14584,7 +14734,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1454
+      ID: 1470
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14610,7 +14760,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1456
+      ID: 1472
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -14676,7 +14826,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1458
+      ID: 1474
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14702,7 +14852,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1460
+      ID: 1476
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14728,7 +14878,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1462
+      ID: 1478
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14754,7 +14904,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1423
+      ID: 1439
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 62
       PresenceBitsetSize: 2
@@ -14860,7 +15010,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1449
+      ID: 1465
       Name: Probe[main.testNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14886,7 +15036,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1451
+      ID: 1467
       Name: Probe[main.testNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14912,7 +15062,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1450
+      ID: 1466
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14928,7 +15078,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1452
+      ID: 1468
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14954,7 +15104,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1544
+      ID: 1560
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14980,7 +15130,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1545
+      ID: 1561
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15002,10 +15152,10 @@ Types:
                   Bias: 8
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1546
+      ID: 1562
       Name: Probe[main.testNestedPointer]
     - __kind: EventRootType
-      ID: 1547
+      ID: 1563
       Name: Probe[main.testNestedPointer]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15027,7 +15177,7 @@ Types:
                   Bias: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1433
+      ID: 1449
       Name: Probe[main.testNilPointer]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15073,7 +15223,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1518
+      ID: 1534
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -15119,7 +15269,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1520
+      ID: 1536
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 67
       PresenceBitsetSize: 1
@@ -15185,7 +15335,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1521
+      ID: 1537
       Name: Probe[main.testNilSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -15211,7 +15361,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1534
+      ID: 1550
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15237,7 +15387,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1429
+      ID: 1445
       Name: Probe[main.testPointerLoop]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15263,7 +15413,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1403
+      ID: 1419
       Name: Probe[main.testPointerToMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15289,7 +15439,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1427
+      ID: 1443
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15315,7 +15465,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1443
+      ID: 1459
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 35
       PresenceBitsetSize: 1
@@ -15361,7 +15511,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1444
+      ID: 1460
       Name: Probe[main.testReturnsAnyAndError]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15387,7 +15537,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1445
+      ID: 1461
       Name: Probe[main.testReturnsAny]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15413,7 +15563,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1446
+      ID: 1462
       Name: Probe[main.testReturnsAny]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15429,10 +15579,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1475
+      ID: 1491
       Name: Probe[main.testReturnsArrayOne]
     - __kind: EventRootType
-      ID: 1476
+      ID: 1492
       Name: Probe[main.testReturnsArrayOne]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15448,10 +15598,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1477
+      ID: 1493
       Name: Probe[main.testReturnsArrayZero]
     - __kind: EventRootType
-      ID: 1478
+      ID: 1494
       Name: Probe[main.testReturnsArrayZero]Return
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -15467,10 +15617,10 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1473
+      ID: 1489
       Name: Probe[main.testReturnsArray]
     - __kind: EventRootType
-      ID: 1474
+      ID: 1490
       Name: Probe[main.testReturnsArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15486,10 +15636,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1481
+      ID: 1497
       Name: Probe[main.testReturnsBacktrackInt]
     - __kind: EventRootType
-      ID: 1482
+      ID: 1498
       Name: Probe[main.testReturnsBacktrackInt]Return
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -15585,10 +15735,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1493
+      ID: 1509
       Name: Probe[main.testReturnsBoolAndUintptr]
     - __kind: EventRootType
-      ID: 1494
+      ID: 1510
       Name: Probe[main.testReturnsBoolAndUintptr]Return
       ByteSize: 10
       PresenceBitsetSize: 1
@@ -15614,10 +15764,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1469
+      ID: 1485
       Name: Probe[main.testReturnsComplex]
     - __kind: EventRootType
-      ID: 1470
+      ID: 1486
       Name: Probe[main.testReturnsComplex]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15643,7 +15793,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1441
+      ID: 1457
       Name: Probe[main.testReturnsError]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -15669,7 +15819,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1442
+      ID: 1458
       Name: Probe[main.testReturnsError]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15685,7 +15835,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1439
+      ID: 1455
       Name: Probe[main.testReturnsIntAndFloat]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15711,7 +15861,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1440
+      ID: 1456
       Name: Probe[main.testReturnsIntAndFloat]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15737,7 +15887,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1437
+      ID: 1453
       Name: Probe[main.testReturnsIntPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15763,7 +15913,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1438
+      ID: 1454
       Name: Probe[main.testReturnsIntPointer]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15779,7 +15929,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1435
+      ID: 1451
       Name: Probe[main.testReturnsInt]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15805,7 +15955,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1436
+      ID: 1452
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15821,7 +15971,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1447
+      ID: 1463
       Name: Probe[main.testReturnsInterface]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15847,7 +15997,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1448
+      ID: 1464
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15863,10 +16013,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1471
+      ID: 1487
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1472
+      ID: 1488
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -15882,10 +16032,10 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1467
+      ID: 1483
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1468
+      ID: 1484
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 139
       PresenceBitsetSize: 3
@@ -16061,10 +16211,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1479
+      ID: 1495
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1480
+      ID: 1496
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16080,10 +16230,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1485
+      ID: 1501
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1486
+      ID: 1502
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16139,10 +16289,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1491
+      ID: 1507
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1492
+      ID: 1508
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -16168,10 +16318,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1489
+      ID: 1505
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1490
+      ID: 1506
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -16187,10 +16337,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1465
+      ID: 1481
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1466
+      ID: 1482
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -16276,10 +16426,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1487
+      ID: 1503
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1488
+      ID: 1504
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16295,10 +16445,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1483
+      ID: 1499
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1484
+      ID: 1500
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -16314,7 +16464,7 @@ Types:
                   Offset: 0
                   ByteSize: 88
     - __kind: EventRootType
-      ID: 1325
+      ID: 1341
       Name: Probe[main.testRuneArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16340,7 +16490,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1346
+      ID: 1362
       Name: Probe[main.testSingleBool]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -16366,7 +16516,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1344
+      ID: 1360
       Name: Probe[main.testSingleByte]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -16392,7 +16542,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1357
+      ID: 1373
       Name: Probe[main.testSingleFloat32]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -16418,7 +16568,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1358
+      ID: 1374
       Name: Probe[main.testSingleFloat64]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16444,7 +16594,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1349
+      ID: 1365
       Name: Probe[main.testSingleInt16]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -16470,7 +16620,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1350
+      ID: 1366
       Name: Probe[main.testSingleInt32]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -16496,7 +16646,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1351
+      ID: 1367
       Name: Probe[main.testSingleInt64]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16522,7 +16672,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1348
+      ID: 1364
       Name: Probe[main.testSingleInt8]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -16568,7 +16718,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1347
+      ID: 1363
       Name: Probe[main.testSingleInt]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16594,7 +16744,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1345
+      ID: 1361
       Name: Probe[main.testSingleRune]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -16620,7 +16770,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1528
+      ID: 1544
       Name: Probe[main.testSingleString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16646,7 +16796,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1354
+      ID: 1370
       Name: Probe[main.testSingleUint16]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -16672,7 +16822,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1355
+      ID: 1371
       Name: Probe[main.testSingleUint32]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -16698,7 +16848,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1356
+      ID: 1372
       Name: Probe[main.testSingleUint64]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16724,7 +16874,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1353
+      ID: 1369
       Name: Probe[main.testSingleUint8]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -16750,7 +16900,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1352
+      ID: 1368
       Name: Probe[main.testSingleUint]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16776,7 +16926,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1524
+      ID: 1540
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16802,7 +16952,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1515
+      ID: 1531
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16828,7 +16978,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1401
+      ID: 1417
       Name: Probe[main.testSmallMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16854,7 +17004,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1463
+      ID: 1479
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16880,7 +17030,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1464
+      ID: 1480
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16916,7 +17066,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1505
+      ID: 1521
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -16942,7 +17092,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1506
+      ID: 1522
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16978,7 +17128,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1326
+      ID: 1342
       Name: Probe[main.testStringArray]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -17004,7 +17154,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1432
+      ID: 1448
       Name: Probe[main.testStringPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17030,7 +17180,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1519
+      ID: 1535
       Name: Probe[main.testStringSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17056,7 +17206,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1367
+      ID: 1383
       Name: Probe[main.testStringType1]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17082,7 +17232,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1368
+      ID: 1384
       Name: Probe[main.testStringType2]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17108,7 +17258,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1516
+      ID: 1532
       Name: Probe[main.testStructSlice]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -17154,7 +17304,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1395
+      ID: 1411
       Name: Probe[main.testStructWithAny]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17180,7 +17330,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1509
+      ID: 1525
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17206,7 +17356,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1510
+      ID: 1526
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17232,7 +17382,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1541
+      ID: 1557
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17258,7 +17408,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1540
+      ID: 1556
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 289
       PresenceBitsetSize: 1
@@ -17284,7 +17434,7 @@ Types:
                   Offset: 0
                   ByteSize: 144
     - __kind: EventRootType
-      ID: 1396
+      ID: 1412
       Name: Probe[main.testStructWithMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17310,7 +17460,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1542
+      ID: 1558
       Name: Probe[main.testStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17326,7 +17476,7 @@ Types:
                   Offset: 8
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1543
+      ID: 1559
       Name: Probe[main.testStruct]
       ByteSize: 113
       PresenceBitsetSize: 1
@@ -17352,7 +17502,7 @@ Types:
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1525
+      ID: 1541
       Name: Probe[main.testSubslices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -17418,7 +17568,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1539
+      ID: 1555
       Name: Probe[main.testSubstrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17484,7 +17634,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1532
+      ID: 1548
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17510,7 +17660,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1533
+      ID: 1549
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17555,7 +17705,7 @@ Types:
                   Bias: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1530
+      ID: 1546
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17581,7 +17731,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1531
+      ID: 1547
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17617,7 +17767,7 @@ Types:
                   Offset: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1529
+      ID: 1545
       Name: Probe[main.testThreeStrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17683,7 +17833,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1359
+      ID: 1375
       Name: Probe[main.testTypeAlias]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -17709,7 +17859,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1335
+      ID: 1351
       Name: Probe[main.testUint16Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -17735,7 +17885,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1336
+      ID: 1352
       Name: Probe[main.testUint32Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17761,7 +17911,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1337
+      ID: 1353
       Name: Probe[main.testUint64Array]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17787,7 +17937,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1334
+      ID: 1350
       Name: Probe[main.testUint8Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -17813,7 +17963,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1333
+      ID: 1349
       Name: Probe[main.testUintArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17839,7 +17989,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1431
+      ID: 1447
       Name: Probe[main.testUintPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17865,7 +18015,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1513
+      ID: 1529
       Name: Probe[main.testUintSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17891,7 +18041,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1537
+      ID: 1553
       Name: Probe[main.testUnitializedString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17917,7 +18067,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1430
+      ID: 1446
       Name: Probe[main.testUnsafePointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17943,7 +18093,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1343
+      ID: 1359
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 1601
       PresenceBitsetSize: 1
@@ -17969,7 +18119,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1522
+      ID: 1538
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17995,7 +18145,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1523
+      ID: 1539
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -18021,7 +18171,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1511
+      ID: 1527
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -18067,7 +18217,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1512
+      ID: 1528
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -18328,7 +18478,15 @@ Types:
       HasCount: true
       Element: 33 StructureType internal/runtime/atomic.Uint32
     - __kind: ArrayType
-      ID: 433
+      ID: 341
+      Name: '[3]uint64'
+      ByteSize: 24
+      GoKind: 17
+      Count: 3
+      HasCount: true
+      Element: 8 BaseType uint64
+    - __kind: ArrayType
+      ID: 449
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 689600
@@ -18337,7 +18495,7 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 390
+      ID: 406
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 689888
@@ -18363,7 +18521,15 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 1001
+      ID: 342
+      Name: '[5]int64'
+      ByteSize: 40
+      GoKind: 17
+      Count: 5
+      HasCount: true
+      Element: 13 BaseType int64
+    - __kind: ArrayType
+      ID: 1017
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 691424
@@ -18405,15 +18571,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 340 GoSliceDataType []*main.deepSlice2.array
+      Data: 356 GoSliceDataType []*main.deepSlice2.array
     - __kind: GoSliceDataType
-      ID: 340
+      ID: 356
       Name: '[]*main.deepSlice2.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 146 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 1238
+      ID: 1254
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 483712
@@ -18421,22 +18587,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1239 PointerType **main.deepSlice3
+          Type: 1255 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1242 GoSliceDataType []*main.deepSlice3.array
+      Data: 1258 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 1242
+      ID: 1258
       Name: '[]*main.deepSlice3.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1240 PointerType *main.deepSlice3
+      Element: 1256 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 1263
+      ID: 1279
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 483392
@@ -18444,22 +18610,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1264 PointerType **main.deepSlice8
+          Type: 1280 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1267 GoSliceDataType []*main.deepSlice8.array
+      Data: 1283 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 1267
+      ID: 1283
       Name: '[]*main.deepSlice8.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1265 PointerType *main.deepSlice8
+      Element: 1281 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 1269
+      ID: 1285
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 483328
@@ -18467,20 +18633,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1270 PointerType **main.deepSlice9
+          Type: 1286 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1273 GoSliceDataType []*main.deepSlice9.array
+      Data: 1289 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 1273
+      ID: 1289
       Name: '[]*main.deepSlice9.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1271 PointerType *main.deepSlice9
+      Element: 1287 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 66
       Name: '[]*runtime.p'
@@ -18497,9 +18663,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 335 GoSliceDataType []*runtime.p.array
+      Data: 351 GoSliceDataType []*runtime.p.array
     - __kind: GoSliceDataType
-      ID: 335
+      ID: 351
       Name: '[]*runtime.p.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -18520,171 +18686,171 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 337 GoSliceDataType []*string.array
+      Data: 353 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 337
+      ID: 353
       Name: '[]*string.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 101 PointerType *string
     - __kind: GoSliceDataType
-      ID: 450
+      ID: 466
       Name: '[]*table<[4]int,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 233 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 442
+      ID: 458
       Name: '[]*table<[4]int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 228 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 391
+      ID: 407
       Name: '[]*table<[4]string,[2]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 196 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 409
+      ID: 425
       Name: '[]*table<bool,main.node>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 208 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 350
+      ID: 366
       Name: '[]*table<int,*main.deepMap2>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 154 PointerType *table<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 1257
+      ID: 1273
       Name: '[]*table<int,*main.deepMap3>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1248 PointerType *table<int,*main.deepMap3>
+      Element: 1264 PointerType *table<int,*main.deepMap3>
     - __kind: GoSliceDataType
-      ID: 1291
+      ID: 1307
       Name: '[]*table<int,*main.deepMap8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1282 PointerType *table<int,*main.deepMap8>
+      Element: 1298 PointerType *table<int,*main.deepMap8>
     - __kind: GoSliceDataType
-      ID: 1306
+      ID: 1322
       Name: '[]*table<int,*main.deepMap9>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1297 PointerType *table<int,*main.deepMap9>
+      Element: 1313 PointerType *table<int,*main.deepMap9>
     - __kind: GoSliceDataType
-      ID: 358
+      ID: 374
       Name: '[]*table<int,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 176 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 1319
+      ID: 1335
       Name: '[]*table<int,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1312 PointerType *table<int,interface {}>
+      Element: 1328 PointerType *table<int,interface {}>
     - __kind: GoSliceDataType
-      ID: 466
+      ID: 482
       Name: '[]*table<int,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 243 PointerType *table<int,struct {}>
     - __kind: GoSliceDataType
-      ID: 417
+      ID: 433
       Name: '[]*table<int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 213 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 401
+      ID: 417
       Name: '[]*table<string,[]main.structWithMap>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 203 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 382
+      ID: 398
       Name: '[]*table<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 191 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 1017
+      ID: 1033
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 984 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 1000 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 374
+      ID: 390
       Name: '[]*table<string,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 186 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 366
+      ID: 382
       Name: '[]*table<string,main.nestedStruct>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 181 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 458
+      ID: 474
       Name: '[]*table<struct {},int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 238 PointerType *table<struct {},int>
     - __kind: GoSliceDataType
-      ID: 508
+      ID: 524
       Name: '[]*table<struct {},main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 296 PointerType *table<struct {},main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 516
+      ID: 532
       Name: '[]*table<struct {},map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 301 PointerType *table<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 524
+      ID: 540
       Name: '[]*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 306 PointerType *table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 532
+      ID: 548
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 311 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 540
+      ID: 556
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 316 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 548
+      ID: 564
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 321 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 474
+      ID: 490
       Name: '[]*table<struct {},struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 248 PointerType *table<struct {},struct {}>
     - __kind: GoSliceDataType
-      ID: 434
+      ID: 450
       Name: '[]*table<uint8,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 223 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 425
+      ID: 441
       Name: '[]*table<uint8,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
@@ -18704,9 +18870,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 500 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Data: 516 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 500
+      ID: 516
       Name: '[][][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -18726,9 +18892,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 498 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Data: 514 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 498
+      ID: 514
       Name: '[][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -18748,9 +18914,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 496 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Data: 512 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 496
+      ID: 512
       Name: '[][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -18770,9 +18936,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 494 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Data: 510 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 494
+      ID: 510
       Name: '[][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -18792,9 +18958,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 492 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Data: 508 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 492
+      ID: 508
       Name: '[][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -18814,9 +18980,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 478 GoSliceDataType [][]uint.array
+      Data: 494 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 478
+      ID: 494
       Name: '[][]uint.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -18837,15 +19003,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 484 GoSliceDataType []bool.array
+      Data: 500 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 484
+      ID: 500
       Name: '[]bool.array'
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 996
+      ID: 1012
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 493312
@@ -18860,15 +19026,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1019 GoSliceDataType []float64.array
+      Data: 1035 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 1019
+      ID: 1035
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 14 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 1275
+      ID: 1291
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 493760
@@ -18883,9 +19049,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1276 GoSliceDataType []interface {}.array
+      Data: 1292 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 1276
+      ID: 1292
       Name: '[]interface {}.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -18905,15 +19071,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 490 GoSliceDataType []main.structWithCyclicSlices.array
+      Data: 506 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 490
+      ID: 506
       Name: '[]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 144
       Element: 278 StructureType main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 399
+      ID: 415
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 484032
@@ -18921,16 +19087,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 400 PointerType *main.structWithMap
+          Type: 416 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 550 GoSliceDataType []main.structWithMap.array
+      Data: 566 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 550
+      ID: 566
       Name: '[]main.structWithMap.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -18950,175 +19116,175 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 480 GoSliceDataType []main.structWithNoStrings.array
+      Data: 496 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 480
+      ID: 496
       Name: '[]main.structWithNoStrings.array'
       DynamicSizeClass: slice
       ByteSize: 2
       Element: 268 StructureType main.structWithNoStrings
     - __kind: GoSliceDataType
-      ID: 451
+      ID: 467
       Name: '[]noalg.map.group[[4]int][4]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 520
-      Element: 447 StructureType noalg.map.group[[4]int][4]int
+      Element: 463 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 443
+      ID: 459
       Name: '[]noalg.map.group[[4]int]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 439 StructureType noalg.map.group[[4]int]uint8
+      Element: 455 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 392
+      ID: 408
       Name: '[]noalg.map.group[[4]string][2]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 648
-      Element: 387 StructureType noalg.map.group[[4]string][2]int
+      Element: 403 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 410
+      ID: 426
       Name: '[]noalg.map.group[bool]main.node.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 406 StructureType noalg.map.group[bool]main.node
+      Element: 422 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
-      ID: 351
+      ID: 367
       Name: '[]noalg.map.group[int]*main.deepMap2.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 345 StructureType noalg.map.group[int]*main.deepMap2
+      Element: 361 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSliceDataType
-      ID: 1258
+      ID: 1274
       Name: '[]noalg.map.group[int]*main.deepMap3.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1252 StructureType noalg.map.group[int]*main.deepMap3
+      Element: 1268 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSliceDataType
-      ID: 1292
+      ID: 1308
       Name: '[]noalg.map.group[int]*main.deepMap8.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1286 StructureType noalg.map.group[int]*main.deepMap8
+      Element: 1302 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSliceDataType
-      ID: 1307
+      ID: 1323
       Name: '[]noalg.map.group[int]*main.deepMap9.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1301 StructureType noalg.map.group[int]*main.deepMap9
+      Element: 1317 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSliceDataType
-      ID: 359
+      ID: 375
       Name: '[]noalg.map.group[int]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 355 StructureType noalg.map.group[int]int
+      Element: 371 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 1320
+      ID: 1336
       Name: '[]noalg.map.group[int]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 1316 StructureType noalg.map.group[int]interface {}
+      Element: 1332 StructureType noalg.map.group[int]interface {}
     - __kind: GoSliceDataType
-      ID: 467
+      ID: 483
       Name: '[]noalg.map.group[int]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 463 StructureType noalg.map.group[int]struct {}
+      Element: 479 StructureType noalg.map.group[int]struct {}
     - __kind: GoSliceDataType
-      ID: 418
+      ID: 434
       Name: '[]noalg.map.group[int]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 414 StructureType noalg.map.group[int]uint8
+      Element: 430 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
-      ID: 402
+      ID: 418
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 396 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 412 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
-      ID: 383
+      ID: 399
       Name: '[]noalg.map.group[string][]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 379 StructureType noalg.map.group[string][]string
+      Element: 395 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 1018
+      ID: 1034
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 1014 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 1030 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
-      ID: 375
+      ID: 391
       Name: '[]noalg.map.group[string]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 371 StructureType noalg.map.group[string]int
+      Element: 387 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 367
+      ID: 383
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 363 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 379 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 459
+      ID: 475
       Name: '[]noalg.map.group[struct {}]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 455 StructureType noalg.map.group[struct {}]int
+      Element: 471 StructureType noalg.map.group[struct {}]int
     - __kind: GoSliceDataType
-      ID: 509
+      ID: 525
       Name: '[]noalg.map.group[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 392
-      Element: 505 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      Element: 521 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 517
+      ID: 533
       Name: '[]noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 513 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 529 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 525
+      ID: 541
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 521 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 537 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 533
+      ID: 549
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 529 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 545 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 541
+      ID: 557
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 537 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 553 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 549
+      ID: 565
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 545 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 561 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 475
+      ID: 491
       Name: '[]noalg.map.group[struct {}]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 16
-      Element: 471 StructureType noalg.map.group[struct {}]struct {}
+      Element: 487 StructureType noalg.map.group[struct {}]struct {}
     - __kind: GoSliceDataType
-      ID: 435
+      ID: 451
       Name: '[]noalg.map.group[uint8][4]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 430 StructureType noalg.map.group[uint8][4]int
+      Element: 446 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 426
+      ID: 442
       Name: '[]noalg.map.group[uint8]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 24
-      Element: 422 StructureType noalg.map.group[uint8]uint8
+      Element: 438 StructureType noalg.map.group[uint8]uint8
     - __kind: UnresolvedPointeeType
       ID: 41
       Name: '[]runtime.ancestorInfo'
@@ -19139,9 +19305,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 482 GoSliceDataType []string.array
+      Data: 498 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 482
+      ID: 498
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -19161,9 +19327,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 488 GoSliceDataType []struct {}.array
+      Data: 504 GoSliceDataType []struct {}.array
     - __kind: GoSliceDataType
-      ID: 488
+      ID: 504
       Name: '[]struct {}.array'
       DynamicSizeClass: slice
       Element: 131 StructureType struct {}
@@ -19183,9 +19349,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 476 GoSliceDataType []uint.array
+      Data: 492 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 476
+      ID: 492
       Name: '[]uint.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -19206,9 +19372,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 486 GoSliceDataType []uint16.array
+      Data: 502 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 486
+      ID: 502
       Name: '[]uint16.array'
       DynamicSizeClass: slice
       ByteSize: 2
@@ -19229,9 +19395,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 330 GoSliceDataType []uint8.array
+      Data: 346 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 330
+      ID: 346
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -19252,19 +19418,19 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 332 GoSliceDataType []uintptr.array
+      Data: 348 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 332
+      ID: 348
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 1 BaseType uintptr
     - __kind: UnresolvedPointeeType
-      ID: 1152
+      ID: 1168
       Name: archive/tar.Writer
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 786
+      ID: 802
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 940672
@@ -19279,33 +19445,33 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 787 GoSliceDataType archive/tar.headerError.array
+      Data: 803 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 787
+      ID: 803
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1086
+      ID: 1102
       Name: archive/tar.regFileWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1034
+      ID: 1050
       Name: archive/zip.countWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1036
+      ID: 1052
       Name: archive/zip.dirWriter
       GoRuntimeType: 1.12896e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1129
+      ID: 1145
       Name: archive/zip.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1062
+      ID: 1078
       Name: archive/zip.nopCloser
       ByteSize: 16
       GoRuntimeType: 1.580576e+06
@@ -19315,7 +19481,7 @@ Types:
           Offset: 0
           Type: 137 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1064
+      ID: 1080
       Name: archive/zip.pooledFlateWriter
       ByteSize: 8
     - __kind: BaseType
@@ -19325,15 +19491,15 @@ Types:
       GoRuntimeType: 591328
       GoKind: 1
     - __kind: UnresolvedPointeeType
-      ID: 1110
+      ID: 1126
       Name: bufio.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1139
+      ID: 1155
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1188
+      ID: 1204
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
@@ -19359,13 +19525,13 @@ Types:
       GoRuntimeType: 591072
       GoKind: 15
     - __kind: BaseType
-      ID: 589
+      ID: 605
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 841920
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 590
+      ID: 606
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 842016
@@ -19373,120 +19539,120 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 592 PointerType *compress/flate.InternalError.str
+          Type: 608 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 591 GoStringDataType compress/flate.InternalError.str
+      Data: 607 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 591
+      ID: 607
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1084
+      ID: 1100
       Name: compress/flate.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1030
+      ID: 1046
       Name: compress/flate.dictWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1106
+      ID: 1122
       Name: compress/gzip.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 934
+      ID: 950
       Name: context.deadlineExceededError
       GoRuntimeType: 1.492736e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 600
+      ID: 616
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 844512
       GoKind: 2
     - __kind: BaseType
-      ID: 601
+      ID: 617
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 844608
       GoKind: 2
     - __kind: BaseType
-      ID: 602
+      ID: 618
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 844704
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1101
+      ID: 1117
       Name: crypto/internal/fips140/hmac.HMAC
       ByteSize: 8
     - __kind: StructureType
-      ID: 883
+      ID: 899
       Name: crypto/internal/fips140/hmac.errCloneUnsupported
       GoRuntimeType: 1.300416e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1131
+      ID: 1147
       Name: crypto/internal/fips140/sha256.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1163
+      ID: 1179
       Name: crypto/internal/fips140/sha3.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1137
+      ID: 1153
       Name: crypto/internal/fips140/sha3.SHAKE
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1133
+      ID: 1149
       Name: crypto/internal/fips140/sha512.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1127
+      ID: 1143
       Name: crypto/md5.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 603
+      ID: 619
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 844800
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1150
+      ID: 1166
       Name: crypto/sha1.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1135
+      ID: 1151
       Name: crypto/sha3.SHA3
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1119
+      ID: 1135
       Name: crypto/sha3.SHAKE
       ByteSize: 8
     - __kind: BaseType
-      ID: 593
+      ID: 609
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 842496
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 872
+      ID: 888
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1214
+      ID: 1230
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 706
+      ID: 722
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 703
+      ID: 719
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1.749024e+06
@@ -19497,38 +19663,38 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 1001 ArrayType [5]uint8
+          Type: 1017 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 1002 GoInterfaceType net.Conn
+          Type: 1018 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 825
+      ID: 841
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 1.002752e+06
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1094
+      ID: 1110
       Name: crypto/tls.cthWrapper
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 708
+      ID: 724
       Name: crypto/tls.echConfigErr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1099
+      ID: 1115
       Name: crypto/tls.finishedHash
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 969
+      ID: 985
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 986
+      ID: 1002
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 774
+      ID: 790
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1.751904e+06
@@ -19536,21 +19702,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 985 PointerType *crypto/x509.Certificate
+          Type: 1001 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 1004 BaseType crypto/x509.InvalidReason
+          Type: 1020 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 768
+      ID: 784
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1.1264e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 770
+      ID: 786
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1.615808e+06
@@ -19558,24 +19724,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 985 PointerType *crypto/x509.Certificate
+          Type: 1001 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 599
+      ID: 615
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 844032
       GoKind: 2
     - __kind: BaseType
-      ID: 1004
+      ID: 1020
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 596384
       GoKind: 2
     - __kind: StructureType
-      ID: 877
+      ID: 893
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1.576416e+06
@@ -19585,13 +19751,13 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 776
+      ID: 792
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1.126656e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 772
+      ID: 788
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1.751712e+06
@@ -19599,15 +19765,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 985 PointerType *crypto/x509.Certificate
+          Type: 1001 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 15 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 985 PointerType *crypto/x509.Certificate
+          Type: 1001 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 790
+      ID: 806
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1.448224e+06
@@ -19617,7 +19783,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 794
+      ID: 810
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1.448384e+06
@@ -19627,55 +19793,55 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 792
+      ID: 808
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 584
+      ID: 600
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 841440
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 1052
+      ID: 1068
       Name: encoding/base64.encoder
       ByteSize: 8
     - __kind: BaseType
-      ID: 585
+      ID: 601
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 841632
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 661
+      ID: 677
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 861
+      ID: 877
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 653
+      ID: 669
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 659
+      ID: 675
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 657
+      ID: 673
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 655
+      ID: 671
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1194
+      ID: 1210
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 663
+      ID: 679
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1.431424e+06
@@ -19685,11 +19851,11 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1060
+      ID: 1076
       Name: encoding/pem.lineBreaker
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 765
+      ID: 781
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -19706,11 +19872,11 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 626
+      ID: 642
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 828
+      ID: 844
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -19726,15 +19892,15 @@ Types:
       GoRuntimeType: 591264
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 1182
+      ID: 1198
       Name: fmt.pp
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 830
+      ID: 846
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 832
+      ID: 848
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -19750,11 +19916,11 @@ Types:
       GoRuntimeType: 855072
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 691
+      ID: 707
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 672
+      ID: 688
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1.747872e+06
@@ -19762,7 +19928,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 994 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 1010 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 7 BaseType int
@@ -19770,25 +19936,25 @@ Types:
           Offset: 200
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 674
+      ID: 690
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 998
+      ID: 1014
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 678
+      ID: 694
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1.122688e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1000
+      ID: 1016
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 578
+      ID: 594
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 840864
@@ -19796,18 +19962,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 580 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 596 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 579 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 595 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 579
+      ID: 595
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 994
+      ID: 1010
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2.242656e+06
@@ -19815,7 +19981,7 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 995 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 1011 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -19830,7 +19996,7 @@ Types:
           Type: 14 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 996 GoSliceHeaderType []float64
+          Type: 1012 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 13 BaseType int64
@@ -19839,10 +20005,10 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 997 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 1013 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 999 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 1015 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
           Type: 269 GoSliceHeaderType []string
@@ -19856,13 +20022,13 @@ Types:
           Offset: 184
           Type: 13 BaseType int64
     - __kind: BaseType
-      ID: 995
+      ID: 1011
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 593056
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 575
+      ID: 591
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 840768
@@ -19870,18 +20036,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 577 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 593 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 576 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 592 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 576
+      ID: 592
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 581
+      ID: 597
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 840960
@@ -19889,60 +20055,60 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 583 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 599 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 582 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 598 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 582
+      ID: 598
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1072
+      ID: 1088
       Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1160
+      ID: 1176
       Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 784
+      ID: 800
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 943
+      ID: 959
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1190
+      ID: 1206
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 716
+      ID: 732
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 723
+      ID: 739
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1.125632e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 598
+      ID: 614
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 843168
       GoKind: 2
     - __kind: StructureType
-      ID: 721
+      ID: 737
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1.125504e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 719
+      ID: 735
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1.613728e+06
@@ -19955,7 +20121,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 739
+      ID: 755
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1.614528e+06
@@ -19968,7 +20134,7 @@ Types:
           Offset: 16
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 743
+      ID: 759
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1.751136e+06
@@ -19984,7 +20150,7 @@ Types:
           Offset: 24
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 741
+      ID: 757
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1.441184e+06
@@ -19994,7 +20160,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 737
+      ID: 753
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1.440864e+06
@@ -20004,14 +20170,14 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 980
+      ID: 996
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1.514176e+06
       GoKind: 21
-      HeaderType: 982 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 998 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 1003
+      ID: 1019
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1.060096e+06
@@ -20026,15 +20192,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1021 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 1037 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 1021
+      ID: 1037
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 751
+      ID: 767
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1.614848e+06
@@ -20042,12 +20208,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 980 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 996 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 980 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 996 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 745
+      ID: 761
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1.441344e+06
@@ -20057,7 +20223,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 749
+      ID: 765
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1.751328e+06
@@ -20068,12 +20234,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 1003 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1019 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 1003 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1019 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 747
+      ID: 763
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1.614688e+06
@@ -20086,7 +20252,7 @@ Types:
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 753
+      ID: 769
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1.441504e+06
@@ -20094,9 +20260,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 970 StructureType time.Time
+          Type: 986 StructureType time.Time
     - __kind: StructureType
-      ID: 759
+      ID: 775
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1.615168e+06
@@ -20109,7 +20275,7 @@ Types:
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 761
+      ID: 777
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1.441824e+06
@@ -20119,7 +20285,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 757
+      ID: 773
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1.615008e+06
@@ -20132,7 +20298,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 755
+      ID: 771
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1.441664e+06
@@ -20142,7 +20308,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 763
+      ID: 779
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1.615328e+06
@@ -20155,7 +20321,7 @@ Types:
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 680
+      ID: 696
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1.433664e+06
@@ -20165,11 +20331,11 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1113
+      ID: 1129
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 682
+      ID: 698
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1.433824e+06
@@ -20177,21 +20343,21 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 680 StructureType github.com/cihub/seelog.baseError
+          Type: 696 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1092
+      ID: 1108
       Name: github.com/cihub/seelog.connWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1048
+      ID: 1064
       Name: github.com/cihub/seelog.consoleWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1082
+      ID: 1098
       Name: github.com/cihub/seelog.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 686
+      ID: 702
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1.434144e+06
@@ -20199,13 +20365,13 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 680 StructureType github.com/cihub/seelog.baseError
+          Type: 696 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1148
+      ID: 1164
       Name: github.com/cihub/seelog.rollingFileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1161
+      ID: 1177
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
       GoRuntimeType: 2.128992e+06
@@ -20213,12 +20379,12 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1147 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1163 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: maxFileSize
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 1164
+      ID: 1180
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
       GoRuntimeType: 2.154656e+06
@@ -20226,7 +20392,7 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1147 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1163 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: timePattern
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -20234,11 +20400,11 @@ Types:
           Offset: 24
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1050
+      ID: 1066
       Name: github.com/cihub/seelog.smtpWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 684
+      ID: 700
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1.433984e+06
@@ -20246,9 +20412,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 680 StructureType github.com/cihub/seelog.baseError
+          Type: 696 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 688
+      ID: 704
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1.434304e+06
@@ -20256,64 +20422,64 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 680 StructureType github.com/cihub/seelog.baseError
+          Type: 696 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1115
+      ID: 1131
       Name: github.com/cihub/seelog/archive/gzip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1156
+      ID: 1172
       Name: github.com/cihub/seelog/archive/tar.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1158
+      ID: 1174
       Name: github.com/cihub/seelog/archive/zip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 974
+      ID: 990
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 887
+      ID: 903
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 885
+      ID: 901
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 889
+      ID: 905
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 891
+      ID: 907
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1103
+      ID: 1119
       Name: github.com/gogo/protobuf/proto.textWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 879
+      ID: 895
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 694
+      ID: 710
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1.435264e+06
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 7 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 1206
+      ID: 1222
       Name: github.com/json-iterator/go.Stream
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 945
+      ID: 961
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 918
+      ID: 934
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1.861472e+06
@@ -20329,11 +20495,11 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 912
+      ID: 928
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 847
+      ID: 863
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1.720576e+06
@@ -20346,7 +20512,7 @@ Types:
           Offset: 1
           Type: 19 BaseType int8
     - __kind: StructureType
-      ID: 924
+      ID: 940
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1.86192e+06
@@ -20362,13 +20528,13 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 824
+      ID: 840
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 1.000064e+06
       GoKind: 8
     - __kind: StructureType
-      ID: 916
+      ID: 932
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1.861248e+06
@@ -20384,13 +20550,13 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 1005
+      ID: 1021
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 839040
       GoKind: 8
     - __kind: StructureType
-      ID: 914
+      ID: 930
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1.861024e+06
@@ -20398,15 +20564,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 1005 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 1021 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 1005 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 1021 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 922
+      ID: 938
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1.775264e+06
@@ -20419,7 +20585,7 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 920
+      ID: 936
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1.861696e+06
@@ -20435,11 +20601,11 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1210
+      ID: 1226
       Name: github.com/tinylib/msgp/msgp.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 928
+      ID: 944
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1.640608e+06
@@ -20449,19 +20615,19 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 851
+      ID: 867
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1.293888e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 849
+      ID: 865
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1.29376e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 926
+      ID: 942
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1.775456e+06
@@ -20474,7 +20640,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 608
+      ID: 624
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 846624
@@ -20482,22 +20648,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 610 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 626 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 609 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 625 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 609
+      ID: 625
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 989
+      ID: 1005
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 895
+      ID: 911
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1.460064e+06
@@ -20507,7 +20673,7 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 1078
+      ID: 1094
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
       GoRuntimeType: 1.695904e+06
@@ -20515,13 +20681,13 @@ Types:
       RawFields:
         - Name: WriteSyncer
           Offset: 0
-          Type: 1104 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+          Type: 1120 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
     - __kind: UnresolvedPointeeType
-      ID: 1172
+      ID: 1188
       Name: go.uber.org/zap/buffer.Buffer
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1104
+      ID: 1120
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
       GoRuntimeType: 1.136512e+06
@@ -20534,7 +20700,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1066
+      ID: 1082
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
       GoRuntimeType: 1.585696e+06
@@ -20544,19 +20710,19 @@ Types:
           Offset: 0
           Type: 137 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 611
+      ID: 627
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 847200
       GoKind: 10
     - __kind: BaseType
-      ID: 987
+      ID: 1003
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 1.013312e+06
       GoKind: 10
     - __kind: StructureType
-      ID: 953
+      ID: 969
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1.899776e+06
@@ -20567,12 +20733,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 987 BaseType golang.org/x/net/http2.ErrCode
+          Type: 1003 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 810
+      ID: 826
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1.622848e+06
@@ -20580,12 +20746,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 987 BaseType golang.org/x/net/http2.ErrCode
+          Type: 1003 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 615
+      ID: 631
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 847392
@@ -20593,18 +20759,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 617 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 633 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 616 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 632 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 616
+      ID: 632
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 621
+      ID: 637
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 847584
@@ -20612,18 +20778,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 623 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 639 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 622 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 638 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 622
+      ID: 638
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 618
+      ID: 634
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 847488
@@ -20631,18 +20797,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 620 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 636 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 619 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 635 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 619
+      ID: 635
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 612
+      ID: 628
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 847296
@@ -20650,22 +20816,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 614 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 630 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 613 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 629 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 613
+      ID: 629
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1170
+      ID: 1186
       Name: golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 814
+      ID: 830
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.460704e+06
@@ -20675,13 +20841,13 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: BaseType
-      ID: 624
+      ID: 640
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 847680
       GoKind: 2
     - __kind: StructureType
-      ID: 802
+      ID: 818
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1.455744e+06
@@ -20691,11 +20857,11 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 951
+      ID: 967
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 976
+      ID: 992
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1.92864e+06
@@ -20711,7 +20877,7 @@ Types:
           Offset: 24
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 804
+      ID: 820
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1.622368e+06
@@ -20724,7 +20890,7 @@ Types:
           Offset: 16
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 1121
+      ID: 1137
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
       GoRuntimeType: 1.987968e+06
@@ -20732,16 +20898,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 1002 GoInterfaceType net.Conn
+          Type: 1018 GoInterfaceType net.Conn
         - Name: r
           Offset: 16
-          Type: 1146 GoInterfaceType io.Reader
+          Type: 1162 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 1076
+      ID: 1092
       Name: google.golang.org/grpc/internal/transport.bufWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 893
+      ID: 909
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1.583296e+06
@@ -20751,29 +20917,29 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1038
+      ID: 1054
       Name: google.golang.org/grpc/mem.writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 782
+      ID: 798
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 881
+      ID: 897
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 949
+      ID: 965
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 947
+      ID: 963
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1.525696e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 796
+      ID: 812
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1.449024e+06
@@ -20783,7 +20949,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 798
+      ID: 814
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1.449184e+06
@@ -20793,393 +20959,393 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 731
+      ID: 747
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 445
+      ID: 461
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 446 PointerType *noalg.map.group[[4]int][4]int
+          Type: 462 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 447 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 451 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      GroupType: 463 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 467 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 437
+      ID: 453
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 438 PointerType *noalg.map.group[[4]int]uint8
+          Type: 454 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 439 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 443 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 455 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 459 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 385
+      ID: 401
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 386 PointerType *noalg.map.group[[4]string][2]int
+          Type: 402 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 387 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 392 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 403 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 408 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 404
+      ID: 420
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 405 PointerType *noalg.map.group[bool]main.node
+          Type: 421 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 406 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 410 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 422 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 426 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 343
+      ID: 359
       Name: groupReference<int,*main.deepMap2>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 344 PointerType *noalg.map.group[int]*main.deepMap2
+          Type: 360 PointerType *noalg.map.group[int]*main.deepMap2
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 345 StructureType noalg.map.group[int]*main.deepMap2
-      GroupSliceType: 351 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
+      GroupType: 361 StructureType noalg.map.group[int]*main.deepMap2
+      GroupSliceType: 367 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
     - __kind: GoSwissMapGroupsType
-      ID: 1250
+      ID: 1266
       Name: groupReference<int,*main.deepMap3>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1251 PointerType *noalg.map.group[int]*main.deepMap3
+          Type: 1267 PointerType *noalg.map.group[int]*main.deepMap3
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1252 StructureType noalg.map.group[int]*main.deepMap3
-      GroupSliceType: 1258 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+      GroupType: 1268 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 1274 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
     - __kind: GoSwissMapGroupsType
-      ID: 1284
+      ID: 1300
       Name: groupReference<int,*main.deepMap8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1285 PointerType *noalg.map.group[int]*main.deepMap8
+          Type: 1301 PointerType *noalg.map.group[int]*main.deepMap8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1286 StructureType noalg.map.group[int]*main.deepMap8
-      GroupSliceType: 1292 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
+      GroupType: 1302 StructureType noalg.map.group[int]*main.deepMap8
+      GroupSliceType: 1308 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
     - __kind: GoSwissMapGroupsType
-      ID: 1299
+      ID: 1315
       Name: groupReference<int,*main.deepMap9>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1300 PointerType *noalg.map.group[int]*main.deepMap9
+          Type: 1316 PointerType *noalg.map.group[int]*main.deepMap9
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1301 StructureType noalg.map.group[int]*main.deepMap9
-      GroupSliceType: 1307 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
+      GroupType: 1317 StructureType noalg.map.group[int]*main.deepMap9
+      GroupSliceType: 1323 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
     - __kind: GoSwissMapGroupsType
-      ID: 353
+      ID: 369
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 354 PointerType *noalg.map.group[int]int
+          Type: 370 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 355 StructureType noalg.map.group[int]int
-      GroupSliceType: 359 GoSliceDataType []noalg.map.group[int]int.array
+      GroupType: 371 StructureType noalg.map.group[int]int
+      GroupSliceType: 375 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 1314
+      ID: 1330
       Name: groupReference<int,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1315 PointerType *noalg.map.group[int]interface {}
+          Type: 1331 PointerType *noalg.map.group[int]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1316 StructureType noalg.map.group[int]interface {}
-      GroupSliceType: 1320 GoSliceDataType []noalg.map.group[int]interface {}.array
+      GroupType: 1332 StructureType noalg.map.group[int]interface {}
+      GroupSliceType: 1336 GoSliceDataType []noalg.map.group[int]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 461
+      ID: 477
       Name: groupReference<int,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 462 PointerType *noalg.map.group[int]struct {}
+          Type: 478 PointerType *noalg.map.group[int]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 463 StructureType noalg.map.group[int]struct {}
-      GroupSliceType: 467 GoSliceDataType []noalg.map.group[int]struct {}.array
+      GroupType: 479 StructureType noalg.map.group[int]struct {}
+      GroupSliceType: 483 GoSliceDataType []noalg.map.group[int]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 412
+      ID: 428
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 413 PointerType *noalg.map.group[int]uint8
+          Type: 429 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 414 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 418 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 430 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 434 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 394
+      ID: 410
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 395 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 411 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 396 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 402 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 412 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 418 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 377
+      ID: 393
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 378 PointerType *noalg.map.group[string][]string
+          Type: 394 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 379 StructureType noalg.map.group[string][]string
-      GroupSliceType: 383 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 395 StructureType noalg.map.group[string][]string
+      GroupSliceType: 399 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 1012
+      ID: 1028
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1013 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1029 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1014 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 1018 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 1030 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 1034 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
-      ID: 369
+      ID: 385
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 370 PointerType *noalg.map.group[string]int
+          Type: 386 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 371 StructureType noalg.map.group[string]int
-      GroupSliceType: 375 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 387 StructureType noalg.map.group[string]int
+      GroupSliceType: 391 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 361
+      ID: 377
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 362 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 378 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 363 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 367 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+      GroupType: 379 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 383 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 453
+      ID: 469
       Name: groupReference<struct {},int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 454 PointerType *noalg.map.group[struct {}]int
+          Type: 470 PointerType *noalg.map.group[struct {}]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 455 StructureType noalg.map.group[struct {}]int
-      GroupSliceType: 459 GoSliceDataType []noalg.map.group[struct {}]int.array
+      GroupType: 471 StructureType noalg.map.group[struct {}]int
+      GroupSliceType: 475 GoSliceDataType []noalg.map.group[struct {}]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 503
+      ID: 519
       Name: groupReference<struct {},main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 504 PointerType *noalg.map.group[struct {}]main.structWithCyclicMaps
+          Type: 520 PointerType *noalg.map.group[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 505 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 509 GoSliceDataType []noalg.map.group[struct {}]main.structWithCyclicMaps.array
+      GroupType: 521 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 525 GoSliceDataType []noalg.map.group[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 511
+      ID: 527
       Name: groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 512 PointerType *noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 528 PointerType *noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 513 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 517 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 529 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 533 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 519
+      ID: 535
       Name: groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 520 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 536 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 521 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 525 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 537 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 541 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 527
+      ID: 543
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 528 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 544 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 529 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 533 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 545 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 549 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 535
+      ID: 551
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 536 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 552 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 537 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 541 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 553 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 557 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 543
+      ID: 559
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 544 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 560 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 545 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 549 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 561 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 565 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 469
+      ID: 485
       Name: groupReference<struct {},struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 470 PointerType *noalg.map.group[struct {}]struct {}
+          Type: 486 PointerType *noalg.map.group[struct {}]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 471 StructureType noalg.map.group[struct {}]struct {}
-      GroupSliceType: 475 GoSliceDataType []noalg.map.group[struct {}]struct {}.array
+      GroupType: 487 StructureType noalg.map.group[struct {}]struct {}
+      GroupSliceType: 491 GoSliceDataType []noalg.map.group[struct {}]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 428
+      ID: 444
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 429 PointerType *noalg.map.group[uint8][4]int
+          Type: 445 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 430 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 435 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 446 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 451 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 420
+      ID: 436
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 421 PointerType *noalg.map.group[uint8]uint8
+          Type: 437 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 422 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 426 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 438 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 442 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: UnresolvedPointeeType
-      ID: 1125
+      ID: 1141
       Name: hash/crc32.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 817
+      ID: 833
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -21226,17 +21392,17 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: BaseType
-      ID: 1008
+      ID: 1024
       Name: internal/abi.BoundsErrorCode
       ByteSize: 1
       GoRuntimeType: 593952
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 978
+      ID: 994
       Name: internal/abi.Type
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 699
+      ID: 715
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -21262,29 +21428,29 @@ Types:
           Offset: 296
           Type: 2 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 697
+      ID: 713
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1024
+      ID: 1040
       Name: internal/godebug.runtimeStderr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 910
+      ID: 926
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1212
+      ID: 1228
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 908
+      ID: 924
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1.489536e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 630
+      ID: 646
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -21356,7 +21522,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 586
+      ID: 602
       Name: internal/runtime/cgroup.stringError
       ByteSize: 16
       GoRuntimeType: 841824
@@ -21364,18 +21530,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 588 PointerType *internal/runtime/cgroup.stringError.str
+          Type: 604 PointerType *internal/runtime/cgroup.stringError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 587 GoStringDataType internal/runtime/cgroup.stringError.str
+      Data: 603 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: GoStringDataType
-      ID: 587
+      ID: 603
       Name: internal/runtime/cgroup.stringError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 865
+      ID: 881
       Name: internal/runtime/maps.unhashableTypeError
       ByteSize: 8
       GoRuntimeType: 1.574176e+06
@@ -21383,15 +21549,15 @@ Types:
       RawFields:
         - Name: typ
           Offset: 0
-          Type: 977 PointerType *internal/abi.Type
+          Type: 993 PointerType *internal/abi.Type
     - __kind: BaseType
-      ID: 555
+      ID: 571
       Name: internal/strconv.Error
       ByteSize: 8
       GoRuntimeType: 838848
       GoKind: 2
     - __kind: StructureType
-      ID: 1224
+      ID: 1240
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.486976e+06
@@ -21404,11 +21570,11 @@ Types:
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 1070
+      ID: 1086
       Name: io.PipeWriter
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1111
+      ID: 1127
       Name: io.ReadWriteCloser
       ByteSize: 16
       GoRuntimeType: 1.198464e+06
@@ -21421,7 +21587,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1146
+      ID: 1162
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 1.033088e+06
@@ -21434,7 +21600,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1097
+      ID: 1113
       Name: io.WriteCloser
       ByteSize: 16
       GoRuntimeType: 1.118976e+06
@@ -21460,21 +21626,21 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1068
+      ID: 1084
       Name: io.discard
       GoRuntimeType: 1.475776e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1042
+      ID: 1058
       Name: io.multiWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 906
+      ID: 922
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1117
+      ID: 1133
       Name: log/slog/internal/buffer.Buffer
       ByteSize: 8
     - __kind: StructureType
@@ -21503,7 +21669,25 @@ Types:
       RawFields:
         - Name: nested
           Offset: 0
-          Type: 1321 PointerType *main.nestedStruct
+          Type: 1337 PointerType *main.nestedStruct
+    - __kind: StructureType
+      ID: 331
+      Name: main.bStruct
+      ByteSize: 72
+      GoKind: 25
+      RawFields:
+        - Name: aInt16
+          Offset: 0
+          Type: 102 BaseType int16
+        - Name: nested
+          Offset: 8
+          Type: 322 StructureType main.aStruct
+        - Name: aBool
+          Offset: 64
+          Type: 4 BaseType bool
+        - Name: aInt32
+          Offset: 68
+          Type: 12 BaseType int32
     - __kind: GoInterfaceType
       ID: 168
       Name: main.behavior
@@ -21533,6 +21717,21 @@ Types:
           Offset: 32
           Type: 137 GoInterfaceType io.Writer
     - __kind: StructureType
+      ID: 328
+      Name: main.cStruct
+      ByteSize: 24
+      GoKind: 25
+      RawFields:
+        - Name: aInt32
+          Offset: 0
+          Type: 12 BaseType int32
+        - Name: aUint
+          Offset: 8
+          Type: 11 BaseType uint
+        - Name: nested
+          Offset: 16
+          Type: 268 StructureType main.structWithNoStrings
+    - __kind: StructureType
       ID: 149
       Name: main.deepMap1
       ByteSize: 8
@@ -21543,7 +21742,7 @@ Types:
           Offset: 0
           Type: 150 GoMapType map[int]*main.deepMap2
     - __kind: StructureType
-      ID: 349
+      ID: 365
       Name: main.deepMap2
       ByteSize: 8
       GoRuntimeType: 1.194752e+06
@@ -21551,9 +21750,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1244 GoMapType map[int]*main.deepMap3
+          Type: 1260 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 1256
+      ID: 1272
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -21565,9 +21764,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1278 GoMapType map[int]*main.deepMap8
+          Type: 1294 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 1290
+      ID: 1306
       Name: main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.193984e+06
@@ -21575,9 +21774,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1293 GoMapType map[int]*main.deepMap9
+          Type: 1309 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 1305
+      ID: 1321
       Name: main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.193856e+06
@@ -21585,7 +21784,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1308 GoMapType map[int]interface {}
+          Type: 1324 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 138
       Name: main.deepPtr1
@@ -21605,9 +21804,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1215 PointerType *main.deepPtr3
+          Type: 1231 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 1216
+      ID: 1232
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -21619,9 +21818,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1259 PointerType *main.deepPtr8
+          Type: 1275 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 1260
+      ID: 1276
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1.195136e+06
@@ -21629,9 +21828,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1261 PointerType *main.deepPtr9
+          Type: 1277 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 1262
+      ID: 1278
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1.195008e+06
@@ -21651,7 +21850,7 @@ Types:
           Offset: 0
           Type: 144 GoSliceHeaderType []*main.deepSlice2
     - __kind: StructureType
-      ID: 339
+      ID: 355
       Name: main.deepSlice2
       ByteSize: 24
       GoRuntimeType: 1.197056e+06
@@ -21659,9 +21858,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1238 GoSliceHeaderType []*main.deepSlice3
+          Type: 1254 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 1241
+      ID: 1257
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -21673,9 +21872,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1263 GoSliceHeaderType []*main.deepSlice8
+          Type: 1279 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 1266
+      ID: 1282
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1.196288e+06
@@ -21683,9 +21882,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1269 GoSliceHeaderType []*main.deepSlice9
+          Type: 1285 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 1272
+      ID: 1288
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1.19616e+06
@@ -21693,7 +21892,73 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1275 GoSliceHeaderType []interface {}
+          Type: 1291 GoSliceHeaderType []interface {}
+    - __kind: StructureType
+      ID: 333
+      Name: main.deepStruct1
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: b
+          Offset: 8
+          Type: 334 StructureType main.deepStruct2
+    - __kind: StructureType
+      ID: 334
+      Name: main.deepStruct2
+      ByteSize: 40
+      GoKind: 25
+      RawFields:
+        - Name: c
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: d
+          Offset: 8
+          Type: 335 StructureType main.deepStruct3
+    - __kind: StructureType
+      ID: 335
+      Name: main.deepStruct3
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: e
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: f
+          Offset: 8
+          Type: 336 StructureType main.deepStruct4
+    - __kind: StructureType
+      ID: 336
+      Name: main.deepStruct4
+      ByteSize: 24
+      GoKind: 25
+      RawFields:
+        - Name: g
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: h
+          Offset: 8
+          Type: 337 StructureType main.deepStruct5
+    - __kind: StructureType
+      ID: 337
+      Name: main.deepStruct5
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: i
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: j
+          Offset: 8
+          Type: 338 StructureType main.deepStruct6
+    - __kind: StructureType
+      ID: 338
+      Name: main.deepStruct6
+      ByteSize: 8
+      GoKind: 25
+      RawFields: [{Name: k, Offset: 0, Type: 7 BaseType int}]
     - __kind: StructureType
       ID: 325
       Name: main.emptyStruct
@@ -21711,16 +21976,16 @@ Types:
           Type: 161 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 1222 StructureType sync.Mutex
+          Type: 1238 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 1225 StructureType sync.Once
+          Type: 1241 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 1228 StructureType sync.WaitGroup
+          Type: 1244 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 1231 StructureType sync/atomic.Int32
+          Type: 1247 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 161
       Name: main.esotericStack
@@ -21750,7 +22015,7 @@ Types:
           Offset: 56
           Type: 63 GoSubroutineType func()
     - __kind: StructureType
-      ID: 327
+      ID: 343
       Name: main.firstBehavior
       ByteSize: 16
       GoRuntimeType: 1.424224e+06
@@ -21796,6 +22061,90 @@ Types:
           Offset: 72
           Type: 7 BaseType int
     - __kind: StructureType
+      ID: 339
+      Name: main.lotsOfFields
+      ByteSize: 26
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 3 BaseType uint8
+        - Name: b
+          Offset: 1
+          Type: 3 BaseType uint8
+        - Name: c
+          Offset: 2
+          Type: 3 BaseType uint8
+        - Name: d
+          Offset: 3
+          Type: 3 BaseType uint8
+        - Name: e
+          Offset: 4
+          Type: 3 BaseType uint8
+        - Name: f
+          Offset: 5
+          Type: 3 BaseType uint8
+        - Name: g
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: h
+          Offset: 7
+          Type: 3 BaseType uint8
+        - Name: i
+          Offset: 8
+          Type: 3 BaseType uint8
+        - Name: j
+          Offset: 9
+          Type: 3 BaseType uint8
+        - Name: k
+          Offset: 10
+          Type: 3 BaseType uint8
+        - Name: l
+          Offset: 11
+          Type: 3 BaseType uint8
+        - Name: m
+          Offset: 12
+          Type: 3 BaseType uint8
+        - Name: n
+          Offset: 13
+          Type: 3 BaseType uint8
+        - Name: o
+          Offset: 14
+          Type: 3 BaseType uint8
+        - Name: p
+          Offset: 15
+          Type: 3 BaseType uint8
+        - Name: q
+          Offset: 16
+          Type: 3 BaseType uint8
+        - Name: r
+          Offset: 17
+          Type: 3 BaseType uint8
+        - Name: s
+          Offset: 18
+          Type: 3 BaseType uint8
+        - Name: t
+          Offset: 19
+          Type: 3 BaseType uint8
+        - Name: u
+          Offset: 20
+          Type: 3 BaseType uint8
+        - Name: v
+          Offset: 21
+          Type: 3 BaseType uint8
+        - Name: w
+          Offset: 22
+          Type: 3 BaseType uint8
+        - Name: x
+          Offset: 23
+          Type: 3 BaseType uint8
+        - Name: y
+          Offset: 24
+          Type: 3 BaseType uint8
+        - Name: z
+          Offset: 25
+          Type: 3 BaseType uint8
+    - __kind: StructureType
       ID: 260
       Name: main.mixedStruct
       ByteSize: 24
@@ -21810,6 +22159,21 @@ Types:
         - Name: c
           Offset: 16
           Type: 7 BaseType int
+    - __kind: StructureType
+      ID: 327
+      Name: main.nStruct
+      ByteSize: 24
+      GoKind: 25
+      RawFields:
+        - Name: aBool
+          Offset: 0
+          Type: 4 BaseType bool
+        - Name: aInt
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: aInt16
+          Offset: 16
+          Type: 102 BaseType int16
     - __kind: StructureType
       ID: 129
       Name: main.nestedStruct
@@ -21846,7 +22210,13 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1234
+      ID: 329
+      Name: main.receiver
+      ByteSize: 8
+      GoKind: 25
+      RawFields: [{Name: u, Offset: 0, Type: 11 BaseType uint}]
+    - __kind: StructureType
+      ID: 1250
       Name: main.secondBehavior
       ByteSize: 8
       GoRuntimeType: 1.424384e+06
@@ -21866,7 +22236,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1221
+      ID: 1237
       Name: main.somethingImpl
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -21877,31 +22247,31 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1218 PointerType *main.stringType1.str
+          Type: 1234 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 1217 GoStringDataType main.stringType1.str
+      Data: 1233 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 1217
+      ID: 1233
       Name: main.stringType1.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 1219
+      ID: 1235
       Name: main.stringType2
       ByteSize: 16
       GoKind: 24
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1323 PointerType *main.stringType2.str
+          Type: 1339 PointerType *main.stringType2.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 1322 GoStringDataType main.stringType2.str
+      Data: 1338 GoStringDataType main.stringType2.str
     - __kind: GoStringDataType
-      ID: 1322
+      ID: 1338
       Name: main.stringType2.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -21998,6 +22368,21 @@ Types:
           Offset: 1
           Type: 4 BaseType bool
     - __kind: StructureType
+      ID: 340
+      Name: main.structWithTwoArrays
+      ByteSize: 72
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 341 ArrayType [3]uint64
+        - Name: b
+          Offset: 24
+          Type: 3 BaseType uint8
+        - Name: c
+          Offset: 32
+          Type: 342 ArrayType [5]int64
+    - __kind: StructureType
       ID: 251
       Name: main.structWithTwoValues
       ByteSize: 16
@@ -22017,23 +22402,74 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1235 PointerType **main.t
+          Type: 1251 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1236 GoSliceDataType main.t.array
+      Data: 1252 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 1236
+      ID: 1252
       Name: main.t.array
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 254 PointerType *main.t
     - __kind: StructureType
+      ID: 332
+      Name: main.tenStrings
+      ByteSize: 160
+      GoKind: 25
+      RawFields:
+        - Name: first
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: second
+          Offset: 16
+          Type: 9 GoStringHeaderType string
+        - Name: third
+          Offset: 32
+          Type: 9 GoStringHeaderType string
+        - Name: fourth
+          Offset: 48
+          Type: 9 GoStringHeaderType string
+        - Name: fifth
+          Offset: 64
+          Type: 9 GoStringHeaderType string
+        - Name: sixth
+          Offset: 80
+          Type: 9 GoStringHeaderType string
+        - Name: seventh
+          Offset: 96
+          Type: 9 GoStringHeaderType string
+        - Name: eighth
+          Offset: 112
+          Type: 9 GoStringHeaderType string
+        - Name: ninth
+          Offset: 128
+          Type: 9 GoStringHeaderType string
+        - Name: tenth
+          Offset: 144
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
       ID: 274
       Name: main.threeStringStruct
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: b
+          Offset: 16
+          Type: 9 GoStringHeaderType string
+        - Name: c
+          Offset: 32
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 330
+      Name: main.threestrings
       ByteSize: 48
       GoKind: 25
       RawFields:
@@ -22123,8 +22559,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 450 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 447 StructureType noalg.map.group[[4]int][4]int
+      TablePtrSliceType: 466 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 463 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
       ID: 226
       Name: map<[4]int,uint8>
@@ -22158,8 +22594,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 442 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 439 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 458 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 455 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 194
       Name: map<[4]string,[2]int>
@@ -22193,8 +22629,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 391 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 387 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 407 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 403 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
       ID: 206
       Name: map<bool,main.node>
@@ -22228,8 +22664,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 409 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 406 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 425 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 422 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
       ID: 152
       Name: map<int,*main.deepMap2>
@@ -22263,10 +22699,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 350 GoSliceDataType []*table<int,*main.deepMap2>.array
-      GroupType: 345 StructureType noalg.map.group[int]*main.deepMap2
+      TablePtrSliceType: 366 GoSliceDataType []*table<int,*main.deepMap2>.array
+      GroupType: 361 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSwissMapHeaderType
-      ID: 1246
+      ID: 1262
       Name: map<int,*main.deepMap3>
       ByteSize: 48
       GoKind: 25
@@ -22279,7 +22715,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1247 PointerType **table<int,*main.deepMap3>
+          Type: 1263 PointerType **table<int,*main.deepMap3>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -22298,10 +22734,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1257 GoSliceDataType []*table<int,*main.deepMap3>.array
-      GroupType: 1252 StructureType noalg.map.group[int]*main.deepMap3
+      TablePtrSliceType: 1273 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 1268 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSwissMapHeaderType
-      ID: 1280
+      ID: 1296
       Name: map<int,*main.deepMap8>
       ByteSize: 48
       GoKind: 25
@@ -22314,7 +22750,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1281 PointerType **table<int,*main.deepMap8>
+          Type: 1297 PointerType **table<int,*main.deepMap8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -22333,10 +22769,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1291 GoSliceDataType []*table<int,*main.deepMap8>.array
-      GroupType: 1286 StructureType noalg.map.group[int]*main.deepMap8
+      TablePtrSliceType: 1307 GoSliceDataType []*table<int,*main.deepMap8>.array
+      GroupType: 1302 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSwissMapHeaderType
-      ID: 1295
+      ID: 1311
       Name: map<int,*main.deepMap9>
       ByteSize: 48
       GoKind: 25
@@ -22349,7 +22785,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1296 PointerType **table<int,*main.deepMap9>
+          Type: 1312 PointerType **table<int,*main.deepMap9>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -22368,8 +22804,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1306 GoSliceDataType []*table<int,*main.deepMap9>.array
-      GroupType: 1301 StructureType noalg.map.group[int]*main.deepMap9
+      TablePtrSliceType: 1322 GoSliceDataType []*table<int,*main.deepMap9>.array
+      GroupType: 1317 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSwissMapHeaderType
       ID: 174
       Name: map<int,int>
@@ -22403,10 +22839,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 358 GoSliceDataType []*table<int,int>.array
-      GroupType: 355 StructureType noalg.map.group[int]int
+      TablePtrSliceType: 374 GoSliceDataType []*table<int,int>.array
+      GroupType: 371 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
-      ID: 1310
+      ID: 1326
       Name: map<int,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -22419,7 +22855,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1311 PointerType **table<int,interface {}>
+          Type: 1327 PointerType **table<int,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -22438,8 +22874,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1319 GoSliceDataType []*table<int,interface {}>.array
-      GroupType: 1316 StructureType noalg.map.group[int]interface {}
+      TablePtrSliceType: 1335 GoSliceDataType []*table<int,interface {}>.array
+      GroupType: 1332 StructureType noalg.map.group[int]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 241
       Name: map<int,struct {}>
@@ -22473,8 +22909,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 466 GoSliceDataType []*table<int,struct {}>.array
-      GroupType: 463 StructureType noalg.map.group[int]struct {}
+      TablePtrSliceType: 482 GoSliceDataType []*table<int,struct {}>.array
+      GroupType: 479 StructureType noalg.map.group[int]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 211
       Name: map<int,uint8>
@@ -22508,8 +22944,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 417 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 414 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 433 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 430 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 201
       Name: map<string,[]main.structWithMap>
@@ -22543,8 +22979,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 401 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 396 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 417 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 412 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
       ID: 189
       Name: map<string,[]string>
@@ -22578,10 +23014,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 382 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 379 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 398 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 395 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 982
+      ID: 998
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -22594,7 +23030,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 983 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 999 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -22613,8 +23049,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1017 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 1014 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 1033 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 1030 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
       ID: 184
       Name: map<string,int>
@@ -22648,8 +23084,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 374 GoSliceDataType []*table<string,int>.array
-      GroupType: 371 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 390 GoSliceDataType []*table<string,int>.array
+      GroupType: 387 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
       ID: 179
       Name: map<string,main.nestedStruct>
@@ -22683,8 +23119,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 366 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 363 StructureType noalg.map.group[string]main.nestedStruct
+      TablePtrSliceType: 382 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 379 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSwissMapHeaderType
       ID: 236
       Name: map<struct {},int>
@@ -22718,8 +23154,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 458 GoSliceDataType []*table<struct {},int>.array
-      GroupType: 455 StructureType noalg.map.group[struct {}]int
+      TablePtrSliceType: 474 GoSliceDataType []*table<struct {},int>.array
+      GroupType: 471 StructureType noalg.map.group[struct {}]int
     - __kind: GoSwissMapHeaderType
       ID: 294
       Name: map<struct {},main.structWithCyclicMaps>
@@ -22753,8 +23189,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 508 GoSliceDataType []*table<struct {},main.structWithCyclicMaps>.array
-      GroupType: 505 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 524 GoSliceDataType []*table<struct {},main.structWithCyclicMaps>.array
+      GroupType: 521 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 299
       Name: map<struct {},map[struct {}]main.structWithCyclicMaps>
@@ -22788,8 +23224,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 516 GoSliceDataType []*table<struct {},map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 513 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 532 GoSliceDataType []*table<struct {},map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 529 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 304
       Name: map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -22823,8 +23259,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 524 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 521 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 540 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 537 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 309
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -22858,8 +23294,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 532 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 529 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 548 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 545 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 314
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -22893,8 +23329,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 540 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 537 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 556 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 553 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 319
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -22928,8 +23364,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 548 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 545 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 564 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 561 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 246
       Name: map<struct {},struct {}>
@@ -22963,8 +23399,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 474 GoSliceDataType []*table<struct {},struct {}>.array
-      GroupType: 471 StructureType noalg.map.group[struct {}]struct {}
+      TablePtrSliceType: 490 GoSliceDataType []*table<struct {},struct {}>.array
+      GroupType: 487 StructureType noalg.map.group[struct {}]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 221
       Name: map<uint8,[4]int>
@@ -22998,8 +23434,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 434 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 430 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 450 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 446 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
       ID: 216
       Name: map<uint8,uint8>
@@ -23033,8 +23469,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 425 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 422 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 441 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 438 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
       ID: 229
       Name: map[[4]int][4]int
@@ -23071,26 +23507,26 @@ Types:
       GoKind: 21
       HeaderType: 152 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 1244
+      ID: 1260
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 1.138176e+06
       GoKind: 21
-      HeaderType: 1246 GoSwissMapHeaderType map<int,*main.deepMap3>
+      HeaderType: 1262 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 1278
+      ID: 1294
       Name: map[int]*main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.137536e+06
       GoKind: 21
-      HeaderType: 1280 GoSwissMapHeaderType map<int,*main.deepMap8>
+      HeaderType: 1296 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
-      ID: 1293
+      ID: 1309
       Name: map[int]*main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.137408e+06
       GoKind: 21
-      HeaderType: 1295 GoSwissMapHeaderType map<int,*main.deepMap9>
+      HeaderType: 1311 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 172
       Name: map[int]int
@@ -23099,12 +23535,12 @@ Types:
       GoKind: 21
       HeaderType: 174 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
-      ID: 1308
+      ID: 1324
       Name: map[int]interface {}
       ByteSize: 8
       GoRuntimeType: 1.13728e+06
       GoKind: 21
-      HeaderType: 1310 GoSwissMapHeaderType map<int,interface {}>
+      HeaderType: 1326 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
       ID: 239
       Name: map[int]struct {}
@@ -23212,7 +23648,7 @@ Types:
       GoKind: 21
       HeaderType: 216 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: StructureType
-      ID: 735
+      ID: 751
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1.440384e+06
@@ -23222,7 +23658,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1032
+      ID: 1048
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
       GoRuntimeType: 1.437344e+06
@@ -23232,11 +23668,11 @@ Types:
           Offset: 0
           Type: 137 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 937
+      ID: 953
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1002
+      ID: 1018
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1.612448e+06
@@ -23249,35 +23685,35 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 963
+      ID: 979
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1176
+      ID: 1192
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 961
+      ID: 977
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 939
+      ID: 955
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1186
+      ID: 1202
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1196
+      ID: 1212
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1184
+      ID: 1200
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 898
+      ID: 914
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1.122304e+06
@@ -23285,28 +23721,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 900 PointerType *net.UnknownNetworkError.str
+          Type: 916 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 899 GoStringDataType net.UnknownNetworkError.str
+      Data: 915 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 899
+      ID: 915
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 863
+      ID: 879
       Name: net.canceledError
       GoRuntimeType: 1.295168e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1154
+      ID: 1170
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 1007
+      ID: 1023
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2.128288e+06
@@ -23314,7 +23750,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 1002 GoInterfaceType net.Conn
+          Type: 1018 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 15 GoInterfaceType error
@@ -23325,27 +23761,27 @@ Types:
           Offset: 33
           Type: 4 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 1198
+      ID: 1214
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 1192
+      ID: 1208
       Name: net.noReadFrom
       GoRuntimeType: 1.12256e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1191
+      ID: 1207
       Name: net.noWriteTo
       GoRuntimeType: 1.122432e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 665
+      ID: 681
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
-      ID: 667
+      ID: 683
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1.74768e+06
@@ -23353,7 +23789,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 990 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 1006 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 9 GoStringHeaderType string
@@ -23361,7 +23797,7 @@ Types:
           Offset: 96
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 1180
+      ID: 1196
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.310464e+06
@@ -23369,12 +23805,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1192 StructureType net.noReadFrom
+          Type: 1208 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 1185 PointerType *net.TCPConn
+          Type: 1201 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 1178
+      ID: 1194
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.30992e+06
@@ -23382,24 +23818,24 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1191 StructureType net.noWriteTo
+          Type: 1207 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 1185 PointerType *net.TCPConn
+          Type: 1201 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 941
+      ID: 957
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 965
+      ID: 981
       Name: net.timeoutError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 853
+      ID: 869
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1026
+      ID: 1042
       Name: net/http.bufioFlushWriter
       ByteSize: 16
       GoRuntimeType: 1.428864e+06
@@ -23409,19 +23845,19 @@ Types:
           Offset: 0
           Type: 137 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 556
+      ID: 572
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 839520
       GoKind: 10
     - __kind: BaseType
-      ID: 979
+      ID: 995
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 1.00016e+06
       GoKind: 10
     - __kind: StructureType
-      ID: 643
+      ID: 659
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1.745184e+06
@@ -23432,12 +23868,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 979 BaseType net/http.http2ErrCode
+          Type: 995 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 957
+      ID: 973
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1.917888e+06
@@ -23448,12 +23884,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 979 BaseType net/http.http2ErrCode
+          Type: 995 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 647
+      ID: 663
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1.611968e+06
@@ -23461,16 +23897,16 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 979 BaseType net/http.http2ErrCode
+          Type: 995 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1088
+      ID: 1104
       Name: net/http.http2dataBuffer
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 560
+      ID: 576
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 839712
@@ -23478,18 +23914,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 562 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 578 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 561 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 577 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 561
+      ID: 577
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 566
+      ID: 582
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 839904
@@ -23497,18 +23933,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 568 PointerType *net/http.http2headerFieldNameError.str
+          Type: 584 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 567 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 583 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 567
+      ID: 583
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 563
+      ID: 579
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 839808
@@ -23516,32 +23952,32 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 565 PointerType *net/http.http2headerFieldValueError.str
+          Type: 581 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 564 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 580 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 564
+      ID: 580
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 932
+      ID: 948
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 859
+      ID: 875
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1.2944e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1143
+      ID: 1159
       Name: net/http.http2pipe
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 557
+      ID: 573
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 839616
@@ -23549,18 +23985,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 559 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 575 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 558 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 574 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 558
+      ID: 574
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1028
+      ID: 1044
       Name: net/http.http2stickyErrWriter
       ByteSize: 32
       GoRuntimeType: 1.745952e+06
@@ -23568,22 +24004,22 @@ Types:
       RawFields:
         - Name: conn
           Offset: 0
-          Type: 1002 GoInterfaceType net.Conn
+          Type: 1018 GoInterfaceType net.Conn
         - Name: timeout
           Offset: 16
-          Type: 1107 BaseType time.Duration
+          Type: 1123 BaseType time.Duration
         - Name: err
           Offset: 24
           Type: 111 PointerType *error
     - __kind: ArrayType
-      ID: 1108
+      ID: 1124
       Name: net/http.incomparable
       GoRuntimeType: 912448
       GoKind: 17
       HasCount: true
       Element: 63 GoSubroutineType func()
     - __kind: StructureType
-      ID: 855
+      ID: 871
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1.570176e+06
@@ -23593,11 +24029,11 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1090
+      ID: 1106
       Name: net/http.persistConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 1046
+      ID: 1062
       Name: net/http.persistConnWriter
       ByteSize: 8
       GoRuntimeType: 1.570016e+06
@@ -23605,9 +24041,9 @@ Types:
       RawFields:
         - Name: pc
           Offset: 0
-          Type: 1089 PointerType *net/http.persistConn
+          Type: 1105 PointerType *net/http.persistConn
     - __kind: StructureType
-      ID: 1080
+      ID: 1096
       Name: net/http.readWriteCloserBody
       ByteSize: 24
       GoRuntimeType: 1.81936e+06
@@ -23615,15 +24051,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1108 ArrayType net/http.incomparable
+          Type: 1124 ArrayType net/http.incomparable
         - Name: br
           Offset: 0
-          Type: 1109 PointerType *bufio.Reader
+          Type: 1125 PointerType *bufio.Reader
         - Name: ReadWriteCloser
           Offset: 8
-          Type: 1111 GoInterfaceType io.ReadWriteCloser
+          Type: 1127 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 651
+      ID: 667
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1.429824e+06
@@ -23633,17 +24069,17 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 959
+      ID: 975
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 930
+      ID: 946
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1.492416e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 857
+      ID: 873
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1.570336e+06
@@ -23653,7 +24089,7 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 1123
+      ID: 1139
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
       GoRuntimeType: 2.048672e+06
@@ -23661,16 +24097,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 1002 GoInterfaceType net.Conn
+          Type: 1018 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 1002 GoInterfaceType net.Conn
+          Type: 1018 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 640
+      ID: 656
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1145
+      ID: 1161
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
       GoRuntimeType: 2.064416e+06
@@ -23678,13 +24114,13 @@ Types:
       RawFields:
         - Name: Writer
           Offset: 0
-          Type: 1138 PointerType *bufio.Writer
+          Type: 1154 PointerType *bufio.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1056
+      ID: 1072
       Name: net/http/internal.chunkedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 727
+      ID: 743
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1.750752e+06
@@ -23700,7 +24136,7 @@ Types:
           Offset: 32
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 725
+      ID: 741
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1.613888e+06
@@ -23713,11 +24149,11 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1096
+      ID: 1112
       Name: net/smtp.Client
       ByteSize: 8
     - __kind: StructureType
-      ID: 1058
+      ID: 1074
       Name: net/smtp.dataCloser
       ByteSize: 24
       GoRuntimeType: 1.616128e+06
@@ -23725,16 +24161,16 @@ Types:
       RawFields:
         - Name: c
           Offset: 0
-          Type: 1095 PointerType *net/smtp.Client
+          Type: 1111 PointerType *net/smtp.Client
         - Name: WriteCloser
           Offset: 8
-          Type: 1097 GoInterfaceType io.WriteCloser
+          Type: 1113 GoInterfaceType io.WriteCloser
     - __kind: UnresolvedPointeeType
-      ID: 711
+      ID: 727
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 594
+      ID: 610
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 842592
@@ -23742,26 +24178,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 596 PointerType *net/textproto.ProtocolError.str
+          Type: 612 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 595 GoStringDataType net/textproto.ProtocolError.str
+      Data: 611 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 595
+      ID: 611
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1054
+      ID: 1070
       Name: net/textproto.dotWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 967
+      ID: 983
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 569
+      ID: 585
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 840480
@@ -23769,18 +24205,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 571 PointerType *net/url.EscapeError.str
+          Type: 587 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 570 GoStringDataType net/url.EscapeError.str
+      Data: 586 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 570
+      ID: 586
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 572
+      ID: 588
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 840576
@@ -23788,254 +24224,254 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 574 PointerType *net/url.InvalidHostError.str
+          Type: 590 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 573 GoStringDataType net/url.InvalidHostError.str
+      Data: 589 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 573
+      ID: 589
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: ArrayType
-      ID: 448
+      ID: 464
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
       GoRuntimeType: 689696
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 449 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 465 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 440
+      ID: 456
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
       GoRuntimeType: 689792
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 441 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 457 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 388
+      ID: 404
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
       GoRuntimeType: 690080
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 389 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 405 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 407
+      ID: 423
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
       GoRuntimeType: 690176
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 408 StructureType noalg.struct { key bool; elem main.node }
+      Element: 424 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 346
+      ID: 362
       Name: noalg.[8]struct { key int; elem *main.deepMap2 }
       ByteSize: 128
       GoRuntimeType: 689024
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 347 StructureType noalg.struct { key int; elem *main.deepMap2 }
+      Element: 363 StructureType noalg.struct { key int; elem *main.deepMap2 }
     - __kind: ArrayType
-      ID: 1253
+      ID: 1269
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
       GoRuntimeType: 688928
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1254 StructureType noalg.struct { key int; elem *main.deepMap3 }
+      Element: 1270 StructureType noalg.struct { key int; elem *main.deepMap3 }
     - __kind: ArrayType
-      ID: 1287
+      ID: 1303
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
       ByteSize: 128
       GoRuntimeType: 688448
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1288 StructureType noalg.struct { key int; elem *main.deepMap8 }
+      Element: 1304 StructureType noalg.struct { key int; elem *main.deepMap8 }
     - __kind: ArrayType
-      ID: 1302
+      ID: 1318
       Name: noalg.[8]struct { key int; elem *main.deepMap9 }
       ByteSize: 128
       GoRuntimeType: 688352
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1303 StructureType noalg.struct { key int; elem *main.deepMap9 }
+      Element: 1319 StructureType noalg.struct { key int; elem *main.deepMap9 }
     - __kind: ArrayType
-      ID: 356
+      ID: 372
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
       GoRuntimeType: 687200
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 357 StructureType noalg.struct { key int; elem int }
+      Element: 373 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 1317
+      ID: 1333
       Name: noalg.[8]struct { key int; elem interface {} }
       ByteSize: 192
       GoRuntimeType: 688256
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1318 StructureType noalg.struct { key int; elem interface {} }
+      Element: 1334 StructureType noalg.struct { key int; elem interface {} }
     - __kind: ArrayType
-      ID: 464
+      ID: 480
       Name: noalg.[8]struct { key int; elem struct {} }
       ByteSize: 128
       GoRuntimeType: 690272
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 465 StructureType noalg.struct { key int; elem struct {} }
+      Element: 481 StructureType noalg.struct { key int; elem struct {} }
     - __kind: ArrayType
-      ID: 415
+      ID: 431
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
       GoRuntimeType: 690368
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 416 StructureType noalg.struct { key int; elem uint8 }
+      Element: 432 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 397
+      ID: 413
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
       GoRuntimeType: 690464
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 398 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 414 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 380
+      ID: 396
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 690560
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 381 StructureType noalg.struct { key string; elem []string }
+      Element: 397 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 1015
+      ID: 1031
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 766656
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1016 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 1032 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
-      ID: 372
+      ID: 388
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 690656
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 373 StructureType noalg.struct { key string; elem int }
+      Element: 389 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 364
+      ID: 380
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
       GoRuntimeType: 690752
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 365 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 381 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 456
+      ID: 472
       Name: noalg.[8]struct { key struct {}; elem int }
       ByteSize: 64
       GoRuntimeType: 690848
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 457 StructureType noalg.struct { key struct {}; elem int }
+      Element: 473 StructureType noalg.struct { key struct {}; elem int }
     - __kind: ArrayType
-      ID: 506
+      ID: 522
       Name: noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
       ByteSize: 384
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 507 StructureType noalg.struct { key struct {}; elem main.structWithCyclicMaps }
+      Element: 523 StructureType noalg.struct { key struct {}; elem main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 514
+      ID: 530
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 515 StructureType noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+      Element: 531 StructureType noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 522
+      ID: 538
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 523 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 539 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 530
+      ID: 546
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 531 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 547 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 538
+      ID: 554
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 539 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 555 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 546
+      ID: 562
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 547 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 563 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 472
+      ID: 488
       Name: noalg.[8]struct { key struct {}; elem struct {} }
       GoRuntimeType: 690944
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 473 StructureType noalg.struct { key struct {}; elem struct {} }
+      Element: 489 StructureType noalg.struct { key struct {}; elem struct {} }
     - __kind: ArrayType
-      ID: 431
+      ID: 447
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
       GoRuntimeType: 691040
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 432 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 448 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 423
+      ID: 439
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 691136
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 424 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 440 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 447
+      ID: 463
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
       GoRuntimeType: 1.306432e+06
@@ -24046,9 +24482,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 448 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 464 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 439
+      ID: 455
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
       GoRuntimeType: 1.306688e+06
@@ -24059,9 +24495,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 440 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 456 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 387
+      ID: 403
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
       GoRuntimeType: 1.306944e+06
@@ -24072,9 +24508,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 388 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 404 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 406
+      ID: 422
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
       GoRuntimeType: 1.3072e+06
@@ -24085,9 +24521,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 407 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 423 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 345
+      ID: 361
       Name: noalg.map.group[int]*main.deepMap2
       ByteSize: 136
       GoRuntimeType: 1.306176e+06
@@ -24098,9 +24534,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 346 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
+          Type: 362 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
     - __kind: StructureType
-      ID: 1252
+      ID: 1268
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
       GoRuntimeType: 1.30592e+06
@@ -24111,9 +24547,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1253 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+          Type: 1269 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
     - __kind: StructureType
-      ID: 1286
+      ID: 1302
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
       GoRuntimeType: 1.30464e+06
@@ -24124,9 +24560,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1287 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
+          Type: 1303 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
     - __kind: StructureType
-      ID: 1301
+      ID: 1317
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
       GoRuntimeType: 1.304384e+06
@@ -24137,9 +24573,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1302 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
+          Type: 1318 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
     - __kind: StructureType
-      ID: 355
+      ID: 371
       Name: noalg.map.group[int]int
       ByteSize: 136
       GoRuntimeType: 1.30336e+06
@@ -24150,9 +24586,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 356 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 372 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 1316
+      ID: 1332
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
       GoRuntimeType: 1.304128e+06
@@ -24163,9 +24599,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1317 ArrayType noalg.[8]struct { key int; elem interface {} }
+          Type: 1333 ArrayType noalg.[8]struct { key int; elem interface {} }
     - __kind: StructureType
-      ID: 463
+      ID: 479
       Name: noalg.map.group[int]struct {}
       ByteSize: 136
       GoRuntimeType: 1.307456e+06
@@ -24176,9 +24612,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 464 ArrayType noalg.[8]struct { key int; elem struct {} }
+          Type: 480 ArrayType noalg.[8]struct { key int; elem struct {} }
     - __kind: StructureType
-      ID: 414
+      ID: 430
       Name: noalg.map.group[int]uint8
       ByteSize: 136
       GoRuntimeType: 1.307712e+06
@@ -24189,9 +24625,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 415 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 431 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 396
+      ID: 412
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
       GoRuntimeType: 1.307968e+06
@@ -24202,9 +24638,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 397 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 413 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 379
+      ID: 395
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.308224e+06
@@ -24215,9 +24651,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 380 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 396 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 1014
+      ID: 1030
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1.369664e+06
@@ -24228,9 +24664,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1015 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 1031 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
-      ID: 371
+      ID: 387
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 1.30848e+06
@@ -24241,9 +24677,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 372 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 388 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 363
+      ID: 379
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
       GoRuntimeType: 1.308736e+06
@@ -24254,9 +24690,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 364 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 380 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 455
+      ID: 471
       Name: noalg.map.group[struct {}]int
       ByteSize: 72
       GoRuntimeType: 1.308992e+06
@@ -24267,9 +24703,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 456 ArrayType noalg.[8]struct { key struct {}; elem int }
+          Type: 472 ArrayType noalg.[8]struct { key struct {}; elem int }
     - __kind: StructureType
-      ID: 505
+      ID: 521
       Name: noalg.map.group[struct {}]main.structWithCyclicMaps
       ByteSize: 392
       GoKind: 25
@@ -24279,9 +24715,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 506 ArrayType noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
+          Type: 522 ArrayType noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 513
+      ID: 529
       Name: noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -24291,9 +24727,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 514 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+          Type: 530 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 521
+      ID: 537
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -24303,9 +24739,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 522 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 538 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 529
+      ID: 545
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -24315,9 +24751,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 530 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 546 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 537
+      ID: 553
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -24327,9 +24763,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 538 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 554 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 545
+      ID: 561
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -24339,9 +24775,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 546 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 562 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 471
+      ID: 487
       Name: noalg.map.group[struct {}]struct {}
       ByteSize: 16
       GoRuntimeType: 1.309248e+06
@@ -24352,9 +24788,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 472 ArrayType noalg.[8]struct { key struct {}; elem struct {} }
+          Type: 488 ArrayType noalg.[8]struct { key struct {}; elem struct {} }
     - __kind: StructureType
-      ID: 430
+      ID: 446
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
       GoRuntimeType: 1.309504e+06
@@ -24365,9 +24801,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 431 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 447 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 422
+      ID: 438
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
       GoRuntimeType: 1.30976e+06
@@ -24378,9 +24814,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 423 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 439 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 449
+      ID: 465
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
       GoRuntimeType: 1.306304e+06
@@ -24388,12 +24824,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 433 ArrayType [4]int
+          Type: 449 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 433 ArrayType [4]int
+          Type: 449 ArrayType [4]int
     - __kind: StructureType
-      ID: 441
+      ID: 457
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
       GoRuntimeType: 1.30656e+06
@@ -24401,12 +24837,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 433 ArrayType [4]int
+          Type: 449 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 389
+      ID: 405
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
       GoRuntimeType: 1.306816e+06
@@ -24414,12 +24850,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 390 ArrayType [4]string
+          Type: 406 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 119 ArrayType [2]int
     - __kind: StructureType
-      ID: 408
+      ID: 424
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
       GoRuntimeType: 1.307072e+06
@@ -24432,7 +24868,7 @@ Types:
           Offset: 8
           Type: 252 StructureType main.node
     - __kind: StructureType
-      ID: 347
+      ID: 363
       Name: noalg.struct { key int; elem *main.deepMap2 }
       ByteSize: 16
       GoRuntimeType: 1.306048e+06
@@ -24443,9 +24879,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 348 PointerType *main.deepMap2
+          Type: 364 PointerType *main.deepMap2
     - __kind: StructureType
-      ID: 1254
+      ID: 1270
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
       GoRuntimeType: 1.305792e+06
@@ -24456,9 +24892,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1255 PointerType *main.deepMap3
+          Type: 1271 PointerType *main.deepMap3
     - __kind: StructureType
-      ID: 1288
+      ID: 1304
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
       GoRuntimeType: 1.304512e+06
@@ -24469,9 +24905,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1289 PointerType *main.deepMap8
+          Type: 1305 PointerType *main.deepMap8
     - __kind: StructureType
-      ID: 1303
+      ID: 1319
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
       GoRuntimeType: 1.304256e+06
@@ -24482,9 +24918,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1304 PointerType *main.deepMap9
+          Type: 1320 PointerType *main.deepMap9
     - __kind: StructureType
-      ID: 357
+      ID: 373
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
       GoRuntimeType: 1.303232e+06
@@ -24497,7 +24933,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 1318
+      ID: 1334
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
       GoRuntimeType: 1.304e+06
@@ -24510,7 +24946,7 @@ Types:
           Offset: 8
           Type: 163 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 465
+      ID: 481
       Name: noalg.struct { key int; elem struct {} }
       ByteSize: 16
       GoRuntimeType: 1.307328e+06
@@ -24523,7 +24959,7 @@ Types:
           Offset: 8
           Type: 131 StructureType struct {}
     - __kind: StructureType
-      ID: 416
+      ID: 432
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 1.307584e+06
@@ -24536,7 +24972,7 @@ Types:
           Offset: 8
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 398
+      ID: 414
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
       GoRuntimeType: 1.30784e+06
@@ -24547,9 +24983,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 399 GoSliceHeaderType []main.structWithMap
+          Type: 415 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 381
+      ID: 397
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.308096e+06
@@ -24562,7 +24998,7 @@ Types:
           Offset: 16
           Type: 269 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 1016
+      ID: 1032
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1.369536e+06
@@ -24573,9 +25009,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 1003 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1019 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 373
+      ID: 389
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 1.308352e+06
@@ -24588,7 +25024,7 @@ Types:
           Offset: 16
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 365
+      ID: 381
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
       GoRuntimeType: 1.308608e+06
@@ -24601,7 +25037,7 @@ Types:
           Offset: 16
           Type: 129 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 457
+      ID: 473
       Name: noalg.struct { key struct {}; elem int }
       ByteSize: 8
       GoRuntimeType: 1.308864e+06
@@ -24614,7 +25050,7 @@ Types:
           Offset: 0
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 507
+      ID: 523
       Name: noalg.struct { key struct {}; elem main.structWithCyclicMaps }
       ByteSize: 48
       GoKind: 25
@@ -24626,7 +25062,7 @@ Types:
           Offset: 0
           Type: 291 StructureType main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 515
+      ID: 531
       Name: noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -24638,7 +25074,7 @@ Types:
           Offset: 0
           Type: 292 GoMapType map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 523
+      ID: 539
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -24650,7 +25086,7 @@ Types:
           Offset: 0
           Type: 297 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 531
+      ID: 547
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -24662,7 +25098,7 @@ Types:
           Offset: 0
           Type: 302 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 539
+      ID: 555
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -24674,7 +25110,7 @@ Types:
           Offset: 0
           Type: 307 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 547
+      ID: 563
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -24686,7 +25122,7 @@ Types:
           Offset: 0
           Type: 312 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 473
+      ID: 489
       Name: noalg.struct { key struct {}; elem struct {} }
       GoRuntimeType: 1.30912e+06
       GoKind: 25
@@ -24698,7 +25134,7 @@ Types:
           Offset: 0
           Type: 131 StructureType struct {}
     - __kind: StructureType
-      ID: 432
+      ID: 448
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
       GoRuntimeType: 1.309376e+06
@@ -24709,9 +25145,9 @@ Types:
           Type: 3 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 433 ArrayType [4]int
+          Type: 449 ArrayType [4]int
     - __kind: StructureType
-      ID: 424
+      ID: 440
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
       GoRuntimeType: 1.309632e+06
@@ -24724,19 +25160,19 @@ Types:
           Offset: 1
           Type: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1204
+      ID: 1220
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 834
+      ID: 850
       Name: os.LinkError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 902
+      ID: 918
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1202
+      ID: 1218
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.380864e+06
@@ -24744,12 +25180,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1208 StructureType os.noReadFrom
+          Type: 1224 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 1203 PointerType *os.File
+          Type: 1219 PointerType *os.File
     - __kind: StructureType
-      ID: 1200
+      ID: 1216
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.380064e+06
@@ -24757,36 +25193,36 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1207 StructureType os.noWriteTo
+          Type: 1223 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 1203 PointerType *os.File
+          Type: 1219 PointerType *os.File
     - __kind: StructureType
-      ID: 1208
+      ID: 1224
       Name: os.noReadFrom
       GoRuntimeType: 1.119872e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1207
+      ID: 1223
       Name: os.noWriteTo
       GoRuntimeType: 1.119744e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 867
+      ID: 883
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1010
+      ID: 1026
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1074
+      ID: 1090
       Name: os/exec.prefixSuffixSaver
       ByteSize: 8
     - __kind: StructureType
-      ID: 869
+      ID: 885
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1.721152e+06
@@ -24799,7 +25235,7 @@ Types:
           Offset: 16
           Type: 15 GoInterfaceType error
     - __kind: GoStringHeaderType
-      ID: 605
+      ID: 621
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 845856
@@ -24807,36 +25243,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 607 PointerType *os/user.UnknownGroupIdError.str
+          Type: 623 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 606 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 622 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 606
+      ID: 622
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 604
+      ID: 620
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 845760
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 632
+      ID: 648
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 733
+      ID: 749
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 838
+      ID: 854
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 842
+      ID: 858
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -24848,7 +25284,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 840
+      ID: 856
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1.906944e+06
@@ -24865,7 +25301,7 @@ Types:
           Type: 4 BaseType bool
         - Name: code
           Offset: 17
-          Type: 1008 BaseType internal/abi.BoundsErrorCode
+          Type: 1024 BaseType internal/abi.BoundsErrorCode
     - __kind: UnresolvedPointeeType
       ID: 70
       Name: runtime.cgoCallers
@@ -24881,7 +25317,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 904
+      ID: 920
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1.772e+06
@@ -24894,7 +25330,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 818
+      ID: 834
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 998720
@@ -24902,13 +25338,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 820 PointerType *runtime.errorString.str
+          Type: 836 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 819 GoStringDataType runtime.errorString.str
+      Data: 835 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 819
+      ID: 835
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -25557,7 +25993,7 @@ Types:
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
-      ID: 334
+      ID: 350
       Name: runtime.p
       ByteSize: 8
     - __kind: StructureType
@@ -25593,7 +26029,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 821
+      ID: 837
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 998816
@@ -25601,13 +26037,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 823 PointerType *runtime.plainError.str
+          Type: 839 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 822 GoStringDataType runtime.plainError.str
+      Data: 838 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 822
+      ID: 838
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -25648,7 +26084,7 @@ Types:
       Name: runtime.synctestBubble
       ByteSize: 8
     - __kind: StructureType
-      ID: 628
+      ID: 644
       Name: runtime.synctestDeadlockError
       ByteSize: 24
       GoRuntimeType: 1.611648e+06
@@ -25720,7 +26156,7 @@ Types:
       Name: runtime.xRegState
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 844
+      ID: 860
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -25732,26 +26168,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 329 PointerType *string.str
+          Type: 345 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 328 GoStringDataType string.str
+      Data: 344 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 328
+      ID: 344
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1141
+      ID: 1157
       Name: strings.Builder
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1044
+      ID: 1060
       Name: strings.appendSliceWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1040
+      ID: 1056
       Name: struct { io.Writer }
       ByteSize: 16
       GoRuntimeType: 1.467424e+06
@@ -25767,7 +26203,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1222
+      ID: 1238
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.476096e+06
@@ -25775,12 +26211,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1223 StructureType sync.noCopy
+          Type: 1239 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 1224 StructureType internal/sync.Mutex
+          Type: 1240 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 1225
+      ID: 1241
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.629472e+06
@@ -25788,15 +26224,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1223 StructureType sync.noCopy
+          Type: 1239 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 1226 StructureType sync/atomic.Bool
+          Type: 1242 StructureType sync/atomic.Bool
         - Name: m
           Offset: 4
-          Type: 1222 StructureType sync.Mutex
+          Type: 1238 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 1228
+      ID: 1244
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.62928e+06
@@ -25804,21 +26240,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 1223 StructureType sync.noCopy
+          Type: 1239 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 1229 StructureType sync/atomic.Uint64
+          Type: 1245 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1223
+      ID: 1239
       Name: sync.noCopy
       GoRuntimeType: 997664
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1226
+      ID: 1242
       Name: sync/atomic.Bool
       ByteSize: 4
       GoRuntimeType: 1.477216e+06
@@ -25826,12 +26262,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1227 StructureType sync/atomic.noCopy
+          Type: 1243 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1231
+      ID: 1247
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.477376e+06
@@ -25839,12 +26275,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1227 StructureType sync/atomic.noCopy
+          Type: 1243 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 1229
+      ID: 1245
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.629856e+06
@@ -25852,33 +26288,33 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1227 StructureType sync/atomic.noCopy
+          Type: 1243 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 1230 StructureType sync/atomic.align64
+          Type: 1246 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 8 BaseType uint64
     - __kind: StructureType
-      ID: 1230
+      ID: 1246
       Name: sync/atomic.align64
       GoRuntimeType: 997856
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1227
+      ID: 1243
       Name: sync/atomic.noCopy
       GoRuntimeType: 997760
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 954
+      ID: 970
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1.293504e+06
       GoKind: 12
     - __kind: StructureType
-      ID: 444
+      ID: 460
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -25900,9 +26336,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 445 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 461 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
-      ID: 436
+      ID: 452
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -25924,9 +26360,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 437 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 453 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
-      ID: 384
+      ID: 400
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
@@ -25948,9 +26384,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 385 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 401 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
-      ID: 403
+      ID: 419
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
@@ -25972,9 +26408,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 404 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 420 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
-      ID: 342
+      ID: 358
       Name: table<int,*main.deepMap2>
       ByteSize: 32
       GoKind: 25
@@ -25996,9 +26432,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 343 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
+          Type: 359 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
     - __kind: StructureType
-      ID: 1249
+      ID: 1265
       Name: table<int,*main.deepMap3>
       ByteSize: 32
       GoKind: 25
@@ -26020,9 +26456,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1250 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+          Type: 1266 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
     - __kind: StructureType
-      ID: 1283
+      ID: 1299
       Name: table<int,*main.deepMap8>
       ByteSize: 32
       GoKind: 25
@@ -26044,9 +26480,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1284 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
+          Type: 1300 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
     - __kind: StructureType
-      ID: 1298
+      ID: 1314
       Name: table<int,*main.deepMap9>
       ByteSize: 32
       GoKind: 25
@@ -26068,9 +26504,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1299 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
+          Type: 1315 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
     - __kind: StructureType
-      ID: 352
+      ID: 368
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
@@ -26092,9 +26528,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 353 GoSwissMapGroupsType groupReference<int,int>
+          Type: 369 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 1313
+      ID: 1329
       Name: table<int,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -26116,9 +26552,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1314 GoSwissMapGroupsType groupReference<int,interface {}>
+          Type: 1330 GoSwissMapGroupsType groupReference<int,interface {}>
     - __kind: StructureType
-      ID: 460
+      ID: 476
       Name: table<int,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -26140,9 +26576,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 461 GoSwissMapGroupsType groupReference<int,struct {}>
+          Type: 477 GoSwissMapGroupsType groupReference<int,struct {}>
     - __kind: StructureType
-      ID: 411
+      ID: 427
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -26164,9 +26600,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 412 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 428 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
-      ID: 393
+      ID: 409
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
@@ -26188,9 +26624,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 394 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 410 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 376
+      ID: 392
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -26212,9 +26648,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 377 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 393 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 1011
+      ID: 1027
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -26236,9 +26672,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1012 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 1028 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
-      ID: 368
+      ID: 384
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -26260,9 +26696,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 369 GoSwissMapGroupsType groupReference<string,int>
+          Type: 385 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 360
+      ID: 376
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
@@ -26284,9 +26720,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 361 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 377 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 452
+      ID: 468
       Name: table<struct {},int>
       ByteSize: 32
       GoKind: 25
@@ -26308,9 +26744,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 453 GoSwissMapGroupsType groupReference<struct {},int>
+          Type: 469 GoSwissMapGroupsType groupReference<struct {},int>
     - __kind: StructureType
-      ID: 502
+      ID: 518
       Name: table<struct {},main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -26332,9 +26768,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 503 GoSwissMapGroupsType groupReference<struct {},main.structWithCyclicMaps>
+          Type: 519 GoSwissMapGroupsType groupReference<struct {},main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 510
+      ID: 526
       Name: table<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -26356,9 +26792,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 511 GoSwissMapGroupsType groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
+          Type: 527 GoSwissMapGroupsType groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 518
+      ID: 534
       Name: table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -26380,9 +26816,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 519 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 535 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 526
+      ID: 542
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -26404,9 +26840,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 527 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 543 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 534
+      ID: 550
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -26428,9 +26864,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 535 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 551 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 542
+      ID: 558
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -26452,9 +26888,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 543 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 559 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 468
+      ID: 484
       Name: table<struct {},struct {}>
       ByteSize: 32
       GoKind: 25
@@ -26476,9 +26912,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 469 GoSwissMapGroupsType groupReference<struct {},struct {}>
+          Type: 485 GoSwissMapGroupsType groupReference<struct {},struct {}>
     - __kind: StructureType
-      ID: 427
+      ID: 443
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -26500,9 +26936,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 428 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 444 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
-      ID: 419
+      ID: 435
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
@@ -26524,13 +26960,13 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 420 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 436 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: UnresolvedPointeeType
-      ID: 1174
+      ID: 1190
       Name: text/tabwriter.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 897
+      ID: 913
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1.725568e+06
@@ -26543,21 +26979,21 @@ Types:
           Offset: 16
           Type: 15 GoInterfaceType error
     - __kind: BaseType
-      ID: 1107
+      ID: 1123
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1.935232e+06
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 972
+      ID: 988
       Name: time.Location
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 637
+      ID: 653
       Name: time.ParseError
       ByteSize: 8
     - __kind: StructureType
-      ID: 970
+      ID: 986
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.395872e+06
@@ -26571,9 +27007,9 @@ Types:
           Type: 13 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 971 PointerType *time.Location
+          Type: 987 PointerType *time.Location
     - __kind: GoStringHeaderType
-      ID: 552
+      ID: 568
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 838560
@@ -26581,18 +27017,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 554 PointerType *time.fileSizeError.str
+          Type: 570 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 553 GoStringDataType time.fileSizeError.str
+      Data: 569 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 553
+      ID: 569
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 635
+      ID: 651
       Name: time.parseDurationError
       ByteSize: 8
     - __kind: BaseType
@@ -26638,7 +27074,7 @@ Types:
       GoRuntimeType: 591392
       GoKind: 26
     - __kind: StructureType
-      ID: 990
+      ID: 1006
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2.085184e+06
@@ -26649,10 +27085,10 @@ Types:
           Type: 39 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 991 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 1007 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 992 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 1008 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: off
           Offset: 40
           Type: 7 BaseType int
@@ -26667,18 +27103,18 @@ Types:
           Type: 7 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 993 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 1009 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 6 BaseType uint16
     - __kind: BaseType
-      ID: 993
+      ID: 1009
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 1.004384e+06
       GoKind: 9
     - __kind: StructureType
-      ID: 991
+      ID: 1007
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1.946496e+06
@@ -26703,21 +27139,21 @@ Types:
           Offset: 10
           Type: 6 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 729
+      ID: 745
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 992
+      ID: 1008
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 595104
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1168
+      ID: 1184
       Name: vendor/golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 713
+      ID: 729
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.437504e+06
@@ -26727,13 +27163,13 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: BaseType
-      ID: 597
+      ID: 613
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 842688
       GoKind: 2
     - __kind: StructureType
-      ID: 874
+      ID: 890
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1.721344e+06
@@ -26746,12 +27182,12 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 826
+      ID: 842
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 1.003232e+06
       GoKind: 5
-MaxTypeID: 1565
+MaxTypeID: 1582
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x1321d00", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/testdata/decoded/sample/testLineProbeTemplateWithStructFields.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLineProbeTemplateWithStructFields.json
@@ -1,0 +1,31 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.executeStructFuncs",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "probe": {
+          "id": "testLineProbeTemplateWithStructFields",
+          "location": {
+            "method": "main.executeStructFuncs",
+            "file": "structs.go",
+            "line": 208
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "message": "sta.a: [1, 2, 3] sta.b: 1 sta.c: [1, 2, 3, ...]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/sample/testLineProbeTemplateWithStructFields.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLineProbeTemplateWithStructFields.json
@@ -26,6 +26,6 @@
       "type": "snapshot"
     },
     "timestamp": "[ts]",
-    "message": "sta.a: [1, 2, 3] sta.b: 1 sta.c: [1, 2, 3, ...]"
+    "message": "sta.a: [1, 2, 3] sta.b: 4 sta.c: [6, 7, 8, ...]"
   }
 ]

--- a/pkg/dyninst/testprogs/testdata/probes/sample.yaml
+++ b/pkg/dyninst/testprogs/testdata/probes/sample.yaml
@@ -2434,3 +2434,25 @@ probes:
             ref: "x"
     sampling:
       snapshotsPerSecond: 100
+  - id: testLineProbeTemplateWithStructFields
+    type: LOG_PROBE
+    where:
+      methodName: main.executeStructFuncs
+      sourceFile: structs.go
+      lines:
+        - "208"
+    template: "sta.a: {sta.a} sta.b: {sta.b} sta.c: {sta.c}"
+    segments:
+      - str: "sta.a: "
+      - json:
+          getmember: [{ ref: "sta" }, "a"]
+        dsl: "sta.a"
+      - str: " sta.b: "
+      - json:
+          getmember: [{ ref: "sta" }, "b"]
+        dsl: "sta.b"
+      - str: " sta.c: "
+      - json:
+          getmember: [{ ref: "sta" }, "c"]
+        dsl: "sta.c"
+    captureSnapshot: false


### PR DESCRIPTION
### What does this PR do?
Fixes a bug in EncodeLocationOp where log probe template expressions accessing multiple fields from the same struct variable would incorrectly display the same value for all fields.

For example, a template like RichError captured - kind={re.kind} message={re.message} would output kind=*errors.withStack message=*errors.withStack instead of showing the distinct values for each field.

When a single loclist piece (e.g., a struct stored entirely on the stack) covered multiple layout pieces, the code only checked if the first layout piece's offset fell within the target range. For fields at
later offsets (like re.message at offset 16), this check failed and no read operation was generated, causing the expression buffer to retain stale data from the previous expression.

### Describe how you validated your changes

- Added unit tests in pkg/dyninst/irgen/resolve_expression_test.go to verify that resolving multiple field accesses on the same struct produces distinct LocationOp offsets
- Updated compiler snapshot tests to reflect the new code generation pattern
- Verified all pkg/dyninst/compiler tests pass

### Additional Notes

https://datadoghq.atlassian.net/browse/DEBUG-5245