### PR TITLE
[apm] Set namespaceSelector for enabledNamespaces in admission webhook

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/label_selectors.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/label_selectors.go
@@ -20,6 +20,7 @@ type LabelSelectorsConfig struct {
 	Enabled            bool
 	MutateUnlabelled   bool
 	AddAksSelectors    bool
+	EnabledNamespaces  []string
 	DisabledNamespaces []string
 }
 
@@ -29,6 +30,7 @@ func NewLabelSelectorsConfig(datadogConfig config.Component) *LabelSelectorsConf
 		Enabled:            datadogConfig.GetBool("apm_config.instrumentation.enabled"),
 		MutateUnlabelled:   datadogConfig.GetBool("admission_controller.mutate_unlabelled"),
 		AddAksSelectors:    datadogConfig.GetBool("admission_controller.add_aks_selectors"),
+		EnabledNamespaces:  datadogConfig.GetStringSlice("apm_config.instrumentation.enabled_namespaces"),
 		DisabledNamespaces: datadogConfig.GetStringSlice("apm_config.instrumentation.disabled_namespaces"),
 	}
 }
@@ -70,6 +72,15 @@ func (ls *LabelSelectors) Get(useNamespaceSelector bool) (*metav1.LabelSelector,
 		Operator: metav1.LabelSelectorOpNotIn,
 		Values:   disabledNamespaces,
 	})
+
+	// Apply enabled namespaces so we only receive mutation requests for them.
+	if len(ls.config.EnabledNamespaces) > 0 {
+		namespaceSelector.MatchExpressions = append(namespaceSelector.MatchExpressions, metav1.LabelSelectorRequirement{
+			Key:      common.NamespaceLabelKey,
+			Operator: metav1.LabelSelectorOpIn,
+			Values:   ls.config.EnabledNamespaces,
+		})
+	}
 
 	// AKS automatically adds some selector requirements if we don't so we need to add them to avoid conflicts when
 	// updating the webhook. Ref: https://docs.microsoft.com/en-us/azure/aks/faq#can-i-use-admission-controller-webhooks-on-aks

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/label_selectors.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/label_selectors.go
@@ -20,8 +20,9 @@ type LabelSelectorsConfig struct {
 	Enabled            bool
 	MutateUnlabelled   bool
 	AddAksSelectors    bool
-	EnabledNamespaces  []string
-	DisabledNamespaces []string
+	EnabledNamespaces              []string
+	EnabledNamespacesWebhookFilter bool
+	DisabledNamespaces             []string
 }
 
 // NewLabelSelectorsConfig initializes a config object from the datadog config.
@@ -30,8 +31,9 @@ func NewLabelSelectorsConfig(datadogConfig config.Component) *LabelSelectorsConf
 		Enabled:            datadogConfig.GetBool("apm_config.instrumentation.enabled"),
 		MutateUnlabelled:   datadogConfig.GetBool("admission_controller.mutate_unlabelled"),
 		AddAksSelectors:    datadogConfig.GetBool("admission_controller.add_aks_selectors"),
-		EnabledNamespaces:  datadogConfig.GetStringSlice("apm_config.instrumentation.enabled_namespaces"),
-		DisabledNamespaces: datadogConfig.GetStringSlice("apm_config.instrumentation.disabled_namespaces"),
+		EnabledNamespaces:              datadogConfig.GetStringSlice("apm_config.instrumentation.enabled_namespaces"),
+		EnabledNamespacesWebhookFilter: datadogConfig.GetBool("admission_controller.auto_instrumentation.webhook_filter_namespaces"),
+		DisabledNamespaces:             datadogConfig.GetStringSlice("apm_config.instrumentation.disabled_namespaces"),
 	}
 }
 
@@ -74,7 +76,11 @@ func (ls *LabelSelectors) Get(useNamespaceSelector bool) (*metav1.LabelSelector,
 	})
 
 	// Apply enabled namespaces so we only receive mutation requests for them.
