### PR TITLE
Block select, extglob, $LINENO in safe-shell

### DIFF
--- a/pkg/shell/interp/validate.go
+++ b/pkg/shell/interp/validate.go
@@ -78,10 +78,17 @@ func validateNode(node syntax.Node) error {
 			err = fmt.Errorf("test declarations are not supported")
 			return false
 		case *syntax.ForClause:
+			if n.Select {
+				err = fmt.Errorf("select statements are not supported")
+				return false
+			}
 			if _, ok := n.Loop.(*syntax.WordIter); !ok {
 				err = fmt.Errorf("c-style for loops are not supported")
 				return false
 			}
+		case *syntax.ExtGlob:
+			err = fmt.Errorf("extended globbing is not supported")
+			return false
 
 		// Blocked statement-level features.
 		case *syntax.Stmt:
@@ -138,6 +145,9 @@ func validateParamExp(pe *syntax.ParamExp) error {
 	// Block special parameters like $#, $0, $1-$9, $@, $*
 	if pe.Param != nil && blockedSpecialParams[pe.Param.Value] {
 		return fmt.Errorf("$%s is not supported", pe.Param.Value)
+	}
+	if pe.Param != nil && pe.Param.Value == "LINENO" {
+		return fmt.Errorf("$LINENO is not supported")
 	}
 	return nil
 }

--- a/pkg/shell/tests/scenarios/shell/blocked_commands/extglob.yaml
+++ b/pkg/shell/tests/scenarios/shell/blocked_commands/extglob.yaml
@@ -1,0 +1,10 @@
+description: Extended globbing is not supported in safe-shell.
+input:
+  # language=bash
+  script: |+
+    echo @(foo|bar)
+expect:
+  stdout: ""
+  stderr: |+
+    extended globbing is not supported
+  exit_code: 2

--- a/pkg/shell/tests/scenarios/shell/blocked_commands/select_statement.yaml
+++ b/pkg/shell/tests/scenarios/shell/blocked_commands/select_statement.yaml
@@ -1,0 +1,10 @@
+description: Select statements are not supported in safe-shell.
+input:
+  # language=bash
+  script: |+
+    select x in a b c; do echo $x; done
+expect:
+  stdout: ""
+  stderr: |+
+    select statements are not supported
+  exit_code: 2

--- a/pkg/shell/tests/scenarios/shell/var_expand/blocked_variables/lineno.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/blocked_variables/lineno.yaml
@@ -1,0 +1,10 @@
+description: The $LINENO variable is not supported in safe-shell.
+input:
+  # language=bash
+  script: |+
+    echo $LINENO
+expect:
+  stdout: ""
+  stderr: |+
+    $LINENO is not supported
+  exit_code: 2


### PR DESCRIPTION
<!-- dd-meta {"pullId":"fb43c3c2-599e-42f6-892d-b916fbddbe03","source":"chat","resourceId":"f19488f9-82cf-4ad3-aba6-330a4dab7357","workflowId":"371f19fc-c02c-4c47-aa18-5c3b8e277d7a","codeChangeId":"371f19fc-c02c-4c47-aa18-5c3b8e277d7a","sourceType":"chat"} -->
PR by Bits
[View session in Datadog](https://app.datadoghq.com/code/f19488f9-82cf-4ad3-aba6-330a4dab7357)

Comment @datadog to request changes

Feedback (especially what can be better) welcome in [#code-gen-aka-bits-dev-feedback](https://dd.enterprise.slack.com/archives/C07JA5N2D25)!

---

### What does this PR do?

Closes three validation gaps in the safe-shell interpreter's AST validator (`pkg/shell/interp/validate.go`):

- **Block `select` statements**: `select x in a b c; do ... done` was parsed as a `ForClause` with `Select=true` and passed validation, executing as a regular `for` loop. Now rejected before execution.
- **Block extended globbing**: `@(foo|bar)`, `*(...)`, etc. (`ExtGlob` AST nodes) were not caught at validation time. The `expand` package rejected them at runtime, but this adds defense-in-depth at the AST layer.
- **Block `$LINENO`**: The `expand` package intercepts `$LINENO` internally, bypassing `lookupVar`, causing it to leak source line numbers. Now rejected at validation.

### Motivation

Security audit of the safe-shell revealed these gaps. The `select` bypass is the most significant — it allowed an unintended shell construct to execute. The other two are defense-in-depth improvements.

### Describe how you validated your changes

- Added 3 new YAML test scenarios (`select_statement.yaml`, `extglob.yaml`, `lineno.yaml`)
- All existing + new tests pass: `go test ./pkg/shell/... -count=1`

### Additional Notes

Full audit also confirmed these vectors are **already safe**: `eval`/`source`/`.` (rejected by `NoExecHandler`), backtick substitution (parser converts to `CmdSubst` → blocked), `$RANDOM`/`$SECONDS`/`$$`/`$!` (expand to empty), symlink traversal (protected by `os.Root`).