### PR TITLE
Deprecate dda inv omnibus --with-sd-agent

### DIFF
--- a/.gitlab/build/package_build/installer.yml
+++ b/.gitlab/build/package_build/installer.yml
@@ -21,7 +21,7 @@
     - chmod 0744 /tmp/system-probe/clang-bpf /tmp/system-probe/llc-bpf
     # NOTE: for now, we consider "ociru" to be a "redhat_target" in omnibus/lib/ostools.rb
     # if we ever start building on a different platform, that might need to change
-    - dda inv -- -e omnibus.build --base-dir $OMNIBUS_BASE_DIR --skip-deps --go-mod-cache="$GOPATH/pkg/mod" --system-probe-bin=/tmp/system-probe --with-sd-agent --host-distribution=ociru --install-directory="$INSTALL_DIR"
+    - dda inv -- -e omnibus.build --base-dir $OMNIBUS_BASE_DIR --skip-deps --go-mod-cache="$GOPATH/pkg/mod" --system-probe-bin=/tmp/system-probe --host-distribution=ociru --install-directory="$INSTALL_DIR"
     - ls -la $OMNIBUS_PACKAGE_DIR
     - !reference [.upload_sbom_artifacts]
   variables:

--- a/.gitlab/build/package_build/linux.yml
+++ b/.gitlab/build/package_build/linux.yml
@@ -11,7 +11,7 @@
   - ${S3_CP_CMD} "${S3_PERMANENT_ARTIFACTS_URI}/llc-${CLANG_LLVM_VER}.${PACKAGE_ARCH}.${CLANG_BUILD_VERSION}" /tmp/system-probe/llc-bpf
   - cp $CI_PROJECT_DIR/minimized-btfs.tar.xz /tmp/system-probe/minimized-btfs.tar.xz
   - chmod 0744 /tmp/system-probe/clang-bpf /tmp/system-probe/llc-bpf
-  - dda inv -- -e omnibus.build --base-dir $OMNIBUS_BASE_DIR --skip-deps --go-mod-cache="$GOPATH/pkg/mod" --system-probe-bin=/tmp/system-probe --with-sd-agent --with-dd-procmgrd --flavor "$FLAVOR" --config-directory "$CONFIG_DIR" --install-directory "$INSTALL_DIR"
+  - dda inv -- -e omnibus.build --base-dir $OMNIBUS_BASE_DIR --skip-deps --go-mod-cache="$GOPATH/pkg/mod" --system-probe-bin=/tmp/system-probe --with-dd-procmgrd --flavor "$FLAVOR" --config-directory "$CONFIG_DIR" --install-directory "$INSTALL_DIR"
   - ls -la $OMNIBUS_PACKAGE_DIR
   - !reference [.upload_sbom_artifacts]
 

--- a/cmd/system-probe/modules/network_tracer.go
+++ b/cmd/system-probe/modules/network_tracer.go
@@ -98,7 +98,7 @@ type networkTracer struct {
 	cancelFunc   context.CancelFunc
 }
 
