### PR TITLE
[ABLD-250] Final cutover of jmxfetch install to bazel

### DIFF
--- a/omnibus/config/software/datadog-agent-dependencies.rb
+++ b/omnibus/config/software/datadog-agent-dependencies.rb
@@ -18,11 +18,6 @@ dependency 'datadog-agent-data-plane' if linux_target? && !heroku_target?
 # Bundled cacerts file (is this a good idea?)
 dependency 'cacerts'
 
-# External agents
-build do
-    command_on_repo_root "bazelisk run -- //deps/jmxfetch:install --destdir=#{install_dir}", :live_stream => Omnibus.logger.live_stream(:info)
-end
-
 # Used for memory profiling with the `status py` agent subcommand
 dependency 'pympler'
 

--- a/packages/agent/dependencies/BUILD.bazel
+++ b/packages/agent/dependencies/BUILD.bazel
@@ -13,8 +13,7 @@ pkg_filegroup(
     name = "all_files",
     srcs = [
         # dependency cacerts
-        # External agents
-        # dependency 'jmxfetch'
+        "//deps/jmxfetch:all_files",
         # Used for memory profiling with the `status py` agent subcommand
         # dependency 'pympler'
         "//deps/snmp_traps:all_files",

--- a/packages/agent/linux/BUILD.bazel
+++ b/packages/agent/linux/BUILD.bazel
@@ -19,8 +19,6 @@ package(default_visibility = ["//packages:__subpackages__"])
 pkg_filegroup(
     name = "agent_components",
     srcs = [
-        # TODO: remove jmxfetch when it is part of //packages/agent/dependencies:all_files
-        "//deps/jmxfetch:all_files",
         "//packages/agent/dependencies:all_files",
         "//packages/install_dir:embedded",
         "//packages/install_dir:etc",

--- a/packages/install_dir/BUILD.bazel
+++ b/packages/install_dir/BUILD.bazel
@@ -29,7 +29,6 @@ filegroup(
     srcs = [
         ":embedded",
         "//deps:all_deps",
-        "//deps/jmxfetch:all_files",
     ] + select({
         "//packages/agent:linux_heroku": [],
         "//packages/agent:linux_default": [


### PR DESCRIPTION
- Remove reference in datadog-agent-dependencies.rb
- Add reference in //packages/agent/dependencies
- Remove placeholder references that we had been using to get the license installed.

Closes [ABLD-250]

[ABLD-250]: https://datadoghq.atlassian.net/browse/ABLD-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