### PR TITLE
Add missing shell interpreter test scenarios

### DIFF
--- a/pkg/shell/tests/scenarios/cmd/echo/literal/double_quote_escapes.yaml
+++ b/pkg/shell/tests/scenarios/cmd/echo/literal/double_quote_escapes.yaml
@@ -1,0 +1,10 @@
+description: Backslash escape sequences in double-quoted echo are passed literally.
+input:
+  # language=bash
+  script: |+
+    echo "hello\nworld"
+expect:
+  stdout: |+
+    hello\nworld
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/allowed_redirects/heredoc.yaml
+++ b/pkg/shell/tests/scenarios/shell/allowed_redirects/heredoc.yaml
@@ -1,4 +1,4 @@
-description: Here-documents are still allowed in safe-shell.
+description: Here-documents are still allowed.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/allowed_redirects/herestring.yaml
+++ b/pkg/shell/tests/scenarios/shell/allowed_redirects/herestring.yaml
@@ -1,4 +1,4 @@
-description: Here-strings are still allowed in safe-shell.
+description: Here-strings are still allowed.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/allowed_redirects/input.yaml
+++ b/pkg/shell/tests/scenarios/shell/allowed_redirects/input.yaml
@@ -1,4 +1,4 @@
-description: Input redirection (<) is still allowed in safe-shell.
+description: Input redirection (<) is still allowed.
 setup:
   files:
     - path: data.txt

--- a/pkg/shell/tests/scenarios/shell/blocked_commands/arithmetic_cmd.yaml
+++ b/pkg/shell/tests/scenarios/shell/blocked_commands/arithmetic_cmd.yaml
@@ -1,4 +1,4 @@
-description: Arithmetic commands are not supported in safe-shell.
+description: Arithmetic commands are not supported.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/blocked_commands/background.yaml
+++ b/pkg/shell/tests/scenarios/shell/blocked_commands/background.yaml
@@ -1,4 +1,4 @@
-description: Background execution (&) is blocked in safe-shell.
+description: Background execution (&) is blocked.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/blocked_commands/c_style_for.yaml
+++ b/pkg/shell/tests/scenarios/shell/blocked_commands/c_style_for.yaml
@@ -1,4 +1,4 @@
-description: C-style for loops are not supported in safe-shell.
+description: C-style for loops are not supported.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/blocked_commands/case_statement.yaml
+++ b/pkg/shell/tests/scenarios/shell/blocked_commands/case_statement.yaml
@@ -1,4 +1,4 @@
-description: Case statements are not supported in safe-shell.
+description: Case statements are not supported.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/blocked_commands/coproc.yaml
+++ b/pkg/shell/tests/scenarios/shell/blocked_commands/coproc.yaml
@@ -1,4 +1,4 @@
-description: Coprocesses are not supported in safe-shell.
+description: Coprocesses are not supported.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/blocked_commands/declare.yaml
+++ b/pkg/shell/tests/scenarios/shell/blocked_commands/declare.yaml
@@ -1,4 +1,4 @@
-description: declare is not supported in safe-shell.
+description: declare is not supported.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/blocked_commands/export.yaml
+++ b/pkg/shell/tests/scenarios/shell/blocked_commands/export.yaml
@@ -1,4 +1,4 @@
-description: export is not supported in safe-shell.
+description: export is not supported.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/blocked_commands/extglob.yaml
+++ b/pkg/shell/tests/scenarios/shell/blocked_commands/extglob.yaml
@@ -1,4 +1,4 @@
-description: Extended globbing is not supported in safe-shell.
+description: Extended globbing is not supported.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/blocked_commands/function_decl.yaml
+++ b/pkg/shell/tests/scenarios/shell/blocked_commands/function_decl.yaml
@@ -1,4 +1,4 @@
-description: Function declarations are not supported in safe-shell.
+description: Function declarations are not supported.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/blocked_commands/if_else.yaml
+++ b/pkg/shell/tests/scenarios/shell/blocked_commands/if_else.yaml
@@ -1,4 +1,4 @@
-description: If-else statements are not supported in safe-shell.
+description: If-else statements are not supported.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/blocked_commands/if_statement.yaml
+++ b/pkg/shell/tests/scenarios/shell/blocked_commands/if_statement.yaml
@@ -1,4 +1,4 @@
-description: If statements are not supported in safe-shell.
+description: If statements are not supported.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/blocked_commands/let.yaml
+++ b/pkg/shell/tests/scenarios/shell/blocked_commands/let.yaml
@@ -1,4 +1,4 @@
-description: let is not supported in safe-shell.
+description: let is not supported.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/blocked_commands/local.yaml
+++ b/pkg/shell/tests/scenarios/shell/blocked_commands/local.yaml
@@ -1,4 +1,4 @@
-description: local is not supported in safe-shell.
+description: local is not supported.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/blocked_commands/process_sub.yaml
+++ b/pkg/shell/tests/scenarios/shell/blocked_commands/process_sub.yaml
@@ -1,4 +1,4 @@
-description: Process substitution is not supported in safe-shell.
+description: Process substitution is not supported.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/blocked_commands/process_sub.yaml
+++ b/pkg/shell/tests/scenarios/shell/blocked_commands/process_sub.yaml
@@ -1,0 +1,10 @@
+description: Process substitution is not supported in safe-shell.
+input:
+  # language=bash
+  script: |+
+    cat <(echo hello)
+expect:
+  stdout: ""
+  stderr: |+
+    process substitution is not supported
+  exit_code: 2

