### PR TITLE
Add 26 shell test scenarios from yash POSIX

### DIFF
--- a/pkg/shell/tests/scenarios/shell/brace_group/exit_inside.yaml
+++ b/pkg/shell/tests/scenarios/shell/brace_group/exit_inside.yaml
@@ -1,0 +1,11 @@
+description: Exit inside a brace group terminates execution.
+input:
+  # language=bash
+  script: |+
+    { echo hello; exit 0; echo not reached; }
+    echo also not reached
+expect:
+  stdout: |+
+    hello
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/brace_group/newlines.yaml
+++ b/pkg/shell/tests/scenarios/shell/brace_group/newlines.yaml
@@ -1,0 +1,14 @@
+description: Brace group works with multi-line formatting using newlines.
+input:
+  # language=bash
+  script: |+
+    {
+    echo hello
+    echo world
+    }
+expect:
+  stdout: |+
+    hello
+    world
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/brace_group/var_shared_scope.yaml
+++ b/pkg/shell/tests/scenarios/shell/brace_group/var_shared_scope.yaml
@@ -1,0 +1,13 @@
+description: Variables modified inside a brace group are visible outside (shared scope).
+input:
+  # language=bash
+  script: |+
+    V=1
+    { V=2; echo inner $V; }
+    echo outer $V
+expect:
+  stdout: |+
+    inner 2
+    outer 2
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/comments/backslash_ending.yaml
+++ b/pkg/shell/tests/scenarios/shell/comments/backslash_ending.yaml
@@ -1,0 +1,11 @@
+description: A backslash at the end of a comment does not continue the line.
+input:
+  # language=bash
+  script: |+
+    # \
+    echo foo
+expect:
+  stdout: |+
+    foo
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/comments/hash_in_word.yaml
+++ b/pkg/shell/tests/scenarios/shell/comments/hash_in_word.yaml
@@ -1,0 +1,11 @@
+description: A hash sign in the middle of a word is literal, not a comment.
+input:
+  # language=bash
+  script: |+
+    V=abc#def
+    echo 123#456 $V
+expect:
+  stdout: |+
+    123#456 abc#def
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/comments/in_and_or.yaml
+++ b/pkg/shell/tests/scenarios/shell/comments/in_and_or.yaml
@@ -1,0 +1,13 @@
+description: A comment after && or || is ignored and the list continues.
+input:
+  # language=bash
+  script: |+
+    echo foo &&# comment after &&
+    echo bar ||# comment after ||
+    echo baz
+expect:
+  stdout: |+
+    foo
+    bar
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/comments/in_brace_group.yaml
+++ b/pkg/shell/tests/scenarios/shell/comments/in_brace_group.yaml
@@ -1,0 +1,12 @@
+description: Comments can appear inside brace groups.
+input:
+  # language=bash
+  script: |+
+    { # comment after open brace
+    echo foo # comment after command
+    } # comment after close brace
+expect:
+  stdout: |+
+    foo
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/comments/in_for_loop.yaml
+++ b/pkg/shell/tests/scenarios/shell/comments/in_for_loop.yaml
@@ -1,0 +1,16 @@
+description: Comments can appear between for loop tokens.
+input:
+  # language=bash
+  script: |+
+    for v # comment after variable
+    in 1 2 3 # comment after items
+    do # comment after do
+    echo $v # comment after body
+    done
+expect:
+  stdout: |+
+    1
+    2
+    3
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/comments/in_pipeline.yaml
+++ b/pkg/shell/tests/scenarios/shell/comments/in_pipeline.yaml
@@ -1,0 +1,11 @@
+description: A comment after a pipe operator is ignored and the pipeline continues.
+input:
+  # language=bash
+  script: |+
+    echo foo |# this is a comment
+    cat
+expect:
+  stdout: |+
+    foo
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/for_clause/basic/in_as_word.yaml
+++ b/pkg/shell/tests/scenarios/shell/for_clause/basic/in_as_word.yaml
@@ -1,0 +1,10 @@
+description: The word "in" can be used as a for loop item.
+input:
+  # language=bash
+  script: |+
+    for i in in; do echo $i; done
+expect:
+  stdout: |+
+    in
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/for_clause/basic/words_not_assignments.yaml
+++ b/pkg/shell/tests/scenarios/shell/for_clause/basic/words_not_assignments.yaml
@@ -1,0 +1,11 @@
+description: Words in for loop items are not treated as variable assignments.
+input:
+  # language=bash
+  script: |+
+    V=foo
+    for i in V=bar; do echo $i $V; done
+expect:
+  stdout: |+
+    V=bar foo
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/for_clause/break_cont/break_after_and.yaml
+++ b/pkg/shell/tests/scenarios/shell/for_clause/break_cont/break_after_and.yaml
@@ -1,0 +1,14 @@
+description: Break after && exits the loop when the left side succeeds.
+input:
+  # language=bash
+  script: |+
+    for i in 1; do
+    true && break
+    echo not reached
+    done
+    echo done
+expect:
+  stdout: |+
+    done
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/for_clause/break_cont/break_after_or.yaml
+++ b/pkg/shell/tests/scenarios/shell/for_clause/break_cont/break_after_or.yaml
@@ -1,0 +1,14 @@
+description: Break after || exits the loop when the left side fails.
+input:
+  # language=bash
+  script: |+
+    for i in 1; do
+    false || break
+    echo not reached
+    done
+    echo done
+expect:
+  stdout: |+
+    done
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/for_clause/break_cont/break_from_brace.yaml
+++ b/pkg/shell/tests/scenarios/shell/for_clause/break_cont/break_from_brace.yaml
@@ -1,0 +1,14 @@
+description: Break inside a brace group exits the enclosing for loop.
+input:
+  # language=bash
+  script: |+
+    for i in 1; do
+    { break; }
+    echo not reached
+    done
+    echo done
+expect:
+  stdout: |+
+    done
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/for_clause/break_cont/continue_after_and.yaml
+++ b/pkg/shell/tests/scenarios/shell/for_clause/break_cont/continue_after_and.yaml
@@ -1,0 +1,14 @@
+description: Continue after && skips to next iteration when left side succeeds.
+input:
+  # language=bash
+  script: |+
+    for i in 1 2; do
+    true && continue
+    echo not reached
+    done
+    echo done
+expect:
+  stdout: |+
+    done
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/for_clause/break_cont/continue_after_or.yaml
+++ b/pkg/shell/tests/scenarios/shell/for_clause/break_cont/continue_after_or.yaml
@@ -1,0 +1,14 @@
+description: Continue after || skips to next iteration when left side fails.
+input:
+  # language=bash
+  script: |+
+    for i in 1 2; do
+    false || continue
+    echo not reached
+    done
+    echo done
+expect:
+  stdout: |+
+    done
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/for_clause/break_cont/continue_from_brace.yaml
+++ b/pkg/shell/tests/scenarios/shell/for_clause/break_cont/continue_from_brace.yaml
@@ -1,0 +1,16 @@
+description: Continue inside a brace group skips to next iteration of the enclosing for loop.
+input:
+  # language=bash
+  script: |+
+    for i in 1 2; do
+    { echo $i; continue; }
+    echo not reached
+    done
+    echo done
+expect:
+  stdout: |+
+    1
+    2
+    done
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/line_continuation/in_and_operator.yaml
+++ b/pkg/shell/tests/scenarios/shell/line_continuation/in_and_operator.yaml
@@ -1,0 +1,15 @@
+description: Line continuation after && operator continues the and-list on the next line.
+input:
+  # language=bash
+  script: |+
+    echo 1 &&
+    echo 2 &&
+
+    echo 3
+expect:
+  stdout: |+
+    1
+    2
+    3
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/line_continuation/in_assignment.yaml
+++ b/pkg/shell/tests/scenarios/shell/line_continuation/in_assignment.yaml
@@ -1,0 +1,12 @@
+description: Line continuation in variable assignment joins name and value across lines.
+input:
+  # language=bash
+  script: |+
+    fo\
+    o=bar
+    echo $foo
+expect:
+  stdout: |+
+    bar
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/line_continuation/in_or_operator.yaml
+++ b/pkg/shell/tests/scenarios/shell/line_continuation/in_or_operator.yaml
@@ -1,0 +1,13 @@
+description: Line continuation after || operator continues the or-list on the next line.
+input:
+  # language=bash
+  script: |+
+    false ||
+    false ||
+
+    echo fallback
+expect:
+  stdout: |+
+    fallback
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/line_continuation/in_pipe_operator.yaml
+++ b/pkg/shell/tests/scenarios/shell/line_continuation/in_pipe_operator.yaml
@@ -1,0 +1,11 @@
+description: Line continuation after pipe operator continues the pipeline on the next line.
+input:
+  # language=bash
+  script: |+
+    echo hello |
+    cat
+expect:
+  stdout: |+
+    hello
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/pipe/exit_code/pipeline_status_via_dollar_question.yaml
+++ b/pkg/shell/tests/scenarios/shell/pipe/exit_code/pipeline_status_via_dollar_question.yaml
@@ -1,0 +1,14 @@
+description: Pipeline exit status is from the last command and can be checked via $?.
+input:
+  # language=bash
+  script: |+
+    echo foo | true
+    echo $?
+    echo bar | false
+    echo $?
+expect:
+  stdout: |+
+    0
+    1
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/var_expand/basic/multiple_same_line.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/basic/multiple_same_line.yaml
@@ -1,0 +1,11 @@
+description: Multiple variables can be assigned on a single line.
+input:
+  # language=bash
+  script: |+
+    a=foo b=bar
+    echo $a $b
+expect:
+  stdout: |+
+    foo bar
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/var_expand/quoting/backslash_in_double_quotes.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/quoting/backslash_in_double_quotes.yaml
@@ -1,0 +1,12 @@
+description: Backslash-backslash inside double quotes produces a single literal backslash.
+input:
+  # language=bash
+  script: |+
+    echo "a\\b"
+    echo "a\\\\b"
+expect:
+  stdout: |+
+    a\b
+    a\\b
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/var_expand/quoting/quotes_in_value.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/quoting/quotes_in_value.yaml
@@ -1,0 +1,14 @@
+description: Assignment values can contain quotes from the other quoting style.
+input:
+  # language=bash
+  script: |+
+    a='A"B"C'
+    b="A'B'C"
+    echo $a
+    echo $b
+expect:
+  stdout: |+
+    A"B"C
+    A'B'C
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/var_expand/quoting/single_quote_concat.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/quoting/single_quote_concat.yaml
@@ -1,0 +1,10 @@
+description: Adjacent single-quoted strings are concatenated.
+input:
+  # language=bash
+  script: |+
+    echo 'hel''lo'
+expect:
+  stdout: |+
+    hello
+  stderr: ""
+  exit_code: 0