-	if len(ls.config.EnabledNamespaces) > 0 {
+	// This is gated behind a config flag because it changes behavior for pods that use per-pod opt-in
+	// (admission.datadoghq.com/enabled=true) outside of enabled namespaces. Without this flag, those pods
+	// are still mutated at the application level; with this flag, the API server drops the request before
+	// it reaches the webhook.
+	if ls.config.EnabledNamespacesWebhookFilter && len(ls.config.EnabledNamespaces) > 0 {
 		namespaceSelector.MatchExpressions = append(namespaceSelector.MatchExpressions, metav1.LabelSelectorRequirement{
 			Key:      common.NamespaceLabelKey,
 			Operator: metav1.LabelSelectorOpIn,

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/label_selectors_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/label_selectors_test.go
@@ -23,6 +23,7 @@ func NewFakeLabelSelector() *autoinstrumentation.LabelSelectors {
 		Enabled:            false,
 		MutateUnlabelled:   false,
 		AddAksSelectors:    false,
+		EnabledNamespaces:  []string{},
 		DisabledNamespaces: []string{},
 	})
 }
@@ -37,6 +38,7 @@ func TestLabelSelectorsConfig(t *testing.T) {
 				Enabled:            false,
 				MutateUnlabelled:   false,
 				AddAksSelectors:    false,
+				EnabledNamespaces:  []string{},
 				DisabledNamespaces: []string{},
 			},
 		},
@@ -51,7 +53,21 @@ func TestLabelSelectorsConfig(t *testing.T) {
 				Enabled:            true,
 				MutateUnlabelled:   true,
 				AddAksSelectors:    true,
+				EnabledNamespaces:  []string{},
 				DisabledNamespaces: []string{"foo"},
+			},
+		},
+		"enabled namespaces values match expected": {
+			config: map[string]any{
+				"apm_config.instrumentation.enabled":            true,
+				"apm_config.instrumentation.enabled_namespaces": []string{"bar"},
+			},
+			expected: &autoinstrumentation.LabelSelectorsConfig{
+				Enabled:            true,
+				MutateUnlabelled:   false,
+				AddAksSelectors:    false,
+				EnabledNamespaces:  []string{"bar"},
+				DisabledNamespaces: []string{},
 			},
 		},
 	}
@@ -187,6 +203,63 @@ func TestLabelSelectors(t *testing.T) {
 					},
 				},
 			},
+		},
+		"enabled namespaces should add an In expression on the namespace selector": {
+			config: &autoinstrumentation.LabelSelectorsConfig{
+				Enabled:           true,
+				EnabledNamespaces: []string{"foo"},
+			},
+			useNamespaceSelector: false,
+			expectedNamespaceSelector: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      common.NamespaceLabelKey,
+						Operator: metav1.LabelSelectorOpNotIn,
+						Values:   mutatecommon.DefaultDisabledNamespaces(),
+					},
+					{
+						Key:      common.NamespaceLabelKey,
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{"foo"},
+					},
+				},
+			},
+			expectedObjectSelector: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      common.EnabledLabelKey,
+						Operator: metav1.LabelSelectorOpNotIn,
+						Values:   []string{"false"},
+					},
+				},
+			},
+		},
+		"enabled namespaces with useNamespaceSelector should merge all expressions into the namespace selector": {
+			config: &autoinstrumentation.LabelSelectorsConfig{
+				Enabled:           true,
+				EnabledNamespaces: []string{"foo", "bar"},
+			},
+			useNamespaceSelector: true,
+			expectedNamespaceSelector: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      common.EnabledLabelKey,
+						Operator: metav1.LabelSelectorOpNotIn,
+						Values:   []string{"false"},
+					},
+					{
+						Key:      common.NamespaceLabelKey,
+						Operator: metav1.LabelSelectorOpNotIn,
+						Values:   mutatecommon.DefaultDisabledNamespaces(),
+					},
+					{
+						Key:      common.NamespaceLabelKey,
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{"foo", "bar"},
+					},
+				},
+			},
+			expectedObjectSelector: nil,
 		},
 		"when add aks selectors is true, the additional selectors should be added": {
 			config: &autoinstrumentation.LabelSelectorsConfig{

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/label_selectors_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/label_selectors_test.go
@@ -70,6 +70,21 @@ func TestLabelSelectorsConfig(t *testing.T) {
 				DisabledNamespaces: []string{},
 			},
 		},
+		"enabled namespaces webhook filter values match expected": {
+			config: map[string]any{
+				"apm_config.instrumentation.enabled":                               true,
+				"apm_config.instrumentation.enabled_namespaces":                    []string{"bar"},
+				"admission_controller.auto_instrumentation.webhook_filter_namespaces": true,
+			},
+			expected: &autoinstrumentation.LabelSelectorsConfig{
+				Enabled:                        true,
+				MutateUnlabelled:               false,
+				AddAksSelectors:                false,
+				EnabledNamespaces:              []string{"bar"},
+				EnabledNamespacesWebhookFilter: true,
+				DisabledNamespaces:             []string{},
+			},
+		},
 	}
 
 	for name, test := range tests {
@@ -204,10 +219,36 @@ func TestLabelSelectors(t *testing.T) {
 				},
 			},
 		},
