### PR TITLE
Update outdated comments in pkg/shell

### DIFF
--- a/pkg/shell/interp/api.go
+++ b/pkg/shell/interp/api.go
@@ -1,16 +1,13 @@
 // Copyright (c) 2017, Daniel Martí <mvdan@mvdan.cc>
 // See LICENSE for licensing information
 
-// Package interp implements an interpreter that executes shell
-// programs. It aims to support POSIX, but its support is not complete
-// yet. It also supports some Bash features.
+// Package interp implements a restricted shell interpreter designed for
+// safe, sandboxed execution. It supports a subset of Bash syntax with
+// many features intentionally blocked (see [validateNode]).
 //
-// The interpreter generally aims to behave like Bash,
-// but it does not support all of its features.
-//
-// The interpreter currently aims to behave like a non-interactive shell,
-// which is how most shells run scripts, and is more useful to machines.
-// In the future, it may gain an option to behave like an interactive shell.
+// The interpreter behaves like a non-interactive shell. External command
+// execution and filesystem access are denied by default and must be
+// explicitly enabled via [RunnerOption] functions.
 package interp
 
 import (
@@ -43,7 +40,8 @@ type Runner struct {
 	Dir string
 
 	// Params are the current shell parameters, e.g. from running a shell
-	// file. Accessible via the $@/$* family of vars.
+	// file. Note: positional parameter expansion ($@, $*, $1, etc.) is
+	// blocked by the AST validator in this restricted interpreter.
 	Params []string
 
 	// execHandler is responsible for executing programs. It must not be nil.
@@ -103,15 +101,10 @@ type Runner struct {
 // exitStatus holds the state of the shell after running one command.
 // Beyond the exit status code, it also holds whether the shell should return or exit,
 // as well as any Go error values that should be given back to the user.
-//
-// TODO(v4): consider replacing ExitStatus with a struct like this,
-// so that an [ExecHandlerFunc] can e.g. mimic `exit 0` or fatal errors
-// with specific exit codes.
 type exitStatus struct {
 	// code is the exit status code.
 	code uint8
 
-	// TODO: consider an enum, as only one of these should be set at a time
 	exiting bool // whether the current shell is exiting
 	fatalExit bool // whether the current shell is exiting due to a fatal error; err below must not be nil
 
@@ -194,8 +187,6 @@ func New(opts ...RunnerOption) (*Runner, error) {
 }
 
 // RunnerOption can be passed to [New] to alter a [Runner]'s behaviour.
-// It can also be applied directly on an existing Runner,
-// such as interp.Params("-e")(runner).
 type RunnerOption func(*Runner) error
 
 func stdinFile(r io.Reader) (*os.File, error) {
@@ -317,7 +308,6 @@ func (r *Runner) Reset() {
 
 		usedNew: r.usedNew,
 	}
-	// TODO(v4): Use the supplied Env directly if it implements enough methods.
 	r.writeEnv = &overlayEnviron{parent: r.Env}
 	r.setVarString("PWD", r.Dir)
 	r.setVarString("IFS", " \t\n")
@@ -333,14 +323,11 @@ func (s ExitStatus) Error() string { return fmt.Sprintf("exit status %d", s) }
 
 // Run interprets a node, which can be a [*File], [*Stmt], or [Command]. If a non-nil
 // error is returned, it will typically contain a command's exit status, which
-// can be retrieved with [IsExitStatus].
+// can be retrieved with [errors.As] and [ExitStatus].
 //
 // Run can be called multiple times synchronously to interpret programs
 // incrementally. To reuse a [Runner] without keeping the internal shell state,
 // call Reset.
-//
-// Calling Run on an entire [*File] implies an exit, meaning that an exit trap may
-// run.
 func (r *Runner) Run(ctx context.Context, node syntax.Node) error {
 	if !r.didReset {
 		r.Reset()
@@ -383,14 +370,15 @@ func (r *Runner) Close() error {
 	return nil
 }
 
-// subshell is like [Runner.Subshell], but allows skipping some allocations and copies
-// when creating subshells which will not be used concurrently with the parent shell.
+// subshell creates a child Runner that inherits the parent's state.
+// If background is false, the child shares the parent's environment overlay
+// without copying, which is more efficient but must not be used concurrently.
 func (r *Runner) subshell(background bool) *Runner {
 	if !r.didReset {
 		r.Reset()
 	}
 	// Keep in sync with the Runner type. Manually copy fields, to not copy
-	// sensitive ones like [errgroup.Group], and to do deep copies of slices.
+	// sensitive ones, and to do deep copies of slices.
 	r2 := &Runner{
 		Dir:             r.Dir,
 		Params:          r.Params,

--- a/pkg/shell/interp/handler.go
+++ b/pkg/shell/interp/handler.go
@@ -44,8 +44,6 @@ type HandlerContext struct {
 	// It may be invalid if the operation has no relevant position information.
 	Pos syntax.Pos
 
-	// TODO(v4): use an os.File for stdin below directly.
-
 	// Stdin is the interpreter's current standard input reader.
 	// It is always an [*os.File], but the type here remains an [io.Reader]
 	// due to backwards compatibility.
@@ -61,7 +59,7 @@ type HandlerContext struct {
 // where the first argument is not a builtin.
 //
 // Returning a nil error means a zero exit status.
-// Other exit statuses can be set by returning or wrapping a [NewExitStatus] error,
+// Other exit statuses can be set by returning or wrapping an [ExitStatus] error,
 // and such an error is returned via the API if it is the last statement executed.
 // Any other error will halt the [Runner] and will be returned via the API.
 type ExecHandlerFunc func(ctx context.Context, args []string) error

--- a/pkg/shell/interp/vars.go
+++ b/pkg/shell/interp/vars.go
@@ -137,8 +137,6 @@ func (r *Runner) setVarWithIndex(prev expand.Variable, name string, index syntax
 	r.setVar(name, vr)
 }
 
-// TODO: make assignVal and [setVar] consistent with the [expand.WriteEnviron] interface
-
 // assignVal evaluates the value of an assignment.  In safe-shell, only simple
 // string assignments are supported (no append, no arrays, no NameRef).  The AST
 // validator rejects those constructs before we get here, so hitting them is a


### PR DESCRIPTION
<!-- dd-meta {"pullId":"fab58fbb-7ffa-4dfc-9047-51eff94d3768","source":"chat","resourceId":"99fc92ca-394a-461f-bb12-9aa706e7719d","workflowId":"8983a73d-ffda-4d57-8657-95a1b0e0b2f7","codeChangeId":"8983a73d-ffda-4d57-8657-95a1b0e0b2f7","sourceType":"chat"} -->
### What does this PR do?

Updates outdated comments in `pkg/shell/interp/` that were inherited from the upstream `mvdan.cc/sh` fork and no longer reflect the restricted safe-shell interpreter.

### Motivation

Several comments referenced features, types, or options that don't exist in this codebase:
- Package doc described a general POSIX/Bash interpreter instead of a restricted safe-shell
- `Params` field referenced `$@/$*` which are blocked by the AST validator
- `RunnerOption` doc referenced a non-existent `Params("-e")` option
- `Run()` doc referenced non-existent `[IsExitStatus]` and exit traps
- `ExecHandlerFunc` doc referenced non-existent `[NewExitStatus]` (should be `[ExitStatus]`)
- `subshell()` doc referenced non-existent `[Runner.Subshell]` and `[errgroup.Group]`
- Multiple `TODO(v4)` comments from upstream that are not applicable

### Describe how you validated your changes

- `go build ./pkg/shell/...` — compiles cleanly
- `go vet ./pkg/shell/...` — no warnings

### Additional Notes

Comment-only changes; no functional changes.

---

PR by Bits
[View session in Datadog](https://app.datadoghq.com/code/99fc92ca-394a-461f-bb12-9aa706e7719d)

Comment @datadog to request changes