### PR TITLE
Fix false rejection of ..-prefixed filenames

### DIFF
--- a/pkg/shell/interp/allowed_paths.go
+++ b/pkg/shell/interp/allowed_paths.go
@@ -55,7 +55,9 @@ func findMatchingRoot(absPath string, roots []*os.Root, allowedPaths []string) (
 		if err != nil {
 			continue
 		}
-		if strings.HasPrefix(rel, "..") {
+		// Check for exact ".." or "..<sep>..." to detect escapes, but not
+		// filenames that happen to start with two dots (e.g. "..hidden").
+		if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 			continue
 		}
 		return roots[i], rel, true

--- a/pkg/shell/interp/allowed_paths_test.go
+++ b/pkg/shell/interp/allowed_paths_test.go
@@ -166,6 +166,17 @@ func TestAllowedPathsTraversalBlocked(t *testing.T) {
 	assert.Contains(t, stderr, "permission denied")
 }
 
+func TestAllowedPathsDoubleDotFilename(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "..hidden"), []byte("dotdot content\n"), 0644))
+
+	stdout, _, exitCode := runScript(t, `cat ..hidden`, dir,
+		interp.AllowedPaths([]string{dir}),
+	)
+	assert.Equal(t, 0, exitCode)
+	assert.Equal(t, "dotdot content\n", stdout)
+}
+
 func TestAllowedPathsEmptyBlocksAll(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "test.txt"), []byte("test"), 0644))

--- a/pkg/shell/interp/api.go
+++ b/pkg/shell/interp/api.go
@@ -154,8 +154,8 @@ func (e *exitStatus) fromHandlerError(err error) {
 // the options results in an error, it is returned.
 //
 // Any unset options fall back to their defaults. For example, not supplying the
-// environment falls back to the process's environment, and not supplying the
-// standard output writer means that the output will be discarded.
+// environment defaults to an empty environment (no host env inherited), and not
+// supplying the standard output writer means that the output will be discarded.
 func New(opts ...RunnerOption) (*Runner, error) {
 	r := &Runner{
 		usedNew:        true,

--- a/pkg/shell/tests/scenarios/shell/allowed_paths/dotdot_filename_allowed.yaml
+++ b/pkg/shell/tests/scenarios/shell/allowed_paths/dotdot_filename_allowed.yaml
@@ -1,0 +1,15 @@
+test_against_local_shell: false
+description: Files with names starting with .. (e.g. ..hidden) are accessible inside allowed paths
+setup:
+  files:
+    - path: allowed/..hidden
+      content: "dotdot content"
+input:
+  allowed_paths: ["allowed"]
+  # language=bash
+  script: |+
+    cat allowed/..hidden
+expect:
+  stdout: "dotdot content"
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/allowed_paths/dotdot_filename_in_subdir.yaml
+++ b/pkg/shell/tests/scenarios/shell/allowed_paths/dotdot_filename_in_subdir.yaml
@@ -1,0 +1,15 @@
+test_against_local_shell: false
+description: Files with ..-prefixed names in subdirectories are accessible inside allowed paths
+setup:
+  files:
+    - path: allowed/sub/..data.txt
+      content: "nested dotdot"
+input:
+  allowed_paths: ["allowed"]
+  # language=bash
+  script: |+
+    cat allowed/sub/..data.txt
+expect:
+  stdout: "nested dotdot"
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios_test.go
+++ b/pkg/shell/tests/scenarios_test.go
@@ -50,6 +50,9 @@ type setupFile struct {
 
 // input holds the shell script to execute.
 type input struct {
+	// Envs sets OS-level environment variables for the bash comparison test
+	// only. These are intentionally NOT passed to the restricted interpreter,
+	// which starts with an empty environment for security (no host env inheritance).
 	Envs         map[string]string `yaml:"envs"`
 	Script       string            `yaml:"script"`
 	AllowedPaths []string          `yaml:"allowed_paths"` // relative to test temp dir; "$DIR" resolves to temp dir itself
@@ -144,6 +147,9 @@ func runScenario(t *testing.T, sc scenario) {
 
 	dir := setupTestDir(t, sc)
 
+	// Set OS-level env vars so the bash comparison path (runScenarioAgainstBash)
+	// picks them up via os.Environ(). The restricted interpreter intentionally
+	// does NOT inherit these — it starts with an empty environment for security.
 	for k, v := range sc.Input.Envs {
 		t.Setenv(k, v)
 	}


### PR DESCRIPTION
<!-- dd-meta {"pullId":"76f48740-ad6a-45ed-9494-f6c173e314e6","source":"chat","resourceId":"4a789e27-0e06-454d-a246-dec8e8a6cc77","workflowId":"c5f5a1b9-7c30-4f63-8dbb-2c5bec1c671e","codeChangeId":"c5f5a1b9-7c30-4f63-8dbb-2c5bec1c671e","sourceType":"chat"} -->
### What does this PR do?

Fixes `findMatchingRoot` in `pkg/shell/interp/allowed_paths.go` to correctly handle files whose names start with two dots (e.g. `..hidden`).

### Motivation

`strings.HasPrefix(rel, "..")` was used to detect parent-directory escapes, but it also rejected legitimate filenames starting with `..` (e.g. `..hidden`). `filepath.Rel("/allowed", "/allowed/..hidden")` returns `"..hidden"`, which matched the prefix check and caused a false "permission denied" error.

The fix checks for the exact `".."` string or `".."` followed by a path separator, so `"..hidden"` is correctly allowed while `"../escape"` is still blocked.

### Describe how you validated your changes

- Added `TestAllowedPathsDoubleDotFilename` that creates a `..hidden` file inside an allowed directory and verifies `cat ..hidden` succeeds.
- Ran the full `pkg/shell/...` test suite (all pass).

### Additional Notes

The underlying `os.Root` API provides the real security boundary via kernel-level `openat` syscalls. This fix corrects the pre-check in `findMatchingRoot` which gates access before delegating to `os.Root`.

---

PR by Bits
[View session in Datadog](https://app.datadoghq.com/code/4a789e27-0e06-454d-a246-dec8e8a6cc77)

Comment @datadog to request changes