### PR TITLE
[testbench/ui] Read scenario json

### DIFF
--- a/cmd/observer-testbench/ui/src/App.tsx
+++ b/cmd/observer-testbench/ui/src/App.tsx
@@ -336,7 +336,7 @@ function App() {
   }, []);
 
   return (
-    <div className="min-h-screen flex flex-col">
+    <div className="h-screen flex flex-col overflow-hidden">
       {/* Header */}
       <header className="bg-slate-800 border-b border-slate-700 px-4 py-3">
         <div className="flex justify-between items-center">
@@ -478,7 +478,7 @@ function App() {
       {/* Episode info panel (shown when episode.json is present) */}
       {episodeInfo && <EpisodeInfoPanel info={episodeInfo} />}
 
-      <div className="flex-1 flex relative">
+      <div className="flex-1 flex relative min-h-0">
         {/* Resize handle */}
         <div
           className="absolute left-0 top-0 bottom-0 w-1 cursor-col-resize hover:bg-purple-500/50 active:bg-purple-500 z-10"

--- a/cmd/observer-testbench/ui/src/App.tsx
+++ b/cmd/observer-testbench/ui/src/App.tsx
@@ -3,6 +3,8 @@ import { useObserver } from './hooks/useObserver';
 import { MetricsView } from './components/MetricsView';
 import { CorrelatorView } from './components/CorrelatorView';
 import { LogView } from './components/LogView';
+import type { EpisodeInfo } from './api/client';
+import type { PhaseMarker } from './components/ChartWithAnomalyDetails';
 
 type TabID = 'timeseries' | 'correlators' | 'logs';
 
@@ -98,6 +100,88 @@ function EditableTimestamp({ value, onChange }: { value: number; onChange: (ts: 
   );
 }
 
+const PHASE_STYLES: Record<string, { bg: string; border: string; label: string }> = {
+  warmup:     { bg: 'bg-blue-900/40',   border: 'border-blue-500/50',   label: 'Warmup' },
+  baseline:   { bg: 'bg-green-900/40',  border: 'border-green-500/50',  label: 'Baseline' },
+  disruption: { bg: 'bg-red-900/40',    border: 'border-red-500/50',    label: 'Disruption' },
+  cooldown:   { bg: 'bg-yellow-900/40', border: 'border-yellow-500/50', label: 'Cooldown' },
+};
+
+function formatTime(isoString: string): string {
+  const d = new Date(isoString);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+}
+
+function EpisodeInfoPanel({ info }: { info: EpisodeInfo }) {
+  const [expanded, setExpanded] = useState(false);
+
+  const phases: { key: string; phase: typeof info.baseline }[] = [
+    { key: 'warmup', phase: info.warmup },
+    { key: 'baseline', phase: info.baseline },
+    { key: 'disruption', phase: info.disruption },
+    { key: 'cooldown', phase: info.cooldown },
+  ].filter(p => p.phase != null);
+
+  return (
+    <div className="bg-slate-800/60 border-b border-slate-700 px-4 py-2">
+      <div className="flex items-start gap-4 flex-wrap">
+        {/* Episode identity */}
+        <div className="flex items-center gap-2 shrink-0">
+          <span className="text-xs font-mono text-slate-400">Episode</span>
+          <span className="text-sm font-semibold text-white">{info.episode}</span>
+          <span className="text-xs text-slate-500">#{info.cycle}</span>
+          <span className={`text-xs px-1.5 py-0.5 rounded font-medium ${info.success ? 'bg-green-900/60 text-green-400' : 'bg-red-900/60 text-red-400'}`}>
+            {info.success ? '✓' : '✗'}
+          </span>
+        </div>
+
+        {/* App name */}
+        <div className="flex items-center gap-1 shrink-0">
+          <span className="text-xs text-slate-400">App</span>
+          <span className="text-sm text-slate-200">{info.scenario.app_name}</span>
+        </div>
+
+        {/* Description (truncated, expandable) */}
+        <div className="flex-1 min-w-0">
+          <button
+            onClick={() => setExpanded(e => !e)}
+            className="text-left w-full group"
+          >
+            {expanded ? (
+              <span className="text-xs text-slate-300 leading-relaxed">{info.scenario.long_description || info.scenario.description}</span>
+            ) : (
+              <span className="text-xs text-slate-400 truncate block group-hover:text-slate-300 transition-colors">
+                {info.scenario.description}
+                <span className="ml-1 text-slate-500">[+]</span>
+              </span>
+            )}
+          </button>
+        </div>
+
+        {/* Phase timeline */}
+        {phases.length > 0 && (
+          <div className="flex items-center gap-1 shrink-0">
+            {phases.map(({ key, phase }) => {
+              if (!phase) return null;
+              const style = PHASE_STYLES[key] ?? { bg: 'bg-slate-700', border: 'border-slate-500', label: key };
+              return (
+                <div
+                  key={key}
+                  className={`flex items-center gap-1 px-2 py-0.5 rounded border text-xs ${style.bg} ${style.border}`}
+                >
+                  <span className="text-slate-300 font-medium">{style.label}</span>
+                  <span className="font-mono text-slate-400">{formatTime(phase.start)}</span>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
 function App() {
   const [state, actions] = useObserver();
   const [activeTab, setActiveTab] = useState<TabID>('timeseries');
@@ -167,6 +251,56 @@ function App() {
     if (start == null || end == null || end <= start) return null;
     return { start, end };
   }, [state.status?.scenarioStart, state.status?.scenarioEnd]);
+
+  // Episode info from JSON (optional)
+  const episodeInfo = state.status?.episodeInfo ?? null;
+  const episodeTimeRange = useMemo<TimeRange | null>(() => {
+    if (!episodeInfo?.start_time || !episodeInfo?.end_time) return null;
+    const start = new Date(episodeInfo.start_time).getTime() / 1000;
+    const end = new Date(episodeInfo.end_time).getTime() / 1000;
+    if (isNaN(start) || isNaN(end) || end <= start) return null;
+    return { start, end };
+  }, [episodeInfo?.start_time, episodeInfo?.end_time]);
+
+  // Phase markers derived from episode info — dotted lines on all charts
+  const phaseMarkers = useMemo<PhaseMarker[]>(() => {
+    if (!episodeInfo) return [];
+    const defs = [
+      { key: 'warmup',     label: 'Warmup',     phase: episodeInfo.warmup,     color: '#3b82f6' },
+      { key: 'baseline',   label: 'Baseline',   phase: episodeInfo.baseline,   color: '#22c55e' },
+      { key: 'disruption', label: 'Disruption', phase: episodeInfo.disruption, color: '#ef4444' },
+      { key: 'cooldown',   label: 'Cooldown',   phase: episodeInfo.cooldown,   color: '#f59e0b' },
+    ];
+    const markers: PhaseMarker[] = [];
+    for (const { key, label, phase, color } of defs) {
+      if (!phase?.start) continue;
+      const ts = new Date(phase.start).getTime() / 1000;
+      if (!isNaN(ts)) markers.push({ key, label, timestamp: ts, color });
+    }
+    return markers;
+  }, [episodeInfo]);
+
+  // When the active scenario changes, reset zoom (episode range effect will re-apply it)
+  const prevScenarioRef = useRef<string | null | undefined>(undefined);
+  const appliedEpisodeRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (state.activeScenario === prevScenarioRef.current) return;
+    prevScenarioRef.current = state.activeScenario;
+    appliedEpisodeRef.current = null; // Allow episode range to be re-applied
+    setTimeRangeLive(null);
+    setNav({ history: [null], index: 0 });
+  }, [state.activeScenario]);
+
+  // Once episode info arrives for a freshly loaded scenario, apply its time range as default
+  useEffect(() => {
+    if (!episodeTimeRange || !episodeInfo) return;
+    const id = episodeInfo.execution_id || episodeInfo.episode;
+    if (appliedEpisodeRef.current === id) return;
+    appliedEpisodeRef.current = id;
+    commitTimeRange(episodeTimeRange);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [episodeTimeRange, episodeInfo]);
+
   const activeTimeRange = timeRange ?? scenarioTimeRange;
 
   // Sidebar resize handlers
@@ -288,15 +422,23 @@ function App() {
                 <span className="text-xs text-slate-500 ml-1">
                   (middle-drag or cmd+drag to pan)
                 </span>
-                {timeRange && (
+                {/* Two reset buttons: scenario range vs all data */}
+                {episodeTimeRange && (
                   <button
-                    onClick={() => commitTimeRange(null)}
-                    className="ml-2 text-xs px-2 py-0.5 bg-slate-600 hover:bg-slate-500 rounded text-slate-300"
-                    title="Reset time span"
+                    onClick={() => commitTimeRange(episodeTimeRange)}
+                    className="ml-1 text-xs px-2 py-0.5 bg-slate-600 hover:bg-purple-700 rounded text-slate-300"
+                    title="Reset to scenario time range (from episode.json)"
                   >
-                    Reset
+                    Scenario
                   </button>
                 )}
+                <button
+                  onClick={() => commitTimeRange(null)}
+                  className="ml-1 text-xs px-2 py-0.5 bg-slate-600 hover:bg-slate-500 rounded text-slate-300"
+                  title="Reset to full metrics/logs time range"
+                >
+                  All Data
+                </button>
               </div>
             )}
             {!activeTimeRange && state.connectionState === 'ready' && (
@@ -333,6 +475,9 @@ function App() {
         </div>
       </header>
 
+      {/* Episode info panel (shown when episode.json is present) */}
+      {episodeInfo && <EpisodeInfoPanel info={episodeInfo} />}
+
       <div className="flex-1 flex relative">
         {/* Resize handle */}
         <div
@@ -350,6 +495,7 @@ function App() {
             timeRange={activeTimeRange}
             onTimeRangeChange={setTimeRange}
             smoothLines={smoothLines}
+            phaseMarkers={phaseMarkers}
           />
         </div>
         <div className={`flex-1 flex ${activeTab !== 'correlators' ? 'hidden' : ''}`}>
@@ -358,6 +504,7 @@ function App() {
             actions={actions}
             sidebarWidth={sidebarWidth}
             timeRange={activeTimeRange}
+            phaseMarkers={phaseMarkers}
           />
         </div>
         <div className={`flex-1 flex ${activeTab !== 'logs' ? 'hidden' : ''}`}>
@@ -367,6 +514,7 @@ function App() {
             sidebarWidth={sidebarWidth}
             timeRange={activeTimeRange}
             onTimeRangeChange={setTimeRange}
+            phaseMarkers={phaseMarkers}
           />
         </div>
       </div>

--- a/cmd/observer-testbench/ui/src/api/client.ts
+++ b/cmd/observer-testbench/ui/src/api/client.ts
@@ -9,6 +9,32 @@ export interface ServerConfig {
   components: Record<string, boolean>;
 }
 
+export interface EpisodePhase {
+  start: string;
+  end: string;
+}
+
+export interface EpisodeScenario {
+  app_name: string;
+  description: string;
+  long_description: string;
+}
+
+export interface EpisodeInfo {
+  episode: string;
+  cycle: number;
+  scenario: EpisodeScenario;
+  environment: string;
+  execution_id: string;
+  success: boolean;
+  start_time: string;
+  end_time: string;
+  warmup?: EpisodePhase;
+  baseline?: EpisodePhase;
+  disruption?: EpisodePhase;
+  cooldown?: EpisodePhase;
+}
+
 export interface StatusResponse {
   ready: boolean;
   scenario: string | null;
@@ -19,6 +45,7 @@ export interface StatusResponse {
   correlatorsProcessing: boolean;
   scenarioStart?: number;
   scenarioEnd?: number;
+  episodeInfo?: EpisodeInfo;
   serverConfig: ServerConfig;
 }
 

--- a/cmd/observer-testbench/ui/src/components/AnomalySwimlane.tsx
+++ b/cmd/observer-testbench/ui/src/components/AnomalySwimlane.tsx
@@ -1,7 +1,7 @@
 import { useRef, useEffect, useMemo, useState } from 'react';
 import * as d3 from 'd3';
 import type { Anomaly, CompressedGroup, Correlation, SeriesID } from '../api/client';
-import type { TimeRange } from './ChartWithAnomalyDetails';
+import type { TimeRange, PhaseMarker } from './ChartWithAnomalyDetails';
 
 // Reuse the detector palette from MetricsChart
 const DETECTOR_PALETTE = [
@@ -44,6 +44,7 @@ interface AnomalySwimlaneProps {
   compressedGroups: CompressedGroup[];
   correlations?: Correlation[];
   timeRange?: TimeRange | null;
+  phaseMarkers?: PhaseMarker[];
 }
 
 // Assign groups to stacked lanes so overlapping time ranges don't collide.
@@ -71,6 +72,7 @@ export function AnomalySwimlane({
   compressedGroups,
   correlations = [],
   timeRange = null,
+  phaseMarkers = [],
 }: AnomalySwimlaneProps) {
   const svgRef = useRef<SVGSVGElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -319,7 +321,30 @@ export function AnomalySwimlane({
       .attr('fill', '#94a3b8')
       .attr('font-size', '9px');
 
-  }, [anomalies, compressedGroups, correlations, sources, denseHeight, laneAssignments, laneCount, totalInnerHeight, containerWidth, margin.left, margin.right, margin.top, margin.bottom, timeRange]);
+    // Phase marker lines (dotted vertical lines)
+    phaseMarkers.forEach((marker) => {
+      const x = xScale(marker.timestamp * 1000);
+      if (x < -20 || x > innerWidth + 20) return;
+      g.append('line')
+        .attr('x1', x).attr('x2', x)
+        .attr('y1', 0).attr('y2', totalInnerHeight)
+        .attr('stroke', marker.color)
+        .attr('stroke-width', 1)
+        .attr('stroke-dasharray', '4,3')
+        .attr('opacity', 0.75)
+        .attr('pointer-events', 'none');
+      g.append('text')
+        .attr('x', x + 3)
+        .attr('y', 10)
+        .attr('fill', marker.color)
+        .attr('font-size', '9px')
+        .attr('font-family', 'monospace')
+        .attr('opacity', 0.9)
+        .attr('pointer-events', 'none')
+        .text(marker.label);
+    });
+
+  }, [anomalies, compressedGroups, correlations, sources, denseHeight, laneAssignments, laneCount, totalInnerHeight, containerWidth, margin.left, margin.right, margin.top, margin.bottom, timeRange, phaseMarkers]);
 
   // Track container width so the drawing effect re-runs on resize/tab switch
   useEffect(() => {

--- a/cmd/observer-testbench/ui/src/components/ChartWithAnomalyDetails.tsx
+++ b/cmd/observer-testbench/ui/src/components/ChartWithAnomalyDetails.tsx
@@ -16,6 +16,13 @@ export interface TimeRange {
   end: number;
 }
 
+export interface PhaseMarker {
+  key: string;      // phase name e.g. "baseline"
+  label: string;    // display label
+  timestamp: number; // Unix seconds (start of phase)
+  color: string;
+}
+
 interface ChartWithAnomalyDetailsProps {
   name: string;
   points: Point[];
@@ -28,6 +35,7 @@ interface ChartWithAnomalyDetailsProps {
   smoothLines?: boolean;
   seriesVariants?: SeriesVariant[];
   isTelemetry?: boolean;
+  phaseMarkers?: PhaseMarker[];
 }
 
 function buildSeriesIDSet(seriesVariants?: SeriesVariant[]): Set<SeriesID> {
@@ -83,6 +91,7 @@ export function ChartWithAnomalyDetails({
   smoothLines = true,
   seriesVariants,
   isTelemetry = false,
+  phaseMarkers,
 }: ChartWithAnomalyDetailsProps) {
   const [expandedIndex, setExpandedIndex] = useState<number | null>(null);
   const [hoveredAnomalyId, setHoveredAnomalyId] = useState<string | null>(null);
@@ -200,6 +209,7 @@ export function ChartWithAnomalyDetails({
         onMarkerHover={setHoveredAnomalyId}
         onMarkerClick={handleMarkerClick}
         isTelemetry={isTelemetry}
+        phaseMarkers={phaseMarkers}
       />
 
       {/* Anomaly details - compact list below chart */}

--- a/cmd/observer-testbench/ui/src/components/CorrelatorView.tsx
+++ b/cmd/observer-testbench/ui/src/components/CorrelatorView.tsx
@@ -4,7 +4,7 @@ import { AnomalySwimlane } from './AnomalySwimlane';
 import { CompressedGroupCard } from './CompressedGroupCard';
 import type { ObserverState, ObserverActions } from '../hooks/useObserver';
 import type { ScenarioInfo, Correlation } from '../api/client';
-import type { TimeRange } from './ChartWithAnomalyDetails';
+import type { TimeRange, PhaseMarker } from './ChartWithAnomalyDetails';
 import { MAIN_TAG_FILTER_KEYS } from '../constants';
 import { parseTagFilter, extractTagGroups, toggleTagInInput, matchesTagFilter } from '../filters';
 import { TagFilterGroups } from './TagFilterGroups';
@@ -14,9 +14,10 @@ interface CorrelatorViewProps {
   actions: ObserverActions;
   sidebarWidth: number;
   timeRange: TimeRange | null;
+  phaseMarkers?: PhaseMarker[];
 }
 
-export function CorrelatorView({ state, actions, sidebarWidth, timeRange }: CorrelatorViewProps) {
+export function CorrelatorView({ state, actions, sidebarWidth, timeRange, phaseMarkers }: CorrelatorViewProps) {
   const scenarios = state.scenarios ?? [];
   const components = state.components ?? [];
   const allCorrelations = state.correlations ?? [];
@@ -149,6 +150,7 @@ export function CorrelatorView({ state, actions, sidebarWidth, timeRange }: Corr
               compressedGroups={compressedGroups}
               correlations={correlations}
               timeRange={timeRange}
+              phaseMarkers={phaseMarkers}
             />
 
             {/* 2. Compressed Groups */}

--- a/cmd/observer-testbench/ui/src/components/CorrelatorView.tsx
+++ b/cmd/observer-testbench/ui/src/components/CorrelatorView.tsx
@@ -64,7 +64,7 @@ export function CorrelatorView({ state, actions, sidebarWidth, timeRange, phaseM
     <div className="flex-1 flex">
       {/* Sidebar */}
       <aside
-        className="bg-slate-800 border-r border-slate-700 flex flex-col"
+        className="bg-slate-800 border-r border-slate-700 overflow-y-auto"
         style={{ width: sidebarWidth }}
       >
         {/* Scenarios */}

--- a/cmd/observer-testbench/ui/src/components/LogView.tsx
+++ b/cmd/observer-testbench/ui/src/components/LogView.tsx
@@ -692,7 +692,7 @@ export function LogView({ state, actions, sidebarWidth, timeRange, onTimeRangeCh
     <div className="flex-1 flex">
       {/* Sidebar */}
       <aside
-        className="bg-slate-800 border-r border-slate-700 flex flex-col"
+        className="bg-slate-800 border-r border-slate-700 overflow-y-auto"
         style={{ width: sidebarWidth }}
       >
         <ScenarioSelector

--- a/cmd/observer-testbench/ui/src/components/LogView.tsx
+++ b/cmd/observer-testbench/ui/src/components/LogView.tsx
@@ -122,8 +122,17 @@ function LogRateChart({
   onTimeRangeChangeRef.current = onTimeRangeChange;
 
   const buckets = useMemo(() => {
-    const displayStart = timeRange?.start ?? scenarioStart;
-    const displayEnd = timeRange?.end ?? scenarioEnd;
+    let displayStart = timeRange?.start ?? scenarioStart;
+    let displayEnd = timeRange?.end ?? scenarioEnd;
+    // Fall back to log timestamp bounds when no other bounds are available
+    if (!displayStart || !displayEnd || displayEnd <= displayStart) {
+      for (const l of logs) {
+        const ts = l.timestampMs / 1000;
+        if (!ts) continue;
+        if (!displayStart || ts < displayStart) displayStart = ts;
+        if (!displayEnd || ts > displayEnd) displayEnd = ts;
+      }
+    }
     if (!displayStart || !displayEnd || displayEnd <= displayStart) return [];
     const bucketSize = Math.max(LOG_CHART_MIN_BUCKET_SIZE_S, (displayEnd - displayStart) / LOG_CHART_TARGET_BUCKETS);
     const bucketCount = Math.ceil((displayEnd - displayStart) / bucketSize);
@@ -156,7 +165,7 @@ function LogRateChart({
   // D3 chart drawing
   useEffect(() => {
     if (!svgRef.current || !containerRef.current) return;
-    if (!scenarioStart || !scenarioEnd || scenarioEnd <= scenarioStart || buckets.length === 0) return;
+    if (buckets.length === 0) return;
     if (isBrushingRef.current) return;
 
     const m = LOG_CHART_MARGIN;
@@ -399,7 +408,10 @@ function LogRateChart({
     };
   }, [timeRange]);
 
-  if (!scenarioStart || !scenarioEnd || scenarioEnd <= scenarioStart) return null;
+  const hasBounds = (scenarioStart && scenarioEnd && scenarioEnd > scenarioStart)
+    || (timeRange && timeRange.end > timeRange.start)
+    || buckets.length > 0;
+  if (!hasBounds) return null;
 
   return (
     <div className="bg-slate-800/60 rounded p-3 mb-4">

--- a/cmd/observer-testbench/ui/src/components/LogView.tsx
+++ b/cmd/observer-testbench/ui/src/components/LogView.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo, useRef, useEffect } from 'react';
 import * as d3 from 'd3';
 import type { ScenarioInfo, LogAnomaly, LogEntry } from '../api/client';
 import type { ObserverState, ObserverActions } from '../hooks/useObserver';
+import type { PhaseMarker } from './ChartWithAnomalyDetails';
 import { MAIN_TAG_FILTER_KEYS } from '../constants';
 import { parseTagFilter, extractTagGroups, toggleTagInInput, matchesTagFilter } from '../filters';
 import { TagFilterGroups } from './TagFilterGroups';
@@ -17,6 +18,7 @@ interface LogViewProps {
   sidebarWidth: number;
   timeRange?: TimeRange | null;
   onTimeRangeChange?: (range: TimeRange | null) => void;
+  phaseMarkers?: PhaseMarker[];
 }
 
 const LOG_CHART_HEIGHT = 80;
@@ -96,6 +98,7 @@ function LogRateChart({
   hoveredAnomalyIndex,
   timeRange,
   onTimeRangeChange,
+  phaseMarkers = [],
 }: {
   logs: LogEntry[];
   anomalies: LogAnomaly[];
@@ -105,6 +108,7 @@ function LogRateChart({
   hoveredAnomalyIndex?: number | null;
   timeRange?: TimeRange | null;
   onTimeRangeChange?: (range: TimeRange | null) => void;
+  phaseMarkers?: PhaseMarker[];
 }) {
   const svgRef = useRef<SVGSVGElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -262,6 +266,29 @@ function LogRateChart({
       }
     }
 
+    // Phase marker lines (dotted vertical lines for episode phases)
+    phaseMarkers.forEach((marker) => {
+      const x = xScale(marker.timestamp * 1000);
+      if (x < -20 || x > innerWidth + 20) return;
+      barsG.append('line')
+        .attr('x1', x).attr('x2', x)
+        .attr('y1', 0).attr('y2', innerHeight)
+        .attr('stroke', marker.color)
+        .attr('stroke-width', 1)
+        .attr('stroke-dasharray', '4,3')
+        .attr('opacity', 0.8)
+        .attr('pointer-events', 'none');
+      barsG.append('text')
+        .attr('x', x + 3)
+        .attr('y', 10)
+        .attr('fill', marker.color)
+        .attr('font-size', '9px')
+        .attr('font-family', 'monospace')
+        .attr('opacity', 0.9)
+        .attr('pointer-events', 'none')
+        .text(marker.label);
+    });
+
     // X axis
     g.append('g')
       .attr('transform', `translate(0,${innerHeight})`)
@@ -301,7 +328,7 @@ function LogRateChart({
       .attr('fill', 'rgba(45, 212, 191, 0.2)')
       .attr('stroke', '#2dd4bf')
       .attr('stroke-width', 1);
-  }, [buckets, anomalies, scenarioStart, scenarioEnd, timeRange, hoveredTimestamp, hoveredAnomalyIndex]);
+  }, [buckets, anomalies, scenarioStart, scenarioEnd, timeRange, hoveredTimestamp, hoveredAnomalyIndex, phaseMarkers]);
 
   // Panning (middle-click or cmd+left-drag)
   useEffect(() => {
@@ -567,7 +594,7 @@ function getEffectiveTags(tags: string[], status: string): string[] {
   return tags.includes(statusTag) ? tags : [statusTag, ...tags];
 }
 
-export function LogView({ state, actions, sidebarWidth, timeRange, onTimeRangeChange }: LogViewProps) {
+export function LogView({ state, actions, sidebarWidth, timeRange, onTimeRangeChange, phaseMarkers }: LogViewProps) {
   const scenarios = state.scenarios ?? [];
   const allLogs = state.logs ?? [];
   const allLogAnomalies = state.logAnomalies ?? [];
@@ -761,6 +788,7 @@ export function LogView({ state, actions, sidebarWidth, timeRange, onTimeRangeCh
               hoveredAnomalyIndex={hoveredAnomalyIndex}
               timeRange={timeRange}
               onTimeRangeChange={onTimeRangeChange}
+              phaseMarkers={phaseMarkers}
             />
 
             {/* Detected Anomalies collapsible section */}

--- a/cmd/observer-testbench/ui/src/components/MetricsChart.tsx
+++ b/cmd/observer-testbench/ui/src/components/MetricsChart.tsx
@@ -1,7 +1,7 @@
 import { useRef, useEffect, useMemo, useState } from 'react';
 import * as d3 from 'd3';
 import type { Point, AnomalyMarker, SeriesID } from '../api/client';
-import type { CorrelationRange, TimeRange } from './ChartWithAnomalyDetails';
+import type { CorrelationRange, TimeRange, PhaseMarker } from './ChartWithAnomalyDetails';
 
 // Detector color palette - colors are assigned by stable index
 const DETECTOR_PALETTE: { fill: string; stroke: string }[] = [
@@ -87,6 +87,7 @@ interface MetricsChartProps {
   onMarkerHover?: (markerId: string | null) => void;
   onMarkerClick?: (markerId: string) => void;
   isTelemetry?: boolean;
+  phaseMarkers?: PhaseMarker[];
 }
 
 export function MetricsChart({
@@ -107,6 +108,7 @@ export function MetricsChart({
   onMarkerHover,
   onMarkerClick,
   isTelemetry = false,
+  phaseMarkers = [],
 }: MetricsChartProps) {
   const [showCorrelationLegend, setShowCorrelationLegend] = useState(false);
   const [showSeriesLegend, setShowSeriesLegend] = useState(false);
@@ -421,6 +423,29 @@ export function MetricsChart({
       .attr('opacity', 0.1)
       .call(d3.axisLeft(yScale).ticks(5).tickSize(-innerWidth).tickFormat(() => ''));
 
+    // Phase marker lines (dotted vertical lines for episode phases)
+    phaseMarkers.forEach((marker) => {
+      const x = xScale(marker.timestamp * 1000);
+      if (x < -20 || x > innerWidth + 20) return;
+      g.append('line')
+        .attr('x1', x).attr('x2', x)
+        .attr('y1', 0).attr('y2', innerHeight)
+        .attr('stroke', marker.color)
+        .attr('stroke-width', 1)
+        .attr('stroke-dasharray', '4,3')
+        .attr('opacity', 0.75)
+        .attr('pointer-events', 'none');
+      g.append('text')
+        .attr('x', x + 3)
+        .attr('y', 10)
+        .attr('fill', marker.color)
+        .attr('font-size', '9px')
+        .attr('font-family', 'monospace')
+        .attr('opacity', 0.9)
+        .attr('pointer-events', 'none')
+        .text(marker.label);
+    });
+
     // Add brush for time range selection
     const brush = d3
       .brushX<unknown>()
@@ -481,6 +506,7 @@ export function MetricsChart({
     activeHighlightedSeriesId,
     onMarkerHover,
     onMarkerClick,
+    phaseMarkers,
   ]);
 
   // Handle resize

--- a/cmd/observer-testbench/ui/src/components/MetricsView.tsx
+++ b/cmd/observer-testbench/ui/src/components/MetricsView.tsx
@@ -5,7 +5,7 @@ import { api } from '../api/client';
 import type { SeriesData, SeriesInfo, ScenarioInfo } from '../api/client';
 import type { SeriesVariant } from './MetricsChart';
 import { getDetectorColorStable } from './MetricsChart';
-import type { TimeRange } from './ChartWithAnomalyDetails';
+import type { TimeRange, PhaseMarker } from './ChartWithAnomalyDetails';
 import type { ObserverState, ObserverActions } from '../hooks/useObserver';
 import { MAIN_TAG_FILTER_KEYS } from '../constants';
 import { parseTagFilter, extractTagGroups, toggleTagInInput, matchesTagFilter } from '../filters';
@@ -48,6 +48,7 @@ interface MetricsViewProps {
   timeRange: TimeRange | null;
   onTimeRangeChange: (range: TimeRange | null) => void;
   smoothLines: boolean;
+  phaseMarkers?: PhaseMarker[];
 }
 
 export function MetricsView({
@@ -57,6 +58,7 @@ export function MetricsView({
   timeRange,
   onTimeRangeChange,
   smoothLines,
+  phaseMarkers,
 }: MetricsViewProps) {
   const [selectedGroups, setSelectedGroups] = useState<Set<string>>(new Set());
   const [enabledDetectors, setEnabledDetectors] = useState<Set<string>>(new Set());
@@ -189,15 +191,23 @@ export function MetricsView({
     const telKeys = visibleGroups.filter((g) => g.namespace === 'telemetry').map((g) => g.key);
     const virtKeys = visibleGroups.filter((g) => g.baseName.startsWith('_virtual.')).map((g) => g.key);
 
-    const ranked = [...visibleGroups]
-      .filter((g) => g.namespace !== 'telemetry' && !g.baseName.startsWith('_virtual.'))
-      .sort((a, b) => {
-        const countDiff = (anomalyCountByGroup.get(b.key) ?? 0) - (anomalyCountByGroup.get(a.key) ?? 0);
-        if (countDiff !== 0) return countDiff;
-        return a.baseName.localeCompare(b.baseName);
-      });
+    const mainGroups = [...visibleGroups]
+      .filter((g) => g.namespace !== 'telemetry' && !g.baseName.startsWith('_virtual.'));
 
-    setSelectedGroups(new Set([...ranked.slice(0, 6).map((g) => g.key), ...telKeys, ...virtKeys]));
+    const DEFAULT_METRIC = 'datadog.dogstatsd.client.metrics';
+    const defaultGroup = mainGroups.find((g) => g.baseName === DEFAULT_METRIC);
+    const defaultKeys = defaultGroup
+      ? [defaultGroup.key]
+      : mainGroups
+          .sort((a, b) => {
+            const countDiff = (anomalyCountByGroup.get(b.key) ?? 0) - (anomalyCountByGroup.get(a.key) ?? 0);
+            if (countDiff !== 0) return countDiff;
+            return a.baseName.localeCompare(b.baseName);
+          })
+          .slice(0, 6)
+          .map((g) => g.key);
+
+    setSelectedGroups(new Set(defaultKeys));
     setAutoSelectedScenario(state.activeScenario);
     onTimeRangeChange(null);
   }, [state.activeScenario, state.connectionState, visibleGroups, anomalyCountByGroup, autoSelectedScenario, onTimeRangeChange]);
@@ -537,6 +547,7 @@ export function MetricsView({
                           onTimeRangeChange={onTimeRangeChange}
                           smoothLines={smoothLines}
                           seriesVariants={seriesVariants}
+                          phaseMarkers={phaseMarkers}
                         />
                       );
                     })
@@ -592,6 +603,7 @@ export function MetricsView({
                               onTimeRangeChange={onTimeRangeChange}
                               smoothLines={smoothLines}
                               seriesVariants={seriesVariants}
+                              phaseMarkers={phaseMarkers}
                             />
                           );
                         })}
@@ -646,6 +658,7 @@ export function MetricsView({
                               smoothLines={smoothLines}
                               seriesVariants={seriesVariants}
                               isTelemetry
+                              phaseMarkers={phaseMarkers}
                             />
                           );
                         })}

--- a/cmd/observer-testbench/ui/src/components/MetricsView.tsx
+++ b/cmd/observer-testbench/ui/src/components/MetricsView.tsx
@@ -103,12 +103,10 @@ export function MetricsView({
     return new Map([...all.entries()].filter(([k]) => MAIN_TAG_FILTER_KEYS.has(k)));
   }, [allSeries]);
 
-  const filteredSeries = useMemo(() => {
-    const byAggType = allSeries.filter((s) => getAggregationType(s.name) === aggregationType);
-    const filter = parseTagFilter(tagFilterInput);
-    if (filter.include.size === 0 && filter.exclude.size === 0) return byAggType;
-    return byAggType.filter((s) => matchesTagFilter(s.tags ?? [], filter));
-  }, [allSeries, aggregationType, tagFilterInput]);
+  const filteredSeries = useMemo(
+    () => allSeries.filter((s) => getAggregationType(s.name) === aggregationType),
+    [allSeries, aggregationType]
+  );
 
   const metricGroups = useMemo(() => {
     const groups = new Map<string, MetricGroup>();
@@ -173,6 +171,8 @@ export function MetricsView({
     () => visibleGroups.map((g) => ({ key: g.key, name: g.baseName, displayName: g.baseName })),
     [visibleGroups]
   );
+
+  const tagFilter = useMemo(() => parseTagFilter(tagFilterInput), [tagFilterInput]);
 
   const initializedScenarioRef = useRef<string | null>(null);
   useEffect(() => {
@@ -267,7 +267,7 @@ export function MetricsView({
   return (
     <div className="flex-1 flex">
       <aside
-        className="bg-slate-800 border-r border-slate-700 flex flex-col"
+        className="bg-slate-800 border-r border-slate-700 overflow-y-auto"
         style={{ width: sidebarWidth }}
       >
         <ScenarioSelector
@@ -356,7 +356,7 @@ export function MetricsView({
           </label>
         </div>
 
-        <div className="flex-1 p-4 overflow-hidden flex flex-col min-h-0">
+        <div className="p-4 border-b border-slate-700">
           <div className="flex items-center justify-between mb-2">
             <h2 className="text-xs font-semibold text-slate-400 uppercase tracking-wider">
               Metric Groups ({displayGroups.length})
@@ -521,9 +521,12 @@ export function MetricsView({
                     .map((groupKey) => {
                       const dataList = groupSeriesData.get(groupKey) ?? [];
                       if (dataList.length === 0) return null;
-                      const chartSeries = showAnomalyOnlySeriesLines
-                        ? dataList.filter((d) => (anomalyCountBySeriesID.get(d.id) ?? 0) > 0)
+                      const tagFiltered = (tagFilter.include.size > 0 || tagFilter.exclude.size > 0)
+                        ? dataList.filter((d) => matchesTagFilter(d.tags ?? [], tagFilter))
                         : dataList;
+                      const chartSeries = showAnomalyOnlySeriesLines
+                        ? tagFiltered.filter((d) => (anomalyCountBySeriesID.get(d.id) ?? 0) > 0)
+                        : tagFiltered;
                       if (chartSeries.length === 0) return null;
                       const seriesIDs = new Set(chartSeries.map((d) => d.id));
                       const seriesAnomalies = anomalies.filter((a) => a.sourceSeriesId && seriesIDs.has(a.sourceSeriesId));

--- a/cmd/observer-testbench/ui/src/components/SeriesTree.tsx
+++ b/cmd/observer-testbench/ui/src/components/SeriesTree.tsx
@@ -276,8 +276,8 @@ export function SeriesTree({
   }
 
   return (
-    <div className="flex flex-col h-full min-h-0">
-      <div className="flex gap-1 mb-2 flex-wrap flex-shrink-0">
+    <div className="flex flex-col">
+      <div className="flex gap-1 mb-2 flex-wrap">
         <button
           onClick={expandAll}
           className="text-xs px-1.5 py-0.5 bg-slate-700 hover:bg-slate-600 rounded text-slate-400"
@@ -301,7 +301,7 @@ export function SeriesTree({
         </button>
       </div>
 
-      <div className="overflow-y-auto flex-1 min-h-0 pr-1">
+      <div className="pr-1">
         {Array.from(tree.children.values()).map((child) => (
           <TreeNodeComponent
             key={child.fullPath}

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -6,6 +6,7 @@
 package observerimpl
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -46,6 +47,36 @@ func (v *logDataView) GetTimestampMs() int64 {
 	return v.data.TimestampMs
 }
 
+// EpisodePhase represents a time phase within an episode (baseline, disruption, cooldown, warmup).
+type EpisodePhase struct {
+	Start string `json:"start"`
+	End   string `json:"end"`
+}
+
+// EpisodeScenario describes the scenario context within an episode.
+type EpisodeScenario struct {
+	AppName         string `json:"app_name"`
+	Description     string `json:"description"`
+	LongDescription string `json:"long_description"`
+}
+
+// EpisodeInfo holds the parsed episode.json metadata for a scenario run.
+// The file is optional; if absent, EpisodeInfo will be nil.
+type EpisodeInfo struct {
+	Episode     string          `json:"episode,omitempty"`
+	Cycle       int             `json:"cycle,omitempty"`
+	Scenario    EpisodeScenario `json:"scenario,omitempty"`
+	Environment string          `json:"environment,omitempty"`
+	ExecutionID string          `json:"execution_id,omitempty"`
+	Success     bool            `json:"success,omitempty"`
+	StartTime   string          `json:"start_time,omitempty"`
+	EndTime     string          `json:"end_time,omitempty"`
+	Warmup      *EpisodePhase   `json:"warmup,omitempty"`
+	Baseline    *EpisodePhase   `json:"baseline,omitempty"`
+	Disruption  *EpisodePhase   `json:"disruption,omitempty"`
+	Cooldown    *EpisodePhase   `json:"cooldown,omitempty"`
+}
+
 // TestBenchConfig configures the test bench.
 type TestBenchConfig struct {
 	ScenariosDir string
@@ -57,7 +88,6 @@ type TestBenchConfig struct {
 	// If a name is present, its value overrides the registry DefaultEnabled.
 	// Components not listed use their registry default.
 	EnableOverrides map[string]bool
-
 }
 
 // TestBench is the main controller for the observer test bench.
@@ -69,6 +99,7 @@ type TestBench struct {
 	storage        *timeSeriesStorage
 	loadedScenario string
 	ready          bool
+	episodeInfo    *EpisodeInfo
 
 	// Components (log detectors are not registry-managed)
 	logDetectors []observerdef.LogDetector
@@ -126,6 +157,7 @@ type StatusResponse struct {
 	CorrelatorsProcessing bool         `json:"correlatorsProcessing"`
 	ScenarioStart         *int64       `json:"scenarioStart,omitempty"`
 	ScenarioEnd           *int64       `json:"scenarioEnd,omitempty"`
+	EpisodeInfo           *EpisodeInfo `json:"episodeInfo,omitempty"`
 	ServerConfig          ServerConfig `json:"serverConfig"`
 }
 
@@ -277,6 +309,15 @@ func (tb *TestBench) LoadScenario(name string) error {
 	tb.logAnomaliesByDetector = make(map[string][]observerdef.Anomaly)
 	tb.ready = false
 	tb.loadedScenario = name
+
+	// Try to read optional episode.json metadata
+	tb.episodeInfo = nil
+	if data, err := os.ReadFile(filepath.Join(scenarioPath, "episode.json")); err == nil {
+		var info EpisodeInfo
+		if jsonErr := json.Unmarshal(data, &info); jsonErr == nil {
+			tb.episodeInfo = &info
+		}
+	}
 
 	// Reset ALL correlators (not just enabled) so disabled ones clear stale state
 	tb.resetAllState()
@@ -550,6 +591,7 @@ func (tb *TestBench) GetStatus() StatusResponse {
 		CorrelatorsProcessing: tb.correlatorsProcessing,
 		ScenarioStart:         scenarioStartPtr,
 		ScenarioEnd:           scenarioEndPtr,
+		EpisodeInfo:           tb.episodeInfo,
 		ServerConfig: ServerConfig{
 			Components: compMap,
 		},


### PR DESCRIPTION
### What does this PR do?

This reads the `episode.json` scenario output (we have to rename it and put it across the parquet files) such that we can see details and the multiple parts of the scenario.

Other fixes:
- Fixed issues with the log timeline to be sure we see it correctly.
- The sidebar / header are now sticky.

<img width="2536" height="514" alt="Screenshot 2026-03-05 at 13 21 14" src="https://github.com/user-attachments/assets/43b56eb1-0be0-4f55-94a5-2ac2e36869cb" />

### Motivation

### Describe how you validated your changes

### Additional Notes
