### PR TITLE
Port rtloader tests to bazel (linux and macos)

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -16,6 +16,11 @@ package(default_visibility = ["//visibility:public"])
 # gazelle:exclude internal/tools/independent-lint
 # gazelle:exclude internal/tools/modformatter
 # gazelle:exclude pkg
+# TODO(agent-build): This exclusion is ready for removal, blocked by issues caused by the interaction of
+# Bazel with directories named `build` created by the CMake builds. We can remove this once we remove CMake
+# support or we upgrade to a Bazel version containing a fix: https://github.com/bazelbuild/bazel/pull/26842
+# In the meantime, temporarily remove this exclusion locally if regeneration of BUILD files is required
+# gazelle:exclude rtloader
 # gazelle:exclude tasks
 # gazelle:exclude test
 # gazelle:exclude tools

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -16,7 +16,6 @@ package(default_visibility = ["//visibility:public"])
 # gazelle:exclude internal/tools/independent-lint
 # gazelle:exclude internal/tools/modformatter
 # gazelle:exclude pkg
-# gazelle:exclude rtloader
 # gazelle:exclude tasks
 # gazelle:exclude test
 # gazelle:exclude tools

--- a/deps/cpython.BUILD.bazel
+++ b/deps/cpython.BUILD.bazel
@@ -315,6 +315,7 @@ select_file(
     name = "python3_bin",
     srcs = ":python_unix",
     subpath = "bin/python{}".format(VERSION_STR),
+    visibility = ["//visibility:public"],
 )
 
 # Using a copy here is the most convenient way to exclude a bunch of things for the final package

--- a/rtloader/BUILD.bazel
+++ b/rtloader/BUILD.bazel
@@ -45,17 +45,8 @@ cc_library(
         "rtloader/api.cpp",
         "rtloader/rtloader.cpp",
     ],
-    hdrs = [
-        "common/rtloader_mem.h",
-        "include/datadog_agent_rtloader.h",
-        "include/rtloader_types.h",
-    ],
+    hdrs = [":rtloader_headers"],
     cxxopts = COMMON_CXXOPTS,
-    includes = [
-        ".",
-        "common",
-        "include",
-    ],
     linkopts = [
         # Make up for the fact that we may be using gcc and not g++
         "-lstdc++",
@@ -74,10 +65,29 @@ cc_library(
         ],
         "//conditions:default": [],
     }),
+    visibility = ["//visibility:public"],
+    deps = [":rtloader_headers"],
+)
+
+cc_library(
+    name = "rtloader_headers",
+    hdrs = [
+        "common/rtloader_mem.h",
+        "include/datadog_agent_rtloader.h",
+        "include/rtloader.h",
+        "include/rtloader_types.h",
+    ],
+    includes = [
+        ".",
+        "common",
+        "include",
+    ],
+    visibility = [":__subpackages__"],
 )
 
 cc_shared_library(
     name = "datadog-agent-rtloader",
+    visibility = [":__subpackages__"],
     deps = [":rtloader"],
 )
 
@@ -129,6 +139,7 @@ cc_library(
         "three/three.h",
         "three/three_mem.cpp",
     ],
+    hdrs = [":three_headers"],
     copts = select({
         "@platforms//os:windows": [],
         "//conditions:default": [
@@ -156,6 +167,7 @@ cc_library(
             "DATADOG_AGENT_THREE",
         ],
     }),
+    visibility = ["//visibility:public"],
     deps = [":rtloader"] + select({
         "@platforms//os:windows": [
             "@cpython//:lib_win",
@@ -167,6 +179,13 @@ cc_library(
             "@cpython//:python_unix_shared",
         ],
     }),
+)
+
+cc_library(
+    name = "three_headers",
+    hdrs = ["common/cgo_free.h"],
+    includes = ["common"],
+    visibility = [":__subpackages__"],
 )
 
 cc_shared_library(
@@ -196,6 +215,7 @@ cc_shared_library(
             "-Wl,-undefined,error",
         ],
     }),
+    visibility = ["//visibility:public"],
     deps = [
         ":three",
     ],

--- a/rtloader/BUILD.bazel
+++ b/rtloader/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_import.bzl", "cc_import")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_shared_library.bzl", "cc_shared_library")
 load("@rules_license//rules:license.bzl", "license")