--- a/pkg/shell/tests/scenarios/shell/blocked_commands/readonly.yaml
+++ b/pkg/shell/tests/scenarios/shell/blocked_commands/readonly.yaml
@@ -1,4 +1,4 @@
-description: readonly is not supported in safe-shell.
+description: readonly is not supported.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/blocked_commands/select_statement.yaml
+++ b/pkg/shell/tests/scenarios/shell/blocked_commands/select_statement.yaml
@@ -1,4 +1,4 @@
-description: Select statements are not supported in safe-shell.
+description: Select statements are not supported.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/blocked_commands/subshell.yaml
+++ b/pkg/shell/tests/scenarios/shell/blocked_commands/subshell.yaml
@@ -1,4 +1,4 @@
-description: Subshells are not supported in safe-shell.
+description: Subshells are not supported.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/blocked_commands/test_clause.yaml
+++ b/pkg/shell/tests/scenarios/shell/blocked_commands/test_clause.yaml
@@ -1,4 +1,4 @@
-description: Test expressions are not supported in safe-shell.
+description: Test expressions are not supported.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/blocked_commands/time.yaml
+++ b/pkg/shell/tests/scenarios/shell/blocked_commands/time.yaml
@@ -1,4 +1,4 @@
-description: time is not supported in safe-shell.
+description: time is not supported.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/blocked_commands/until_loop.yaml
+++ b/pkg/shell/tests/scenarios/shell/blocked_commands/until_loop.yaml
@@ -1,4 +1,4 @@
-description: Until loops are not supported in safe-shell.
+description: Until loops are not supported.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/blocked_commands/while_loop.yaml
+++ b/pkg/shell/tests/scenarios/shell/blocked_commands/while_loop.yaml
@@ -1,4 +1,4 @@
-description: While loops are not supported in safe-shell.
+description: While loops are not supported.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/blocked_redirects/append_all.yaml
+++ b/pkg/shell/tests/scenarios/shell/blocked_redirects/append_all.yaml
@@ -1,4 +1,4 @@
-description: Append all (&>>) is not supported in safe-shell.
+description: Append all (&>>) is not supported.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/blocked_redirects/dup_in.yaml
+++ b/pkg/shell/tests/scenarios/shell/blocked_redirects/dup_in.yaml
@@ -1,4 +1,4 @@
-description: Input fd duplication (<&N) is blocked in safe-shell.
+description: Input fd duplication (<&N) is blocked.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/blocked_redirects/dup_out.yaml
+++ b/pkg/shell/tests/scenarios/shell/blocked_redirects/dup_out.yaml
@@ -1,4 +1,4 @@
-description: Output fd duplication (>&N) is blocked in safe-shell.
+description: Output fd duplication (>&N) is blocked.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/blocked_redirects/read_write.yaml
+++ b/pkg/shell/tests/scenarios/shell/blocked_redirects/read_write.yaml
@@ -1,4 +1,4 @@
-description: Read-write redirection (<>) is not supported in safe-shell.
+description: Read-write redirection (<>) is not supported.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/blocked_redirects/stderr_write.yaml
+++ b/pkg/shell/tests/scenarios/shell/blocked_redirects/stderr_write.yaml
@@ -1,4 +1,4 @@
-description: Stderr redirection (2>) is not supported in safe-shell.
+description: Stderr redirection (2>) is not supported.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/blocked_redirects/write_all.yaml
+++ b/pkg/shell/tests/scenarios/shell/blocked_redirects/write_all.yaml
@@ -1,4 +1,4 @@
-description: Redirect all (&>) is not supported in safe-shell.
+description: Redirect all (&>) is not supported.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/blocked_redirects/write_append.yaml
+++ b/pkg/shell/tests/scenarios/shell/blocked_redirects/write_append.yaml
@@ -1,4 +1,4 @@
-description: Append redirection (>>) is not supported in safe-shell.
+description: Append redirection (>>) is not supported.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/blocked_redirects/write_clobber.yaml
+++ b/pkg/shell/tests/scenarios/shell/blocked_redirects/write_clobber.yaml
@@ -1,4 +1,4 @@
-description: Clobber redirection (>|) is not supported in safe-shell.
+description: Clobber redirection (>|) is not supported.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/blocked_redirects/write_truncate.yaml
+++ b/pkg/shell/tests/scenarios/shell/blocked_redirects/write_truncate.yaml
@@ -1,4 +1,4 @@
-description: Output redirection (>) is not supported in safe-shell.
+description: Output redirection (>) is not supported.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/environment/ifs_default_tab.yaml
+++ b/pkg/shell/tests/scenarios/shell/environment/ifs_default_tab.yaml
@@ -1,0 +1,14 @@
+description: Default IFS splits on spaces, tabs, and newlines.
+input:
+  # language=bash
+  script: |+
+    A="hello	world"
+    for w in $A; do
+      echo "$w"
+    done
+expect:
+  stdout: |+
+    hello
+    world
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/environment/ifs_empty_no_split.yaml
+++ b/pkg/shell/tests/scenarios/shell/environment/ifs_empty_no_split.yaml
@@ -1,0 +1,14 @@
+description: Empty IFS disables word splitting.
+input:
+  # language=bash
+  script: |+
+    IFS=
+    A="hello world"
+    for w in $A; do
+      echo "$w"
+    done
+expect:
+  stdout: |+
+    hello world
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/environment/tilde_path_not_expanded.yaml
+++ b/pkg/shell/tests/scenarios/shell/environment/tilde_path_not_expanded.yaml
@@ -1,0 +1,10 @@
+description: Tilde with path ~/dir is not expanded in safe-shell.
+input:
+  # language=bash
+  script: |+
+    echo ~/mydir
+expect:
+  stdout: |+
+    ~/mydir
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/environment/tilde_path_not_expanded.yaml
+++ b/pkg/shell/tests/scenarios/shell/environment/tilde_path_not_expanded.yaml
@@ -1,4 +1,4 @@
-description: Tilde with path ~/dir is not expanded in safe-shell.
+description: Tilde with path ~/dir is not expanded.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/for_clause/basic/empty_body.yaml
+++ b/pkg/shell/tests/scenarios/shell/for_clause/basic/empty_body.yaml
@@ -1,0 +1,13 @@
+description: Empty for loop body executes successfully with no output.
+input:
+  # language=bash
+  script: |+
+    for i in a b c; do
+      true
+    done
+    echo done
+expect:
+  stdout: |+
+    done
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/for_clause/break_cont/break_exceeds_depth.yaml
+++ b/pkg/shell/tests/scenarios/shell/for_clause/break_cont/break_exceeds_depth.yaml
@@ -1,0 +1,15 @@
+description: Break with argument exceeding nesting depth breaks all loops.
+input:
+  # language=bash
+  script: |+
+    for i in a b c; do
+      echo $i
+      break 99
+    done
+    echo done
+expect:
+  stdout: |+
+    a
+    done
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/for_clause/break_cont/break_invalid_arg.yaml
+++ b/pkg/shell/tests/scenarios/shell/for_clause/break_cont/break_invalid_arg.yaml
@@ -1,0 +1,14 @@
+description: Break with non-numeric argument produces a usage error on each iteration.
+input:
+  # language=bash
+  script: |+
+    for i in a b c; do
+      break abc
+    done
+expect:
+  stdout: ""
+  stderr: |+
+    usage: break [n]
+    usage: break [n]
+    usage: break [n]
+  exit_code: 2

