### PR TITLE
chore: rename team ndm-core to network-device-monitoring-core

### DIFF
--- a/.ddqa/config.toml
+++ b/.ddqa/config.toml
@@ -82,8 +82,8 @@ github_labels = ["team/usm"]
 jira_project = "NDMC"
 jira_issue_type = "HighPriority"
 jira_statuses = ["To Do", "In Progress", "Done"]
-github_team = "ndm-core"
-github_labels = ["team/ndm-core"]
+github_team = "network-device-monitoring-core"
+github_labels = ["team/network-device-monitoring-core"]
 
 [teams."Network Device Monitoring - Integrations"]
 jira_project = "NDINT"

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -207,7 +207,7 @@
 /cmd/agent/subcommands/version          @DataDog/agent-runtimes
 /cmd/agent/subcommands/processchecks    @DataDog/container-experiences
 /cmd/agent/subcommands/remoteconfig     @DataDog/remote-config
-/cmd/agent/subcommands/snmp             @DataDog/ndm-core
+/cmd/agent/subcommands/snmp             @DataDog/network-device-monitoring-core
 /cmd/agent/subcommands/streamlogs       @DataDog/agent-log-pipelines
 /cmd/agent/subcommands/analyzelogs      @DataDog/agent-log-pipelines
 /cmd/agent/subcommands/streamep         @DataDog/container-integrations
@@ -228,7 +228,7 @@
 /cmd/agent/dist/conf.d/network_path.d/  @DataDog/network-path
 /cmd/agent/dist/conf.d/orchestrator_ecs.d/  @DataDog/ecs-experiences
 /cmd/agent/dist/conf.d/sbom.d/          @DataDog/agent-security @DataDog/container-integrations
-/cmd/agent/dist/conf.d/snmp.d/          @DataDog/ndm-core
+/cmd/agent/dist/conf.d/snmp.d/          @DataDog/network-device-monitoring-core
 /cmd/agent/dist/conf.d/win32_event_log.d/ @DataDog/windows-products
 /cmd/agent/dist/conf.d/windows_certificate.d/ @DataDog/windows-products
 /cmd/agent/install*.sh                  @DataDog/agent-onboarding @DataDog/agent-build
@@ -253,7 +253,7 @@
 /cmd/system-probe/modules/compliance*   @DataDog/agent-cspm
 /cmd/system-probe/modules/tcp_queue_tracer* @DataDog/container-integrations
 /cmd/system-probe/modules/traceroute*   @DataDog/network-path
-/cmd/system-probe/modules/ping*         @DataDog/ndm-core
+/cmd/system-probe/modules/ping*         @DataDog/network-device-monitoring-core
 /cmd/system-probe/modules/language_detection* @DataDog/container-experiences @DataDog/agent-discovery
 /cmd/system-probe/modules/dynamic_instrumentation* @DataDog/debugger-go
 /cmd/system-probe/modules/noisy_neighbor* @DataDog/container-experiences
@@ -329,13 +329,13 @@
 /comp/logs @DataDog/agent-log-pipelines
 /comp/logs-library @DataDog/agent-log-pipelines
 /comp/metadata @DataDog/agent-configuration
-/comp/ndmtmp @DataDog/ndm-core
+/comp/ndmtmp @DataDog/network-device-monitoring-core
 /comp/netflow @DataDog/ndm-integrations
 /comp/networkpath @DataDog/network-path
 /comp/otelcol @DataDog/opentelemetry-agent
 /comp/process @DataDog/container-experiences
 /comp/remote-config @DataDog/remote-config
-/comp/snmptraps @DataDog/ndm-core
+/comp/snmptraps @DataDog/network-device-monitoring-core
 /comp/systray @DataDog/windows-products
 /comp/trace @DataDog/agent-apm
 /comp/updater @DataDog/fleet @DataDog/windows-products
@@ -364,7 +364,7 @@
 /comp/forwarder/orchestrator @DataDog/kubernetes-experiences
 /comp/metadata/clusteragent @DataDog/container-platform
 /comp/metadata/clusterchecks @DataDog/container-platform
