### PR TITLE
Set `installer.registry.url` in DDOT installation if present

### DIFF
--- a/pkg/fleet/installer/packages/otel_config_common.go
+++ b/pkg/fleet/installer/packages/otel_config_common.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 
 	"go.yaml.in/yaml/v2"
+
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/env"
 )
 
 // enableOTelCollectorConfigInDatadogYAML adds otelcollector.enabled and agent_ipc defaults to the given datadog.yaml path
@@ -32,6 +34,15 @@ func enableOTelCollectorConfigInDatadogYAML(ctx HookContext, datadogYamlPath str
 	}
 	existing["otelcollector"] = map[string]any{"enabled": true}
 	existing["agent_ipc"] = map[string]any{"port": 5009, "config_refresh_interval": 60}
+
+	_, ok := existing["installer"]
+	registryURL := env.FromEnv().RegistryOverride
+	if !ok && registryURL != "" {
+		existing["installer"] = map[string]any{
+			"registry": map[string]any{"url": registryURL},
+		}
+	}
+
 	updated, err := yaml.Marshal(existing)
 	if err != nil {
 		return fmt.Errorf("failed to serialize datadog.yaml: %w", err)


### PR DESCRIPTION
### What does this PR do?
Sets `installer.registry.url` in `datadog.yaml` in the DDOT extension postinstall if a registry override is present.

### Motivation
We want to persist the registry override across installations, `installer.registry.url` is also required for extension upgrades if customers have their own registry.

### Describe how you validated your changes
Will validate when testing install script changes.

### Additional Notes
