### PR TITLE
[CONTINT-3330] Fix flaky TestOOMKillProbe by retrying on ENOMEM

### DIFF
--- a/pkg/collector/corechecks/ebpf/probe/oomkill/oom_kill_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/oomkill/oom_kill_test.go
@@ -69,24 +69,30 @@ func TestOOMKillProbe(t *testing.T) {
 
 		err = os.WriteFile("/proc/self/oom_score_adj", []byte("42"), 0644)
 		require.NoError(t, err)
-		cmd := exec.CommandContext(ctx, "systemd-run", "--scope", "-p", "MemoryLimit=1M", "dd", "if=/dev/zero", "of=/dev/shm/asdf", "bs=1K", "count=2K")
-		obytes, err := cmd.CombinedOutput()
-		output := string(obytes)
-		require.Error(t, err)
-		require.NotErrorIs(t, err, context.DeadlineExceeded)
 
-		var exiterr *exec.ExitError
-		require.ErrorAs(t, err, &exiterr, output)
-		var status syscall.WaitStatus
+		// Retry the dd command until the OOM killer actually kills it.
+		// Sometimes the kernel returns ENOMEM to the write() syscall instead of
+		// invoking the OOM killer, causing dd to exit gracefully with status 1.
+		var cmd *exec.Cmd
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			cmd = exec.CommandContext(ctx, "systemd-run", "--scope", "-p", "MemoryLimit=1M", "dd", "if=/dev/zero", "of=/dev/shm/asdf", "bs=1K", "count=2K")
+			obytes, err := cmd.CombinedOutput()
+			output := string(obytes)
+			require.Error(c, err)
+			require.NotErrorIs(c, err, context.DeadlineExceeded)
 
-		status, sok := exiterr.Sys().(syscall.WaitStatus)
-		require.True(t, sok, output)
+			var exiterr *exec.ExitError
+			require.ErrorAs(c, err, &exiterr, output)
 
-		if status.Signaled() {
-			require.Equal(t, unix.SIGKILL, status.Signal(), output)
-		} else {
-			require.Equal(t, 128+unix.SIGKILL, status.ExitStatus(), output)
-		}
+			status, sok := exiterr.Sys().(syscall.WaitStatus)
+			require.True(c, sok, output)
+
+			if status.Signaled() {
+				require.Equal(c, unix.SIGKILL, status.Signal(), output)
+			} else {
+				require.Equal(c, 128+unix.SIGKILL, status.ExitStatus(), output)
+			}
+		}, 30*time.Second, 1*time.Second, "failed to trigger OOM kill after multiple attempts")
 
 		var result model.OOMKillStats
 		require.Eventually(t, func() bool {


### PR DESCRIPTION
## What does this PR do?

Fixes the flaky `TestOOMKillProbe` test tracked in [CONTINT-3330](https://datadoghq.atlassian.net/browse/CONTINT-3330).

## Motivation

The test expects `dd` to be OOM-killed (SIGKILL), but sometimes the kernel returns ENOMEM to the `write()` syscall instead of invoking the OOM killer, causing `dd` to exit gracefully with status 1. This is a race condition inherent to cgroup v1 memory controllers, especially on older kernels (debian 9/4.9, ubuntu 18.04/4.18).

The ticket has accumulated 100 failure reports since July 2024 across `runtime_compiled` (37), parent test (47), and `CO-RE` (16) subtests. Every failure shows the same error at `oom_kill_test.go:88`:
```
expected: syscall.Signal(137)
actual  : int(1)
```
The test always passes on re-run, confirming classic flakiness.

## Changes

Wrap the `dd` invocation in `require.EventuallyWithT` to retry until an actual OOM kill occurs. The assertions inside the callback are identical to the original code (just `t` → `c`), keeping the diff minimal.

## Test plan

- [ ] Verify `kmt_run_sysprobe_tests_x64: [debian_9, no_usm]` passes
- [ ] Verify `kmt_run_sysprobe_tests_x64: [ubuntu_18.04, no_usm]` passes
- [ ] Monitor CONTINT-3330 for new failure reports after merge

[CONTINT-3330]: https://datadoghq.atlassian.net/browse/CONTINT-3330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