-/comp/metadata/haagent @DataDog/ndm-core
+/comp/metadata/haagent @DataDog/network-device-monitoring-core
 /comp/metadata/hostgpu @DataDog/ebpf-platform
 /comp/metadata/hostsysteminfo @DataDog/windows-products
 /comp/metadata/packagesigning @DataDog/agent-delivery
@@ -378,7 +378,7 @@
 /comp/etw @DataDog/windows-products
 /comp/filterlist @DataDog/agent-metric-pipelines
 /comp/fleetstatus @DataDog/fleet
-/comp/haagent @DataDog/ndm-core
+/comp/haagent @DataDog/network-device-monitoring-core
 /comp/healthplatform @DataDog/agent-health
 /comp/languagedetection/client @DataDog/container-platform
 /comp/logonduration @DataDog/windows-products
@@ -389,8 +389,8 @@
 /comp/rdnsquerier @DataDog/ndm-integrations
 /comp/serializer/logscompression @DataDog/agent-log-pipelines
 /comp/serializer/metricscompression @DataDog/agent-metric-pipelines
-/comp/snmpscan @DataDog/ndm-core
-/comp/snmpscanmanager @DataDog/ndm-core
+/comp/snmpscan @DataDog/network-device-monitoring-core
+/comp/snmpscanmanager @DataDog/network-device-monitoring-core
 /comp/softwareinventory @DataDog/windows-products
 /comp/syntheticstestscheduler @DataDog/synthetics-executing
 /comp/workloadselection @DataDog/injection-platform
@@ -455,7 +455,7 @@
 /pkg/trace/transform/                   @DataDog/opentelemetry
 /comp/core/autodiscovery/listeners/           @DataDog/container-platform
 /comp/core/autodiscovery/listeners/cloudfoundry*.go  @DataDog/agent-integrations
-/comp/core/autodiscovery/listeners/snmp*.go   @DataDog/ndm-core
+/comp/core/autodiscovery/listeners/snmp*.go   @DataDog/network-device-monitoring-core
 /comp/core/autodiscovery/providers/           @DataDog/container-platform
 /comp/core/autodiscovery/providers/file*.go   @DataDog/agent-log-pipelines
 /comp/core/autodiscovery/providers/config_reader*.go @DataDog/container-platform @DataDog/agent-log-pipelines
@@ -505,7 +505,7 @@
 /pkg/collector/corechecks/net/wlan/     @DataDog/windows-products
 /pkg/collector/corechecks/oracle        @DataDog/database-monitoring
 /pkg/collector/corechecks/sbom/         @DataDog/agent-security @DataDog/container-integrations
-/pkg/collector/corechecks/snmp/         @DataDog/ndm-core
+/pkg/collector/corechecks/snmp/         @DataDog/network-device-monitoring-core
 /pkg/collector/corechecks/system/                 @DataDog/agent-runtimes
 /pkg/collector/corechecks/system/**/*_windows*.go @DataDog/agent-runtimes @DataDog/windows-products
 /pkg/collector/corechecks/system/battery/     @DataDog/windows-products
@@ -535,7 +535,7 @@
 /pkg/containerlifecycle/                @DataDog/container-integrations
 /pkg/diagnose/                          @DataDog/container-platform
 /pkg/diagnose/connectivity/             @DataDog/agent-configuration
