### PR TITLE
Fix exec handler symlink escape in pkg/shell

### DIFF
--- a/pkg/shell/interp/allowed_paths.go
+++ b/pkg/shell/interp/allowed_paths.go
@@ -12,6 +12,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 )
@@ -123,8 +124,9 @@ func wrapReadDirHandler(roots []*os.Root, allowedPaths []string) ReadDirHandlerF
 }
 
 // wrapExecHandler wraps an ExecHandlerFunc to restrict command execution to allowed paths.
-// It resolves the command to an absolute path, validates it against allowed roots,
-// then delegates to next for actual execution. Returns exit code 127 if not found.
+// It resolves the command to an absolute path, validates it against allowed roots
+// using os.Root.Stat for atomic symlink-safe verification, then delegates to next
+// for actual execution. Returns exit code 127 if not found.
 func wrapExecHandler(roots []*os.Root, allowedPaths []string, next ExecHandlerFunc) ExecHandlerFunc {
 	return func(ctx context.Context, args []string) error {
 		hc := HandlerCtx(ctx)
@@ -134,8 +136,24 @@ func wrapExecHandler(roots []*os.Root, allowedPaths []string, next ExecHandlerFu
 			return ExitStatus(127)
 		}
 
-		_, _, ok := findMatchingRoot(path, roots, allowedPaths)
+		root, relPath, ok := findMatchingRoot(path, roots, allowedPaths)
 		if !ok {
+			fmt.Fprintf(hc.Stderr, "%s: command not found\n", args[0])
+			return ExitStatus(127)
+		}
+
+		// Validate via os.Root.Stat which uses openat-based resolution,
+		// atomically rejecting symlinks that escape the root directory.
+		info, err := root.Stat(relPath)
+		if err != nil {
+			fmt.Fprintf(hc.Stderr, "%s: command not found\n", args[0])
+			return ExitStatus(127)
+		}
+		if info.IsDir() {
+			fmt.Fprintf(hc.Stderr, "%s: command not found\n", args[0])
+			return ExitStatus(127)
+		}
+		if runtime.GOOS != "windows" && info.Mode()&0o111 == 0 {
 			fmt.Fprintf(hc.Stderr, "%s: command not found\n", args[0])
 			return ExitStatus(127)
 		}

--- a/pkg/shell/interp/allowed_paths_internal_test.go
+++ b/pkg/shell/interp/allowed_paths_internal_test.go
@@ -9,7 +9,10 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -98,6 +101,25 @@ func TestAllowedPathsExecViaPathLookup(t *testing.T) {
 	dir := t.TempDir()
 	// "ls" is resolved via PATH (not absolute), but /bin and /usr are not allowed
 	_, stderr, exitCode := runScriptInternal(t, `ls`, dir,
+		AllowedPaths([]string{dir}),
+	)
+	assert.Equal(t, 127, exitCode)
+	assert.Contains(t, stderr, "command not found")
+}
+
+func TestAllowedPathsExecSymlinkEscape(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink test not applicable on Windows")
+	}
+	dir := t.TempDir()
+	binDir := filepath.Join(dir, "bin")
+	require.NoError(t, os.MkdirAll(binDir, 0755))
+
+	// Create a symlink inside the allowed dir pointing to /bin/echo outside it.
+	require.NoError(t, os.Symlink("/bin/echo", filepath.Join(binDir, "escape_echo")))
+
+	// Only allow the temp dir — the symlink target (/bin/echo) is outside.
+	_, stderr, exitCode := runScriptInternal(t, filepath.Join(binDir, "escape_echo")+" hello", dir,
 		AllowedPaths([]string{dir}),
 	)
 	assert.Equal(t, 127, exitCode)


### PR DESCRIPTION
<!-- dd-meta {"pullId":"cdf9f81f-1dbf-477e-8f5a-8fc825aa1130","source":"chat","resourceId":"72a912f1-da92-4c5a-96ed-e295ca7e04d9","workflowId":"67351b70-d1e3-48f4-911c-0dee7670f7de","codeChangeId":"67351b70-d1e3-48f4-911c-0dee7670f7de","sourceType":"chat"} -->
### What does this PR do?

Adds `os.Root.Stat` validation to `wrapExecHandler` in `pkg/shell/interp/allowed_paths.go` to prevent symlink-based sandbox escapes during command execution. Previously, only string-based `filepath.Rel` was used for path validation, which didn't detect symlinks pointing outside allowed directories.

### Motivation

The open and readdir handlers already use `os.Root` (kernel-level `openat`) for atomic, symlink-safe path validation. However, the exec handler used `os.Stat` (which follows symlinks) combined with string-based `filepath.Rel`, creating a gap: a symlink inside an allowed directory pointing to a binary outside it would pass validation.

For example, `/allowed/bin/evil -> /outside/bin/malicious` would be accepted because the logical path `/allowed/bin/evil` appears to be within the allowed root, even though the real target is not.

### Describe how you validated your changes

- Added `TestAllowedPathsExecSymlinkEscape` that creates a symlink inside an allowed dir pointing to `/bin/echo` outside it, and verifies it's blocked with exit code 127.
- All 17 existing `TestAllowedPaths*` tests pass.
- All ~200 YAML scenario tests pass (`TestShellScenarios`).

### Additional Notes

The fix uses `root.Stat(relPath)` after `findMatchingRoot` succeeds, which provides the same `openat`-based atomic path validation already used by `wrapOpenHandler` and `wrapReadDirHandler`. After `Stat`, the result is re-checked for `IsDir()` and execute permission since the real target (resolved through symlinks) may differ from what the initial `checkStat` saw.

---

PR by Bits
[View session in Datadog](https://app.datadoghq.com/code/72a912f1-da92-4c5a-96ed-e295ca7e04d9)

Comment @datadog to request changes