@@ -89,6 +90,22 @@ cc_shared_library(
     name = "datadog-agent-rtloader",
     visibility = [":__subpackages__"],
     deps = [":rtloader"],
+)
+
+cc_import(
+    name = "_rtloader_shared",
+    shared_library = "//rtloader:datadog-agent-rtloader",
+)
+
+# Headers + dynamic link against libdatadog-agent-rtloader.so.
+# Use in go_library cdeps instead of //rtloader:rtloader to avoid static linking.
+cc_library(
+    name = "rtloader_dynamic",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":_rtloader_shared",
+        "//rtloader:rtloader_headers",
+    ],
 )
 
 so_symlink(

--- a/rtloader/test/BUILD.bazel
+++ b/rtloader/test/BUILD.bazel
@@ -1,0 +1,27 @@
+load("@rules_cc//cc:cc_import.bzl", "cc_import")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+# gazelle:map_kind go_test rtloader_go_test //rtloader/test:defs.bzl
+# gazelle:map_kind go_library rtloader_go_library //rtloader/test:defs.bzl
+
+filegroup(
+    name = "python_stubs",
+    srcs = glob(["python/**/*.py"]),
+    visibility = ["//rtloader/test:__subpackages__"],
+)
+
+cc_import(
+    name = "_rtloader_shared",
+    shared_library = "//rtloader:datadog-agent-rtloader",
+)
+
+# Headers + dynamic link against libdatadog-agent-rtloader.so.
+# Use in go_library cdeps instead of //rtloader:rtloader to avoid static linking.
+cc_library(
+    name = "rtloader_dynamic",
+    visibility = ["//rtloader/test:__subpackages__"],
+    deps = [
+        ":_rtloader_shared",
+        "//rtloader:rtloader_headers",
+    ],
+)

--- a/rtloader/test/BUILD.bazel
+++ b/rtloader/test/BUILD.bazel
@@ -1,6 +1,3 @@
-load("@rules_cc//cc:cc_import.bzl", "cc_import")
-load("@rules_cc//cc:cc_library.bzl", "cc_library")
-
 # gazelle:map_kind go_test rtloader_go_test //rtloader/test:defs.bzl
 # gazelle:map_kind go_library rtloader_test_go_library //rtloader/test:defs.bzl
 
@@ -8,20 +5,4 @@ filegroup(
     name = "python_stubs",
     srcs = glob(["python/**/*.py"]),
     visibility = ["//rtloader/test:__subpackages__"],
-)
-
-cc_import(
-    name = "_rtloader_shared",
-    shared_library = "//rtloader:datadog-agent-rtloader",
-)
-
-# Headers + dynamic link against libdatadog-agent-rtloader.so.
-# Use in go_library cdeps instead of //rtloader:rtloader to avoid static linking.
-cc_library(
-    name = "rtloader_dynamic",
-    visibility = ["//rtloader/test:__subpackages__"],
-    deps = [
-        ":_rtloader_shared",
-        "//rtloader:rtloader_headers",
-    ],
 )

--- a/rtloader/test/BUILD.bazel
+++ b/rtloader/test/BUILD.bazel
@@ -2,7 +2,7 @@ load("@rules_cc//cc:cc_import.bzl", "cc_import")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 # gazelle:map_kind go_test rtloader_go_test //rtloader/test:defs.bzl
-# gazelle:map_kind go_library rtloader_go_library //rtloader/test:defs.bzl
+# gazelle:map_kind go_library rtloader_test_go_library //rtloader/test:defs.bzl
 
 filegroup(
     name = "python_stubs",

--- a/rtloader/test/aggregator/BUILD.bazel
+++ b/rtloader/test/aggregator/BUILD.bazel
@@ -1,6 +1,6 @@
-load("//rtloader/test:defs.bzl", "rtloader_go_library", "rtloader_go_test")
+load("//rtloader/test:defs.bzl", "rtloader_go_test", "rtloader_test_go_library")
 
-rtloader_go_library(
+rtloader_test_go_library(
     name = "aggregator",
     srcs = ["aggregator.go"],
     cgo = True,

--- a/rtloader/test/aggregator/BUILD.bazel
+++ b/rtloader/test/aggregator/BUILD.bazel
@@ -1,0 +1,20 @@
+load("//rtloader/test:defs.bzl", "rtloader_go_library", "rtloader_go_test")
+
+rtloader_go_library(
+    name = "aggregator",
+    srcs = ["aggregator.go"],
+    cgo = True,
+    importpath = "github.com/DataDog/datadog-agent/rtloader/test/aggregator",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//rtloader/test/common",
+        "//rtloader/test/helpers",
+    ],
+)
+
+rtloader_go_test(
+    name = "aggregator_test",
+    srcs = ["aggregator_test.go"],
+    embed = [":aggregator"],
+    deps = ["//rtloader/test/helpers"],
+)

--- a/rtloader/test/common/BUILD.bazel
+++ b/rtloader/test/common/BUILD.bazel
@@ -1,6 +1,6 @@
-load("//rtloader/test:defs.bzl", "rtloader_go_library", "rtloader_go_test")
+load("//rtloader/test:defs.bzl", "rtloader_go_test", "rtloader_test_go_library")
 
-rtloader_go_library(
+rtloader_test_go_library(
     name = "common",
     srcs = [
         "cgo_free.go",

--- a/rtloader/test/common/BUILD.bazel
+++ b/rtloader/test/common/BUILD.bazel
@@ -1,0 +1,22 @@
+load("//rtloader/test:defs.bzl", "rtloader_go_library", "rtloader_go_test")
+
+rtloader_go_library(
+    name = "common",
+    srcs = [
+        "cgo_free.go",
+        "cgo_free_three.go",
+        "common_three.go",
+    ],
+    cgo = True,
+    clinkopts = [],  # keep: ignore cgo directives
+    importpath = "github.com/DataDog/datadog-agent/rtloader/test/common",
+    visibility = ["//visibility:public"],
+    deps = ["//rtloader/test/helpers"],
+)
+
+rtloader_go_test(
+    name = "common_test",
+    srcs = ["cgo_free_test.go"],
+    embed = [":common"],
+    deps = ["//rtloader/test/helpers"],
+)

--- a/rtloader/test/common/common_three.go
+++ b/rtloader/test/common/common_three.go
@@ -9,7 +9,11 @@ package testcommon
 //
 import "C"
 
-import "unsafe"
+import (
+	"os"
+	"path/filepath"
+	"unsafe"
+)
 
 // GetRtLoader returns a RtLoader instance
 func GetRtLoader() *C.rtloader_t {
@@ -18,5 +22,17 @@ func GetRtLoader() *C.rtloader_t {
 	executablePath := C.CString("/folder/mock_python_interpeter_bin_path")
 	defer C.free(unsafe.Pointer(executablePath))
 
-	return C.make3(nil, executablePath, &err)
+	var pythonHome *C.char
+	// Use an explicit "Python Home" (the root directory of the Python installation)
+	// Intended for driving the tests from Bazel
+	if pythonBin := os.Getenv("PYTHON_BIN"); pythonBin != "" {
+		// PYTHON_BIN points to the python executable under bin
+		// Get the full path based on Bazel-provided variables
+		absPath := filepath.Join(os.Getenv("TEST_SRCDIR"), os.Getenv("TEST_WORKSPACE"), pythonBin)
+		// And then walk back to get the "Python Home"
+		pythonHome = C.CString(filepath.Dir(filepath.Dir(absPath)))
+		defer C.free(unsafe.Pointer(pythonHome))
+	}
+
+	return C.make3(pythonHome, executablePath, &err)
 }

--- a/rtloader/test/containers/BUILD.bazel
+++ b/rtloader/test/containers/BUILD.bazel
@@ -1,6 +1,6 @@
-load("//rtloader/test:defs.bzl", "rtloader_go_library", "rtloader_go_test")
+load("//rtloader/test:defs.bzl", "rtloader_go_test", "rtloader_test_go_library")
 
-rtloader_go_library(
+rtloader_test_go_library(
     name = "containers",
     srcs = ["containers.go"],
     cgo = True,

--- a/rtloader/test/containers/BUILD.bazel
+++ b/rtloader/test/containers/BUILD.bazel
@@ -1,0 +1,20 @@
+load("//rtloader/test:defs.bzl", "rtloader_go_library", "rtloader_go_test")
+
+rtloader_go_library(
+    name = "containers",
+    srcs = ["containers.go"],
+    cgo = True,
+    importpath = "github.com/DataDog/datadog-agent/rtloader/test/containers",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//rtloader/test/common",
+        "//rtloader/test/helpers",
+    ],
+)
+
+rtloader_go_test(
+    name = "containers_test",
+    srcs = ["containers_test.go"],
+    embed = [":containers"],
+    deps = ["//rtloader/test/helpers"],
+)

--- a/rtloader/test/datadog_agent/BUILD.bazel
+++ b/rtloader/test/datadog_agent/BUILD.bazel
@@ -1,6 +1,6 @@
-load("//rtloader/test:defs.bzl", "rtloader_go_library", "rtloader_go_test")
+load("//rtloader/test:defs.bzl", "rtloader_go_test", "rtloader_test_go_library")
 
-rtloader_go_library(
+rtloader_test_go_library(
     name = "datadog_agent",
     srcs = ["datadog_agent.go"],
     cgo = True,

--- a/rtloader/test/datadog_agent/BUILD.bazel
+++ b/rtloader/test/datadog_agent/BUILD.bazel
@@ -1,0 +1,29 @@
+load("//rtloader/test:defs.bzl", "rtloader_go_library", "rtloader_go_test")
+
+rtloader_go_library(
+    name = "datadog_agent",
+    srcs = ["datadog_agent.go"],
+    cgo = True,
+    importpath = "github.com/DataDog/datadog-agent/rtloader/test/datadog_agent",
+    tags = ["manual"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//rtloader/test/common",
+        "//rtloader/test/helpers",
+        "@com_github_datadog_datadog_agent_pkg_obfuscate//:obfuscate",
+    ],
+)
+
+# TODO(agent-build): remove manual tag once pkg/ is migrated to Bazel.
+# @com_github_datadog_datadog_agent_pkg_obfuscate is excluded from bazelify_go_work
+# (via `# gazelle:exclude pkg` in the root BUILD.bazel) so it cannot be fetched yet.
+rtloader_go_test(
+    name = "datadog_agent_test",
+    srcs = [
+        "datadog_agent_py3_test.go",
+        "datadog_agent_test.go",
+    ],
+    embed = [":datadog_agent"],
+    tags = ["manual"],
+    deps = ["//rtloader/test/helpers"],
+)

--- a/rtloader/test/defs.bzl
+++ b/rtloader/test/defs.bzl
@@ -1,0 +1,58 @@
+"""Bazel rules for rtloader tests."""
+
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+def rtloader_go_library(**kwargs):
+    """A go_library wrapper that adds the rtloader library.
+
+    Args:
+      **kwargs: arguments to be forwarded to go_library
+    """
+    cdeps = kwargs.pop("cdeps", []) + ["//rtloader/test:rtloader_dynamic"]
+
+    go_library(
+        cdeps = cdeps,
+        # WIP: support for windows to come later
+        target_compatible_with = select({
+            "@platforms//os:linux": [],
+            "@platforms//os:macos": [],
+            "@platforms//os:windows": ["@platforms//:incompatible"],
+        }),
+        **kwargs
+    )
+
+def rtloader_go_test(**kwargs):
+    """A go_test wrapper for rtloader tests that sets up the all the necessary dynamic libraries and runtime context.
+
+    Args:
+      **kwargs: arguments to be forwarded to go_test
+    """
+    env = {
+        "LD_LIBRARY_PATH": ".",
+        "PYTHON_BIN": "$(rootpath @cpython//:python3_bin)",
+        "PYTHONPATH": "test/python",
+    }
+    env.update(kwargs.pop("env", {}))
+    data = kwargs.pop("data", []) + [
+        "//rtloader:datadog-agent-three",
+        "@cpython//:python_unix",
+        "@cpython//:python3_bin",
+        "//rtloader/test:python_stubs",
+    ]
+    cdeps = kwargs.pop("cdeps", []) + ["//rtloader/test:rtloader_dynamic"]
+
+    go_test(
+        # Running from the folder where the "three" library we want to dlopen simplifies finding it
+        # at runtime for macos, where we can't modify the library search path as easily.
+        rundir = "rtloader",
+        data = data,
+        env = env,
+        cdeps = cdeps,
+        # WIP: support for windows to come later
+        target_compatible_with = select({
+            "@platforms//os:linux": [],
+            "@platforms//os:macos": [],
+            "@platforms//os:windows": ["@platforms//:incompatible"],
+        }),
+        **kwargs
+    )

--- a/rtloader/test/defs.bzl
+++ b/rtloader/test/defs.bzl
@@ -8,7 +8,7 @@ def rtloader_test_go_library(**kwargs):
     Args:
       **kwargs: arguments to be forwarded to go_library
     """
-    cdeps = kwargs.pop("cdeps", []) + ["//rtloader/test:rtloader_dynamic"]
+    cdeps = kwargs.pop("cdeps", []) + ["//rtloader:rtloader_dynamic"]
 
     go_library(
         cdeps = cdeps,
@@ -40,7 +40,6 @@ def rtloader_go_test(**kwargs):
         "@cpython//:python3_bin",
         "//rtloader/test:python_stubs",
     ]
-    cdeps = kwargs.pop("cdeps", []) + ["//rtloader/test:rtloader_dynamic"]
 
     go_test(
         # Running from the folder where the "three" library we want to dlopen simplifies finding it
@@ -48,7 +47,6 @@ def rtloader_go_test(**kwargs):
         rundir = "rtloader",
         data = data,
         env = env,
-        cdeps = cdeps,
         # WIP: support for windows to come later
         target_compatible_with = select({
             "@platforms//os:linux": [],

--- a/rtloader/test/defs.bzl
+++ b/rtloader/test/defs.bzl
@@ -18,6 +18,7 @@ def rtloader_test_go_library(**kwargs):
             "@platforms//os:macos": [],
             "@platforms//os:windows": ["@platforms//:incompatible"],
         }),
+        testonly = True,
         **kwargs
     )
 

--- a/rtloader/test/defs.bzl
+++ b/rtloader/test/defs.bzl
@@ -2,7 +2,7 @@
 
 load("@rules_go//go:def.bzl", "go_library", "go_test")
 
-def rtloader_go_library(**kwargs):
+def rtloader_test_go_library(**kwargs):
     """A go_library wrapper that adds the rtloader library.
 
     Args:

--- a/rtloader/test/helpers/BUILD.bazel
+++ b/rtloader/test/helpers/BUILD.bazel
@@ -1,6 +1,6 @@
-load("//rtloader/test:defs.bzl", "rtloader_go_library")
+load("//rtloader/test:defs.bzl", "rtloader_test_go_library")
 
-rtloader_go_library(
+rtloader_test_go_library(
     name = "helpers",
     srcs = [
         "helpers.go",

--- a/rtloader/test/helpers/BUILD.bazel
+++ b/rtloader/test/helpers/BUILD.bazel
@@ -1,0 +1,13 @@
+load("//rtloader/test:defs.bzl", "rtloader_go_library")
+
+rtloader_go_library(
+    name = "helpers",
+    srcs = [
+        "helpers.go",
+        "helpers_native.go",
+    ],
+    cgo = True,
+    importpath = "github.com/DataDog/datadog-agent/rtloader/test/helpers",
+    visibility = ["//visibility:public"],
+    deps = ["@com_github_stretchr_testify//assert"],
+)

--- a/rtloader/test/init/BUILD.bazel
+++ b/rtloader/test/init/BUILD.bazel
@@ -1,0 +1,23 @@
+load("//rtloader/test:defs.bzl", "rtloader_go_library", "rtloader_go_test")
+
+rtloader_go_library(
+    name = "init",
+    srcs = [
+        "init.go",
+        "init_three.go",
+    ],
+    cgo = True,
+    importpath = "github.com/DataDog/datadog-agent/rtloader/test/init",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//rtloader/test/common",
+        "//rtloader/test/helpers",
+    ],
+)
+
+rtloader_go_test(
+    name = "init_test",
+    srcs = ["init_test.go"],
+    embed = [":init"],
+    deps = ["//rtloader/test/helpers"],
+)

--- a/rtloader/test/init/BUILD.bazel
+++ b/rtloader/test/init/BUILD.bazel
@@ -1,6 +1,6 @@
-load("//rtloader/test:defs.bzl", "rtloader_go_library", "rtloader_go_test")
+load("//rtloader/test:defs.bzl", "rtloader_go_test", "rtloader_test_go_library")
 
-rtloader_go_library(
+rtloader_test_go_library(
     name = "init",
     srcs = [
         "init.go",

--- a/rtloader/test/kubeutil/BUILD.bazel
+++ b/rtloader/test/kubeutil/BUILD.bazel
@@ -1,0 +1,20 @@
+load("//rtloader/test:defs.bzl", "rtloader_go_library", "rtloader_go_test")
+
+rtloader_go_library(
+    name = "kubeutil",
+    srcs = ["kubeutil.go"],
+    cgo = True,
+    importpath = "github.com/DataDog/datadog-agent/rtloader/test/kubeutil",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//rtloader/test/common",
+        "//rtloader/test/helpers",
+    ],
+)
+
+rtloader_go_test(
+    name = "kubeutil_test",
+    srcs = ["kubeutil_test.go"],
+    embed = [":kubeutil"],
+    deps = ["//rtloader/test/helpers"],
+)

--- a/rtloader/test/kubeutil/BUILD.bazel
+++ b/rtloader/test/kubeutil/BUILD.bazel
@@ -1,6 +1,6 @@
-load("//rtloader/test:defs.bzl", "rtloader_go_library", "rtloader_go_test")
+load("//rtloader/test:defs.bzl", "rtloader_go_test", "rtloader_test_go_library")
 
-rtloader_go_library(
+rtloader_test_go_library(
     name = "kubeutil",
     srcs = ["kubeutil.go"],
     cgo = True,

--- a/rtloader/test/rtloader/BUILD.bazel
+++ b/rtloader/test/rtloader/BUILD.bazel
@@ -1,0 +1,21 @@
+load("//rtloader/test:defs.bzl", "rtloader_go_library", "rtloader_go_test")
+
+rtloader_go_library(
+    name = "rtloader",
+    srcs = ["rtloader.go"],
+    cgo = True,
+    importpath = "github.com/DataDog/datadog-agent/rtloader/test/rtloader",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//rtloader/test/common",
+        "//rtloader/test/helpers",
+        "@in_yaml_go_yaml_v2//:yaml",
+    ],
+)
+
+rtloader_go_test(
+    name = "rtloader_test",
+    srcs = ["rtloader_test.go"],
+    embed = [":rtloader"],
+    deps = ["//rtloader/test/helpers"],
+)

--- a/rtloader/test/rtloader/BUILD.bazel
+++ b/rtloader/test/rtloader/BUILD.bazel
@@ -1,6 +1,6 @@
-load("//rtloader/test:defs.bzl", "rtloader_go_library", "rtloader_go_test")
+load("//rtloader/test:defs.bzl", "rtloader_go_test", "rtloader_test_go_library")
 
-rtloader_go_library(
+rtloader_test_go_library(
     name = "rtloader",
     srcs = ["rtloader.go"],
     cgo = True,

--- a/rtloader/test/tagger/BUILD.bazel
+++ b/rtloader/test/tagger/BUILD.bazel
@@ -1,6 +1,6 @@
-load("//rtloader/test:defs.bzl", "rtloader_go_library", "rtloader_go_test")
+load("//rtloader/test:defs.bzl", "rtloader_go_test", "rtloader_test_go_library")
 
-rtloader_go_library(
+rtloader_test_go_library(
     name = "tagger",
     srcs = ["tagger.go"],
     cgo = True,

--- a/rtloader/test/tagger/BUILD.bazel
+++ b/rtloader/test/tagger/BUILD.bazel
@@ -1,0 +1,20 @@
+load("//rtloader/test:defs.bzl", "rtloader_go_library", "rtloader_go_test")
+
+rtloader_go_library(
+    name = "tagger",
+    srcs = ["tagger.go"],
+    cgo = True,
+    importpath = "github.com/DataDog/datadog-agent/rtloader/test/tagger",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//rtloader/test/common",
+        "//rtloader/test/helpers",
+    ],
+)
+
+rtloader_go_test(
+    name = "tagger_test",
+    srcs = ["tagger_test.go"],
+    embed = [":tagger"],
+    deps = ["//rtloader/test/helpers"],
+)

--- a/rtloader/test/util/BUILD.bazel
+++ b/rtloader/test/util/BUILD.bazel
@@ -1,0 +1,20 @@
+load("//rtloader/test:defs.bzl", "rtloader_go_library", "rtloader_go_test")
+
+rtloader_go_library(
+    name = "util",
+    srcs = ["util.go"],
+    cgo = True,
+    importpath = "github.com/DataDog/datadog-agent/rtloader/test/util",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//rtloader/test/common",
+        "//rtloader/test/helpers",
+    ],
+)
+
+rtloader_go_test(
+    name = "util_test",
+    srcs = ["util_test.go"],
+    embed = [":util"],
+    deps = ["//rtloader/test/helpers"],
+)

--- a/rtloader/test/util/BUILD.bazel
+++ b/rtloader/test/util/BUILD.bazel
@@ -1,6 +1,6 @@
-load("//rtloader/test:defs.bzl", "rtloader_go_library", "rtloader_go_test")
+load("//rtloader/test:defs.bzl", "rtloader_go_test", "rtloader_test_go_library")
 
-rtloader_go_library(
+rtloader_test_go_library(
     name = "util",
     srcs = ["util.go"],
     cgo = True,

--- a/rtloader/test/uutil/BUILD.bazel
+++ b/rtloader/test/uutil/BUILD.bazel
@@ -1,0 +1,23 @@
+load("//rtloader/test:defs.bzl", "rtloader_go_library", "rtloader_go_test")
+
+rtloader_go_library(
+    name = "uutil",
+    srcs = ["uutil.go"],
+    cgo = True,
+    copts = [
+        "-Wno-deprecated-declarations",  # keep
+    ],
+    importpath = "github.com/DataDog/datadog-agent/rtloader/test/uutil",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//rtloader/test/common",
+        "//rtloader/test/helpers",
+    ],
+)
+
+rtloader_go_test(
+    name = "uutil_test",
+    srcs = ["uutil_test.go"],
+    embed = [":uutil"],
+    deps = ["//rtloader/test/helpers"],
+)

--- a/rtloader/test/uutil/BUILD.bazel
+++ b/rtloader/test/uutil/BUILD.bazel
@@ -1,6 +1,6 @@
-load("//rtloader/test:defs.bzl", "rtloader_go_library", "rtloader_go_test")
+load("//rtloader/test:defs.bzl", "rtloader_go_test", "rtloader_test_go_library")
 
-rtloader_go_library(
+rtloader_test_go_library(
     name = "uutil",
     srcs = ["uutil.go"],
     cgo = True,


### PR DESCRIPTION
### What does this PR do?

Ports rtloader tests to Bazel, such that they can be run with `bazel test //rtloader/...`.

This only covers Linux and macos for now, though most of the work should be also applicable to windows; but it's different enough that it's better handled in a follow-up.

### Motivation

Part of migrating rtloader to Bazel ([ABLD-323](https://datadoghq.atlassian.net/browse/ABLD-323)).

### Describe how you validated your changes

I ran `bazel test //rtloader/...` locally successfully, and I also used `ldd` to verify that the test binaries were linking dynamically to their dependencies, to match how it's implemented in CMake, as well as how rtloader is used in practice in the context of the Agent. These tests also run on CI.

### Additional Notes

- Most of the content of the newly created BUILD.bazel were gazelle-generated, by removing the exclusion on the `rtloader` folder. I had to reenable the exclusion on rtloader to avoid issues with directories named "build" (as described in https://github.com/DataDog/datadog-agent/pull/47230). I've chosen to not attempt a workaround (such as changing the output directory of CMake to something different than `build`) because it might still cause unnecessary disruption to contributors, and the rate of change that these files are likely to have is very low.
- A specific test file is excluded from `test //...` for now by setting it to manual, the reason being that it depends on another go package that is still not under bazel.
- ~~I'd like to avoid having the dependency on pyyaml, which was implicit and bazel makes explicit, for which I filed #47146. If that lands, everything I added here to wire pyyaml into the tests would be dropped.~~ This got merged and I dropped the necessary scaffolding from this PR.


[ABLD-323]: https://datadoghq.atlassian.net/browse/ABLD-323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