-/pkg/diagnose/firewallscanner/          @DataDog/ndm-core
+/pkg/diagnose/firewallscanner/          @DataDog/network-device-monitoring-core
 /pkg/diagnose/ports/                    @DataDog/agent-configuration
 /pkg/diagnose/ports/*windows*.go        @DataDog/windows-products
 /pkg/eventmonitor/                      @DataDog/ebpf-platform @DataDog/agent-security
@@ -682,8 +682,8 @@
 /pkg/databasemonitoring                 @DataDog/database-monitoring
 /pkg/kubestatemetrics                   @DataDog/container-integrations
 /pkg/security/                          @DataDog/agent-security
-/pkg/networkdevice/                     @DataDog/ndm-core
-/pkg/snmp/                              @DataDog/ndm-core
+/pkg/networkdevice/                     @DataDog/network-device-monitoring-core
+/pkg/snmp/                              @DataDog/network-device-monitoring-core
 /pkg/ssi/                               @DataDog/injection-platform
 /pkg/tagger/                            @DataDog/container-platform
 /pkg/windowsdriver/                     @DataDog/windows-products
@@ -781,8 +781,8 @@
 /test/e2e-framework/components/datadog/agent/ecsFargate.go @DataDog/ecs-experiences
 /test/e2e-framework/components/datadog/ecsagentparams/  @DataDog/ecs-experiences
 /test/fakeintake/                              @DataDog/agent-devx
-/test/fakeintake/aggregator/ndmAggregator.go @DataDog/ndm-core
-/test/fakeintake/aggregator/ndmAggregator_test.go @DataDog/ndm-core
+/test/fakeintake/aggregator/ndmAggregator.go @DataDog/network-device-monitoring-core
+/test/fakeintake/aggregator/ndmAggregator_test.go @DataDog/network-device-monitoring-core
 /test/fakeintake/aggregator/ndmflowAggregator.go @DataDog/ndm-integrations
 /test/fakeintake/aggregator/ndmflowAggregator_test.go @DataDog/ndm-integrations
 /test/fakeintake/aggregator/agenthealthAggregator.go @DataDog/agent-health
@@ -814,9 +814,9 @@
 /test/new-e2e/tests/containers/ecs_test.go    @DataDog/ecs-experiences
 /test/new-e2e/tests/discovery                 @DataDog/agent-discovery
 /test/new-e2e/tests/fips-compliance           @DataDog/agent-runtimes
-/test/new-e2e/tests/ha-agent                  @DataDog/ndm-core
+/test/new-e2e/tests/ha-agent                  @DataDog/network-device-monitoring-core
 /test/new-e2e/tests/language-detection        @DataDog/container-experiences
-/test/new-e2e/tests/ndm                       @DataDog/ndm-core
+/test/new-e2e/tests/ndm                       @DataDog/network-device-monitoring-core
 /test/new-e2e/tests/ndm/netflow               @DataDog/ndm-integrations
 /test/new-e2e/tests/netpath                   @DataDog/windows-products @DataDog/network-path
 /test/new-e2e/tests/npm                       @DataDog/cloud-network-monitoring

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -144,7 +144,7 @@ updates:
     labels:
       - dependencies
       - dependencies-go
-      - team/ndm-core
+      - team/network-device-monitoring-core
       - changelog/no-changelog
     ignore:
       # Ignore internal modules

--- a/.gitlab/test/e2e/e2e.yml
+++ b/.gitlab/test/e2e/e2e.yml
@@ -861,7 +861,7 @@ new-e2e-ndm-snmp:
     - qa_agent_linux
   variables:
     TARGETS: ./tests/ndm/snmp
-    TEAM: ndm-core
+    TEAM: network-device-monitoring-core
     ON_NIGHTLY_FIPS: "true"
 
 new-e2e-ha-agent:
@@ -871,7 +871,7 @@ new-e2e-ha-agent:
     - !reference [.manual]
   variables:
     TARGETS: ./tests/ha-agent
-    TEAM: ndm-core
+    TEAM: network-device-monitoring-core
     # Temporarily disable the test on FIPS pipeline, as remote-configuration is not available with FIPS Agent yet
     # ON_NIGHTLY_FIPS: "true"
     EXTRA_PARAMS: --skip TestHAAgentFailoverSuite
@@ -883,7 +883,7 @@ new-e2e-ha-agent-failover:
     - !reference [.manual]
   variables:
     TARGETS: ./tests/ha-agent
-    TEAM: ndm-core
+    TEAM: network-device-monitoring-core
     ON_NIGHTLY_FIPS: "true"
     EXTRA_PARAMS: --run TestHAAgentFailoverSuite
   allow_failure: true

--- a/comp/README.md
+++ b/comp/README.md
@@ -382,7 +382,7 @@ Package clusterchecks provides the clusterchecks metadata component
 
 ### [comp/metadata/haagent](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/metadata/haagent)
 
-*Datadog Team*: ndm-core
+*Datadog Team*: network-device-monitoring-core
 
 Package haagent implements a component to generate the 'ha_agent_metadata' metadata payload for inventory.
 
@@ -438,7 +438,7 @@ Package systemprobe is the metadata provider for system-probe process
 
 ## [comp/ndmtmp](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/ndmtmp) (Component Bundle)
 
-*Datadog Team*: ndm-core
+*Datadog Team*: network-device-monitoring-core
 
 Package ndmtmp implements the "ndmtmp" bundle, which exposes the default
 sender.Sender and the event platform forwarder. This is a temporary module
@@ -612,7 +612,7 @@ Package rctelemetryreporter provides a component that sends RC-specific metrics 
 
 ## [comp/snmptraps](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/snmptraps) (Component Bundle)
 
-*Datadog Team*: ndm-core
+*Datadog Team*: network-device-monitoring-core
 
 Package snmptraps implements the a server that listens for SNMP trap data
 and sends it to the backend.
@@ -770,7 +770,7 @@ Package fleetstatus implements the core status component information provider in
 
 ### [comp/haagent](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/haagent)
 
-*Datadog Team*: ndm-core
+*Datadog Team*: network-device-monitoring-core
 
 Package haagent handles states for HA Agent feature.
 
@@ -839,13 +839,13 @@ Package metricscompression provides the component for metrics compression
 
 ### [comp/snmpscan](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/snmpscan)
 
-*Datadog Team*: ndm-core
+*Datadog Team*: network-device-monitoring-core
 
 Package snmpscan is a light component that can be used to perform a scan or a walk of a particular device
 
 ### [comp/snmpscanmanager](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/snmpscanmanager)
 
-*Datadog Team*: ndm-core
+*Datadog Team*: network-device-monitoring-core
 
 Package snmpscanmanager is a component that is used to manage SNMP device scans
 

--- a/comp/haagent/def/component.go
+++ b/comp/haagent/def/component.go
@@ -6,7 +6,7 @@
 // Package haagent handles states for HA Agent feature.
 package haagent
 
-// team: ndm-core
+// team: network-device-monitoring-core
 
 // Component is the component type.
 type Component interface {

--- a/comp/metadata/haagent/def/component.go
+++ b/comp/metadata/haagent/def/component.go
@@ -6,7 +6,7 @@
 // Package haagent implements a component to generate the 'ha_agent_metadata' metadata payload for inventory.
 package haagent
 
-// team: ndm-core
+// team: network-device-monitoring-core
 
 // Component is the component type.
 type Component interface{}

--- a/comp/ndmtmp/bundle.go
+++ b/comp/ndmtmp/bundle.go
@@ -13,7 +13,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
-// team: ndm-core
+// team: network-device-monitoring-core
 
 // TODO: (components) Delete this module when the sender and event platform forwarder are fully componentized.
 

--- a/comp/ndmtmp/bundle_mock.go
+++ b/comp/ndmtmp/bundle_mock.go
@@ -16,7 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
-// team: ndm-core
+// team: network-device-monitoring-core
 
 // MockBundle defines the fx options for mock versions of everything in this bundle.
 func MockBundle() fxutil.BundleOptions {

--- a/comp/ndmtmp/forwarder/component.go
+++ b/comp/ndmtmp/forwarder/component.go
@@ -10,7 +10,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
 )
 
-// team: ndm-core
+// team: network-device-monitoring-core
 
 // Component is the component type.
 type Component interface {

--- a/comp/snmpscan/def/component.go
+++ b/comp/snmpscan/def/component.go
@@ -16,7 +16,7 @@ import (
 	"github.com/gosnmp/gosnmp"
 )
 
-// team: ndm-core
+// team: network-device-monitoring-core
 
 // Component is the component type.
 type Component interface {

--- a/comp/snmpscanmanager/def/component.go
+++ b/comp/snmpscanmanager/def/component.go
@@ -6,7 +6,7 @@
 // Package snmpscanmanager is a component that is used to manage SNMP device scans
 package snmpscanmanager
 
-// team: ndm-core
+// team: network-device-monitoring-core
 
 // Component is the component type
 type Component interface {

--- a/comp/snmptraps/bundle.go
+++ b/comp/snmptraps/bundle.go
@@ -12,7 +12,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
-// team: ndm-core
+// team: network-device-monitoring-core
 
 // Bundle defines the fx options for this bundle.
 func Bundle() fxutil.BundleOptions {

--- a/comp/snmptraps/config/component.go
+++ b/comp/snmptraps/config/component.go
@@ -7,7 +7,7 @@
 // a component that provides it.
 package config
 
-// team: ndm-core
+// team: network-device-monitoring-core
 
 // Component is the component type.
 type Component interface {

--- a/comp/snmptraps/formatter/component.go
+++ b/comp/snmptraps/formatter/component.go
@@ -10,7 +10,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/snmptraps/packet"
 )
 
-// team: ndm-core
+// team: network-device-monitoring-core
 
 // Component is the component type.
 type Component interface {

--- a/comp/snmptraps/forwarder/component.go
+++ b/comp/snmptraps/forwarder/component.go
@@ -7,7 +7,7 @@
 // listener component, formats it properly, and sends it to the backend.
 package forwarder
 
-// team: ndm-core
+// team: network-device-monitoring-core
 
 // Component is the component type.
 type Component interface{}

--- a/comp/snmptraps/listener/component.go
+++ b/comp/snmptraps/listener/component.go
@@ -11,7 +11,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/snmptraps/packet"
 )
 
-// team: ndm-core
+// team: network-device-monitoring-core
 
 // Component is the component type.
 type Component interface {

--- a/comp/snmptraps/oidresolver/component.go
+++ b/comp/snmptraps/oidresolver/component.go
@@ -6,7 +6,7 @@
 // Package oidresolver resolves OIDs
 package oidresolver
 
-// team: ndm-core
+// team: network-device-monitoring-core
 
 // Component is a interface to get Trap and Variable metadata from OIDs
 type Component interface {

--- a/comp/snmptraps/server/component.go
+++ b/comp/snmptraps/server/component.go
@@ -8,7 +8,7 @@
 // reformats them, and sends the resulting data to the backend.
 package server
 
-// team: ndm-core
+// team: network-device-monitoring-core
 
 // Component is the SNMP traps server. It listens for SNMP traps messages and
 // sends traps data to the DD backend.

--- a/comp/snmptraps/status/component.go
+++ b/comp/snmptraps/status/component.go
@@ -7,7 +7,7 @@
 // component system.
 package status
 
-// team: ndm-core
+// team: network-device-monitoring-core
 
 // Component is the component type.
 type Component interface {

--- a/tasks/libs/pipeline/github_jira_map.yaml
+++ b/tasks/libs/pipeline/github_jira_map.yaml
@@ -11,7 +11,7 @@
 '@datadog/core-authn': AUTHN
 '@datadog/agent-security': CWS
 '@datadog/agent-apm': APMSP
-'@datadog/ndm-core': NDMC
+'@datadog/network-device-monitoring-core': NDMC
 '@datadog/ndm-integrations': NDINT
 '@datadog/container-experiences': CXP
 '@datadog/ecs-experiences': EXP

--- a/tasks/libs/pipeline/github_slack_map.yaml
+++ b/tasks/libs/pipeline/github_slack_map.yaml
@@ -41,7 +41,7 @@
 '@datadog/fleet': '#fleet-automation-monitoring'
 '@datadog/injection-platform': '#injection-platform'
 '@datadog/metrics-aggregation': '#metrics-aggregation'
-'@datadog/ndm-core': '#ndm-core'
+'@datadog/network-device-monitoring-core': '#ndm-core'
 '@datadog/ndm-integrations': '#ndm-integrations'
 '@datadog/cloud-network-monitoring': '#cloud-network-monitoring'
 '@datadog/network-path': '#network-path-dev'

--- a/tasks/libs/pipeline/github_slack_review_map.yaml
+++ b/tasks/libs/pipeline/github_slack_review_map.yaml
@@ -44,7 +44,7 @@
 '@datadog/injection-platform': '#injection-platform'
 '@datadog/kubernetes-experiences': '#kubernetes-experiences'
 '@datadog/metrics-aggregation': '#metrics-aggregation'
-'@datadog/ndm-core': '#ndm-core'
+'@datadog/network-device-monitoring-core': '#ndm-core'
 '@datadog/ndm-integrations': '#ndm-integrations'
 '@datadog/network-path': '#network-path-dev'
 '@datadog/opentelemetry': '#opentelemetry-ops'

--- a/tasks/unit_tests/testdata/TEST_JUNIT_CODEOWNERS
+++ b/tasks/unit_tests/testdata/TEST_JUNIT_CODEOWNERS
@@ -204,7 +204,7 @@
 /cmd/agent/subcommands/hostname         @DataDog/agent-runtimes
 /cmd/agent/subcommands/version          @DataDog/agent-runtimes
 /cmd/agent/subcommands/remoteconfig     @Datadog/remote-config
-/cmd/agent/subcommands/snmp             @DataDog/ndm-core
+/cmd/agent/subcommands/snmp             @DataDog/network-device-monitoring-core
 /cmd/agent/subcommands/streamlogs       @DataDog/agent-log-pipelines
 /cmd/agent/subcommands/analyzelogs      @DataDog/agent-log-pipelines
 /cmd/agent/subcommands/streamep         @DataDog/container-integrations
@@ -223,7 +223,7 @@
 /cmd/agent/dist/conf.d/oracle-dbm.d/    @DataDog/database-monitoring
 /cmd/agent/dist/conf.d/network_path.d/ @DataDog/cloud-network-monitoring
 /cmd/agent/dist/conf.d/sbom.d/          @DataDog/agent-security @DataDog/container-integrations
-/cmd/agent/dist/conf.d/snmp.d/          @DataDog/ndm-core
+/cmd/agent/dist/conf.d/snmp.d/          @DataDog/network-device-monitoring-core
 /cmd/agent/dist/conf.d/win32_event_log.d/ @DataDog/windows-products
 /cmd/agent/dist/conf.d/windows_certificate.d/ @DataDog/windows-products
 /cmd/agent/installer.go                 @DataDog/fleet
@@ -247,7 +247,7 @@
 /cmd/system-probe/modules/eventmonitor* @DataDog/agent-security
 /cmd/system-probe/modules/tcp_queue_tracer* @DataDog/container-integrations
 /cmd/system-probe/modules/traceroute*  @DataDog/cloud-network-monitoring
-/cmd/system-probe/modules/ping*         @DataDog/ndm-core
+/cmd/system-probe/modules/ping*         @DataDog/network-device-monitoring-core
 /cmd/system-probe/modules/language_detection* @DataDog/container-experiences @DataDog/agent-discovery
 /cmd/system-probe/modules/dynamic_instrumentation* @DataDog/debugger-go
 /cmd/system-probe/windows_resources/    @DataDog/windows-products
@@ -292,7 +292,7 @@
 /omnibus/config/software/datadog-agent-integrations-*.rb  @DataDog/agent-integrations
 /omnibus/config/software/datadog-security-agent*.rb       @Datadog/agent-security @DataDog/agent-build
 /omnibus/config/software/openscap.rb                      @DataDog/agent-cspm
-/omnibus/config/software/snmp-traps.rb                    @DataDog/ndm-core
+/omnibus/config/software/snmp-traps.rb                    @DataDog/network-device-monitoring-core
 /omnibus/config/templates/init-scripts-agent/             @DataDog/agent-build @DataDog/fleet
 /omnibus/resources/*/msi/                                 @DataDog/windows-products
 
