### PR TITLE
[ACTP] Use cluster name for DCA PAR enrollment

### DIFF
--- a/comp/privateactionrunner/impl/privateactionrunner.go
+++ b/comp/privateactionrunner/impl/privateactionrunner.go
@@ -302,17 +302,18 @@ func (p *PrivateActionRunner) performSelfEnrollment(ctx context.Context, cfg *pa
 		return nil, fmt.Errorf("failed to get hostname: %w", err)
 	}
 
+	runnerNamePrefix := runnerHostname
 	// For cluster agent, use cluster name instead of hostname for better identification
 	if flavor.GetFlavor() == flavor.ClusterAgent {
 		clusterName := clustername.GetClusterName(ctx, runnerHostname)
 		if clusterName != "" {
-			runnerHostname = clusterName
+			runnerNamePrefix = clusterName
 		} else {
 			p.logger.Warnf("Cluster name not found, falling back to hostname '%s' for cluster agent enrollment", runnerHostname)
 		}
 	}
 
-	enrollmentResult, err := enrollment.SelfEnroll(ctx, ddSite, runnerHostname, apiKey, appKey)
+	enrollmentResult, err := enrollment.SelfEnroll(ctx, ddSite, runnerNamePrefix, runnerHostname, apiKey, appKey)
 	if err != nil {
 		return nil, fmt.Errorf("enrollment API call failed: %w", err)
 	}

--- a/comp/privateactionrunner/impl/privateactionrunner.go
+++ b/comp/privateactionrunner/impl/privateactionrunner.go
@@ -35,6 +35,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/runners"
 	taskverifier "github.com/DataDog/datadog-agent/pkg/privateactionrunner/task-verifier"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/util"
+	"github.com/DataDog/datadog-agent/pkg/util/flavor"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername"
 )
 
 // Configuration keys for the private action runner.
@@ -298,6 +300,16 @@ func (p *PrivateActionRunner) performSelfEnrollment(ctx context.Context, cfg *pa
 	runnerHostname, err := p.hostnameGetter.Get(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get hostname: %w", err)
+	}
+
+	// For cluster agent, use cluster name instead of hostname for better identification
+	if flavor.GetFlavor() == flavor.ClusterAgent {
+		clusterName := clustername.GetClusterName(ctx, runnerHostname)
+		if clusterName != "" {
+			runnerHostname = clusterName
+		} else {
+			p.logger.Warnf("Cluster name not found, falling back to hostname '%s' for cluster agent enrollment", runnerHostname)
+		}
 	}
 
 	enrollmentResult, err := enrollment.SelfEnroll(ctx, ddSite, runnerHostname, apiKey, appKey)

--- a/pkg/privateactionrunner/enrollment/enrollment.go
+++ b/pkg/privateactionrunner/enrollment/enrollment.go
@@ -34,10 +34,10 @@ type PersistedIdentity struct {
 }
 
 // SelfEnroll performs self-registration of a private action runner using API credentials
-func SelfEnroll(ctx context.Context, ddSite, runnerHostname, apiKey, appKey string) (*Result, error) {
+func SelfEnroll(ctx context.Context, ddSite, runnerNamePrefix, runnerHostname, apiKey, appKey string) (*Result, error) {
 	now := time.Now().UTC()
 	formattedTime := now.Format("20060102150405")
-	runnerName := runnerHostname + "-" + formattedTime
+	runnerName := runnerNamePrefix + "-" + formattedTime
 
 	privateJwk, publicJwk, err := util.GenerateKeys()
 	if err != nil {


### PR DESCRIPTION
### What does this PR do?

Changes the Private Action Runner (PAR) to use the cluster name instead of pod hostname when self-enrolling in the Datadog Cluster Agent (DCA).

### Motivation

For cluster-level components like the DCA, using the pod hostname (e.g., `i-010dd4e49ead185d9-20250305`) as the runner identifier is semantically incorrect and confusing. The cluster name (e.g., `prod-cluster-20250305`) is more meaningful and clearly identifies which cluster the runner belongs to.

Node agents continue to use hostname as before, which remains appropriate for node-level components.

### Describe how you validated your changes

- Code review: verified the logic uses `clustername.GetClusterName()` which follows the standard pattern used by other cluster-level components (cluster agent metadata, cluster checks dispatcher, orchestrator)
- The implementation follows the priority order: config value → cloud provider autodiscovery → node labels
- Fallback to hostname is preserved if cluster name is not available

Also deployed this in a local kube cluster
<img width="2130" height="253" alt="Screenshot 2026-03-05 at 17 31 14" src="https://github.com/user-attachments/assets/ef4745bf-e600-4814-9449-0589343b0f6b" />


### Additional Notes

The change uses the existing `pkg/util/kubernetes/clustername` package, which is the canonical way components retrieve cluster names throughout the agent codebase.