### PR TITLE
Add MarshalJSON to fakeintake Aggregator

### DIFF
--- a/test/fakeintake/aggregator/common.go
+++ b/test/fakeintake/aggregator/common.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"compress/zlib"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -62,6 +63,14 @@ func newAggregator[P PayloadItem](parse parseFunc[P]) Aggregator[P] {
 		parse:          parse,
 		mutex:          sync.RWMutex{},
 	}
+}
+
+// MarshalJSON implements json.Marshaler so that the unexported payloadsByName
+// map is included in JSON output (e.g. from the fakeintake CLI client).
+func (agg *Aggregator[P]) MarshalJSON() ([]byte, error) {
+	agg.mutex.RLock()
+	defer agg.mutex.RUnlock()
+	return json.Marshal(agg.payloadsByName)
 }
 
 // UnmarshallPayloads parses a list of payloads and stores them in the aggregator


### PR DESCRIPTION
### What does this PR do?

Adds a `MarshalJSON()` method to the fakeintake `Aggregator` generic type so that the unexported `payloadsByName` map is included when the aggregator is serialized to JSON.

### Motivation

The fakeintake CLI client's `get connections` command returns an empty JSON object `{}` because the `Aggregator` struct only has unexported fields, which `encoding/json` skips by default. The `get connections names` command works fine (it uses `GetNames()` directly), but the full payload dump via JSON marshaling produces no output.

Adding `MarshalJSON()` as a `json.Marshaler` implementation allows `json.Marshal` to serialize the aggregator's internal payload data. This fixes the CLI client output for all aggregator-backed endpoints (connections, metrics, etc.).

### Describe how you validated your changes

Tested against a live fakeintake instance running during a new-e2e test (with `E2E_DEV_MODE=true`):
- Before the change: `fakeintake-client get connections` returned `{}`
- After the change: `fakeintake-client get connections` returns the full parsed connection data with hostnames, network IDs, and individual connection details

### Additional Notes

This affects all aggregator types (connections, metrics, logs, etc.) since `MarshalJSON` is defined on the generic `Aggregator[P]` type.