@@ -309,13 +309,13 @@
 /comp/forwarder @DataDog/agent-metric-pipelines
 /comp/logs @DataDog/agent-log-pipelines
 /comp/metadata @DataDog/agent-configuration
-/comp/ndmtmp @DataDog/ndm-core
+/comp/ndmtmp @DataDog/network-device-monitoring-core
 /comp/netflow @DataDog/ndm-integrations
 /comp/networkpath @DataDog/cloud-network-monitoring
 /comp/otelcol @DataDog/opentelemetry-agent
 /comp/process @DataDog/container-experiences
 /comp/remote-config @DataDog/remote-config
-/comp/snmptraps @DataDog/ndm-core
+/comp/snmptraps @DataDog/network-device-monitoring-core
 /comp/systray @DataDog/windows-products
 /comp/trace @DataDog/agent-apm
 /comp/updater @DataDog/fleet @DataDog/windows-products
@@ -341,7 +341,7 @@
 /comp/forwarder/eventplatformreceiver @DataDog/agent-log-pipelines
 /comp/forwarder/orchestrator @DataDog/kubernetes-experiences
 /comp/metadata/clusteragent @DataDog/container-platform
-/comp/metadata/haagent @DataDog/ndm-core
+/comp/metadata/haagent @DataDog/network-device-monitoring-core
 /comp/metadata/hostgpu @DataDog/ebpf-platform
 /comp/metadata/packagesigning @DataDog/agent-delivery
 /comp/metadata/softwareinventory @DataDog/windows-products
