### PR TITLE
Add SHELL_FEATURES.md and README.md to pkg/shell

### DIFF
--- a/pkg/shell/README.md
+++ b/pkg/shell/README.md
@@ -1,0 +1,61 @@
+# pkg/shell — Restricted Shell Interpreter
+
+A restricted shell interpreter designed for AI agents performing SRE investigation tasks.
+Safety is the primary design goal: the shell defaults to denying all external command execution
+and all filesystem access, requiring explicit opt-in via configuration.
+
+## Execution Model
+
+Scripts are processed in two phases:
+
+1. **Parse & Validate** — The script is parsed into an AST, then validated against an allowlist of
+   supported syntax nodes. Disallowed constructs (e.g., `if`, `while`, command substitution) are
+   rejected with exit code 2 _before any code runs_. This guarantees that partially executed
+   scripts cannot occur due to an unsupported feature mid-script.
+
+2. **Execute** — The validated AST is interpreted. Commands are dispatched to builtins or to the
+   configured ExecHandler. File access goes through the configured OpenHandler, which enforces
+   AllowedPaths restrictions.
+
+See [SHELL_FEATURES.md](SHELL_FEATURES.md) for the complete list of supported and blocked features.
+
+## Security Model
+
+Every access path is default-deny:
+
+| Resource             | Default                          | Opt-in                                       |
+|----------------------|----------------------------------|----------------------------------------------|
+| External commands    | Blocked (exit code 127)          | Provide an `ExecHandler`                     |
+| Filesystem access    | Blocked                          | Configure `AllowedPaths` with directory list |
+| Environment variables| Empty (no host env inherited)    | Pass variables via the `Env` option          |
+| Output redirections  | Blocked at validation (exit code 2) | Not configurable — always blocked         |
+
+**AllowedPaths** restricts all file operations (open, read, readdir, exec) to a set of specified
+directories. It uses kernel-level `openat` syscalls for atomic path validation, making it immune
+to symlink traversal, TOCTOU races, and `..` escape attacks.
+
+## Configuration
+
+The interpreter is configured through `RunnerOption` functions passed to `New()`:
+
+- **`StdIO(in, out, err)`** — Sets stdin, stdout, stderr streams.
+- **`AllowedPaths(dirs)`** — Restricts filesystem access to the given directories.
+- **`Env`** — Sets the initial environment variables (empty by default).
+- **`ExecHandler`** — Handles external command execution. Defaults to `NoExecHandler` which rejects all commands.
+
+## Testing
+
+Tests use a YAML scenario-driven framework located in `tests/scenarios/`. Each `.yaml` file defines
+a self-contained test with `input.script`, optional `setup.files`, and `expect` (stdout, stderr, exit_code).
+
+Scenarios are organized by feature area:
+
+```
+tests/scenarios/
+├── cmd/          # builtin command tests (echo, cat, exit, true, false)
+└── shell/        # shell feature tests (pipes, variables, control flow, globbing, ...)
+```
+
+## Platform Support
+
+Linux, macOS, and Windows.