--- a/pkg/shell/tests/scenarios/shell/for_clause/break_cont/break_multiple_args.yaml
+++ b/pkg/shell/tests/scenarios/shell/for_clause/break_cont/break_multiple_args.yaml
@@ -1,0 +1,14 @@
+description: Break with multiple arguments produces a usage error on each iteration.
+input:
+  # language=bash
+  script: |+
+    for i in a b c; do
+      break 1 2
+    done
+expect:
+  stdout: ""
+  stderr: |+
+    usage: break [n]
+    usage: break [n]
+    usage: break [n]
+  exit_code: 2

--- a/pkg/shell/tests/scenarios/shell/for_clause/break_cont/continue_invalid_arg.yaml
+++ b/pkg/shell/tests/scenarios/shell/for_clause/break_cont/continue_invalid_arg.yaml
@@ -1,0 +1,14 @@
+description: Continue with non-numeric argument produces a usage error on each iteration.
+input:
+  # language=bash
+  script: |+
+    for i in a b c; do
+      continue abc
+    done
+expect:
+  stdout: ""
+  stderr: |+
+    usage: continue [n]
+    usage: continue [n]
+    usage: continue [n]
+  exit_code: 2

--- a/pkg/shell/tests/scenarios/shell/for_clause/nested/break_three_levels.yaml
+++ b/pkg/shell/tests/scenarios/shell/for_clause/nested/break_three_levels.yaml
@@ -1,0 +1,21 @@
+description: Break 3 in three-level nested loop breaks all loops.
+input:
+  # language=bash
+  script: |+
+    for i in a b; do
+      for j in 1 2; do
+        for k in x y; do
+          echo "$i$j$k"
+          break 3
+        done
+        echo "inner-done"
+      done
+      echo "mid-done"
+    done
+    echo done
+expect:
+  stdout: |+
+    a1x
+    done
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/for_clause/nested/continue_outer.yaml
+++ b/pkg/shell/tests/scenarios/shell/for_clause/nested/continue_outer.yaml
@@ -1,0 +1,19 @@
+description: Continue 2 in inner loop continues the outer loop.
+input:
+  # language=bash
+  script: |+
+    for i in a b; do
+      for j in 1 2 3; do
+        echo "$i$j"
+        continue 2
+      done
+      echo "inner-done"
+    done
+    echo done
+expect:
+  stdout: |+
+    a1
+    b1
+    done
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/for_clause/nested/continue_three_levels.yaml
+++ b/pkg/shell/tests/scenarios/shell/for_clause/nested/continue_three_levels.yaml
@@ -1,0 +1,22 @@
+description: Continue 3 in three-level nested loop continues the outermost loop.
+input:
+  # language=bash
+  script: |+
+    for i in a b; do
+      for j in 1 2; do
+        for k in x y; do
+          echo "$i$j$k"
+          continue 3
+        done
+        echo "inner-done"
+      done
+      echo "mid-done"
+    done
+    echo done
+expect:
+  stdout: |+
+    a1x
+    b1x
+    done
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/pipe/basic/empty_echo.yaml
+++ b/pkg/shell/tests/scenarios/shell/pipe/basic/empty_echo.yaml
@@ -1,0 +1,10 @@
+description: Piping empty echo output to cat produces a newline.
+input:
+  # language=bash
+  script: |+
+    echo "" | cat
+expect:
+  stdout: |+
+
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/all_params.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/all_params.yaml
@@ -1,4 +1,4 @@
-description: All positional parameters $@ is not supported in safe-shell.
+description: All positional parameters $@ is not supported.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/all_params_star.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/all_params_star.yaml
@@ -1,0 +1,10 @@
+description: All positional parameters $* is not supported in safe-shell.
+input:
+  # language=bash
+  script: |+
+    echo $*
+expect:
+  stdout: ""
+  stderr: |+
+    $* is not supported
+  exit_code: 2