@@ -352,13 +352,13 @@
 /comp/connectivitychecker @DataDog/fleet
 /comp/etw @DataDog/windows-products
 /comp/fleetstatus @DataDog/fleet
-/comp/haagent @DataDog/ndm-core
+/comp/haagent @DataDog/network-device-monitoring-core
 /comp/languagedetection/client @DataDog/container-platform
 /comp/networkdeviceconfig @DataDog/ndm-integrations
 /comp/rdnsquerier @DataDog/ndm-integrations
 /comp/serializer/logscompression @DataDog/agent-log-pipelines
 /comp/serializer/metricscompression @DataDog/agent-metric-pipelines
-/comp/snmpscan @DataDog/ndm-core
+/comp/snmpscan @DataDog/network-device-monitoring-core
 # END COMPONENTS
 
 # Additional notification to  @iglendd about Agent Telemetry changes for optional approval and governance acknowledgement
@@ -409,7 +409,7 @@
 /pkg/trace/transform/                   @DataDog/opentelemetry-agent
 /comp/core/autodiscovery/listeners/           @DataDog/container-platform
 /comp/core/autodiscovery/listeners/cloudfoundry*.go  @DataDog/agent-integrations
-/comp/core/autodiscovery/listeners/snmp*.go   @DataDog/ndm-core
+/comp/core/autodiscovery/listeners/snmp*.go   @DataDog/network-device-monitoring-core
 /comp/core/autodiscovery/providers/           @DataDog/container-platform
 /comp/core/autodiscovery/providers/file*.go   @DataDog/agent-log-pipelines
 /comp/core/autodiscovery/providers/config_reader*.go @DataDog/container-platform @DataDog/agent-log-pipelines
