### PR TITLE
Update claude skill for migrating omnibus to bazel to acount for release.json

### DIFF
--- a/.claude/skills/omnibus-to-bazel/SKILL.md
+++ b/.claude/skills/omnibus-to-bazel/SKILL.md
@@ -129,6 +129,105 @@ http_archive(
 If the archive has been mirrored to the S3 bucket, add:
 `"https://dd-agent-omnibus.s3.amazonaws.com/bazel/<name>-<version>.tar.gz"` as the first URL.
 
+### 4a. (Optional) Load version dynamically from `release.json`
+
+Use this approach **instead of step 4** when the omnibus script has no pinned version of its own
+(e.g. it reads `ENV['FOO_VERSION']` or defaults to `'master'`), and the version is instead
+managed in `release.json["dependencies"]`.
+
+**Check release.json first:**
+```
+grep -i "<NAME>" release.json
+```
+
+If a `<NAME>_VERSION` key exists there (e.g. `SECURITY_AGENT_POLICIES_VERSION`), use the
+dynamic approach. Reference: `deps/jmxfetch/module_utils.bzl` and
+`deps/security_agent_policies/module_utils.bzl`.
+
+**a) Add a SHA256 key to `release.json`**
+
+Next to the existing `<NAME>_VERSION` key, add a `<NAME>_SHA256` key holding the sha256 of
+the archive for the current version (compute with `sha256sum /tmp/<name>-<version>.tar.gz`):
+
+```json
+"<NAME>_SHA256": "<sha256>",
+"<NAME>_VERSION": "v<version>",
+```
+
+**b) Create `deps/<name>/module_utils.bzl`**
+
+This is an approximate template that works for tar format downloads. Sometimes we download a single file, and would use rctx.download() to download that instead.
+
+```python
+"""MODULE wrapper to download <name> using variables from release.json."""
+
+load("@bazel_tools//tools/build_defs/repo:cache.bzl", "DEFAULT_CANONICAL_ID_ENV", "get_default_canonical_id")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "get_auth")
+
+_attrs = {
+    "canonical_id": attr.string(),
+    "_release_info": attr.label(default = "//:release.json", allow_single_file = True),
+}
+
+def _impl(rctx):
+    vars = json.decode(rctx.read(rctx.path(rctx.attr._release_info)))["dependencies"]
+
+    version = vars["<NAME>_VERSION"]   # e.g. "v0.77.0"
+    sha256 = vars.get("<NAME>_SHA256", "")
+
+    version_num = version.lstrip("v")  # strip leading 'v' for strip_prefix
+    url = "https://github.com/<org>/<repo>/archive/refs/tags/{version}.tar.gz".format(
+        version = version,
+    )
+
+    rctx.download_and_extract(
+        url = [url],
+        sha256 = sha256,
+        stripPrefix = "<repo>-{version}".format(version = version_num),
+        canonical_id = rctx.attr.canonical_id or get_default_canonical_id(rctx, [url]),
+        auth = get_auth(rctx, [url]),
+    )
+
+    rctx.file("MODULE.bazel", "module(name = \"{name}\")\n".format(name = rctx.name))
+    rctx.template(
+        "BUILD.bazel",
+        Label("//deps/<name>:<name>.BUILD.bazel"),
+        substitutions = {},
+    )
+
+    return rctx.repo_metadata(reproducible = True)
+
+get_<name>_using_release_constants = repository_rule(
+    implementation = _impl,
+    attrs = _attrs,
+    environ = [DEFAULT_CANONICAL_ID_ENV],
+)
+```
+
+**c) Replace `deps/<name>/<name>.MODULE.bazel` with a `use_repo_rule` call**
+
+```python
+"""Fetch <name> archive based on current values in //release.json."""
+
+get_<name>_using_release_constants = use_repo_rule(
+    "//deps/<name>:module_utils.bzl",
+    "get_<name>_using_release_constants",
+)
+
+get_<name>_using_release_constants(
+    name = "<name>",
+)
+```
+
+And include it from `MODULE.bazel` (alphabetical order, with `# buildifier: leave-alone`):
+```python
+# buildifier: leave-alone
+include("//deps/<name>:<name>.MODULE.bazel")
+```
+
+This MODULE file replaces the `http_archive` entry in `deps/repos.MODULE.bazel` entirely —
+do **not** also add an `http_archive` there.
+
 ### 5. Verify
 
 Run:


### PR DESCRIPTION
This builds on the work in https://github.com/DataDog/datadog-agent/pull/47376
where we had to pull the version # of a download from releases.json.