--- a/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/all_params_star.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/all_params_star.yaml
@@ -1,4 +1,4 @@
-description: All positional parameters $* is not supported in safe-shell.
+description: All positional parameters $* is not supported.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/alternative.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/alternative.yaml
@@ -1,4 +1,4 @@
-description: Alternative value expansion ${var:+alt} is not supported in safe-shell.
+description: Alternative value expansion ${var:+alt} is not supported.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/append.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/append.yaml
@@ -1,4 +1,4 @@
-description: The += append operator is not supported in safe-shell.
+description: The += append operator is not supported.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/arithmetic.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/arithmetic.yaml
@@ -1,4 +1,4 @@
-description: Arithmetic expansion is not supported in safe-shell.
+description: Arithmetic expansion is not supported.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/array.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/array.yaml
@@ -1,4 +1,4 @@
-description: Array assignment is not supported in safe-shell.
+description: Array assignment is not supported.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/array_index.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/array_index.yaml
@@ -1,4 +1,4 @@
-description: Array indexing ${var[i]} is not supported in safe-shell.
+description: Array indexing ${var[i]} is not supported.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/array_index_assign.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/array_index_assign.yaml
@@ -1,0 +1,10 @@
+description: Array index assignment arr[0]=value is not supported in safe-shell.
+input:
+  # language=bash
+  script: |+
+    arr[0]=hello
+expect:
+  stdout: ""
+  stderr: |+
+    array index assignment is not supported
+  exit_code: 2