--- a/pkg/shell/SHELL_FEATURES.md
+++ b/pkg/shell/SHELL_FEATURES.md
@@ -1,0 +1,89 @@
+# Shell Features Reference
+
+This document lists every shell feature and whether it is supported (✅) or blocked (❌).
+Blocked features are rejected before execution with exit code 2.
+
+## Builtins
+
+- ✅ `echo` — prints arguments separated by spaces, followed by a newline
+- ✅ `cat` — reads files or stdin (`-`); respects AllowedPaths
+- ✅ `true` — exits with code 0
+- ✅ `false` — exits with code 1
+- ✅ `exit [N]` — exits with code N (default: last exit code)
+- ✅ `break [N]` / `continue [N]` — loop control
+- ❌ All other commands — return exit code 127 with `<cmd>: not found` unless an ExecHandler is configured
+
+## Variables
+
+- ✅ Assignment: `VAR=value`
+- ✅ Expansion: `$VAR`, `${VAR}`
+- ✅ `$?` — last exit code (the only supported special variable)
+- ✅ Inline assignment: `VAR=value command` (scoped to that command)
+- ❌ Command substitution: `$(cmd)`, `` `cmd` ``
+- ❌ Arithmetic expansion: `$(( expr ))`
+- ❌ Array assignment: `arr=(a b c)`, `arr[0]=x`
+- ❌ Append assignment: `VAR+=value`
+- ❌ Parameter expansion operations: `${#var}`, `${var:-default}`, `${var:=default}`, `${var:?msg}`, `${var:+alt}`, `${var:offset}`, `${var/pattern/repl}`, `${var#prefix}`, `${var%suffix}`, `${!var}`, `${!prefix*}`, case conversion
+- ❌ Positional parameters: `$1`–`$9`, `$@`, `$*`, `$#`, `$0`
+- ❌ Special variables: `$!`, `$LINENO`
+
+## Control Flow
+
+- ✅ `for VAR in WORDS; do CMDS; done`
+- ✅ `&&` — AND list (short-circuit)
+- ✅ `||` — OR list (short-circuit)
+- ✅ `!` — negation (inverts exit code)
+- ✅ `{ CMDS; }` — brace group
+- ✅ `;` and newline as command separators
+- ❌ `if` / `elif` / `else`
+- ❌ `while` / `until`
+- ❌ `case`
+- ❌ `select`
+- ❌ C-style for loop: `for (( i=0; i<N; i++ ))`
+- ❌ Functions: `fname() { ... }`
+- ❌ Subshells: `( CMDS )`
+
+## Pipes and Redirections
+
+- ✅ `|` — pipe stdout
+- ✅ `|&` — pipe stdout and stderr
+- ✅ `<` — input redirection (read-only, within AllowedPaths)
+- ✅ `<<DELIM` — heredoc
+- ✅ `<<-DELIM` — heredoc with tab stripping
+- ✅ `<<<` — herestring
+- ❌ `>` — write/truncate
+- ❌ `>>` — append
+- ❌ `&>` — redirect all
+- ❌ `&>>` — append all
+- ❌ `<>` — read-write
+- ❌ `>&N` / `<&N` — file descriptor duplication
+
+## Quoting and Expansion
+
+- ✅ Single quotes: `'literal'`
+- ✅ Double quotes: `"with $expansion"`
+- ✅ Globbing: `*`, `?`, `[abc]`, `[a-z]`, `[!a]`
+- ✅ Line continuation: `\` at end of line
+- ✅ Comments: `# text`
+- ❌ Extended globbing: `@(pat)`, `*(pat)`, etc.
+- ❌ Tilde expansion: `~`, `~/path`
+- ❌ Process substitution: `<(cmd)`, `>(cmd)`
+
+## Execution
+
+- ✅ External commands — when an ExecHandler is configured and the binary is within AllowedPaths
+- ✅ AllowedPaths filesystem sandboxing — restricts all file access to specified directories
+- ❌ Background execution: `cmd &`
+- ❌ Coprocesses: `coproc`
+- ❌ `time`
+- ❌ `[[ ... ]]` test expressions
+- ❌ `(( ... ))` arithmetic commands
+- ❌ `declare`, `export`, `local`, `readonly`, `let`
+
+## Environment
+
+- ✅ Empty by default — no parent environment variables are inherited
+- ✅ Caller-provided variables via the `Env` option
+- ✅ `IFS` is set to space/tab/newline by default
+- ❌ No automatic inheritance from the host process
+- ❌ `export`, `readonly` are blocked


### PR DESCRIPTION
<!-- dd-meta {"pullId":"4238a053-1ab9-4fe8-91a1-4a157ee42d45","source":"chat","resourceId":"2f8bf1d5-e60a-4ab2-8f7b-10ad121631b7","workflowId":"c4e4396e-8b89-4eee-aa53-624d4c85cf03","codeChangeId":"c4e4396e-8b89-4eee-aa53-624d4c85cf03","sourceType":"chat"} -->
### What does this PR do?

Adds two documentation files to `pkg/shell`:

- **`SHELL_FEATURES.md`** — Complete reference of supported (✅) and blocked (❌) shell features, grouped by category (builtins, variables, control flow, pipes/redirections, quoting, execution, environment).
- **`README.md`** — High-level architecture overview covering the two-phase execution model (parse/validate → execute), default-deny security model, configuration options, and testing approach.

### Motivation

The shell interpreter is used by AI agents for SRE investigation. These docs are optimized for machine readability so that LLMs can quickly determine what shell features are available and understand the interpreter's security boundaries.

### Describe how you validated your changes

Documentation-only change. Content was derived directly from the source code (`validate.go`, `builtin.go`, `runner.go`, `handler.go`, `allowed_paths.go`) and verified against the YAML test scenarios.

### Additional Notes

The existing `AGENTS.md` is kept as-is — it serves a different purpose (developer-facing guidance for contributing to the shell interpreter).

---

PR by Bits
[View session in Datadog](https://app.datadoghq.com/code/2f8bf1d5-e60a-4ab2-8f7b-10ad121631b7)

Comment @datadog to request changes