### PR TITLE
Add glob expansion test scenarios for shell

### DIFF
--- a/pkg/shell/tests/scenarios/shell/globbing/bracket/character_range.yaml
+++ b/pkg/shell/tests/scenarios/shell/globbing/bracket/character_range.yaml
@@ -1,0 +1,22 @@
+description: Bracket glob with range matches characters in the range.
+setup:
+  files:
+    - path: a.txt
+      content: ""
+    - path: b.txt
+      content: ""
+    - path: c.txt
+      content: ""
+    - path: d.txt
+      content: ""
+    - path: z.txt
+      content: ""
+input:
+  # language=bash
+  script: |+
+    echo [a-c].txt
+expect:
+  stdout: |+
+    a.txt b.txt c.txt
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/globbing/bracket/character_set.yaml
+++ b/pkg/shell/tests/scenarios/shell/globbing/bracket/character_set.yaml
@@ -1,0 +1,18 @@
+description: Bracket glob matches any single character in the set.
+setup:
+  files:
+    - path: a.txt
+      content: ""
+    - path: b.txt
+      content: ""
+    - path: c.txt
+      content: ""
+input:
+  # language=bash
+  script: |+
+    echo [ab].txt
+expect:
+  stdout: |+
+    a.txt b.txt
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/globbing/bracket/negation.yaml
+++ b/pkg/shell/tests/scenarios/shell/globbing/bracket/negation.yaml
@@ -1,0 +1,18 @@
+description: Bracket glob with negation excludes specified characters.
+setup:
+  files:
+    - path: a.txt
+      content: ""
+    - path: b.txt
+      content: ""
+    - path: c.txt
+      content: ""
+input:
+  # language=bash
+  script: |+
+    echo [!a].txt
+expect:
+  stdout: |+
+    b.txt c.txt
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/globbing/bracket/no_match_literal.yaml
+++ b/pkg/shell/tests/scenarios/shell/globbing/bracket/no_match_literal.yaml
@@ -1,0 +1,10 @@
+description: Bracket glob with no matches expands to the literal pattern.
+input:
+  # language=bash
+  script: |+
+    echo [abc].xyz
+expect:
+  stdout: |+
+    [abc].xyz
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/globbing/for_loop/iterate_glob.yaml
+++ b/pkg/shell/tests/scenarios/shell/globbing/for_loop/iterate_glob.yaml
@@ -1,0 +1,20 @@
+description: For loop iterates over glob-expanded filenames.
+setup:
+  files:
+    - path: a.txt
+      content: ""
+    - path: b.txt
+      content: ""
+    - path: c.txt
+      content: ""
+input:
+  # language=bash
+  script: |+
+    for f in *.txt; do echo "file:$f"; done
+expect:
+  stdout: |+
+    file:a.txt
+    file:b.txt
+    file:c.txt
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/globbing/question_mark/mixed_with_star.yaml
+++ b/pkg/shell/tests/scenarios/shell/globbing/question_mark/mixed_with_star.yaml
@@ -1,0 +1,18 @@
+description: Question mark and star can be combined in a pattern.
+setup:
+  files:
+    - path: a1.txt
+      content: ""
+    - path: b2.txt
+      content: ""
+    - path: cc.log
+      content: ""
+input:
+  # language=bash
+  script: |+
+    echo ?*.txt
+expect:
+  stdout: |+
+    a1.txt b2.txt
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/globbing/question_mark/multiple_question_marks.yaml
+++ b/pkg/shell/tests/scenarios/shell/globbing/question_mark/multiple_question_marks.yaml
@@ -1,0 +1,20 @@
+description: Multiple question marks match exact number of characters.
+setup:
+  files:
+    - path: ab.txt
+      content: ""
+    - path: cd.txt
+      content: ""
+    - path: a.txt
+      content: ""
+    - path: abc.txt
+      content: ""
+input:
+  # language=bash
+  script: |+
+    echo ??.txt
+expect:
+  stdout: |+
+    ab.txt cd.txt
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/globbing/question_mark/no_match_literal.yaml
+++ b/pkg/shell/tests/scenarios/shell/globbing/question_mark/no_match_literal.yaml
@@ -1,0 +1,10 @@
+description: Question mark glob with no matches expands to the literal pattern.
+input:
+  # language=bash
+  script: |+
+    echo ?.xyz
+expect:
+  stdout: |+
+    ?.xyz
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/globbing/question_mark/single_char_match.yaml
+++ b/pkg/shell/tests/scenarios/shell/globbing/question_mark/single_char_match.yaml
@@ -1,0 +1,18 @@
+description: Question mark glob matches exactly one character.
+setup:
+  files:
+    - path: a.txt
+      content: ""
+    - path: b.txt
+      content: ""
+    - path: ab.txt
+      content: ""
+input:
+  # language=bash
+  script: |+
+    echo ?.txt
+expect:
+  stdout: |+
+    a.txt b.txt
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/globbing/quoting/double_quotes_no_expand.yaml
+++ b/pkg/shell/tests/scenarios/shell/globbing/quoting/double_quotes_no_expand.yaml
@@ -1,0 +1,14 @@
+description: Glob inside double quotes is treated as literal.
+setup:
+  files:
+    - path: a.txt
+      content: ""
+input:
+  # language=bash
+  script: |+
+    echo "*.txt"
+expect:
+  stdout: |+
+    *.txt
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/globbing/quoting/single_quotes_no_expand.yaml
+++ b/pkg/shell/tests/scenarios/shell/globbing/quoting/single_quotes_no_expand.yaml
@@ -1,0 +1,14 @@
+description: Glob inside single quotes is treated as literal.
+setup:
+  files:
+    - path: a.txt
+      content: ""
+input:
+  # language=bash
+  script: |+
+    echo '*.txt'
+expect:
+  stdout: |+
+    *.txt
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/globbing/star/all_files.yaml
+++ b/pkg/shell/tests/scenarios/shell/globbing/star/all_files.yaml
@@ -1,0 +1,17 @@
+description: Star glob matches all non-hidden files.
+setup:
+  files:
+    - path: a.txt
+      content: ""
+    - path: b.log
+      content: ""
+    - path: c
+      content: ""
+input:
+  # language=bash
+  script: |+
+    echo *
+expect:
+  stdout_contains: ["a.txt", "b.log", "c"]
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/globbing/star/basic_match.yaml
+++ b/pkg/shell/tests/scenarios/shell/globbing/star/basic_match.yaml
@@ -1,0 +1,18 @@
+description: Star glob expands to matching files.
+setup:
+  files:
+    - path: foo.txt
+      content: ""
+    - path: bar.txt
+      content: ""
+    - path: baz.log
+      content: ""
+input:
+  # language=bash
+  script: |+
+    echo *.txt
+expect:
+  stdout: |+
+    bar.txt foo.txt
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/globbing/star/in_subdirectory.yaml
+++ b/pkg/shell/tests/scenarios/shell/globbing/star/in_subdirectory.yaml
@@ -1,0 +1,16 @@
+description: Star glob matches files in a subdirectory.
+setup:
+  files:
+    - path: sub/x.txt
+      content: ""
+    - path: sub/y.txt
+      content: ""
+input:
+  # language=bash
+  script: |+
+    echo sub/*.txt
+expect:
+  stdout: |+
+    sub/x.txt sub/y.txt
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/globbing/star/matches_directories.yaml
+++ b/pkg/shell/tests/scenarios/shell/globbing/star/matches_directories.yaml
@@ -1,0 +1,15 @@
+description: Star glob matches directories alongside files.
+setup:
+  files:
+    - path: dir/placeholder
+      content: ""
+    - path: file.txt
+      content: ""
+input:
+  # language=bash
+  script: |+
+    echo *
+expect:
+  stdout_contains: ["dir", "file.txt"]
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/globbing/star/no_match_literal.yaml
+++ b/pkg/shell/tests/scenarios/shell/globbing/star/no_match_literal.yaml
@@ -1,0 +1,10 @@
+description: Star glob with no matches expands to the literal pattern.
+input:
+  # language=bash
+  script: |+
+    echo *.xyz
+expect:
+  stdout: |+
+    *.xyz
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/globbing/star/prefix_match.yaml
+++ b/pkg/shell/tests/scenarios/shell/globbing/star/prefix_match.yaml
@@ -1,0 +1,18 @@
+description: Star glob with prefix matches files starting with that prefix.
+setup:
+  files:
+    - path: test_one.sh
+      content: ""
+    - path: test_two.sh
+      content: ""
+    - path: other.sh
+      content: ""
+input:
+  # language=bash
+  script: |+
+    echo test_*
+expect:
+  stdout: |+
+    test_one.sh test_two.sh
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/globbing/star/skips_dotfiles.yaml
+++ b/pkg/shell/tests/scenarios/shell/globbing/star/skips_dotfiles.yaml
@@ -1,0 +1,16 @@
+description: Star glob does not match dotfiles.
+setup:
+  files:
+    - path: visible.txt
+      content: ""
+    - path: .hidden
+      content: ""
+input:
+  # language=bash
+  script: |+
+    echo *
+expect:
+  stdout: |+
+    visible.txt
+  stderr: ""
+  exit_code: 0


### PR DESCRIPTION
<!-- dd-meta {"pullId":"d08d807c-6ff8-40b8-a6e8-fb15ba3c8fbf","source":"chat","resourceId":"f05d6bb9-ad24-4707-bedc-5202fa0c7e68","workflowId":"0c77c0ba-1c6d-4a52-b3eb-a8f35a89bd74","codeChangeId":"0c77c0ba-1c6d-4a52-b3eb-a8f35a89bd74","sourceType":"chat"} -->
PR by Bits
[View session in Datadog](https://app.datadoghq.com/code/f05d6bb9-ad24-4707-bedc-5202fa0c7e68)

Comment @datadog to request changes

Feedback (especially what can be better) welcome in [#code-gen-aka-bits-dev-feedback](https://dd.enterprise.slack.com/archives/C07JA5N2D25)!

---

### What does this PR do?

Adds 18 YAML test scenarios covering basic glob/pathname expansion (`*`, `?`, `[...]`) in the restricted shell interpreter (`pkg/shell`).

**Star glob (`*`)** — 7 scenarios:
- basic extension match, match all files, no-match falls back to literal, skips dotfiles, subdirectory glob, matches directories, prefix match

**Question mark glob (`?`)** — 4 scenarios:
- single character match, no-match literal, multiple `??`, combined `?*`

**Bracket glob (`[...]`)** — 4 scenarios:
- character set, character range `[a-c]`, negation `[!a]`, no-match literal

**Quoting suppression** — 2 scenarios:
- single-quoted and double-quoted globs stay literal

**For loop integration** — 1 scenario:
- `for f in *.txt` iterates over expanded filenames

### Motivation

The shell interpreter supports glob expansion but lacked dedicated test coverage for the three POSIX glob metacharacters and their edge cases.

### Describe how you validated your changes

All 18 new scenarios pass: `go test -v -run 'TestShellScenarios/shell/globbing' ./pkg/shell/tests/`

### Additional Notes

No code changes — YAML test scenarios only.