### PR TITLE
[network-path] Downgrade noisy log statements to appropriate levels

### DIFF
--- a/comp/networkpath/npcollector/npcollectorimpl/npcollector.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/npcollector.go
@@ -90,7 +90,7 @@ func newNoopNpCollectorImpl() *npCollectorImpl {
 }
 
 func newNpCollectorImpl(epForwarder eventplatform.Forwarder, collectorConfigs *collectorConfigs, traceroute traceroute.Component, logger log.Component, rdnsquerier rdnsquerier.Component, statsd ddgostatsd.ClientInterface) *npCollectorImpl {
-	logger.Infof("New NpCollector %+v", collectorConfigs)
+	logger.Debugf("New NpCollector %+v", collectorConfigs)
 	filter, errs := connfilter.NewConnFilter(collectorConfigs.filterConfig, collectorConfigs.ddSite, collectorConfigs.monitorIPWithoutDomain)
 
 	if len(errs) > 0 {
@@ -327,7 +327,7 @@ func (s *npCollectorImpl) listenPathtests() {
 	for {
 		select {
 		case <-s.stopChan:
-			s.logger.Info("Stopped listening for pathtests")
+			s.logger.Debug("Stopped listening for pathtests")
 			s.pathtestsListenerDone <- struct{}{}
 			return
 		case ptest := <-s.pathtestInputChan:

--- a/pkg/networkpath/traceroute/runner/runner.go
+++ b/pkg/networkpath/traceroute/runner/runner.go
@@ -80,7 +80,7 @@ type Runner struct {
 func New(telemetryComp telemetryComponent.Component) (*Runner, error) {
 	gatewayLookup, nsIno, err := createGatewayLookup(telemetryComp)
 	if err != nil {
-		log.Errorf("failed to create gateway lookup: %s", err.Error())
+		log.Warnf("failed to create gateway lookup: %s", err.Error())
 	}
 	if gatewayLookup == nil {
 		log.Warnf("gateway lookup is not enabled")


### PR DESCRIPTION
  ## Summary

  Following a recent fix to downgrade the network ID fetch failure from `Error` to `Warn`, this PR audits **all** log statements across the Network Path product to ensure log levels match the actual urgency of each condition.

  Scope reviewed:
  - `pkg/networkpath/traceroute/runner/runner.go`
  - `pkg/collector/corechecks/networkpath/networkpath.go`
  - `comp/networkpath/traceroute/impl-remote/traceroute.go`
  - `comp/networkpath/npcollector/npcollectorimpl/npcollectorcomp.go`
  - `comp/networkpath/npcollector/npcollectorimpl/config.go`
  - `comp/networkpath/npcollector/npcollectorimpl/npcollector.go`
  - `comp/networkpath/npcollector/npcollectorimpl/pathteststore/pathteststore.go`

  Total: 44 log statements audited. 3 changes made.

  ## Changes

  ### 1. `runner.go:83` — `Errorf` → `Warnf`

  **Rationale:** `createGatewayLookup` failure is non-fatal — the runner is still created and returned successfully. Gateway lookup is enrichment, not core traceroute functionality. The nil case immediately below already uses `Warn`; the error case should be consistent. Same pattern as the recent network ID fix.

  ### 2. `npcollector.go:93` — `Infof` → `Debugf`

  **Rationale:** `%+v` on a full config struct at `Info` level dumps verbose internals to customer logs on every startup. This is startup noise, not actionable operational information. `Debug` is the right level for full struct dumps.

  ### 3. `npcollector.go:330` — `Info` → `Debug`

  **Rationale:** The matching start log at line 326 is `Debug` ("Starting listening for pathtests"). The stop log being `Info` is asymmetric — this is routine lifecycle noise. Should match its pair.

  ## Not Changed (Rationale)

  | Location | Log | Why kept as-is |
  |---|---|---|
  | `npcollectorcomp.go:70` | `Errorf("Error getting EpForwarder")` | Results in noop collector — no data ever collected. Genuine Error. |
  | `npcollectorcomp.go:64` | `Infof("Reverse DNS enrichment is disabled...")` | Actionable config note that affects behavior. Info is correct. |
  | `config.go:50` | `Errorf("Error unmarshalling...filters")` | User misconfiguration that silently drops filter rules. Error is appropriate. |
  | `npcollector.go:97` | `Errorf("connection filter errors")` | Initialization-time filter errors affect which connections get tracerouted. Error is appropriate. |
  | `npcollector.go:254` | `Errorf("Failed to get VPC subnets to skip")` | Causes entire scheduled batch to be dropped. Error is appropriate. |
  | `npcollector.go:292` | `Warnf("collector input channel is full")` | Already Warn with rate limiting. Correct. |
  | `npcollector.go:362` | `Errorf("run traceroute error")` | Kept at Error per owner preference. |
  | `npcollector.go:446` | `Tracef("collector processing channel is full")` | Fixing requires adding rate limiting — more invasive change, out of scope. |

  ## Test plan

  - [ ] Build: `dda inv agent.build --build-exclude=systemd`
  - [ ] Lint: `dda inv linter.go --targets=./pkg/networkpath/... --targets=./comp/networkpath/...`
  - [ ] Test: `dda inv test --targets=./pkg/networkpath/... --targets=./comp/networkpath/...`
  - [ ] Manual: Run agent locally with `log_level: debug`, confirm changed log lines appear at new levels