-func (nt *networkTracer) GetStats() map[string]interface{} {
+func (nt *networkTracer) GetStats() map[string]any {
 	stats, _ := nt.tracer.GetStats()
 	return stats
 }

--- a/pkg/network/state.go
+++ b/pkg/network/state.go
@@ -109,7 +109,7 @@ type State interface {
 	StoreClosedConnection(connection *ConnectionStats)
 
 	// GetStats returns a map of statistics about the current network state
-	GetStats() map[string]interface{}
+	GetStats() map[string]any
 
 	// DumpState returns a map with the current network state for a client ID
 	DumpState(clientID string) map[string]interface{}
@@ -795,11 +795,11 @@ func (ns *networkState) RemoveConnections(conns []*ConnectionStats) {
 }
 
 // GetStats returns a map of statistics about the current network state
-func (ns *networkState) GetStats() map[string]interface{} {
+func (ns *networkState) GetStats() map[string]any {
 	ns.Lock()
 	defer ns.Unlock()
 
-	clientInfo := map[string]interface{}{}
+	clientInfo := map[string]any{}
 	for id, c := range ns.clients {
 		clientInfo[id] = map[string]int{
 			"stats":              len(c.stats),
@@ -808,7 +808,7 @@ func (ns *networkState) GetStats() map[string]interface{} {
 		}
 	}
 
-	return map[string]interface{}{
+	return map[string]any{
 		"clients": clientInfo,
 		"telemetry": map[string]int64{
 			"closed_conn_dropped": stateTelemetry.closedConnDropped.Load(),

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -507,12 +507,7 @@ func (t *Tracer) getConnTelemetry(mapSize int) map[network.ConnTelemetryType]int
 		network.MonotonicConnsClosed:      tracerTelemetry.closedConns.Load(),
 	}
 
-	stats, err := t.getStats(stateStats)
-	if err != nil {
-		return nil
-	}
-
-	stateStats := stats["state"].(map[string]int64)
+	stateStats := t.state.GetStats()["telemetry"].(map[string]int64)
 	if ccd, ok := stateStats["closed_conn_dropped"]; ok {
 		tm[network.MonotonicClosedConnDropped] = ccd
 	}
@@ -675,58 +670,25 @@ func (t *Tracer) udpConnTimeout(isAssured bool) uint64 {
 	return defaultUDPConnTimeoutNanoSeconds
 }
 
-type statsComp int
-
-const (
-	conntrackStats statsComp = iota
-	dnsStats
-	epbfStats
-	gatewayLookupStats
-	httpStats
-	kprobesStats
-	stateStats
-	tracerStats
-	processCacheStats
-	kafkaStats
-)
-
-var allStats = []statsComp{
-	stateStats,
-	tracerStats,
-	httpStats,
-}
-
-func (t *Tracer) getStats(comps ...statsComp) (map[string]interface{}, error) {
+func (t *Tracer) getStats() (map[string]any, error) {
 	if t.state == nil {
 		return nil, errors.New("internal state not yet initialized")
 	}
 
-	if len(comps) == 0 {
-		comps = allStats
-	}
-
-	ret := map[string]interface{}{}
-	for _, c := range comps {
-		switch c {
-		case stateStats:
-			ret["state"] = t.state.GetStats()["telemetry"]
-		case tracerStats:
-			tracerStats := make(map[string]interface{})
-			tracerStats["last_check"] = t.lastCheck.Load()
-			tracerStats["runtime"] = runtime.Tracer.GetTelemetry()
-			ret["tracer"] = tracerStats
-		case httpStats:
-			ret["universal_service_monitoring"] = t.usmMonitor.GetUSMStats()
-		}
-	}
-
-	return ret, nil
+	return map[string]any{
+		"state": t.state.GetStats()["telemetry"],
+		"tracer": map[string]any{
+			"last_check": t.lastCheck.Load(),
+			"runtime":    runtime.Tracer.GetTelemetry(),
+		},
+		"universal_service_monitoring": t.usmMonitor.GetUSMStats(),
+	}, nil
 }
 
 // GetStats returns a map of statistics about the current tracer's internal state
-func (t *Tracer) GetStats() (map[string]interface{}, error) {
-	return map[string]interface{}{
-		"tracer": map[string]interface{}{
+func (t *Tracer) GetStats() (map[string]any, error) {
+	return map[string]any{
+		"tracer": map[string]any{
 			"last_check": t.lastCheck.Load(),
 		},
 		"universal_service_monitoring": t.usmMonitor.GetUSMStats(),

--- a/pkg/network/usm/monitor.go
+++ b/pkg/network/usm/monitor.go
@@ -173,8 +173,8 @@ func (m *Monitor) Resume() error {
 }
 
 // GetUSMStats returns the current state of the USM monitor
-func (m *Monitor) GetUSMStats() map[string]interface{} {
-	response := map[string]interface{}{
+func (m *Monitor) GetUSMStats() map[string]any {
+	response := map[string]any{
 		"state": usmstate.Get(),
 	}
 

--- a/pkg/system-probe/api/module/loader.go
+++ b/pkg/system-probe/api/module/loader.go
@@ -40,7 +40,7 @@ type loader struct {
 	sync.Mutex
 	modules map[sysconfigtypes.ModuleName]Module
 	errors  map[sysconfigtypes.ModuleName]error
-	stats   map[string]interface{}
+	stats   map[string]any
 	cfg     *sysconfigtypes.Config
 	routers map[sysconfigtypes.ModuleName]*Router
 	closed  bool
@@ -125,7 +125,7 @@ func Register(cfg *sysconfigtypes.Config, httpMux *mux.Router, factories []*Fact
 
 	l.configureTelemetry(deps.Telemetry)
 
-	l.stats = make(map[string]interface{})
+	l.stats = make(map[string]any)
 	l.forEachModule(func(name sysconfigtypes.ModuleName, mod Module) {
 		go updateModuleStats(name, mod)
 	})
@@ -135,7 +135,7 @@ func Register(cfg *sysconfigtypes.Config, httpMux *mux.Router, factories []*Fact
 }
 
 // GetStats returns the stats from all modules, namespaced by their names
-func GetStats() map[string]interface{} {
+func GetStats() map[string]any {
 	l.Lock()
 	defer l.Unlock()
 

--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -138,7 +138,7 @@ def get_omnibus_env(
     if system_probe_bin:
         env['SYSTEM_PROBE_BIN'] = system_probe_bin
     if with_sd_agent:
-        env['WITH_SD_AGENT'] = 'true'
+        print("--with-sd-agent is a no-op. It is always built when appropriate for the platform.")
     if with_dd_procmgrd:
         env['WITH_DD_PROCMGRD'] = 'true'
     env['AGENT_FLAVOR'] = flavor.name


### PR DESCRIPTION
- Stop using the `dda inv omnibus.build --with-sd-agent` flag.
- Leave the flag available so that we don't have to backport tasks to release branches if we update gitlab.

Next:
- Wait a release or two and then delete the flag from tasks/omnibus.py