@@ -446,7 +446,7 @@
 /pkg/collector/corechecks/net/wlan/     @DataDog/windows-products
 /pkg/collector/corechecks/oracle        @DataDog/database-monitoring
 /pkg/collector/corechecks/sbom/         @DataDog/agent-security @DataDog/container-integrations
-/pkg/collector/corechecks/snmp/         @DataDog/ndm-core
+/pkg/collector/corechecks/snmp/         @DataDog/network-device-monitoring-core
 /pkg/collector/corechecks/system/                 @DataDog/agent-runtimes
 /pkg/collector/corechecks/system/**/*_windows*.go @DataDog/agent-runtimes @DataDog/windows-products
 /pkg/collector/corechecks/system/wincrashdetect/  @DataDog/windows-products
@@ -472,7 +472,7 @@
 /pkg/containerlifecycle/                @Datadog/container-integrations
 /pkg/diagnose/                          @Datadog/container-platform
 /pkg/diagnose/connectivity/             @DataDog/agent-configuration
-/pkg/diagnose/firewallscanner/          @DataDog/ndm-core
+/pkg/diagnose/firewallscanner/          @DataDog/network-device-monitoring-core
 /pkg/diagnose/ports/                    @DataDog/agent-configuration
 /pkg/diagnose/ports/*windows*.go        @DataDog/windows-products
 /pkg/eventmonitor/                      @DataDog/ebpf-platform @DataDog/agent-security
@@ -600,8 +600,8 @@
 /pkg/databasemonitoring                 @DataDog/database-monitoring
 /pkg/kubestatemetrics                   @DataDog/container-integrations
 /pkg/security/                          @DataDog/agent-security
-/pkg/networkdevice/                     @DataDog/ndm-core
-/pkg/snmp/                              @DataDog/ndm-core
+/pkg/networkdevice/                     @DataDog/network-device-monitoring-core
+/pkg/snmp/                              @DataDog/network-device-monitoring-core
 /pkg/tagger/                            @DataDog/container-platform
 /pkg/windowsdriver/                     @DataDog/windows-products
 /comp/core/workloadmeta/collectors/internal/cloudfoundry  @DataDog/agent-integrations
@@ -675,8 +675,8 @@
 /test/integration/                      @DataDog/serverless @Datadog/serverless-azure-gcp
 /test/integration/docker/               @DataDog/opentelemetry-agent
 /test/fakeintake/                             @DataDog/agent-e2e-testing @DataDog/agent-devx
-/test/fakeintake/aggregator/ndmAggregator.go @DataDog/ndm-core
-/test/fakeintake/aggregator/ndmAggregator_test.go @DataDog/ndm-core
+/test/fakeintake/aggregator/ndmAggregator.go @DataDog/network-device-monitoring-core
+/test/fakeintake/aggregator/ndmAggregator_test.go @DataDog/network-device-monitoring-core
 /test/fakeintake/aggregator/ndmflowAggregator.go @DataDog/ndm-integrations
 /test/fakeintake/aggregator/ndmflowAggregator_test.go @DataDog/ndm-integrations
 /test/fakeintake/aggregator/servicediscovery* @DataDog/agent-discovery
@@ -705,9 +705,9 @@
 /test/new-e2e/tests/containers                @DataDog/container-integrations @DataDog/container-platform
 /test/new-e2e/tests/discovery                 @DataDog/agent-discovery
 /test/new-e2e/tests/fips-compliance           @DataDog/agent-runtimes
-/test/new-e2e/tests/ha-agent                  @DataDog/ndm-core
+/test/new-e2e/tests/ha-agent                  @DataDog/network-device-monitoring-core
 /test/new-e2e/tests/language-detection        @DataDog/container-experiences
-/test/new-e2e/tests/ndm                       @DataDog/ndm-core
+/test/new-e2e/tests/ndm                       @DataDog/network-device-monitoring-core
 /test/new-e2e/tests/ndm/netflow               @DataDog/ndm-integrations
 /test/new-e2e/tests/netpath                   @DataDog/cloud-network-monitoring @DataDog/windows-products
 /test/new-e2e/tests/npm                       @DataDog/cloud-network-monitoring


### PR DESCRIPTION
## Summary
- Renames all team identifier references from `ndm-core` to `network-device-monitoring-core`
- Updates component annotations, pipeline maps, CI config, CODEOWNERS, dependabot labels, and README
- Slack channel references (`#ndm-core`) remain unchanged
- Part of consolidating to a single team config

## Test plan
- [ ] Verify CI passes
- [ ] Verify team ownership is correctly attributed

🤖 Generated with [Claude Code](https://claude.com/claude-code)