### PR TITLE
Fix 3 bugs in pkg/shell interpreter

### DIFF
--- a/pkg/shell/interp/builtins/break_continue.go
+++ b/pkg/shell/interp/builtins/break_continue.go
@@ -28,8 +28,12 @@ func loopControl(call *CallContext, name string, args []string) Result {
 	case 1:
 		parsed, err := strconv.Atoi(args[0])
 		if err != nil {
-			call.Errf("usage: %s [n]\n", name)
+			call.Errf("%s: %s: numeric argument required\n", name, args[0])
 			return Result{Code: 2}
+		}
+		if parsed < 1 {
+			call.Errf("%s: %s: loop count out of range\n", name, args[0])
+			return Result{Code: 1}
 		}
 		n = parsed
 	default:

--- a/pkg/shell/interp/validate.go
+++ b/pkg/shell/interp/validate.go
@@ -113,6 +113,7 @@ func validateNode(node syntax.Node) error {
 // supported in the safe-shell interpreter (positional params, $#, $0, $@, $*).
 var blockedSpecialParams = map[string]bool{
 	"#": true,
+	"!": true,
 	"0": true,
 	"1": true, "2": true, "3": true, "4": true,
 	"5": true, "6": true, "7": true, "8": true, "9": true,

--- a/pkg/shell/interp/vars.go
+++ b/pkg/shell/interp/vars.go
@@ -69,6 +69,7 @@ func (o *overlayEnviron) Set(name string, vr expand.Variable) error {
 			return nil
 		}
 		delete(o.values, name)
+		return nil
 	}
 	// modifying the entire variable
 	vr.Local = prev.Local || vr.Local

--- a/pkg/shell/tests/scenarios/shell/for_clause/break_cont/break_invalid_arg.yaml
+++ b/pkg/shell/tests/scenarios/shell/for_clause/break_cont/break_invalid_arg.yaml
@@ -1,4 +1,4 @@
-description: Break with non-numeric argument produces a usage error on each iteration.
+description: Break with non-numeric argument produces an error on each iteration.
 input:
   # language=bash
   script: |+
@@ -8,7 +8,7 @@ input:
 expect:
   stdout: ""
   stderr: |+
-    usage: break [n]
-    usage: break [n]
-    usage: break [n]
+    break: abc: numeric argument required
+    break: abc: numeric argument required
+    break: abc: numeric argument required
   exit_code: 2

--- a/pkg/shell/tests/scenarios/shell/for_clause/break_cont/continue_invalid_arg.yaml
+++ b/pkg/shell/tests/scenarios/shell/for_clause/break_cont/continue_invalid_arg.yaml
@@ -1,4 +1,4 @@
-description: Continue with non-numeric argument produces a usage error on each iteration.
+description: Continue with non-numeric argument produces an error on each iteration.
 input:
   # language=bash
   script: |+
@@ -8,7 +8,7 @@ input:
 expect:
   stdout: ""
   stderr: |+
-    usage: continue [n]
-    usage: continue [n]
-    usage: continue [n]
+    continue: abc: numeric argument required
+    continue: abc: numeric argument required
+    continue: abc: numeric argument required
   exit_code: 2

--- a/pkg/shell/tests/scenarios/shell/var_expand/blocked_variables/background_pid.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/blocked_variables/background_pid.yaml
@@ -1,10 +1,10 @@
-description: The $! variable has no special meaning and expands to empty.
+description: The $! variable is blocked.
 input:
   # language=bash
   script: |+
     echo "[$!]"
 expect:
-  stdout: |+
-    []
-  stderr: ""
-  exit_code: 0
+  stdout: ""
+  stderr: |+
+    $! is not supported
+  exit_code: 2


### PR DESCRIPTION
<!-- dd-meta {"pullId":"8931283e-38fe-4ba7-ab35-aefc56e74736","source":"chat","resourceId":"3acafd1d-3dbe-4f32-bf48-6750f2586b0f","workflowId":"3b0692a5-5da8-4e9d-ab7d-5768a7eff75f","codeChangeId":"3b0692a5-5da8-4e9d-ab7d-5768a7eff75f","sourceType":"chat"} -->
### What does this PR do?

Fixes three bugs found during code review of `pkg/shell`:

1. **`overlayEnviron.Set` missing `return` on unset path** (`vars.go`): When unsetting a non-local variable, `delete(o.values, name)` was immediately undone by `o.values[name] = vr` on the next line because of a missing `return nil`. The deleted entry was re-added to the map, masking any parent value.

2. **`$!` not blocked despite documentation** (`validate.go`): `SHELL_FEATURES.md` marks `$!` as blocked, but `"!"` was missing from `blockedSpecialParams`. Now `$!` is rejected at validation time with exit code 2, consistent with other blocked special variables.

3. **`break`/`continue` accept zero and negative arguments** (`break_continue.go`): `break 0` and `break -1` were silently accepted. Bash rejects both with "loop count out of range". Now values < 1 are rejected with exit code 1, and non-numeric arguments use a bash-style "numeric argument required" error message.

### Motivation

These bugs were identified during a comprehensive code review of the safe-shell interpreter.

### Describe how you validated your changes

- `go test ./pkg/shell/... -count=1` — all tests pass
- Updated test scenarios for `$!` (now expects exit code 2 rejection) and `break`/`continue` invalid args (updated error messages)

### Additional Notes

None.

---

PR by Bits
[View session in Datadog](https://app.datadoghq.com/code/3acafd1d-3dbe-4f32-bf48-6750f2586b0f)

Comment @datadog to request changes