### PR DESCRIPTION
<!-- dd-meta {"pullId":"e650e4fd-e126-4441-a584-c2cdd3b6a077","source":"chat","resourceId":"b7713007-83b3-48e8-b424-703677dea353","workflowId":"4eb25d34-6118-4b9f-b025-ee3836d8a0d6","codeChangeId":"4eb25d34-6118-4b9f-b025-ee3836d8a0d6","sourceType":"chat"} -->
### What does this PR do?

Adds 26 new YAML test scenarios to `pkg/shell/tests/scenarios/` to improve coverage of the restricted shell interpreter, inspired by test patterns from `pkg/shell/yash_posix_tests/`.

### Motivation

The existing scenario tests had gaps in several areas that the yash POSIX test suite covers thoroughly. This PR fills those gaps without duplicating existing coverage, across 7 feature areas:

- **Line continuation** (4 new): assignment, `&&`, `||`, and pipe operators
- **Comments** (6 new): backslash ending, hash-in-word, in pipeline/and-or/for-loop/brace-group
- **Break/continue with logic ops** (6 new): `break`/`continue` after `&&`/`||`, from brace groups
- **For loop edge cases** (2 new): words-not-treated-as-assignments, `in` as a literal word
- **Brace group** (3 new): variable shared scope, exit inside, multi-line newlines
- **Variable/quoting** (4 new): multiple assignments, quotes in values, single-quote concat, backslash in double quotes
- **Pipeline exit status** (1 new): checking `$?` after pipelines

### Describe how you validated your changes

- All 26 new scenarios pass `TestShellScenarios` (interpreter tests)
- All 26 new scenarios pass `TestShellScenariosAgainstBash` (bash comparison tests)

### Additional Notes

Two originally planned scenarios (`break_before_and`, `continue_before_and`) were excluded because they exercise a known interpreter behavior difference where break/continue flags get overwritten by subsequent builtin calls in `&&`/`||` chains.

---

PR by Bits
[View session in Datadog](https://app.datadoghq.com/code/b7713007-83b3-48e8-b424-703677dea353)

Comment @datadog to request changes