-		"enabled namespaces should add an In expression on the namespace selector": {
+		"enabled namespaces without webhook filter should not add an In expression": {
 			config: &autoinstrumentation.LabelSelectorsConfig{
 				Enabled:           true,
 				EnabledNamespaces: []string{"foo"},
+			},
+			useNamespaceSelector: false,
+			expectedNamespaceSelector: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      common.NamespaceLabelKey,
+						Operator: metav1.LabelSelectorOpNotIn,
+						Values:   mutatecommon.DefaultDisabledNamespaces(),
+					},
+				},
+			},
+			expectedObjectSelector: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      common.EnabledLabelKey,
+						Operator: metav1.LabelSelectorOpNotIn,
+						Values:   []string{"false"},
+					},
+				},
+			},
+		},
+		"enabled namespaces with webhook filter should add an In expression on the namespace selector": {
+			config: &autoinstrumentation.LabelSelectorsConfig{
+				Enabled:                        true,
+				EnabledNamespaces:              []string{"foo"},
+				EnabledNamespacesWebhookFilter: true,
 			},
 			useNamespaceSelector: false,
 			expectedNamespaceSelector: &metav1.LabelSelector{
@@ -234,10 +275,11 @@ func TestLabelSelectors(t *testing.T) {
 				},
 			},
 		},
