### PR TITLE
Add builtin commands reference doc

### DIFF
--- a/pkg/shell/COMMANDS.md
+++ b/pkg/shell/COMMANDS.md
@@ -1,0 +1,13 @@
+# Builtin Commands
+
+Short reference for builtin commands available in `pkg/shell`.
+
+| Command | Options | Short description |
+| --- | --- | --- |
+| `true` | none | Exit with status `0`. |
+| `false` | none | Exit with status `1`. |
+| `echo [ARG ...]` | none | Print arguments separated by spaces, then newline. |
+| `cat [FILE ...]` | `-` (read stdin) | Print files; with no args, read stdin. |
+| `exit [N]` | `N` (status code) | Exit the shell with `N` (default: last status). |
+| `break [N]` | `N` (loop levels) | Break current loop, or `N` enclosing loops. |
+| `continue [N]` | `N` (loop levels) | Continue current loop, or `N` enclosing loops. |


### PR DESCRIPTION
<!-- dd-meta {"pullId":"24cba446-6f36-4d49-b691-a13777f5d199","source":"chat","resourceId":"77a25789-5b54-46d4-8244-605d7e3c4c81","workflowId":"a5bd7414-0743-4d41-bd89-ebcbd69faae7","codeChangeId":"a5bd7414-0743-4d41-bd89-ebcbd69faae7","sourceType":"chat"} -->
### What does this PR do?

Adds `pkg/shell/COMMANDS.md`, a short reference for all builtin commands and their options.

### Motivation

Provide a quick, command-focused doc that is easier to scan than broader shell feature docs.

### Describe how you validated your changes

- Verified the new table matches the builtin registry in `pkg/shell/interp/builtins/builtins.go`.
- Ran `Format` and `Lint`; this `.md` file was skipped because no formatter/linter was detected.

### Additional Notes

- Content is intentionally brief and covers essentials only.

---

PR by Bits
[View session in Datadog](https://app.datadoghq.com/code/77a25789-5b54-46d4-8244-605d7e3c4c81)

Comment @datadog to request changes