### PR TITLE
[SINT-4824] Backport #40856 (CI Identities) to 7.76.x

### DIFF
--- a/.gitlab/build/bazel/defs.yml
+++ b/.gitlab/build/bazel/defs.yml
@@ -90,6 +90,7 @@
       $EncodedCommand = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes("$FailFast`n$Utf8Script"))
     - >-
       .\tools\ci\docker-run-with-bazel-cache.ps1
+      --env=CI_IDENTITIES_GITLAB_ID_TOKEN
       --volume="${CI_PROJECT_DIR}:$CI_PROJECT_DIR"
       --workdir="$CI_PROJECT_DIR"
       "$WINBUILDIMAGE"

--- a/.gitlab/build/lint/windows.yml
+++ b/.gitlab/build/lint/windows.yml
@@ -21,6 +21,7 @@
       -e AWS_NETWORKING=true
       -e CI_PIPELINE_ID
       -e CI_PROJECT_NAME
+      -e CI_IDENTITIES_GITLAB_ID_TOKEN
       -e GOMODCACHE="c:\modcache"
       -e RUST_LOG="uv=trace"
       ${WINBUILDIMAGE}

--- a/.gitlab/build/package_build/windows.yml
+++ b/.gitlab/build/package_build/windows.yml
@@ -46,6 +46,7 @@
       -e E2E_COVERAGE_PIPELINE
       -e DEPLOY_AGENT
       -e CI_JOB_TOKEN
+      -e CI_IDENTITIES_GITLAB_ID_TOKEN
       ${WINBUILDIMAGE}
       powershell -C "c:\mnt\tasks\winbuildscripts\Build-AgentPackages.ps1 -BuildOutOfSource 1 -InstallDeps 1 -CheckGoVersion 1 -BuildUpgrade 1"
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
@@ -122,6 +123,7 @@ windows_msi_and_bosh_zip_x64-a7-fips:
       -e BUNDLE_MIRROR__RUBYGEMS__ORG
       -e PIP_INDEX_URL
       -e API_KEY_ORG2
+      -e CI_IDENTITIES_GITLAB_ID_TOKEN
       ${WINBUILDIMAGE}
       powershell -C "c:\mnt\tasks\winbuildscripts\Build-OmnibusTarget.ps1 -BuildOutOfSource 1 -InstallDeps 1 -CheckGoVersion 1"
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }

--- a/.gitlab/build/source_test/windows.yml
+++ b/.gitlab/build/source_test/windows.yml
@@ -47,6 +47,7 @@
       -e S3_PERMANENT_ARTIFACTS_URI
       -e COVERAGE_CACHE_FLAG
       -e FLAKY_PATTERNS_CONFIG="\mnt\flaky-patterns-runtime.yaml"
+      -e CI_IDENTITIES_GITLAB_ID_TOKEN
       ${WINBUILDIMAGE}
       powershell.exe -c "c:\mnt\tasks\winbuildscripts\Invoke-UnitTests.ps1 -BuildOutOfSource 1 -CheckGoVersion 1 -InstallDeps 1 -UploadCoverage 1 -UploadTestResults 1"
     - If ($lastExitCode -ne "0") { exit "$lastExitCode" }

--- a/.gitlab/deploy/conditions.yml
+++ b/.gitlab/deploy/conditions.yml
@@ -160,6 +160,14 @@
     # Clone is required since cancelled Windows jobs with fetch strategy
     # can cause CIEXE-1152 which makes the runner unusable.
     OVERRIDE_GIT_STRATEGY: "clone"
+    # Avoid using ~/.aws/credentials to avoid conflicts with other CI jobs
+    # this env var is understood by both ci-identities-gitlab-job-client.exe and aws.exe
+    AWS_SHARED_CREDENTIALS_FILE: ${CI_PROJECT_DIR}\.aws\credentials-by-job-id\${CI_JOB_ID}
+  before_script:
+    - C:\ci-identities-gitlab-job-client.exe assume-role
+  id_tokens:
+    CI_IDENTITIES_GITLAB_ID_TOKEN:
+      aud: ci-identities
 
 # The windows-v2 runner is currently only used in container_build jobs needed to do authenticated push. It should not replace the basic windows runner, unless agreeded first with #ci-infra team
 .windows_docker_v2_2022:
@@ -171,6 +179,14 @@
     # Clone is required since cancelled Windows jobs with fetch strategy
     # can cause CIEXE-1152 which makes the runner unusable.
     OVERRIDE_GIT_STRATEGY: "clone"
+    # Avoid using ~/.aws/credentials to avoid conflicts with other CI jobs
+    # this env var is understood by both ci-identities-gitlab-job-client.exe and aws.exe
+    AWS_SHARED_CREDENTIALS_FILE: ${CI_PROJECT_DIR}\.aws\credentials-by-job-id\${CI_JOB_ID}
+  before_script:
+    - C:\ci-identities-gitlab-job-client.exe assume-role
+  id_tokens:
+    CI_IDENTITIES_GITLAB_ID_TOKEN:
+      aud: ci-identities
 
 # The windows-v2 runner is currently only used in container_build jobs needed to do authenticated push. It should not replace the basic windows runner, unless agreeded first with #ci-infra team
 .windows_docker_2025:
@@ -185,6 +201,14 @@
     # Clone is required since cancelled Windows jobs with fetch strategy
     # can cause CIEXE-1152 which makes the runner unusable.
     OVERRIDE_GIT_STRATEGY: "clone"
+    # Avoid using ~/.aws/credentials to avoid conflicts with other CI jobs
+    # this env var is understood by both ci-identities-gitlab-job-client.exe and aws.exe
+    AWS_SHARED_CREDENTIALS_FILE: ${CI_PROJECT_DIR}\.aws\credentials-by-job-id\${CI_JOB_ID}
+  before_script:
+    - C:\ci-identities-gitlab-job-client.exe assume-role
+  id_tokens:
+    CI_IDENTITIES_GITLAB_ID_TOKEN:
+      aud: ci-identities
 
 # windows_docker_default configures the job to use the default Windows Server runners
 # Use in jobs that may need to have their version updated in the future.

--- a/.gitlab/test/integration_test/windows.yml
+++ b/.gitlab/test/integration_test/windows.yml
@@ -26,6 +26,7 @@
       -e CI_JOB_NAME
       -e CI_PIPELINE_ID
       -e CI_PROJECT_NAME
+      -e CI_IDENTITIES_GITLAB_ID_TOKEN
       -e AWS_NETWORKING=true
       -e GOMODCACHE="c:\modcache"
       -e VCPKG_BINARY_SOURCES="clear;x-azblob,${vcpkgBlobSaSUrl}"

--- a/tasks/winbuildscripts/common.ps1
+++ b/tasks/winbuildscripts/common.ps1
@@ -303,6 +303,11 @@ function Invoke-BuildScript {
 
         Enable-DevEnv
 
+        # Initialize CI identity if running in CI environment
+        if ($env:CI) {
+            Initialize-CIIdentity
+        }
+
         # Expand modcache
         if ($InstallDeps) {
             Expand-ModCache -modcache modcache
@@ -342,3 +347,24 @@ function Invoke-BuildScript {
         }
     }
 }
+
+<#
+.SYNOPSIS
+Downloads the CI identity client and assumes the CI Identity IAM role.
+
+.DESCRIPTION
+This function downloads the CI identity client from S3 and uses it to assume the CI Identity IAM role.
+It is typically called in CI environments to authenticate with AWS services.
+
+.NOTES
+This function requires AWS CLI to be available and properly configured.
+#>
+function Initialize-CIIdentity() {
+    Write-Host "Assuming CI role..."
+    C:\devtools\ci-identities-gitlab-job-client.exe assume-role
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Failed to assume CI role (exit code: $LASTEXITCODE)"
+        exit 1
+    }
+}
+


### PR DESCRIPTION
### What does this PR do?

Backports https://github.com/DataDog/datadog-agent/pull/40856

### Motivation

Making sure all Windows CI jobs use CI Identities so that we can remove legacy permissions.

### Describe how you validated your changes

### Additional Notes
