### PR TITLE
fix(apm): obfuscate stats group SQL resource before truncation

### DIFF
--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -897,6 +897,7 @@ func (a *Agent) processStats(in *pb.ClientStatsPayload, lang, tracerVersion, con
 			if shouldObfuscate {
 				a.obfuscateStatsGroup(b)
 			}
+			b.Resource, _ = a.TruncateResource(b.Resource)
 			a.Replacer.ReplaceStatsGroup(b)
 			group.Stats[n] = b
 			n++

--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -3447,6 +3447,43 @@ func TestConvertStats(t *testing.T) {
 	}
 }
 
+func TestProcessStatsLongSQLResource(t *testing.T) {
+	// A valid SQL resource longer than MaxResourceLen (5000). Using backtick-quoted
+	// identifiers ensures the obfuscator must see the full string to tokenize it
+	// correctly — truncating before obfuscation would leave a mid-token fragment and
+	// produce textNonParsable.
+	longResource := "INSERT INTO `table` (`col1`) VALUES " + strings.Repeat("(?),", 2000)
+
+	cfg := config.New()
+	cfg.DefaultEnv = "agent_env"
+	cfg.Hostname = "agent_hostname"
+	cfg.MaxResourceLen = 5000
+
+	a := Agent{
+		Blacklister:    filters.NewBlacklister([]string{}),
+		obfuscatorConf: &obfuscate.Config{},
+		Replacer:       filters.NewReplacer([]*config.ReplaceRule{}),
+		conf:           cfg,
+	}
+
+	in := &pb.ClientStatsPayload{
+		Stats: []*pb.ClientStatsBucket{{
+			Stats: []*pb.ClientGroupedStats{{
+				Type:     "sql",
+				Resource: longResource,
+			}},
+		}},
+	}
+
+	out := a.processStats(in, "java", "v1", "", "")
+	require.Len(t, out.Stats, 1)
+	require.Len(t, out.Stats[0].Stats, 1)
+	got := out.Stats[0].Stats[0].Resource
+	assert.NotEqual(t, textNonParsable, got, "long SQL resource should be obfuscated, not treated as non-parsable")
+	assert.LessOrEqual(t, len(got), cfg.MaxResourceLen, "obfuscated resource should be truncated to MaxResourceLen")
+	assert.True(t, strings.HasPrefix(got, "INSERT INTO"), "obfuscated resource should start with INSERT INTO, got: %q", got)
+}
+
 func TestMergeDuplicates(t *testing.T) {
 	in := &pb.ClientStatsBucket{
 		Stats: []*pb.ClientGroupedStats{

--- a/pkg/trace/agent/normalizer.go
+++ b/pkg/trace/agent/normalizer.go
@@ -455,7 +455,6 @@ func (a *Agent) normalizeStatsGroup(b *pb.ClientGroupedStats, lang string) {
 	if b.Resource == "" {
 		b.Resource = b.Name
 	}
-	b.Resource, _ = a.TruncateResource(b.Resource)
 }
 
 func isValidStatusCode(sc string) bool {

--- a/releasenotes/notes/APMObfuscateTruncatedSQL-485c15b19bbb4212.yaml
+++ b/releasenotes/notes/APMObfuscateTruncatedSQL-485c15b19bbb4212.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: Fix an issue where SQL stats group resources longer than 5000 characters were truncated before obfuscation, causing the trace-agent to fail to parse mid-token fragments and log an error instead of correctly obfuscating the query.


### PR DESCRIPTION
### What does this PR do?
Long SQL resources were truncated to 5000 chars before obfuscation, leaving mid-token fragments that the SQL tokenizer could not parse, resulting in 'Non-parsable SQL query' errors. Move TruncateResource to run after obfuscateStatsGroup, matching the span pipeline order.

### Motivation

See above

### Describe how you validated your changes

unit test

### Additional Notes