--- a/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/array_index_assign.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/array_index_assign.yaml
@@ -1,4 +1,4 @@
-description: Array index assignment arr[0]=value is not supported in safe-shell.
+description: Array index assignment arr[0]=value is not supported.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/assign_default.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/assign_default.yaml
@@ -1,4 +1,4 @@
-description: Assign default expansion ${var:=default} is not supported in safe-shell.
+description: Assign default expansion ${var:=default} is not supported.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/case_conversion.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/case_conversion.yaml
@@ -1,4 +1,4 @@
-description: Case conversion ${var^^} is not supported in safe-shell.
+description: Case conversion ${var^^} is not supported.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/command_sub.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/command_sub.yaml
@@ -1,4 +1,4 @@
-description: Command substitution is not supported in safe-shell.
+description: Command substitution is not supported.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/command_sub_backtick.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/command_sub_backtick.yaml
@@ -1,0 +1,10 @@
+description: Backtick command substitution is not supported in safe-shell.
+input:
+  # language=bash
+  script: |+
+    echo `echo hello`
+expect:
+  stdout: ""
+  stderr: |+
+    command substitution is not supported
+  exit_code: 2

--- a/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/command_sub_backtick.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/command_sub_backtick.yaml
@@ -1,4 +1,4 @@
-description: Backtick command substitution is not supported in safe-shell.
+description: Backtick command substitution is not supported.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/default_value.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/default_value.yaml
@@ -1,4 +1,4 @@
-description: Default value expansion ${var:-default} is not supported in safe-shell.
+description: Default value expansion ${var:-default} is not supported.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/error_unset.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/error_unset.yaml
@@ -1,4 +1,4 @@
-description: Error if unset expansion ${var:?message} is not supported in safe-shell.
+description: Error if unset expansion ${var:?message} is not supported.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/indirect.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/indirect.yaml
@@ -1,4 +1,4 @@
-description: Indirect expansion ${!var} is not supported in safe-shell.
+description: Indirect expansion ${!var} is not supported.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/param_count.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/param_count.yaml
@@ -1,4 +1,4 @@
-description: Parameter count $# is not supported in safe-shell.
+description: Parameter count $# is not supported.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/positional_params.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/positional_params.yaml
@@ -1,4 +1,4 @@
-description: Positional parameter $1 is not supported in safe-shell.
+description: Positional parameter $1 is not supported.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/prefix_list.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/prefix_list.yaml
@@ -1,0 +1,12 @@
+description: Prefix variable listing ${!prefix*} is not supported in safe-shell (caught by indirect expansion check).
+input:
+  # language=bash
+  script: |+
+    MY_A=1
+    MY_B=2
+    echo ${!MY_*}
+expect:
+  stdout: ""
+  stderr: |+
+    ${!var} is not supported
+  exit_code: 2

