### PR TITLE
Remove obsolete `ref_protected` from STS trust policies

### DIFF
--- a/.github/chainguard/self.ask-review-bot-pr.label-pr.sts.yaml
+++ b/.github/chainguard/self.ask-review-bot-pr.label-pr.sts.yaml
@@ -6,7 +6,6 @@ subject: repo:DataDog/datadog-agent:environment:main
 claim_pattern:
   event_name: workflow_run
   ref: refs/heads/main
-  ref_protected: "true"
   job_workflow_ref: DataDog/datadog-agent/\.github/workflows/ask_review_bot_pr\.yml@refs/heads/main
 
 permissions:

--- a/.github/chainguard/self.assign-issue.label-issue.sts.yaml
+++ b/.github/chainguard/self.assign-issue.label-issue.sts.yaml
@@ -6,7 +6,6 @@ subject: repo:DataDog/datadog-agent:environment:main
 claim_pattern:
   event_name: (issues|issue_comment|workflow_dispatch|workflow_run)
   ref: refs/heads/main
-  ref_protected: "true"
   job_workflow_ref: DataDog/datadog-agent/\.github/workflows/(assign_issue_triage|check_issue_status)\.yml@refs/heads/main
 
 permissions:

--- a/.github/chainguard/self.buildimages-update.create-pr.sts.yaml
+++ b/.github/chainguard/self.buildimages-update.create-pr.sts.yaml
@@ -6,7 +6,6 @@ subject: repo:DataDog/datadog-agent:ref:refs/heads/main
 claim_pattern:
   event_name: workflow_dispatch
   ref: refs/heads/main
-  ref_protected: "true"
   job_workflow_ref: DataDog/datadog-agent/\.github/workflows/buildimages-update\.yml@refs/heads/main
 
 permissions:

--- a/.github/chainguard/self.collector-generate-and-update.create-pr.sts.yaml
+++ b/.github/chainguard/self.collector-generate-and-update.create-pr.sts.yaml
@@ -6,7 +6,6 @@ subject: repo:DataDog/datadog-agent:ref:refs/heads/main
 claim_pattern:
   event_name: (workflow_dispatch|schedule)
   ref: refs/heads/main
-  ref_protected: "true"
   job_workflow_ref: DataDog/datadog-agent/\.github/workflows/collector-generate-and-update\.yml@refs/heads/main
 
 permissions:

--- a/.github/chainguard/self.cws-btfhub-sync.create-pr.sts.yaml
+++ b/.github/chainguard/self.cws-btfhub-sync.create-pr.sts.yaml
@@ -6,7 +6,6 @@ subject: repo:DataDog/datadog-agent:ref:refs/heads/main
 claim_pattern:
   event_name: (workflow_dispatch|schedule)
   ref: refs/heads/main
-  ref_protected: "true"
   job_workflow_ref: DataDog/datadog-agent/\.github/workflows/cws-btfhub-sync\.yml@refs/heads/main
 
 permissions:

--- a/.github/chainguard/self.gitlab.pull-request-read.sts.yaml
+++ b/.github/chainguard/self.gitlab.pull-request-read.sts.yaml
@@ -8,7 +8,6 @@ claim_pattern:
   ref_type: "branch"
   ref: ".+"
   ref_path: "refs/heads/.+"
-  ref_protected: "true"
 
 # This token is used by the skip-ci-check merge queue job to read PR title and
 # body via the GitHub API, ensuring [skip ci] tags are not propagated to main.

--- a/.github/chainguard/self.gitlab.security-events-write.sts.yaml
+++ b/.github/chainguard/self.gitlab.security-events-write.sts.yaml
@@ -5,6 +5,5 @@ claim_pattern:
   ref_type: "branch"
   ref: ".+"
   ref_path: "refs/heads/.+"
-  ref_protected: "true"
 permissions:
   security_events: write

--- a/.github/chainguard/self.stale.manage-stale.sts.yaml
+++ b/.github/chainguard/self.stale.manage-stale.sts.yaml
@@ -6,7 +6,6 @@ subject: repo:DataDog/datadog-agent:environment:main
 claim_pattern:
   event_name: (workflow_dispatch|schedule)
   ref: refs/heads/main
-  ref_protected: "true"
   job_workflow_ref: DataDog/datadog-agent/\.github/workflows/stale\.yml@refs/heads/main
 
 permissions:

--- a/.github/chainguard/self.update-dependencies.create-pr.sts.yaml
+++ b/.github/chainguard/self.update-dependencies.create-pr.sts.yaml
@@ -6,7 +6,6 @@ subject: repo:DataDog/datadog-agent:environment:main
 claim_pattern:
   event_name: workflow_dispatch|schedule
   ref: refs/heads/main
-  ref_protected: "true"
   job_workflow_ref: DataDog/datadog-agent/\.github/workflows/update_dependencies\.yml@refs/heads/main
 
 permissions:

--- a/.github/chainguard/self.update-kubernetes-versions.create-pr.sts.yaml
+++ b/.github/chainguard/self.update-kubernetes-versions.create-pr.sts.yaml
@@ -6,7 +6,6 @@ subject: repo:DataDog/datadog-agent:environment:main
 claim_pattern:
   event_name: (workflow_dispatch|schedule)
   ref: refs/heads/main
-  ref_protected: "true"
   job_workflow_ref: DataDog/datadog-agent/\.github/workflows/update-kubernetes-versions\.yml@refs/heads/main
 
 permissions:

--- a/.github/chainguard/self.upgrade-python-version.create-pr.sts.yaml
+++ b/.github/chainguard/self.upgrade-python-version.create-pr.sts.yaml
@@ -6,7 +6,6 @@ subject: repo:DataDog/datadog-agent:environment:main
 claim_pattern:
   event_name: workflow_dispatch|schedule
   ref: refs/heads/main
-  ref_protected: "true"
   job_workflow_ref: DataDog/datadog-agent/\.github/workflows/upgrade-python-patch-version\.yml@refs/heads/main
 
 permissions:


### PR DESCRIPTION
## Summary

- Remove `ref_protected: "true"` from dd-octo-sts trust policy claim patterns

The `ref_protected` OIDC claim is now obsolete in the DataDog org:

- **GitHub**: The org-level "incompatible file paths on windows" push ruleset causes ALL branches to report `ref_protected: true` in OIDC tokens, making it useless as a security signal
- **GitLab**: All branches on `gitlab.ddbuild.io` report `ref_protected: true` due to org-level `pushAccessLevels: 40` config

Since the claim is universally `true`, it provides no actual filtering — only a false sense of security. Removing it has zero functional impact on policy enforcement.

All other constraints (subject, ref, job_workflow_ref, project_path, pipeline_source, etc.) remain unchanged and continue to provide the real security boundaries.

Ticket: https://datadoghq.atlassian.net/browse/SINT-4732

## Test plan

- [ ] Verify that the remaining policy constraints are sufficient (ref, job_workflow_ref, etc. are unchanged)
- [ ] No functional change expected since ref_protected was already always true

🤖 Generated with [Claude Code](https://claude.com/claude-code)
