### PR TITLE
fix(fleet-installer): suppress expected warnings when dd-agent group/user don't exist yet

### DIFF
--- a/pkg/fleet/installer/packages/user/user.go
+++ b/pkg/fleet/installer/packages/user/user.go
@@ -164,7 +164,7 @@ func ensureGroup(ctx context.Context, groupName string) (err error) {
 	if err == nil {
 		return nil
 	}
-	var unknownGroupError *user.UnknownGroupError
+	var unknownGroupError user.UnknownGroupError
 	if !errors.As(err, &unknownGroupError) {
 		log.Warnf("error looking up %s group: %v", groupName, err)
 	}
@@ -184,7 +184,7 @@ func ensureUser(ctx context.Context, userName string, installPath string) (err e
 	if err == nil {
 		return nil
 	}
-	var unknownUserError *user.UnknownUserError
+	var unknownUserError user.UnknownUserError
 	if !errors.As(err, &unknownUserError) {
 		log.Warnf("error looking up %s user: %v", userName, err)
 	}

--- a/pkg/fleet/installer/packages/user/user_test.go
+++ b/pkg/fleet/installer/packages/user/user_test.go
@@ -1,0 +1,45 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !windows
+
+package user
+
+import (
+	"errors"
+	"os/user"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetGroupIDUnknownGroupError verifies that GetGroupID returns an error that
+// matches user.UnknownGroupError (value type, not pointer) for a non-existent group.
+// This is important because ensureGroup uses errors.As with the value type to suppress
+// expected "group not found" warnings.
+func TestGetGroupIDUnknownGroupError(t *testing.T) {
+	_, err := user.LookupGroup("dd-agent-this-group-definitely-does-not-exist-12345")
+	require.Error(t, err)
+
+	var unknownGroupError user.UnknownGroupError
+	assert.True(t, errors.As(err, &unknownGroupError), "error should match user.UnknownGroupError value type")
+
+	var unknownGroupErrorPtr *user.UnknownGroupError
+	assert.False(t, errors.As(err, &unknownGroupErrorPtr), "error should NOT match *user.UnknownGroupError pointer type (this was the original bug)")
+}
+
+// TestGetUserIDUnknownUserError verifies that user.Lookup returns an error that
+// matches user.UnknownUserError (value type, not pointer) for a non-existent user.
+func TestGetUserIDUnknownUserError(t *testing.T) {
+	_, err := user.Lookup("dd-agent-this-user-definitely-does-not-exist-12345")
+	require.Error(t, err)
+
+	var unknownUserError user.UnknownUserError
+	assert.True(t, errors.As(err, &unknownUserError), "error should match user.UnknownUserError value type")
+
+	var unknownUserErrorPtr *user.UnknownUserError
+	assert.False(t, errors.As(err, &unknownUserErrorPtr), "error should NOT match *user.UnknownUserError pointer type (this was the original bug)")
+}


### PR DESCRIPTION
### What does this PR do?

Fixes `errors.As` calls in `ensureGroup` and `ensureUser` to use value types (`user.UnknownGroupError`, `user.UnknownUserError`) instead of pointer types. This makes the error matching work correctly, suppressing the spurious warning logs when the `dd-agent` group/user don't exist yet during the first Agent postinst run.

### Motivation

During the first postinstall run, `dd-agent` group and user don't exist yet. This is expected — the code proceeds to create them. However, the `errors.As` check was using pointer types (`*user.UnknownGroupError`, `*user.UnknownUserError`), which never matched because `user.LookupGroup`/`user.Lookup` return value types. As a result, a warning was always logged even for the expected "group/user not found" case, producing noise like:

```
error looking up dd-agent group: group: unknown group dd-agent
error looking up dd-agent user: user: unknown user dd-agent
```

### Describe how you validated your changes

Added unit tests (`user_test.go`) that verify:
- `errors.As` with a value type target correctly matches `UnknownGroupError`/`UnknownUserError`
- `errors.As` with a pointer type target does NOT match (documents the original bug)

### Additional Notes

`user.UnknownGroupError` and `user.UnknownUserError` are defined in the Go stdlib as `type UnknownGroupError string` — value types, not pointer types. `errors.As` requires the target type to match the concrete error type exactly.