### PR TITLE
add zlib to debian package

### DIFF
--- a/packages/agent/linux/BUILD.bazel
+++ b/packages/agent/linux/BUILD.bazel
@@ -45,6 +45,7 @@ pkg_filegroup(
         "@krb5//:all_files",
         "@nghttp2//:all_files",
         "@xz//:all_files",
+        "@zlib//:all_files",
     ],
     prefix = "/opt/datadog-agent",
 )


### PR DESCRIPTION
### What does this PR do?
- Add zlib to the list of things which should be in the debian package.
- This is a needed step until https://datadoghq.atlassian.net/browse/ABLD-363 is done.