### PR TITLE
feat(fleet): Allow DD_INSTALLER_REGISTRY_URL_AGENT_PACKAGE to override installer.registry.url when restoring agent extensions

### DIFF
--- a/pkg/fleet/installer/packages/datadog_agent_extensions.go
+++ b/pkg/fleet/installer/packages/datadog_agent_extensions.go
@@ -73,9 +73,14 @@ func setRegistryConfig(env *env.Env) {
 		return
 	}
 
-	// Update env with values from config if not already set
-	if config.Installer.Registry.URL != "" && env.RegistryOverride == "" {
-		env.RegistryOverride = config.Installer.Registry.URL
+	// Update env with values from config if not already set.
+	// DD_INSTALLER_REGISTRY_URL_AGENT_PACKAGE takes precedence over installer.registry.url.
+	if env.RegistryOverride == "" {
+		if agentPackageURL := os.Getenv("DD_INSTALLER_REGISTRY_URL_AGENT_PACKAGE"); agentPackageURL != "" {
+			env.RegistryOverride = agentPackageURL
+		} else if config.Installer.Registry.URL != "" {
+			env.RegistryOverride = config.Installer.Registry.URL
+		}
 	}
 	if config.Installer.Registry.Auth != "" && env.RegistryAuthOverride == "" {
 		env.RegistryAuthOverride = config.Installer.Registry.Auth


### PR DESCRIPTION
### What does this PR do?

In `setRegistryConfig` (called during `restoreAgentExtensions`), allow `DD_INSTALLER_REGISTRY_URL_AGENT_PACKAGE` to take precedence over `installer.registry.url` from `datadog.yaml`.

Previously, only `DD_INSTALLER_REGISTRY_URL` could prevent `installer.registry.url` from being applied. Now, if `DD_INSTALLER_REGISTRY_URL_AGENT_PACKAGE` is set, it is used as the registry override instead of falling through to `installer.registry.url`.

Precedence order (highest to lowest):
1. `DD_INSTALLER_REGISTRY_URL` — already set via `env.FromEnv()`
2. `DD_INSTALLER_REGISTRY_URL_AGENT_PACKAGE` — new, takes precedence over `installer.registry.url`
3. `installer.registry.url` from `datadog.yaml` — fallback

### Motivation

When restoring agent extensions after an upgrade, users may want to pull from a custom registry specific to the agent package without setting the global `DD_INSTALLER_REGISTRY_URL`. `DD_INSTALLER_REGISTRY_URL_AGENT_PACKAGE` provides this per-package granularity but was previously ignored in favor of `installer.registry.url` from `datadog.yaml`.

### Describe how you validated your changes

Logic change only; covered by code review.

### Additional Notes

`DD_INSTALLER_REGISTRY_URL_AGENT_PACKAGE` is also already stored in `env.RegistryOverrideByImage["agent-package"]` via `env.FromEnv()`, so it takes precedence at download time via `getRefAndKeychain` even without this change. This PR makes `env.RegistryOverride` consistently reflect that intent within `setRegistryConfig`.