--- a/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/prefix_list.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/prefix_list.yaml
@@ -1,4 +1,4 @@
-description: Prefix variable listing ${!prefix*} is not supported in safe-shell (caught by indirect expansion check).
+description: Prefix variable listing ${!prefix*} is not supported (caught by indirect expansion check).
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/prefix_removal.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/prefix_removal.yaml
@@ -1,4 +1,4 @@
-description: Prefix removal ${var#pattern} is not supported in safe-shell.
+description: Prefix removal ${var#pattern} is not supported.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/replace.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/replace.yaml
@@ -1,4 +1,4 @@
-description: Pattern replacement ${var/pattern/replacement} is not supported in safe-shell.
+description: Pattern replacement ${var/pattern/replacement} is not supported.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/script_name.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/script_name.yaml
@@ -1,4 +1,4 @@
-description: Script name $0 is not supported in safe-shell.
+description: Script name $0 is not supported.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/string_length.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/string_length.yaml
@@ -1,4 +1,4 @@
-description: String length expansion ${#var} is not supported in safe-shell.
+description: String length expansion ${#var} is not supported.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/substring.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/substring.yaml
@@ -1,4 +1,4 @@
-description: Substring expansion ${var:offset:length} is not supported in safe-shell.
+description: Substring expansion ${var:offset:length} is not supported.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/suffix_removal.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/blocked_features/suffix_removal.yaml
@@ -1,4 +1,4 @@
-description: Suffix removal ${var%pattern} is not supported in safe-shell.
+description: Suffix removal ${var%pattern} is not supported.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/var_expand/blocked_variables/background_pid.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/blocked_variables/background_pid.yaml
@@ -1,4 +1,4 @@
-description: The $! variable has no special meaning in safe-shell and expands to empty.
+description: The $! variable has no special meaning and expands to empty.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/var_expand/blocked_variables/euid.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/blocked_variables/euid.yaml
@@ -1,4 +1,4 @@
-description: The $EUID variable has no special meaning in safe-shell and expands to empty.
+description: The $EUID variable has no special meaning and expands to empty.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/var_expand/blocked_variables/gid.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/blocked_variables/gid.yaml
@@ -1,4 +1,4 @@
-description: The $GID variable has no special meaning in safe-shell and expands to empty.
+description: The $GID variable has no special meaning and expands to empty.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/var_expand/blocked_variables/last_argument.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/blocked_variables/last_argument.yaml
@@ -1,0 +1,12 @@
+description: The $_ variable (last argument) expands to empty in safe-shell.
+input:
+  # language=bash
+  script: |+
+    echo hello
+    echo "[$_]"
+expect:
+  stdout: |+
+    hello
+    []
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/var_expand/blocked_variables/last_argument.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/blocked_variables/last_argument.yaml
@@ -1,4 +1,4 @@
-description: The $_ variable (last argument) expands to empty in safe-shell.
+description: The $_ variable (last argument) expands to empty.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/var_expand/blocked_variables/lineno.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/blocked_variables/lineno.yaml
@@ -1,4 +1,4 @@
-description: The $LINENO variable is not supported in safe-shell.
+description: The $LINENO variable is not supported.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/var_expand/blocked_variables/pid.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/blocked_variables/pid.yaml
@@ -1,4 +1,4 @@
-description: The $$ variable has no special meaning in safe-shell and expands to empty.
+description: The $$ variable has no special meaning and expands to empty.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/var_expand/blocked_variables/ppid.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/blocked_variables/ppid.yaml
@@ -1,4 +1,4 @@
-description: The $PPID variable has no special meaning in safe-shell and expands to empty.
+description: The $PPID variable has no special meaning and expands to empty.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/var_expand/blocked_variables/random.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/blocked_variables/random.yaml
@@ -1,4 +1,4 @@
-description: The $RANDOM variable has no special meaning in safe-shell and expands to empty.
+description: The $RANDOM variable has no special meaning and expands to empty.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/var_expand/blocked_variables/shell_options.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/blocked_variables/shell_options.yaml
@@ -1,0 +1,10 @@
+description: The $- variable (shell options) expands to empty in safe-shell.
+input:
+  # language=bash
+  script: |+
+    echo "[$-]"
+expect:
+  stdout: |+
+    []
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/var_expand/blocked_variables/shell_options.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/blocked_variables/shell_options.yaml
@@ -1,4 +1,4 @@
-description: The $- variable (shell options) expands to empty in safe-shell.
+description: The $- variable (shell options) expands to empty.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/var_expand/blocked_variables/srandom.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/blocked_variables/srandom.yaml
@@ -1,4 +1,4 @@
-description: The $SRANDOM variable has no special meaning in safe-shell and expands to empty.
+description: The $SRANDOM variable has no special meaning and expands to empty.
 input:
   # language=bash
   script: |+

--- a/pkg/shell/tests/scenarios/shell/var_expand/blocked_variables/uid.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/blocked_variables/uid.yaml
@@ -1,4 +1,4 @@
-description: The $UID variable has no special meaning in safe-shell and expands to empty.
+description: The $UID variable has no special meaning and expands to empty.
 input:
   # language=bash
   script: |+


### PR DESCRIPTION
<!-- dd-meta {"pullId":"a8155a1c-4f74-4240-a7a2-46eaefeb947b","source":"chat","resourceId":"711f4e63-69a3-4bae-89b5-1e7bc9b503d8","workflowId":"76d7c510-116d-4ac4-8848-80d8b0f1a7c2","codeChangeId":"76d7c510-116d-4ac4-8848-80d8b0f1a7c2","sourceType":"chat"} -->
PR by Bits
[View session in Datadog](https://app.datadoghq.com/code/711f4e63-69a3-4bae-89b5-1e7bc9b503d8)

Comment @datadog to request changes

Feedback (especially what can be better) welcome in [#code-gen-aka-bits-dev-feedback](https://dd.enterprise.slack.com/archives/C07JA5N2D25)!

---

### What does this PR do?

Adds 20 new YAML integration test scenarios for the `pkg/shell` restricted shell interpreter, covering features and code paths that had no test coverage.

**Blocked features now tested:**
- Process substitution `<(cmd)` / `>(cmd)`
- `${!prefix*}` prefix variable listing (caught by indirect expansion check)
- `$*` (all positional params as single word)
- Array index assignment `arr[0]=value`
- Backtick command substitution `` `cmd` ``

**Allowed features now tested:**
- `continue 2` in nested loops
- `break`/`continue` with invalid args (non-numeric, multiple args, exceeds nesting depth)
- Empty for loop body
- 3-level nested loops with `break 3` / `continue 3`
- Empty pipe output (`echo "" | cat`)

**Silently-blocked variables now tested:**
- `$-` (shell options) expands to empty
- `$_` (last argument) expands to empty

**Edge cases now tested:**
- `~/path` tilde expansion (not expanded)
- IFS with tabs (default splitting) and empty IFS (disables splitting)
- Escape sequences in double-quoted echo strings (passed literally)

### Motivation

Coverage analysis identified 17 gaps in integration test scenarios. Several blocked shell features in `validate.go` had no corresponding tests (process substitution, `${!prefix*}`, `$*`, array index assignment, backtick syntax). Multiple allowed code paths in `runner.go` and `builtin.go` were also untested (nested continue, invalid break/continue args, empty for body, deep nesting).

### Describe how you validated your changes

All 20 new scenarios pass. Pre-existing test failures (globbing, cat errors) are unrelated.

### Additional Notes

- `TestDecl` (ksh/bats test declarations) was identified as a gap but cannot be tested — it requires Bats language mode in the parser, which the safe-shell doesn't use. The check in `validate.go` is defense-in-depth.
- `${!prefix*}` is caught by the `Excl` check before reaching the `Names` check — the `Names != 0` validator is also defense-in-depth.
- `for i; do` (no `in` keyword) was identified as dead code since positional params are blocked.