### PR TITLE
Bump `buildifier` for `*.MODULE.bazel` and own fix

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -88,11 +88,12 @@ http_archive(
         "//bazel/patches:buildifier-internal-factory.patch",  # bazelbuild/buildtools#1399
         "//bazel/patches:buildifier-runner-bat-template.patch",  # bazelbuild/buildtools#1400 bazelbuild/buildtools#1404
     ],
-    sha256 = "53119397bbce1cd7e4c590e117dcda343c2086199de62932106c80733526c261",
-    strip_prefix = "buildtools-8.2.1",
+    sha256 = "f3b800e9f6ca60bdef3709440f393348f7c18a29f30814288a7326285c80aab9",
+    strip_prefix = "buildtools-8.5.1",
+    type = "tar.gz",
     urls = [
-        "https://dd-agent-omnibus.s3.amazonaws.com/bazel/buildtools-8.2.1.tar.gz",
-        "https://github.com/bazelbuild/buildtools/archive/refs/tags/v8.2.1.tar.gz",
+        "https://codeload.github.com/bazelbuild/buildtools/tar.gz/refs/tags/v8.5.1",
+        "https://github.com/bazelbuild/buildtools/archive/refs/tags/v8.5.1.tar.gz",
     ],
 )
 

--- a/bazel/buildifier/BUILD.bazel
+++ b/bazel/buildifier/BUILD.bazel
@@ -19,7 +19,7 @@ buildifier(
 
 # PROS of `buildifier_test` over `buildifier`:
 # - renders diffs without having to provide `tkdiff`
-# - also works as a `test` action: `bazel test //bazel/buildifier:test` as well as `bazel test //...`
+# - also works as a `test` action: `bazel test //bazel/buildifier:test`
 # CONS:
 # - requires additional arguments: `no_sandbox` and `workspace`
 buildifier_test(
@@ -30,5 +30,6 @@ buildifier_test(
     lint_warnings = ["-module-docstring"],
     mode = "diff",
     no_sandbox = True,
+    tags = ["manual"],  # not cacheable
     workspace = "//:BUILD.bazel",
 )

--- a/bazel/patches/buildifier-build.patch
+++ b/bazel/patches/buildifier-build.patch
@@ -2,16 +2,10 @@ diff --git a/buildifier/BUILD.bazel b/buildifier/BUILD.bazel
 index 1f1cd67..2f2a5b1 100644
 --- a/buildifier/BUILD.bazel
 +++ b/buildifier/BUILD.bazel
-@@ -1,3 +1,4 @@
+@@ -1 +1,2 @@
 +INHIBITED_IN_FAVOR_OF_PREBUILT = """
  load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
- load("@rules_shell//shell:sh_test.bzl", "sh_test")
- 
-@@ -108,6 +109,7 @@ go_library(
-         "//wspace",
-     ],
+@@ -120,2 +121,3 @@
  )
 +"""
  
- exports_files(
-     [

--- a/bazel/patches/buildifier-runner-bat-template.patch
+++ b/bazel/patches/buildifier-runner-bat-template.patch
@@ -2,7 +2,7 @@ diff --git a/buildifier/runner.bat.template b/buildifier/runner.bat.template
 index 13ca3fa..3c8882f 100644
 --- a/buildifier/runner.bat.template
 +++ b/buildifier/runner.bat.template
-@@ -11,9 +11,28 @@ set stripped_args=%stripped_args:'=%
+@@ -11,7 +11,28 @@ set stripped_args=%stripped_args:'=%
  rem Get the absolute path to the buildifier executable
 -for /f "tokens=2" %%i in ('findstr /r "\<buildifier\.exe\>" MANIFEST') do (set buildifier_abs_path=%%i)
 +if exist MANIFEST (
@@ -16,11 +16,8 @@ index 13ca3fa..3c8882f 100644
 +for /f "tokens=2" %%i in ('findstr /r "\<buildifier\.exe\>" "%manifest_file%"') do (set buildifier_abs_path=%%i)
  
  powershell ^
--function Buildify($Root)^
 +function Should-Exclude($Path)^
- {^
--    $Folder = (New-Object -Com Scripting.FileSystemObject).GetFolder($Root);^
--    $Files = $Folder.Files ^| Where-Object {^
++{^
 +    $relPath = '.' + $Path.Substring('%BUILD_WORKSPACE_DIRECTORY%'.Length);^
 +    foreach ($pattern in @(@@EXCLUDE_PATTERNS@@))^
 +    {^
@@ -31,32 +28,11 @@ index 13ca3fa..3c8882f 100644
 +    };^
 +    return $false;^
 +};^
-+$Files = Get-ChildItem -LiteralPath '%BUILD_WORKSPACE_DIRECTORY:/=\%' -Recurse -File -ErrorAction SilentlyContinue ^|^
-+    Where-Object {^
+ $Files = Get-ChildItem -LiteralPath '%BUILD_WORKSPACE_DIRECTORY:/=\%' -Recurse -File -ErrorAction SilentlyContinue ^|^
+     Where-Object {^
 +        (^
          $_.Name -eq 'BUILD.bazel' `^
-@@ -30,16 +49,10 @@ function Buildify($Root)^
+@@ -28,2 +49,3 @@ $Files = Get-ChildItem -LiteralPath '%BUILD_WORKSPACE_DIRECTORY:/=\%' -Recurse -
          -or $_.Name -clike 'WORKSPACE.*.oss'^
 +        ) -and -not (Should-Exclude $_.FullName)^
      };^
--    foreach ($File in $Files)^
--    {^
--        ^& '%buildifier_abs_path%' %stripped_args% $File.Path;^
--    };^
--    foreach ($SubFolder in $Folder.Subfolders)^
--    {^
--        $CurrentItem = Get-Item $SubFolder.Path -ErrorAction SilentlyContinue;^
--        if ($CurrentItem -and !$CurrentItem.Attributes.ToString().Contains('ReparsePoint'))^
--        {^
--            Buildify($SubFolder.Path);^
--        };^
--    };^
--};^
--Buildify('%BUILD_WORKSPACE_DIRECTORY%');
-+$i = 0;^
-+while ($i -lt $Files.Count)^
-+{^
-+    $Batch = $Files[$i..($i + 99)];^
-+    ^& '%buildifier_abs_path%' %stripped_args% $Batch.FullName;^
-+    $i += $Batch.Count;^
-+};

--- a/deps/openscap/openscap.MODULE.bazel
+++ b/deps/openscap/openscap.MODULE.bazel
@@ -24,6 +24,6 @@ http_archive(
         "//deps:openscap/patches/dpkginfo-virtual-packages-revert.patch",
     ],
     sha256 = "96ebe697aafc83eb297a8f29596d57319278112467c46e6aaf3649b311cf8fba",
-    strip_prefix = "openscap-1.4.3",
-    url = "https://github.com/OpenSCAP/openscap/releases/download/1.4.3/openscap-1.4.3.tar.gz",
+    strip_prefix = "openscap-{}".format(VERSION),
+    url = "https://github.com/OpenSCAP/openscap/releases/download/{0}/openscap-{0}.tar.gz".format(VERSION),
 )


### PR DESCRIPTION
### What does this PR do?
Bump `buildtools` to 8.5.1 and shrink down patches against the new version.

### Motivation
8.5.1 ships `*.MODULE.bazel` in the `find` patterns of the bash runner template (bazelbuild/buildtools#1374), so `bazel run //bazel/buildifier` now reformats `deps/*.MODULE.bazel` files.

Additionally, one of our fixes (bazelbuild/buildtools#1404) got merged in the meantime, which allows to shrink down patches.

### Describe how you validated your changes
- locally appended a trailing newline to all `deps/*.MODULE.bazel` files, ran `bazel run //bazel/buildifier`, and confirmed `git` reported no remaining changes,
- better, CI spotted a [new finding](https://gitlab.ddbuild.io/datadog/datadog-agent/builds/1477977667):
  > ./deps/openscap/openscap.MODULE.bazel:5: unused-variable: Variable "VERSION" is unused. Please remove it. (https://github.com/bazelbuild/buildtools/blob/main/WARNINGS.md#unused-variable)
 

### Additional Notes
Had to replace the S3 mirror URL with codeload.github.com, relying on ADMS rewrite rules otherwise.