### PR TITLE
[chore] exclude otel Go packages from dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -17,8 +17,8 @@ updates:
       - dependency-name: github.com/DataDog/datadog-agent/*
       # Ignore golang.org/x/... deps to avoid noise, they are updated together, pretty regularly
       - dependency-name: golang.org/x/*
-      # OpenTelemetry collector packages need to be updated with `dda inv` rather than dependabot
-      - dependency-name: go.opentelemetry.io/collector/*
+      # OpenTelemetry packages need to be updated with `dda inv` rather than dependabot
+      - dependency-name: go.opentelemetry.io/*
       - dependency-name: github.com/open-telemetry/opentelemetry-collector-contrib/*
     schedule:
       interval: weekly
@@ -53,8 +53,8 @@ updates:
       - dependency-name: github.com/mailru/easyjson
       # Ignore golang.org/x/... deps to avoid noise, they are updated together, pretty regularly
       - dependency-name: golang.org/x/*
-      # OpenTelemetry collector packages need to be updated with `dda inv` rather than dependabot
-      - dependency-name: go.opentelemetry.io/collector/*
+      # OpenTelemetry packages need to be updated with `dda inv` rather than dependabot
+      - dependency-name: go.opentelemetry.io/*
       - dependency-name: github.com/open-telemetry/opentelemetry-collector-contrib/*
     schedule:
       interval: weekly
@@ -74,6 +74,8 @@ updates:
       - dependency-name: github.com/mailru/easyjson
       # Ignore golang.org/x/... deps to avoid noise, they are updated together, pretty regularly
       - dependency-name: golang.org/x/*
+      # OpenTelemetry packages need to be updated with `dda inv` rather than dependabot
+      - dependency-name: go.opentelemetry.io/*
     schedule:
       interval: weekly
       day: saturday
@@ -92,6 +94,8 @@ updates:
       - dependency-name: github.com/mailru/easyjson
       # Ignore golang.org/x/... deps to avoid noise, they are updated together, pretty regularly
       - dependency-name: golang.org/x/*
+      # OpenTelemetry packages need to be updated with `dda inv` rather than dependabot
+      - dependency-name: go.opentelemetry.io/*
     schedule:
       interval: weekly
       day: saturday
@@ -108,6 +112,8 @@ updates:
       - dependency-name: github.com/DataDog/datadog-agent/*
       # Ignore golang.org/x/... deps to avoid noise, they are updated together, pretty regularly
       - dependency-name: golang.org/x/*
+      # OpenTelemetry packages need to be updated with `dda inv` rather than dependabot
+      - dependency-name: go.opentelemetry.io/*
     schedule:
       interval: weekly
       day: saturday
@@ -130,6 +136,8 @@ updates:
     ignore:
       # Ignore golang.org/x/... deps to avoid noise, they are updated together, pretty regularly
       - dependency-name: golang.org/x/*
+      # OpenTelemetry packages need to be updated with `dda inv` rather than dependabot
+      - dependency-name: go.opentelemetry.io/*
     open-pull-requests-limit: 100
   - package-ecosystem: gomod
     directory: /pkg/networkdevice/profile
@@ -143,6 +151,8 @@ updates:
       - dependency-name: github.com/DataDog/datadog-agent/*
       # Ignore golang.org/x/... deps to avoid noise, they are updated together, pretty regularly
       - dependency-name: golang.org/x/*
+      # OpenTelemetry packages need to be updated with `dda inv` rather than dependabot
+      - dependency-name: go.opentelemetry.io/*
     schedule:
       interval: weekly
       day: saturday
@@ -166,6 +176,8 @@ updates:
       - dependency-name: github.com/pulumi*
       # Ignore golang.org/x/... deps to avoid noise, they are updated together, pretty regularly
       - dependency-name: golang.org/x/*
+      # OpenTelemetry packages need to be updated with `dda inv` rather than dependabot
+      - dependency-name: go.opentelemetry.io/*
     groups:
       aws-sdk-go-v2:
         patterns:
@@ -194,6 +206,8 @@ updates:
     ignore:
       # Ignore golang.org/x/... deps to avoid noise, they are updated together, pretty regularly
       - dependency-name: golang.org/x/*
+      # OpenTelemetry packages need to be updated with `dda inv` rather than dependabot
+      - dependency-name: go.opentelemetry.io/*
   - package-ecosystem: docker
     directory: /test/fakeintake
     labels:


### PR DESCRIPTION
### What does this PR do?
Exclude go.opentelemetry.io/* packages from dependabot auto-updates.

### Motivation
OTel packages are manually updated via `inv collector.update` for now, e.g. https://github.com/DataDog/datadog-agent/pull/47192. The dependabot PRs are just noise.

### Describe how you validated your changes
N/A

### Additional Notes
