### PR TITLE
optimize map update for tcp queue length

### DIFF
--- a/pkg/collector/corechecks/ebpf/c/runtime/tcp-queue-length-kern.c
+++ b/pkg/collector/corechecks/ebpf/c/runtime/tcp-queue-length-kern.c
@@ -43,10 +43,12 @@ static __always_inline void check_sock(struct sock *sk) {
         return;
     }
 
-    bpf_map_update_elem(&tcp_queue_stats, &k, &zero, BPF_NOEXIST);
     struct stats_value *v = bpf_map_lookup_elem(&tcp_queue_stats, &k);
     if (!v) {
-        return;
+        bpf_map_update_elem(&tcp_queue_stats, &k, &zero, BPF_NOEXIST);
+        v = bpf_map_lookup_elem(&tcp_queue_stats, &k);
+        if (!v)
+            return;
     }
 
     int rqueue_size = BPF_CORE_READ(sk, sk_rcvbuf);

--- a/pkg/collector/corechecks/ebpf/c/runtime/tcp-queue-length-kern.c
+++ b/pkg/collector/corechecks/ebpf/c/runtime/tcp-queue-length-kern.c
@@ -38,7 +38,7 @@ static __always_inline void check_sock(struct sock *sk) {
         .write_buffer_max_usage = 0
     };
 
-    struct stats_key k;
+    struct stats_key k = { 0 };
     if (!get_cgroup_name(k.cgroup, sizeof(k.cgroup))) {
         return;
     }


### PR DESCRIPTION
### What does this PR do?
This PR removes the unconditional map update call in tcp queue length ebpf code.

### Motivation
The goal is to reduce lock contention on the hash bucket lock due to parallel accesses to the same bucket from different CPUs.

The following pattern unconditionally calls map update element to initialize a key if it does not exist. 
```
bpf_map_update_elem(&tcp_queue_stats, &k, &zero, BPF_NOEXIST);
struct stats_value* v = bpf_map_lookup_elem(&tcp_queue_stats, &k);
```
This is terrible for scalability, especially in the tcp_queue_length case, since this helper takes a lock on the hash bucket in which the element lies. For tcp_queue_length if there is high traffic in a specific cgroup then multiple instances of tcp_sendmsg and tcp_recvmsg serialize on this lock.

Experiments have shown more than 80% reduction in throughput

On a 64 core machine with 128 thread server and 128 thread client the unoptimized application level throughput is 330841 and after the optimization it is 1651528.

Throughput here represents an application level count of the number of ping-pongs.

### Describe how you validated your changes
Changes covered by existing tests.

### Additional Notes
