### PR TITLE
[ACTP-1300] Pass agent metadata in PAR enrollment request

### DIFF
--- a/comp/privateactionrunner/impl/privateactionrunner.go
+++ b/comp/privateactionrunner/impl/privateactionrunner.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 	"sync"
 	"time"
 
@@ -20,6 +21,8 @@ import (
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	secretsutils "github.com/DataDog/datadog-agent/comp/core/secrets/utils"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
+	tagNames "github.com/DataDog/datadog-agent/comp/core/tagger/tags"
+	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	compdef "github.com/DataDog/datadog-agent/comp/def"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
 	traceroute "github.com/DataDog/datadog-agent/comp/networkpath/traceroute/def"
@@ -87,6 +90,20 @@ func validateAppKey(key string) error {
 // isEnabled checks if the private action runner is enabled in the configuration
 func isEnabled(cfg config.Component) bool {
 	return cfg.GetBool(parEnabled)
+}
+
+func (p *PrivateActionRunner) getOrchClusterID() string {
+	globalTags, err := p.tagger.GlobalTags(types.LowCardinality)
+	if err != nil {
+		return ""
+	}
+	for _, tag := range globalTags {
+		name, value, ok := strings.Cut(tag, ":")
+		if ok && name == tagNames.OrchClusterID {
+			return value
+		}
+	}
+	return ""
 }
 
 // Requires defines the dependencies for the privateactionrunner component
@@ -302,9 +319,12 @@ func (p *PrivateActionRunner) performSelfEnrollment(ctx context.Context, cfg *pa
 		return nil, fmt.Errorf("failed to get hostname: %w", err)
 	}
 
+	orchClusterID := p.getOrchClusterID()
+	agentFlavor := flavor.GetFlavor()
+
 	runnerNamePrefix := runnerHostname
 	// For cluster agent, use cluster name instead of hostname for better identification
-	if flavor.GetFlavor() == flavor.ClusterAgent {
+	if agentFlavor == flavor.ClusterAgent {
 		clusterName := clustername.GetClusterName(ctx, runnerHostname)
 		if clusterName != "" {
 			runnerNamePrefix = clusterName
@@ -313,7 +333,7 @@ func (p *PrivateActionRunner) performSelfEnrollment(ctx context.Context, cfg *pa
 		}
 	}
 
-	enrollmentResult, err := enrollment.SelfEnroll(ctx, ddSite, runnerNamePrefix, runnerHostname, apiKey, appKey)
+	enrollmentResult, err := enrollment.SelfEnroll(ctx, ddSite, runnerNamePrefix, runnerHostname, apiKey, appKey, runnerHostname, orchClusterID, agentFlavor)
 	if err != nil {
 		return nil, fmt.Errorf("enrollment API call failed: %w", err)
 	}

--- a/comp/privateactionrunner/impl/privateactionrunner.go
+++ b/comp/privateactionrunner/impl/privateactionrunner.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
-	"strings"
 	"sync"
 	"time"
 
@@ -21,8 +20,6 @@ import (
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	secretsutils "github.com/DataDog/datadog-agent/comp/core/secrets/utils"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
-	tagNames "github.com/DataDog/datadog-agent/comp/core/tagger/tags"
-	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	compdef "github.com/DataDog/datadog-agent/comp/def"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
 	traceroute "github.com/DataDog/datadog-agent/comp/networkpath/traceroute/def"
@@ -40,6 +37,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/util"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername"
+	pkglog "github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // Configuration keys for the private action runner.
@@ -90,20 +88,6 @@ func validateAppKey(key string) error {
 // isEnabled checks if the private action runner is enabled in the configuration
 func isEnabled(cfg config.Component) bool {
 	return cfg.GetBool(parEnabled)
-}
-
-func (p *PrivateActionRunner) getOrchClusterID() string {
-	globalTags, err := p.tagger.GlobalTags(types.LowCardinality)
-	if err != nil {
-		return ""
-	}
-	for _, tag := range globalTags {
-		name, value, ok := strings.Cut(tag, ":")
-		if ok && name == tagNames.OrchClusterID {
-			return value
-		}
-	}
-	return ""
 }
 
 // Requires defines the dependencies for the privateactionrunner component
@@ -319,7 +303,10 @@ func (p *PrivateActionRunner) performSelfEnrollment(ctx context.Context, cfg *pa
 		return nil, fmt.Errorf("failed to get hostname: %w", err)
 	}
 
-	orchClusterID := p.getOrchClusterID()
+	orchClusterID, err := clustername.GetClusterID()
+	if err != nil {
+		pkglog.Warnf("Failed to get orchestrator cluster ID: %v", err)
+	}
 	agentFlavor := flavor.GetFlavor()
 
 	runnerNamePrefix := runnerHostname

--- a/comp/privateactionrunner/impl/privateactionrunner.go
+++ b/comp/privateactionrunner/impl/privateactionrunner.go
@@ -37,7 +37,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/util"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername"
-	pkglog "github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // Configuration keys for the private action runner.
@@ -303,15 +302,9 @@ func (p *PrivateActionRunner) performSelfEnrollment(ctx context.Context, cfg *pa
 		return nil, fmt.Errorf("failed to get hostname: %w", err)
 	}
 
-	orchClusterID, err := clustername.GetClusterID()
-	if err != nil {
-		pkglog.Warnf("Failed to get orchestrator cluster ID: %v", err)
-	}
-	agentFlavor := flavor.GetFlavor()
-
 	runnerNamePrefix := runnerHostname
 	// For cluster agent, use cluster name instead of hostname for better identification
-	if agentFlavor == flavor.ClusterAgent {
+	if flavor.GetFlavor() == flavor.ClusterAgent {
 		clusterName := clustername.GetClusterName(ctx, runnerHostname)
 		if clusterName != "" {
 			runnerNamePrefix = clusterName
@@ -320,7 +313,7 @@ func (p *PrivateActionRunner) performSelfEnrollment(ctx context.Context, cfg *pa
 		}
 	}
 
-	enrollmentResult, err := enrollment.SelfEnroll(ctx, ddSite, runnerNamePrefix, runnerHostname, apiKey, appKey, runnerHostname, orchClusterID, agentFlavor)
+	enrollmentResult, err := enrollment.SelfEnroll(ctx, ddSite, runnerNamePrefix, runnerHostname, apiKey, appKey)
 	if err != nil {
 		return nil, fmt.Errorf("enrollment API call failed: %w", err)
 	}

--- a/pkg/privateactionrunner/autoconnections/tags_provider.go
+++ b/pkg/privateactionrunner/autoconnections/tags_provider.go
@@ -57,11 +57,11 @@ func (p *taggerBasedTagsProvider) GetTags(ctx context.Context, runnerID, hostnam
 
 	for _, keyValue := range globalTags {
 		tagName, _, ok := strings.Cut(keyValue, ":")
-		if ok {
-			if _, found := tagSet[tagName]; found {
-
-				tags = append(tags, keyValue)
-			}
+		if !ok {
+			continue
+		}
+		if _, found := tagSet[tagName]; found {
+			tags = append(tags, keyValue)
 		}
 	}
 

--- a/pkg/privateactionrunner/enrollment/enrollment.go
+++ b/pkg/privateactionrunner/enrollment/enrollment.go
@@ -34,7 +34,7 @@ type PersistedIdentity struct {
 }
 
 // SelfEnroll performs self-registration of a private action runner using API credentials
-func SelfEnroll(ctx context.Context, ddSite, runnerNamePrefix, runnerHostname, apiKey, appKey string) (*Result, error) {
+func SelfEnroll(ctx context.Context, ddSite, runnerNamePrefix, runnerHostname, apiKey, appKey, agentHostname, orchClusterID, agentFlavor string) (*Result, error) {
 	now := time.Now().UTC()
 	formattedTime := now.Format("20060102150405")
 	runnerName := runnerNamePrefix + "-" + formattedTime
@@ -56,6 +56,9 @@ func SelfEnroll(ctx context.Context, ddSite, runnerNamePrefix, runnerHostname, a
 		runnerName,
 		runnerModes,
 		publicJwk,
+		agentHostname,
+		orchClusterID,
+		agentFlavor,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("enrollment API call failed: %w", err)

--- a/pkg/privateactionrunner/enrollment/enrollment.go
+++ b/pkg/privateactionrunner/enrollment/enrollment.go
@@ -15,6 +15,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/regions"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/opms"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/util"
+	"github.com/DataDog/datadog-agent/pkg/util/flavor"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername"
+	pkglog "github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const defaultIdentityFileName = "privateactionrunner_private_identity.json"
@@ -34,7 +37,13 @@ type PersistedIdentity struct {
 }
 
 // SelfEnroll performs self-registration of a private action runner using API credentials
-func SelfEnroll(ctx context.Context, ddSite, runnerNamePrefix, runnerHostname, apiKey, appKey, agentHostname, orchClusterID, agentFlavor string) (*Result, error) {
+func SelfEnroll(ctx context.Context, ddSite, runnerNamePrefix, runnerHostname, apiKey, appKey string) (*Result, error) {
+	orchClusterID, err := clustername.GetClusterID()
+	if err != nil {
+		pkglog.Warnf("Failed to get orchestrator cluster ID: %v", err)
+	}
+	agentFlavor := flavor.GetFlavor()
+
 	now := time.Now().UTC()
 	formattedTime := now.Format("20060102150405")
 	runnerName := runnerNamePrefix + "-" + formattedTime
@@ -56,7 +65,7 @@ func SelfEnroll(ctx context.Context, ddSite, runnerNamePrefix, runnerHostname, a
 		runnerName,
 		runnerModes,
 		publicJwk,
-		agentHostname,
+		runnerHostname,
 		orchClusterID,
 		agentFlavor,
 	)

--- a/pkg/privateactionrunner/libs/par/opms_api.go
+++ b/pkg/privateactionrunner/libs/par/opms_api.go
@@ -11,17 +11,23 @@ import (
 
 // CreateRunnerRequest represents the request to create a runner with API key auth
 type CreateRunnerRequest struct {
-	ID           string       `jsonapi:"primary,createRunnerRequest"`
-	RunnerName   string       `json:"runner_name" jsonapi:"attribute" validate:"required"`
-	RunnerModes  []modes.Mode `json:"runner_modes" jsonapi:"attribute" validate:"gt=0,max=2,dive"`
-	RunnerHost   string       `json:"runner_host" jsonapi:"attribute" validate:"omitempty,hostname"`
-	PublicKeyPEM string       `json:"public_key_pem" jsonapi:"attribute" validate:"required"`
+	ID            string       `jsonapi:"primary,createRunnerRequest"`
+	RunnerName    string       `json:"runner_name" jsonapi:"attribute" validate:"required"`
+	RunnerModes   []modes.Mode `json:"runner_modes" jsonapi:"attribute" validate:"gt=0,max=2,dive"`
+	RunnerHost    string       `json:"runner_host" jsonapi:"attribute" validate:"omitempty,hostname"`
+	PublicKeyPEM  string       `json:"public_key_pem" jsonapi:"attribute" validate:"required"`
+	AgentHostname string       `json:"agent_hostname,omitempty" jsonapi:"attribute" validate:"omitempty"`
+	OrchClusterID string       `json:"orch_cluster_id,omitempty" jsonapi:"attribute" validate:"omitempty"`
+	AgentFlavor   string       `json:"agent_flavor,omitempty" jsonapi:"attribute" validate:"omitempty"`
 }
 
 // CreateRunnerResponse represents the response for runner creation
 type CreateRunnerResponse struct {
-	ID          string   `jsonapi:"primary,createRunnerResponse"`
-	RunnerID    string   `json:"runner_id" jsonapi:"attribute"`
-	OrgID       int64    `json:"org_id" jsonapi:"attribute"`
-	RunnerModes []string `json:"runner_modes" jsonapi:"attribute"`
+	ID            string   `jsonapi:"primary,createRunnerResponse"`
+	RunnerID      string   `json:"runner_id" jsonapi:"attribute"`
+	OrgID         int64    `json:"org_id" jsonapi:"attribute"`
+	RunnerModes   []string `json:"runner_modes" jsonapi:"attribute"`
+	AgentHostname string   `json:"agent_hostname,omitempty" jsonapi:"attribute"`
+	OrchClusterID string   `json:"orch_cluster_id,omitempty" jsonapi:"attribute"`
+	AgentFlavor   string   `json:"agent_flavor,omitempty" jsonapi:"attribute"`
 }

--- a/pkg/privateactionrunner/opms/public_opms.go
+++ b/pkg/privateactionrunner/opms/public_opms.go
@@ -37,6 +37,9 @@ type PublicClient interface {
 		runnerName string,
 		runnerModes []modes.Mode,
 		publicJwk *jose.JSONWebKey,
+		agentHostname string,
+		orchClusterID string,
+		agentFlavor string,
 	) (*par.CreateRunnerResponse, error)
 }
 
@@ -62,6 +65,9 @@ func (p *publicClient) EnrollWithApiKey(
 	runnerName string,
 	runnerModes []modes.Mode,
 	publicJwk *jose.JSONWebKey,
+	agentHostname string,
+	orchClusterID string,
+	agentFlavor string,
 ) (*par.CreateRunnerResponse, error) {
 	publicKeyPEM, err := util.JWKToPEM(publicJwk)
 	if err != nil {
@@ -75,9 +81,12 @@ func (p *publicClient) EnrollWithApiKey(
 	}
 
 	request := par.CreateRunnerRequest{
-		RunnerName:   runnerName,
-		RunnerModes:  runnerModes,
-		PublicKeyPEM: publicKeyPEM,
+		RunnerName:    runnerName,
+		RunnerModes:   runnerModes,
+		PublicKeyPEM:  publicKeyPEM,
+		AgentHostname: agentHostname,
+		OrchClusterID: orchClusterID,
+		AgentFlavor:   agentFlavor,
 	}
 
 	requestBodyJSON, err := jsonapi.Marshal(request, jsonapi.MarshalClientMode())


### PR DESCRIPTION
### Description

Pass agent metadata (`AgentHostname`, `OrchClusterID`, `AgentFlavor`) in the PAR enrollment request so the backend can associate runner identity with the agent that enrolled it.