-		"enabled namespaces with useNamespaceSelector should merge all expressions into the namespace selector": {
+		"enabled namespaces with webhook filter and useNamespaceSelector should merge all expressions into the namespace selector": {
 			config: &autoinstrumentation.LabelSelectorsConfig{
-				Enabled:           true,
-				EnabledNamespaces: []string{"foo", "bar"},
+				Enabled:                        true,
+				EnabledNamespaces:              []string{"foo", "bar"},
+				EnabledNamespacesWebhookFilter: true,
 			},
 			useNamespaceSelector: true,
 			expectedNamespaceSelector: &metav1.LabelSelector{

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -973,7 +973,8 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("admission_controller.namespace_selector_fallback", false)
 	config.BindEnvAndSetDefault("admission_controller.failure_policy", "Ignore")
 	config.BindEnvAndSetDefault("admission_controller.reinvocation_policy", "IfNeeded")
-	config.BindEnvAndSetDefault("admission_controller.add_aks_selectors", false) // adds in the webhook some selectors that are required in AKS
+	config.BindEnvAndSetDefault("admission_controller.add_aks_selectors", false)                           // adds in the webhook some selectors that are required in AKS
+	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.webhook_filter_namespaces", false) // adds an In namespaceSelector for enabled_namespaces
 	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.enabled", true)
 	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.endpoint", "/injectlib")
 	config.BindEnv("admission_controller.auto_instrumentation.container_registry") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'

--- a/releasenotes/notes/[apm]-fix-enabled-namespaces-webhook-selector-ef11702e99f3cfbe.yaml
+++ b/releasenotes/notes/[apm]-fix-enabled-namespaces-webhook-selector-ef11702e99f3cfbe.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Set ``namespaceSelector`` on the MutatingWebhookConfiguration when
+    ``apm_config.instrumentation.enabled_namespaces`` is configured. Previously,
+    only ``disabled_namespaces`` set a namespace selector at the Kubernetes level;
+    ``enabled_namespaces`` was only filtered at the application level, causing
+    every pod CREATE event across all namespaces to be sent to the admission
+    controller webhook. This could overwhelm the Cluster Agent on large clusters.

--- a/releasenotes/notes/[apm]-fix-enabled-namespaces-webhook-selector-ef11702e99f3cfbe.yaml
+++ b/releasenotes/notes/[apm]-fix-enabled-namespaces-webhook-selector-ef11702e99f3cfbe.yaml
@@ -1,9 +1,13 @@
 ---
-fixes:
+features:
   - |
-    Set ``namespaceSelector`` on the MutatingWebhookConfiguration when
-    ``apm_config.instrumentation.enabled_namespaces`` is configured. Previously,
-    only ``disabled_namespaces`` set a namespace selector at the Kubernetes level;
-    ``enabled_namespaces`` was only filtered at the application level, causing
-    every pod CREATE event across all namespaces to be sent to the admission
-    controller webhook. This could overwhelm the Cluster Agent on large clusters.
+    Add optional webhook-level namespace filtering for
+    ``apm_config.instrumentation.enabled_namespaces``. When
+    ``admission_controller.auto_instrumentation.webhook_filter_namespaces`` is
+    set to ``true``, the MutatingWebhookConfiguration includes a
+    ``namespaceSelector`` that restricts admission requests to only the enabled
+    namespaces. This prevents the Kubernetes API server from sending pod CREATE
+    events from all namespaces to the Cluster Agent, reducing load on large
+    clusters. Note that enabling this filter means pods with per-pod opt-in
+    (``admission.datadoghq.com/enabled=true``) outside of the enabled namespaces
+    will no longer be mutated.


### PR DESCRIPTION
### What does this PR do?

Adds optional Kubernetes-level namespace filtering to the MutatingWebhookConfiguration when `apm_config.instrumentation.enabled_namespaces` is configured. When the new `admission_controller.auto_instrumentation.webhook_filter_namespaces` config flag is set to `true`, a `LabelSelectorOpIn` match expression on `kubernetes.io/metadata.name` is added to the webhook's `namespaceSelector`, mirroring the existing `disabledNamespaces` implementation.

### Motivation

When `enabledNamespaces` is configured, the webhook's `namespaceSelector` is empty, so the Kubernetes API server sends every pod CREATE event from all namespaces to the admission controller. The agent then filters at the application level. On large clusters this can overwhelm the Cluster Agent. Setting the `namespaceSelector` at the webhook level prevents irrelevant requests from ever reaching the agent.

This is gated behind a config flag because enabling it changes behavior for pods that use per-pod opt-in (`admission.datadoghq.com/enabled=true`) outside of enabled namespaces. Currently those pods are still mutated at the application level; with the flag enabled, the API server drops the request before it reaches the webhook. This is consistent with how `disabledNamespaces` already works (namespace filtering takes precedence over pod-level opt-in), but is opt-in to preserve backwards compatibility.

### Describe how you validated your changes

Added unit tests in `label_selectors_test.go` covering:
- `EnabledNamespaces` and `EnabledNamespacesWebhookFilter` populate correctly from config
- `Get()` does not add an `In` expression when the webhook filter flag is disabled (default)
- `Get()` adds an `In` expression when the webhook filter flag is enabled
- `useNamespaceSelector=true` merges all expressions into the namespace selector

All existing tests continue to pass.

### Additional Notes

- When `enabledNamespaces` is empty (default), behavior is unchanged regardless of the flag.
- `enabledNamespaces` and `disabledNamespaces` are mutually exclusive (validated in `config.go`), but both expressions can coexist at the selector level since Kubernetes ANDs them.
- A single webhook entry cannot express "namespace in [enabled list] OR pod has label enabled=true" since Kubernetes ANDs `namespaceSelector` and `objectSelector`. Supporting both would require registering two separate webhooks, which is a larger architectural change.