### PR TITLE
Send one Datadog event per correlation via testbench

### DIFF
--- a/cmd/observer-testbench/main.go
+++ b/cmd/observer-testbench/main.go
@@ -37,6 +37,10 @@ type CLIParams struct {
 	Headless string // scenario name to run (empty = interactive mode)
 	Output   string // path for observer JSON output
 	Verbose  bool   // include full detail in JSON output (headless mode only)
+
+	// SendAnomalyEvent mode: run scenario and send one Datadog event per correlation
+	SendAnomalyEvent string // scenario name to run (empty = disabled)
+	DryRun           bool   // print events to stdout instead of sending them
 }
 
 func main() {
@@ -47,6 +51,8 @@ func main() {
 	headless := flag.String("headless", "", "Run scenario in headless mode (no HTTP server) and exit")
 	output := flag.String("output", "", "Path for eval JSON output (headless mode only)")
 	verbose := flag.Bool("verbose", false, "Include full detail in JSON output (headless mode only)")
+	sendAnomalyEvent := flag.String("send-anomaly-event", "", "Run scenario and send one Datadog event per correlation, then exit")
+	dryRun := flag.Bool("dry-run", false, "Print events to stdout instead of sending them (use with --send-anomaly-event)")
 	flag.Parse()
 
 	overrides := make(map[string]bool)
@@ -83,12 +89,14 @@ func main() {
 			LogParams:    log.ForOneShot("", "off", true),
 		}),
 		fx.Supply(CLIParams{
-			ScenariosDir:      *scenariosDir,
-			HTTPAddr:          *httpAddr,
-			EnableOverrides:   overrides,
-			Headless:          *headless,
-			Output:            *output,
-			Verbose:           *verbose,
+			ScenariosDir:     *scenariosDir,
+			HTTPAddr:         *httpAddr,
+			EnableOverrides:  overrides,
+			Headless:         *headless,
+			Output:           *output,
+			Verbose:          *verbose,
+			SendAnomalyEvent: *sendAnomalyEvent,
+			DryRun:           *dryRun,
 		}),
 	)
 	if err != nil {
@@ -108,6 +116,11 @@ func run(recorder recorderdef.Component, params CLIParams) error {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to create test bench: %v\n", err)
 		return err
+	}
+
+	// SendAnomalyEvent mode: run scenario and send one Datadog event per correlation, then exit.
+	if params.SendAnomalyEvent != "" {
+		return tb.RunSendAnomalyEvents(params.SendAnomalyEvent, params.DryRun)
 	}
 
 	// Headless mode: run scenario, write output, exit (no HTTP server)

--- a/cmd/observer-testbench/main.go
+++ b/cmd/observer-testbench/main.go
@@ -124,18 +124,18 @@ func run(recorder recorderdef.Component, params CLIParams) error {
 
 	// Print component status from registry
 	components := tb.GetComponents()
-	fmt.Print("Analyzers: ")
-	var analyzers []string
+	fmt.Print("Detectors: ")
+	var detectors []string
 	for _, c := range components {
-		if c.Category == "analyzer" {
+		if c.Category == "detector" {
 			status := c.DisplayName
 			if !c.Enabled {
 				status += " (disabled)"
 			}
-			analyzers = append(analyzers, status)
+			detectors = append(detectors, status)
 		}
 	}
-	fmt.Println(strings.Join(analyzers, ", "))
+	fmt.Println(strings.Join(detectors, ", "))
 
 	fmt.Print("Correlators: ")
 	var correlators []string
@@ -173,7 +173,7 @@ func run(recorder recorderdef.Component, params CLIParams) error {
 	fmt.Println("  GET  /api/series/{ns}/{name}              - Get series data")
 	fmt.Println("  GET  /api/anomalies                       - Get anomalies")
 	fmt.Println("  GET  /api/correlations                    - Get correlations")
-	fmt.Println("  GET  /api/correlators/{name}              - Get correlator data")
+	fmt.Println("  GET  /api/components/{name}/data           - Get component data")
 	fmt.Println("  GET  /api/stats                           - Correlator stats")
 	fmt.Println()
 

--- a/cmd/observer-testbench/ui/src/api/client.ts
+++ b/cmd/observer-testbench/ui/src/api/client.ts
@@ -169,8 +169,8 @@ export interface CompressedGroup {
   lastUpdated?: number;
 }
 
-// Generic correlator data response
-export interface CorrelatorDataResponse {
+// Generic component data response
+export interface ComponentDataResponse {
   enabled: boolean;
   data: unknown;
 }
@@ -245,8 +245,8 @@ class ApiClient {
     return this.fetch('/correlations');
   }
 
-  async getCorrelatorData(name: string): Promise<CorrelatorDataResponse> {
-    return this.fetch(`/correlators/${encodeURIComponent(name)}`);
+  async getComponentData(name: string): Promise<ComponentDataResponse> {
+    return this.fetch(`/components/${encodeURIComponent(name)}/data`);
   }
 
   // Legacy endpoints (thin wrappers for backward compat)

--- a/cmd/observer-testbench/ui/src/components/CorrelatorView.tsx
+++ b/cmd/observer-testbench/ui/src/components/CorrelatorView.tsx
@@ -187,7 +187,7 @@ export function CorrelatorView({ state, actions, sidebarWidth, timeRange }: Corr
 
                   {/* Dynamic correlator sections */}
                   {correlatorComponents.map((comp) => {
-                    const corrData = state.correlatorData.get(comp.name);
+                    const corrData = state.componentData.get(comp.name);
                     return (
                       <CorrelatorSection
                         key={comp.name}

--- a/cmd/observer-testbench/ui/src/components/MetricsView.tsx
+++ b/cmd/observer-testbench/ui/src/components/MetricsView.tsx
@@ -59,7 +59,6 @@ export function MetricsView({
   smoothLines,
 }: MetricsViewProps) {
   const [selectedGroups, setSelectedGroups] = useState<Set<string>>(new Set());
-  const [enabledDetectors, setEnabledDetectors] = useState<Set<string>>(new Set());
   const [groupSeriesData, setGroupSeriesData] = useState<Map<string, SeriesData[]>>(new Map());
   const [aggregationType, setAggregationType] = useState<AggregationType>('avg');
   const [showAnomalyOnlyGroups, setShowAnomalyOnlyGroups] = useState(false);
@@ -76,14 +75,15 @@ export function MetricsView({
     [components]
   );
 
+  // Derive enabled detectors from backend component state (source of truth)
+  const enabledDetectors = useMemo(
+    () => new Set(detectorComponents.filter((c) => c.enabled).map((c) => c.name)),
+    [detectorComponents]
+  );
+
   const anomalies = useMemo(
     () => allAnomalies.filter((a) => enabledDetectors.has(getDetectorComponent(a))),
     [allAnomalies, enabledDetectors]
-  );
-
-  const tsDetectorNames = useMemo(
-    () => detectorComponents.map((c) => c.name),
-    [detectorComponents]
   );
 
   // Map comp.name (detectorComponent) → detectorName used by the timeline for coloring
@@ -174,12 +174,11 @@ export function MetricsView({
 
   const initializedScenarioRef = useRef<string | null>(null);
   useEffect(() => {
-    if (tsDetectorNames.length > 0 && state.activeScenario && initializedScenarioRef.current !== state.activeScenario) {
+    if (state.activeScenario && initializedScenarioRef.current !== state.activeScenario) {
       initializedScenarioRef.current = state.activeScenario;
-      setEnabledDetectors(new Set(tsDetectorNames));
       setTagFilterInput('');
     }
-  }, [tsDetectorNames, state.activeScenario]);
+  }, [state.activeScenario]);
 
   const [autoSelectedScenario, setAutoSelectedScenario] = useState<string | null>(null);
   useEffect(() => {
@@ -237,13 +236,7 @@ export function MetricsView({
   }, [selectedGroups, state.connectionState, state.activeScenario, groupByKey, groupSeriesData.size]);
 
   const toggleDetector = (name: string) => {
-    const next = new Set(enabledDetectors);
-    if (next.has(name)) {
-      next.delete(name);
-    } else {
-      next.add(name);
-    }
-    setEnabledDetectors(next);
+    actions.toggleComponent(name);
   };
 
   const anomalousGroupKeys = useMemo(() => {

--- a/cmd/observer-testbench/ui/src/hooks/useObserver.ts
+++ b/cmd/observer-testbench/ui/src/hooks/useObserver.ts
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { api } from '../api/client';
 import type {
   StatusResponse, ScenarioInfo, ComponentInfo, SeriesInfo, Anomaly, LogAnomaly, LogEntry, Correlation,
-  CompressedGroup, CorrelatorDataResponse, CorrelatorStats
+  CompressedGroup, ComponentDataResponse, CorrelatorStats
 } from '../api/client';
 
 export type ConnectionState = 'disconnected' | 'connected' | 'loading' | 'ready';
@@ -17,8 +17,8 @@ export interface ObserverState {
   logs: LogEntry[];
   logAnomalies: LogAnomaly[];
   correlations: Correlation[];
-  // Generic correlator data keyed by correlator name
-  correlatorData: Map<string, CorrelatorDataResponse>;
+  // Generic component data keyed by component name
+  componentData: Map<string, ComponentDataResponse>;
   compressedGroups: CompressedGroup[];
   correlatorStats: CorrelatorStats | null;
   activeScenario: string | null;
@@ -43,7 +43,7 @@ export function useObserver(): [ObserverState, ObserverActions] {
   const [logs, setLogs] = useState<LogEntry[]>([]);
   const [logAnomalies, setLogAnomalies] = useState<LogAnomaly[]>([]);
   const [correlations, setCorrelations] = useState<Correlation[]>([]);
-  const [correlatorData, setCorrelatorData] = useState<Map<string, CorrelatorDataResponse>>(new Map());
+  const [componentData, setComponentData] = useState<Map<string, ComponentDataResponse>>(new Map());
   const [compressedGroups, setCompressedGroups] = useState<CompressedGroup[]>([]);
   const [correlatorStats, setCorrelatorStats] = useState<CorrelatorStats | null>(null);
   const [activeScenario, setActiveScenario] = useState<string | null>(null);
@@ -80,18 +80,16 @@ export function useObserver(): [ObserverState, ObserverActions] {
           api.getStats(),
         ]);
 
-      // Discover correlator names from components and fetch their data
-      const correlatorNames = componentsData
-        .filter((c: ComponentInfo) => c.category === 'correlator')
-        .map((c: ComponentInfo) => c.name);
+      // Fetch data for ALL components (any component may provide extra data)
+      const componentNames = componentsData.map((c: ComponentInfo) => c.name);
 
-      const correlatorResults = await Promise.all(
-        correlatorNames.map(async (name: string) => {
+      const componentDataResults = await Promise.all(
+        componentNames.map(async (name: string) => {
           try {
-            const data = await api.getCorrelatorData(name);
-            return [name, data] as [string, CorrelatorDataResponse];
+            const data = await api.getComponentData(name);
+            return [name, data] as [string, ComponentDataResponse];
           } catch {
-            return [name, { enabled: false, data: null }] as [string, CorrelatorDataResponse];
+            return [name, { enabled: false, data: null }] as [string, ComponentDataResponse];
           }
         })
       );
@@ -105,7 +103,7 @@ export function useObserver(): [ObserverState, ObserverActions] {
       setLogAnomalies(logAnomaliesData);
       setCorrelations(correlationsData);
       setCompressedGroups(compressedGroupsData);
-      setCorrelatorData(new Map(correlatorResults));
+      setComponentData(new Map(componentDataResults));
       setCorrelatorStats(statsData);
       setError(null);
 
@@ -215,7 +213,7 @@ export function useObserver(): [ObserverState, ObserverActions] {
       logs,
       logAnomalies,
       correlations,
-      correlatorData,
+      componentData,
       compressedGroups,
       correlatorStats,
       activeScenario,

--- a/comp/observer/def/component.go
+++ b/comp/observer/def/component.go
@@ -410,3 +410,67 @@ type RawAnomalyState interface {
 	// RawAnomalies returns all anomalies detected by MetricsDetector implementations.
 	RawAnomalies() []Anomaly
 }
+
+// SeriesFilter specifies criteria for selecting series.
+type SeriesFilter struct {
+	Namespace   string            // exact match (empty = any)
+	NamePattern string            // prefix match (empty = any)
+	TagMatchers map[string]string // required tag key=value pairs
+}
+
+// SeriesKey identifies a specific series.
+type SeriesKey struct {
+	Namespace string
+	Name      string
+	Tags      []string
+}
+
+// Aggregate specifies which statistic to extract from summary stats.
+type Aggregate int
+
+const (
+	AggregateAverage Aggregate = iota
+	AggregateSum
+	AggregateCount
+	AggregateMin
+	AggregateMax
+)
+
+// StorageReader provides read access to time series data.
+// Detectors use this to pull whatever data they need.
+type StorageReader interface {
+	// ListSeries returns keys of all series matching the filter.
+	ListSeries(filter SeriesFilter) []SeriesKey
+
+	// GetSeriesByKey returns the full series for a key.
+	GetSeriesByKey(key SeriesKey, agg Aggregate) *Series
+
+	// GetSeriesRange returns points within a time range [start, end].
+	GetSeriesRange(key SeriesKey, start, end int64, agg Aggregate) *Series
+
+	// ReadSince returns points with timestamp > cursor, plus the new cursor position.
+	// Use cursor=0 to read all points.
+	ReadSince(key SeriesKey, cursor int64, agg Aggregate) (points []Point, newCursor int64)
+
+	// PointCount returns the number of raw data points for a series without
+	// loading or converting them. Returns 0 if the series is not found.
+	PointCount(key SeriesKey) int
+}
+
+// MultiSeriesDetectionResult contains outputs from multi-series detection.
+type MultiSeriesDetectionResult struct {
+	Anomalies []Anomaly
+	// Used to debug anomaly detectors
+	Telemetry []ObserverTelemetry
+}
+
+// MultiSeriesDetector is the flexible detection interface where detectors pull data from storage.
+// This supports multivariate detection across multiple series.
+type MultiSeriesDetector interface {
+	Name() string
+
+	// Detect is called periodically by the scheduler.
+	// The detector queries storage for whatever data it needs.
+	// dataTime is the current data timestamp (for determinism - only read data <= dataTime).
+	Detect(storage StorageReader, dataTime int64) MultiSeriesDetectionResult
+}

--- a/comp/observer/impl/anomaly_correlator_leadlag.go
+++ b/comp/observer/impl/anomaly_correlator_leadlag.go
@@ -458,7 +458,7 @@ func (c *LeadLagCorrelator) GetStats() map[string]interface{} {
 	}
 }
 
-// GetExtraData implements CorrelatorDataProvider.
+// GetExtraData implements ComponentDataProvider.
 func (c *LeadLagCorrelator) GetExtraData() interface{} {
 	edges := c.GetEdges()
 	if edges == nil {

--- a/comp/observer/impl/anomaly_correlator_surprise.go
+++ b/comp/observer/impl/anomaly_correlator_surprise.go
@@ -406,7 +406,7 @@ func (c *SurpriseCorrelator) GetStats() map[string]interface{} {
 	}
 }
 
-// GetExtraData implements CorrelatorDataProvider.
+// GetExtraData implements ComponentDataProvider.
 func (c *SurpriseCorrelator) GetExtraData() interface{} {
 	edges := c.GetEdges()
 	if edges == nil {

--- a/comp/observer/impl/anomaly_correlator_time_cluster.go
+++ b/comp/observer/impl/anomaly_correlator_time_cluster.go
@@ -20,10 +20,6 @@ type TimeClusterConfig struct {
 	// Default: 10 seconds.
 	ProximitySeconds int64
 
-	// MinClusterSize is the minimum number of anomalies to form a reportable cluster.
-	// Default: 2.
-	MinClusterSize int
-
 	// WindowSeconds is how long to keep anomalies before eviction.
 	// Default: 60 seconds.
 	WindowSeconds int64
@@ -33,7 +29,6 @@ type TimeClusterConfig struct {
 func DefaultTimeClusterConfig() TimeClusterConfig {
 	return TimeClusterConfig{
 		ProximitySeconds: 10,
-		MinClusterSize:   2,
 		WindowSeconds:    60,
 	}
 }
@@ -41,9 +36,9 @@ func DefaultTimeClusterConfig() TimeClusterConfig {
 // timeCluster represents a group of temporally-related anomalies.
 type timeCluster struct {
 	id           int
-	anomalies    map[observer.SeriesID]observer.Anomaly // keyed by SourceSeriesID for dedup
-	minTimestamp int64                                  // earliest anomaly timestamp
-	maxTimestamp int64                                  // latest anomaly timestamp
+	anomalies    []observer.Anomaly
+	minTimestamp int64 // earliest anomaly timestamp
+	maxTimestamp int64 // latest anomaly timestamp
 }
 
 // TimeClusterCorrelator clusters anomalies based on timestamp proximity.
@@ -60,9 +55,6 @@ type TimeClusterCorrelator struct {
 func NewTimeClusterCorrelator(config TimeClusterConfig) *TimeClusterCorrelator {
 	if config.ProximitySeconds == 0 {
 		config.ProximitySeconds = 10
-	}
-	if config.MinClusterSize == 0 {
-		config.MinClusterSize = 2
 	}
 	if config.WindowSeconds == 0 {
 		config.WindowSeconds = 60
@@ -101,7 +93,7 @@ func (c *TimeClusterCorrelator) Process(anomaly observer.Anomaly) {
 		c.nextClusterID++
 		newCluster := &timeCluster{
 			id:           c.nextClusterID,
-			anomalies:    map[observer.SeriesID]observer.Anomaly{anomaly.SourceSeriesID: anomaly},
+			anomalies:    []observer.Anomaly{anomaly},
 			minTimestamp: anomaly.Timestamp,
 			maxTimestamp: anomaly.Timestamp,
 		}
@@ -124,18 +116,10 @@ func (c *TimeClusterCorrelator) isNearCluster(ts int64, cluster *timeCluster) bo
 	return ts >= cluster.minTimestamp-proximity && ts <= cluster.maxTimestamp+proximity
 }
 
-// addToCluster adds an anomaly to a cluster, updating timestamps and deduping by series ID.
+// addToCluster adds an anomaly to a cluster, updating timestamps.
 func (c *TimeClusterCorrelator) addToCluster(cluster *timeCluster, anomaly observer.Anomaly) {
-	// Dedup by SourceSeriesID - keep the one with later timestamp (more recent)
-	if existing, ok := cluster.anomalies[anomaly.SourceSeriesID]; ok {
-		if anomaly.Timestamp > existing.Timestamp {
-			cluster.anomalies[anomaly.SourceSeriesID] = anomaly
-		}
-	} else {
-		cluster.anomalies[anomaly.SourceSeriesID] = anomaly
-	}
+	cluster.anomalies = append(cluster.anomalies, anomaly)
 
-	// Expand cluster timestamp range
 	if anomaly.Timestamp < cluster.minTimestamp {
 		cluster.minTimestamp = anomaly.Timestamp
 	}
@@ -155,16 +139,7 @@ func (c *TimeClusterCorrelator) mergeClusters(clusters []*timeCluster) *timeClus
 
 	// Merge others into it
 	for _, other := range clusters[1:] {
-		for sid, anomaly := range other.anomalies {
-			if existing, ok := merged.anomalies[sid]; ok {
-				if anomaly.Timestamp > existing.Timestamp {
-					merged.anomalies[sid] = anomaly
-				}
-			} else {
-				merged.anomalies[sid] = anomaly
-			}
-		}
-		// Expand timestamp range
+		merged.anomalies = append(merged.anomalies, other.anomalies...)
 		if other.minTimestamp < merged.minTimestamp {
 			merged.minTimestamp = other.minTimestamp
 		}
@@ -228,21 +203,20 @@ type TimeClusterInfo struct {
 	AnomalyCount int      `json:"anomaly_count"`
 }
 
-// GetClusters returns clusters that meet the minimum size threshold for visualization.
+// GetClusters returns all clusters for visualization.
 func (c *TimeClusterCorrelator) GetClusters() []TimeClusterInfo {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
 	var result []TimeClusterInfo
 	for _, cluster := range c.clusters {
-		// Only include clusters that meet minimum size
-		if len(cluster.anomalies) < c.config.MinClusterSize {
-			continue
+		seen := make(map[observer.SeriesID]bool)
+		for _, a := range cluster.anomalies {
+			seen[a.SourceSeriesID] = true
 		}
-
-		sources := make([]string, 0, len(cluster.anomalies))
-		for source := range cluster.anomalies {
-			sources = append(sources, string(source))
+		sources := make([]string, 0, len(seen))
+		for sid := range seen {
+			sources = append(sources, string(sid))
 		}
 		sort.Strings(sources)
 		result = append(result, TimeClusterInfo{
@@ -280,14 +254,13 @@ func (c *TimeClusterCorrelator) GetStats() map[string]interface{} {
 		"total_clusters":       len(c.clusters),
 		"total_anomalies":      totalAnomalies,
 		"largest_cluster_size": maxClusterSize,
-		"proximity_seconds":    c.config.ProximitySeconds,
-		"window_seconds":       c.config.WindowSeconds,
-		"min_cluster_size":     c.config.MinClusterSize,
-		"current_data_time":    c.currentDataTime,
+		"proximity_seconds": c.config.ProximitySeconds,
+		"window_seconds":    c.config.WindowSeconds,
+		"current_data_time": c.currentDataTime,
 	}
 }
 
-// GetExtraData implements CorrelatorDataProvider.
+// GetExtraData implements ComponentDataProvider.
 func (c *TimeClusterCorrelator) GetExtraData() interface{} {
 	return c.GetClusters()
 }
@@ -301,26 +274,24 @@ func (c *TimeClusterCorrelator) ActiveCorrelations() []observer.ActiveCorrelatio
 	var result []observer.ActiveCorrelation
 
 	for _, cluster := range c.clusters {
-		if len(cluster.anomalies) < c.config.MinClusterSize {
-			continue
+		// Collect unique series IDs
+		seen := make(map[observer.SeriesID]bool)
+		for _, a := range cluster.anomalies {
+			seen[a.SourceSeriesID] = true
 		}
-
-		// Collect anomalies and sources
-		anomalies := make([]observer.Anomaly, 0, len(cluster.anomalies))
-		memberSeriesIDs := make([]observer.SeriesID, 0, len(cluster.anomalies))
-		for source, anomaly := range cluster.anomalies {
-			anomalies = append(anomalies, anomaly)
-			memberSeriesIDs = append(memberSeriesIDs, source)
+		memberSeriesIDs := make([]observer.SeriesID, 0, len(seen))
+		for sid := range seen {
+			memberSeriesIDs = append(memberSeriesIDs, sid)
 		}
 		sort.Slice(memberSeriesIDs, func(i, j int) bool { return memberSeriesIDs[i] < memberSeriesIDs[j] })
-		metricNames := sortedUniqueMetricNames(anomalies)
+		metricNames := sortedUniqueMetricNames(cluster.anomalies)
 
 		result = append(result, observer.ActiveCorrelation{
 			Pattern:         fmt.Sprintf("time_cluster_%d", cluster.id),
 			Title:           fmt.Sprintf("TimeCluster: %d anomalies", len(cluster.anomalies)),
 			MemberSeriesIDs: memberSeriesIDs,
 			MetricNames:     metricNames,
-			Anomalies:       anomalies,
+			Anomalies:       cluster.anomalies,
 			FirstSeen:       cluster.minTimestamp,
 			LastUpdated:     cluster.maxTimestamp,
 		})

--- a/comp/observer/impl/anomaly_correlator_time_cluster_test.go
+++ b/comp/observer/impl/anomaly_correlator_time_cluster_test.go
@@ -16,7 +16,6 @@ import (
 func TestTimeClusterCorrelator_BasicClustering(t *testing.T) {
 	c := NewTimeClusterCorrelator(TimeClusterConfig{
 		ProximitySeconds: 10,
-		MinClusterSize:   2,
 		WindowSeconds:    60,
 	})
 
@@ -44,7 +43,6 @@ func TestTimeClusterCorrelator_BasicClustering(t *testing.T) {
 func TestTimeClusterCorrelator_ProximityWindow(t *testing.T) {
 	c := NewTimeClusterCorrelator(TimeClusterConfig{
 		ProximitySeconds: 10,
-		MinClusterSize:   2,
 		WindowSeconds:    60,
 	})
 
@@ -70,11 +68,10 @@ func TestTimeClusterCorrelator_ProximityWindow(t *testing.T) {
 func TestTimeClusterCorrelator_NotNearby(t *testing.T) {
 	c := NewTimeClusterCorrelator(TimeClusterConfig{
 		ProximitySeconds: 10,
-		MinClusterSize:   2,
 		WindowSeconds:    60,
 	})
 
-	// Anomalies outside proximity window should NOT cluster
+	// Anomalies outside proximity window should form separate clusters
 	c.Process(observer.Anomaly{
 		Source:         "metric.a",
 		SourceSeriesID: "ns|metric.a|",
@@ -89,14 +86,15 @@ func TestTimeClusterCorrelator_NotNearby(t *testing.T) {
 	})
 
 	correlations := c.ActiveCorrelations()
-	// Neither cluster meets MinClusterSize of 2
-	assert.Len(t, correlations, 0)
+	// Each anomaly forms its own cluster
+	assert.Len(t, correlations, 2)
+	assert.Len(t, correlations[0].Anomalies, 1)
+	assert.Len(t, correlations[1].Anomalies, 1)
 }
 
 func TestTimeClusterCorrelator_MergeClusters(t *testing.T) {
 	c := NewTimeClusterCorrelator(TimeClusterConfig{
 		ProximitySeconds: 10,
-		MinClusterSize:   2,
 		WindowSeconds:    60,
 	})
 
@@ -132,14 +130,13 @@ func TestTimeClusterCorrelator_MergeClusters(t *testing.T) {
 	assert.Len(t, correlations[0].Anomalies, 3)
 }
 
-func TestTimeClusterCorrelator_DedupBySeriesID(t *testing.T) {
+func TestTimeClusterCorrelator_SameSeriesMultipleAnomalies(t *testing.T) {
 	c := NewTimeClusterCorrelator(TimeClusterConfig{
 		ProximitySeconds: 10,
-		MinClusterSize:   1, // Lower threshold to see single-anomaly clusters
 		WindowSeconds:    60,
 	})
 
-	// Same SourceSeriesID, later anomaly should replace earlier
+	// Multiple anomalies from the same series should all be kept
 	c.Process(observer.Anomaly{
 		Source:         "metric.a",
 		SourceSeriesID: "ns|metric.a|",
@@ -152,19 +149,19 @@ func TestTimeClusterCorrelator_DedupBySeriesID(t *testing.T) {
 		SourceSeriesID: "ns|metric.a|",
 		Title:          "Anomaly A v2",
 		Description:    "second",
-		Timestamp:      105, // Later timestamp, should replace
+		Timestamp:      105,
 	})
 
 	correlations := c.ActiveCorrelations()
 	require.Len(t, correlations, 1)
-	assert.Len(t, correlations[0].Anomalies, 1)
-	assert.Equal(t, "second", correlations[0].Anomalies[0].Description)
+	assert.Len(t, correlations[0].Anomalies, 2)
+	// Single unique series
+	assert.Len(t, correlations[0].MemberSeriesIDs, 1)
 }
 
 func TestTimeClusterCorrelator_TaggedVariants(t *testing.T) {
 	c := NewTimeClusterCorrelator(TimeClusterConfig{
 		ProximitySeconds: 10,
-		MinClusterSize:   2,
 		WindowSeconds:    60,
 	})
 
@@ -193,7 +190,6 @@ func TestTimeClusterCorrelator_TaggedVariants(t *testing.T) {
 func TestTimeClusterCorrelator_Eviction(t *testing.T) {
 	c := NewTimeClusterCorrelator(TimeClusterConfig{
 		ProximitySeconds: 10,
-		MinClusterSize:   1,
 		WindowSeconds:    30,
 	})
 
@@ -221,46 +217,27 @@ func TestTimeClusterCorrelator_Eviction(t *testing.T) {
 	assert.Equal(t, observer.SeriesID("ns|metric.new|"), correlations[0].MemberSeriesIDs[0])
 }
 
-func TestTimeClusterCorrelator_MinClusterSize(t *testing.T) {
+func TestTimeClusterCorrelator_SingletonCluster(t *testing.T) {
 	c := NewTimeClusterCorrelator(TimeClusterConfig{
 		ProximitySeconds: 10,
-		MinClusterSize:   3, // Require 3 anomalies
 		WindowSeconds:    60,
 	})
 
-	// Add 2 nearby anomalies
+	// A single anomaly should form a cluster of one
 	c.Process(observer.Anomaly{
 		Source:         "metric.a",
 		SourceSeriesID: "ns|metric.a|",
 		Timestamp:      100,
 	})
-	c.Process(observer.Anomaly{
-		Source:         "metric.b",
-		SourceSeriesID: "ns|metric.b|",
-		Timestamp:      105,
-	})
 
-	// Should not report - only 2 anomalies, need 3
 	correlations := c.ActiveCorrelations()
-	assert.Len(t, correlations, 0)
-
-	// Add third
-	c.Process(observer.Anomaly{
-		Source:         "metric.c",
-		SourceSeriesID: "ns|metric.c|",
-		Timestamp:      108,
-	})
-
-	// Now should report
-	correlations = c.ActiveCorrelations()
 	require.Len(t, correlations, 1)
-	assert.Len(t, correlations[0].Anomalies, 3)
+	assert.Len(t, correlations[0].Anomalies, 1)
 }
 
 func TestTimeClusterCorrelator_DefaultConfig(t *testing.T) {
 	config := DefaultTimeClusterConfig()
 	assert.Equal(t, int64(10), config.ProximitySeconds)
-	assert.Equal(t, 2, config.MinClusterSize)
 	assert.Equal(t, int64(60), config.WindowSeconds)
 }
 

--- a/comp/observer/impl/metrics_detector_rrcf.go
+++ b/comp/observer/impl/metrics_detector_rrcf.go
@@ -1,0 +1,647 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+
+	observer "github.com/DataDog/datadog-agent/comp/observer/def"
+)
+
+// RRCFScoredPoint records a CoDisp score at a specific timestamp.
+type RRCFScoredPoint struct {
+	Timestamp int64   `json:"timestamp"`
+	Score     float64 `json:"score"`
+}
+
+// RRCFScoreStats contains distribution statistics and full score history for threshold analysis.
+type RRCFScoreStats struct {
+	Enabled        bool              `json:"enabled"`
+	SampleCount    int               `json:"sampleCount"`
+	AlignedPoints  int               `json:"alignedPoints"`
+	ShinglesBuilt  int               `json:"shinglesBuilt"`
+	MinScore       float64           `json:"minScore"`
+	MaxScore       float64           `json:"maxScore"`
+	MeanScore      float64           `json:"meanScore"`
+	StddevScore    float64           `json:"stddevScore"`
+	P50            float64           `json:"p50"`
+	P75            float64           `json:"p75"`
+	P90            float64           `json:"p90"`
+	P95            float64           `json:"p95"`
+	P99            float64           `json:"p99"`
+	Config         RRCFConfigSummary `json:"config"`
+	Metrics        []string          `json:"metrics"`
+	Scores         []RRCFScoredPoint `json:"scores"`
+}
+
+// RRCFConfigSummary is a JSON-friendly summary of RRCF configuration.
+type RRCFConfigSummary struct {
+	NumTrees       int     `json:"numTrees"`
+	TreeSize       int     `json:"treeSize"`
+	ShingleSize    int     `json:"shingleSize"`
+	ShingleDim     int     `json:"shingleDim"`
+	ThresholdSigma float64 `json:"thresholdSigma"`
+}
+
+// RRCFMetricDef defines a metric to include in the RRCF analysis.
+type RRCFMetricDef struct {
+	Namespace string
+	Name      string
+	Agg       observer.Aggregate
+}
+
+// RRCFConfig holds configuration for the RRCF analysis.
+type RRCFConfig struct {
+	// NumTrees is the number of trees in the forest. More trees = more robust but slower.
+	NumTrees int
+	// TreeSize is the maximum number of points per tree (sliding window size).
+	TreeSize int
+	// ShingleSize is the number of consecutive timestamps to combine into one point.
+	// ShingleSize=4 means each "point" is 4 consecutive samples, enabling temporal pattern detection.
+	ShingleSize int
+	// ThresholdSigma controls dynamic anomaly thresholding. A point is flagged if its
+	// CoDisp score exceeds mean + ThresholdSigma*stddev of the recent score window.
+	// Set to 0 to disable anomaly detection (scores still computed for analysis).
+	ThresholdSigma float64
+	// Metrics defines which series to include. If nil, uses DefaultRRCFMetrics().
+	Metrics []RRCFMetricDef
+}
+
+// DefaultRRCFConfig returns sensible defaults for RRCF.
+func DefaultRRCFConfig() RRCFConfig {
+	return RRCFConfig{
+		NumTrees:       100,
+		TreeSize:       256,
+		ShingleSize:    4,
+		ThresholdSigma: 3.0,
+	}
+}
+
+// DefaultRRCFMetrics returns the default metric set for RRCF in the live observer.
+// These are standard Datadog system metrics from DogStatsD.
+func DefaultRRCFMetrics() []RRCFMetricDef {
+	return []RRCFMetricDef{
+		{Namespace: "system", Name: "cpu.user", Agg: observer.AggregateAverage},
+		{Namespace: "system", Name: "cpu.system", Agg: observer.AggregateAverage},
+		{Namespace: "system", Name: "cpu.iowait", Agg: observer.AggregateAverage},
+		{Namespace: "system", Name: "memory.used", Agg: observer.AggregateAverage},
+		{Namespace: "system", Name: "memory.rss", Agg: observer.AggregateAverage},
+		{Namespace: "system", Name: "disk.read_bytes", Agg: observer.AggregateSum},
+		{Namespace: "system", Name: "disk.write_bytes", Agg: observer.AggregateSum},
+	}
+}
+
+// TestBenchRRCFMetrics returns a metric set for RRCF matching cgroup.v2 data
+// from FGM parquet exports (namespace "parquet").
+func TestBenchRRCFMetrics() []RRCFMetricDef {
+	return []RRCFMetricDef{
+		// CPU
+		{Namespace: "parquet", Name: "cgroup.v2.cpu.stat.user_usec", Agg: observer.AggregateAverage},
+		{Namespace: "parquet", Name: "cgroup.v2.cpu.stat.system_usec", Agg: observer.AggregateAverage},
+		{Namespace: "parquet", Name: "cgroup.v2.cpu.pressure.some.avg10", Agg: observer.AggregateAverage},
+		// Memory
+		{Namespace: "parquet", Name: "cgroup.v2.memory.current", Agg: observer.AggregateAverage},
+		{Namespace: "parquet", Name: "smaps_rollup.rss", Agg: observer.AggregateAverage},
+		// IO
+		{Namespace: "parquet", Name: "cgroup.v2.io.stat.rbytes", Agg: observer.AggregateAverage},
+		{Namespace: "parquet", Name: "cgroup.v2.io.stat.wbytes", Agg: observer.AggregateAverage},
+	}
+}
+
+// RRCFDetector implements multivariate anomaly detection using Robust Random Cut Forest.
+// It queries multiple system metrics and detects unusual combinations/trajectories.
+type RRCFDetector struct {
+	config RRCFConfig
+
+	// metrics defines which series to include in the multivariate analysis.
+	// Each metric becomes a dimension in the feature vector.
+	metrics []RRCFMetricDef
+
+	// resolvedKeys caches the actual SeriesKey (with tags) for each metric.
+	// Populated lazily on first Detect call via ListSeries discovery.
+	resolvedKeys map[string]observer.SeriesKey
+
+	// cursors tracks read position per metric for incremental reads.
+	cursors map[string]int64
+
+	// shingleBuffer accumulates recent points to form shingles.
+	// Key is metric name, value is recent values (up to ShingleSize).
+	shingleBuffer map[string][]float64
+
+	// forest is the RRCF forest structure.
+	forest *rcForest
+
+	// recentScores tracks recent CoDisp scores for dynamic thresholding.
+	// Only populated after warmup (first TreeSize points are skipped).
+	recentScores []float64
+
+	// totalScored counts total shingles scored (including warmup).
+	totalScored int
+
+	// allScores tracks every score with its timestamp for offline threshold analysis.
+	allScores []RRCFScoredPoint
+
+	// alignedCount and shingleCount track pipeline throughput for diagnostics.
+	alignedCount int
+	shingleCount int
+}
+
+// NewRRCFDetector creates an RRCF detector with the given config.
+func NewRRCFDetector(config RRCFConfig) *RRCFDetector {
+	metrics := config.Metrics
+	if len(metrics) == 0 {
+		metrics = DefaultRRCFMetrics()
+	}
+
+	// Compute shingle dimension: numMetrics * shingleSize
+	numMetrics := len(metrics)
+	shingleDim := numMetrics * config.ShingleSize
+
+	// Create forest with fixed seed for reproducibility (can be made configurable)
+	forest := newRCForest(config.NumTrees, config.TreeSize, shingleDim, 42)
+
+	return &RRCFDetector{
+		config:        config,
+		metrics:       metrics,
+		resolvedKeys:  make(map[string]observer.SeriesKey),
+		cursors:       make(map[string]int64),
+		shingleBuffer: make(map[string][]float64),
+		forest:        forest,
+		recentScores:  make([]float64, 0, 100),
+		allScores:     make([]RRCFScoredPoint, 0, 1024),
+	}
+}
+
+// Name returns the detector name.
+func (r *RRCFDetector) Name() string {
+	return "rrcf"
+}
+
+// Detect implements MultiSeriesDetector. It queries storage for system metrics,
+// builds multivariate shingles, and detects anomalies using RRCF.
+func (r *RRCFDetector) Detect(storage observer.StorageReader, dataTime int64) observer.MultiSeriesDetectionResult {
+	// Step 0: Resolve all metric keys to the same tag set (on first call)
+	if !r.resolveAllKeys(storage) {
+		return observer.MultiSeriesDetectionResult{}
+	}
+
+	// Step 1: Read new points for each metric since last cursor
+	newPointsByMetric := r.readNewPoints(storage, dataTime)
+	if len(newPointsByMetric) == 0 {
+		return observer.MultiSeriesDetectionResult{}
+	}
+
+	// Step 2: Align points by timestamp and build multivariate vectors
+	alignedPoints := r.alignByTimestamp(newPointsByMetric)
+	if len(alignedPoints) == 0 {
+		return observer.MultiSeriesDetectionResult{}
+	}
+
+	r.alignedCount += len(alignedPoints)
+
+	// Step 3: Build shingles from aligned points
+	shingles := r.buildShingles(alignedPoints)
+	if len(shingles) == 0 {
+		return observer.MultiSeriesDetectionResult{}
+	}
+
+	r.shingleCount += len(shingles)
+
+	// Step 4: Score shingles with RRCF and detect anomalies
+	return r.scoreAndDetect(shingles, dataTime)
+}
+
+// resolveKey returns the cached SeriesKey for a metric definition.
+// Keys are populated by resolveAllKeys on the first Detect call.
+func (r *RRCFDetector) resolveKey(m RRCFMetricDef) (observer.SeriesKey, bool) {
+	cursorKey := m.Namespace + "|" + m.Name
+	key, ok := r.resolvedKeys[cursorKey]
+	return key, ok
+}
+
+// resolveAllKeys discovers series keys for all metrics at once, ensuring they share
+// the same tag set (e.g., same container_id). This is necessary because data from
+// parquet exports has per-container tags, and alignment only works if all metrics
+// come from the same container.
+func (r *RRCFDetector) resolveAllKeys(storage observer.StorageReader) bool {
+	if len(r.resolvedKeys) > 0 {
+		return true // already resolved
+	}
+
+	// For each metric, collect all matching series grouped by tag string
+	// Collect all series per metric
+	seriesByMetric := make(map[string][]observer.SeriesKey) // cursorKey -> all matching keys
+	for _, m := range r.metrics {
+		cursorKey := m.Namespace + "|" + m.Name
+		matches := storage.ListSeries(observer.SeriesFilter{
+			Namespace:   m.Namespace,
+			NamePattern: m.Name,
+		})
+		for _, key := range matches {
+			if key.Name == m.Name {
+				seriesByMetric[cursorKey] = append(seriesByMetric[cursorKey], key)
+			}
+		}
+	}
+
+	// Build a tag signature for each series key
+	tagSig := func(tags []string) string {
+		sorted := make([]string, len(tags))
+		copy(sorted, tags)
+		sort.Strings(sorted)
+		return strings.Join(sorted, ",")
+	}
+
+	// Group series by tag signature and find a tag set that has ALL metrics
+	tagSetMetrics := make(map[string]map[string]observer.SeriesKey) // tagSig -> cursorKey -> SeriesKey
+	for cursorKey, keys := range seriesByMetric {
+		for _, key := range keys {
+			sig := tagSig(key.Tags)
+			if tagSetMetrics[sig] == nil {
+				tagSetMetrics[sig] = make(map[string]observer.SeriesKey)
+			}
+			tagSetMetrics[sig][cursorKey] = key
+		}
+	}
+
+	// Find tag set with most metrics, breaking ties by total data points.
+	numMetrics := len(r.metrics)
+	var bestSig string
+	bestMetricCount := 0
+	bestPointCount := 0
+	for sig, metricsMap := range tagSetMetrics {
+		mc := len(metricsMap)
+		if mc < bestMetricCount {
+			continue
+		}
+		// Count total points across all metrics for this tag set
+		pc := 0
+		for _, key := range metricsMap {
+			pc += storage.PointCount(key)
+		}
+		if mc > bestMetricCount || (mc == bestMetricCount && pc > bestPointCount) {
+			bestMetricCount = mc
+			bestPointCount = pc
+			bestSig = sig
+		}
+	}
+
+	if bestMetricCount == 0 {
+		return false
+	}
+
+	if bestMetricCount < numMetrics {
+		fmt.Printf("  RRCF: best tag set has %d/%d metrics (tags=%s)\n", bestMetricCount, numMetrics, bestSig)
+	}
+	fmt.Printf("  RRCF: resolved %d metrics to tag set with %d total points\n", bestMetricCount, bestPointCount)
+
+	// Resolve all metrics to this tag set
+	for cursorKey, key := range tagSetMetrics[bestSig] {
+		r.resolvedKeys[cursorKey] = key
+	}
+
+	return true
+}
+
+// readNewPoints reads new data points for each metric since the last cursor position.
+func (r *RRCFDetector) readNewPoints(storage observer.StorageReader, dataTime int64) map[string][]observer.Point {
+	result := make(map[string][]observer.Point)
+
+	for _, m := range r.metrics {
+		key, found := r.resolveKey(m)
+		if !found {
+			continue
+		}
+
+		cursorKey := m.Namespace + "|" + m.Name
+		cursor := r.cursors[cursorKey]
+
+		points, newCursor := storage.ReadSince(key, cursor, m.Agg)
+
+		// Only include points up to dataTime for determinism
+		var filteredPoints []observer.Point
+		for _, p := range points {
+			if p.Timestamp <= dataTime {
+				filteredPoints = append(filteredPoints, p)
+			}
+		}
+
+		if len(filteredPoints) > 0 {
+			result[cursorKey] = filteredPoints
+			r.cursors[cursorKey] = newCursor
+		}
+	}
+
+	return result
+}
+
+// timestampedVector represents a multivariate point at a specific timestamp.
+type timestampedVector struct {
+	timestamp int64
+	values    []float64 // One value per metric, in order of r.metrics
+}
+
+// alignByTimestamp aligns points from different metrics by timestamp.
+// Only timestamps that have data for ALL metrics are included.
+func (r *RRCFDetector) alignByTimestamp(pointsByMetric map[string][]observer.Point) []timestampedVector {
+	// Collect all timestamps and their values per metric
+	type metricValue struct {
+		metricIdx int
+		value     float64
+	}
+	timestampData := make(map[int64][]metricValue)
+
+	for i, m := range r.metrics {
+		cursorKey := m.Namespace + "|" + m.Name
+		points, ok := pointsByMetric[cursorKey]
+		if !ok {
+			continue
+		}
+		for _, p := range points {
+			timestampData[p.Timestamp] = append(timestampData[p.Timestamp], metricValue{
+				metricIdx: i,
+				value:     p.Value,
+			})
+		}
+	}
+
+	// Build aligned vectors (only timestamps with all metrics present)
+	numMetrics := len(r.metrics)
+	var result []timestampedVector
+
+	for ts, values := range timestampData {
+		if len(values) != numMetrics {
+			continue // Skip timestamps with missing metrics
+		}
+
+		vec := timestampedVector{
+			timestamp: ts,
+			values:    make([]float64, numMetrics),
+		}
+		for _, mv := range values {
+			vec.values[mv.metricIdx] = mv.value
+		}
+		result = append(result, vec)
+	}
+
+	// Sort by timestamp
+	sortTimestampedVectors(result)
+
+	return result
+}
+
+// sortTimestampedVectors sorts vectors by timestamp ascending.
+func sortTimestampedVectors(vecs []timestampedVector) {
+	// Simple insertion sort (vectors are typically small and nearly sorted)
+	for i := 1; i < len(vecs); i++ {
+		for j := i; j > 0 && vecs[j].timestamp < vecs[j-1].timestamp; j-- {
+			vecs[j], vecs[j-1] = vecs[j-1], vecs[j]
+		}
+	}
+}
+
+// shingle represents a temporal pattern combining multiple consecutive timestamps.
+type shingle struct {
+	endTimestamp int64     // Timestamp of the last point in the shingle
+	vector       []float64 // Flattened: [t0_m0, t0_m1, ..., t1_m0, t1_m1, ..., etc.]
+}
+
+// buildShingles creates shingles by combining consecutive aligned points.
+// A shingle of size 4 with 7 metrics produces a 28-dimensional vector.
+func (r *RRCFDetector) buildShingles(aligned []timestampedVector) []shingle {
+	if len(aligned) < r.config.ShingleSize {
+		return nil
+	}
+
+	numMetrics := len(r.metrics)
+	shingleDim := r.config.ShingleSize * numMetrics
+
+	var result []shingle
+
+	// Sliding window over aligned points
+	for i := r.config.ShingleSize - 1; i < len(aligned); i++ {
+		vec := make([]float64, 0, shingleDim)
+
+		// Concatenate values from ShingleSize consecutive points
+		for j := i - r.config.ShingleSize + 1; j <= i; j++ {
+			vec = append(vec, aligned[j].values...)
+		}
+
+		result = append(result, shingle{
+			endTimestamp: aligned[i].timestamp,
+			vector:       vec,
+		})
+	}
+
+	return result
+}
+
+// scoreAndDetect scores shingles using RRCF and returns anomalies and telemetry.
+// Uses rolling z-score thresholding: after a warmup period (TreeSize points), a point
+// is anomalous if its score exceeds mean + ThresholdSigma*stddev of the recent window.
+func (r *RRCFDetector) scoreAndDetect(shingles []shingle, _ int64) observer.MultiSeriesDetectionResult {
+	var anomalies []observer.Anomaly
+	var telemetry []observer.ObserverTelemetry
+	warmup := r.config.TreeSize
+
+	for _, s := range shingles {
+		score := r.scoreShingle(s)
+		r.totalScored++
+
+		// Track all scores for offline threshold analysis
+		r.allScores = append(r.allScores, RRCFScoredPoint{
+			Timestamp: s.endTimestamp,
+			Score:     score,
+		})
+
+		// Emit telemetry for the CoDisp score at every scored shingle
+		telemetry = append(telemetry, observer.ObserverTelemetry{
+			DetectorName: r.Name(),
+			Metric: &metricObs{
+				name:      "score",
+				value:     score,
+				timestamp: s.endTimestamp,
+			},
+		})
+
+		// Skip warmup phase — scores are artificial during forest filling
+		if r.totalScored <= warmup {
+			continue
+		}
+
+		// Compute dynamic threshold from recent scores
+		threshold := r.dynamicThreshold()
+
+		// Emit telemetry for the dynamic threshold (only after warmup when threshold is meaningful)
+		if threshold > 0 {
+			telemetry = append(telemetry, observer.ObserverTelemetry{
+				DetectorName: r.Name(),
+				Metric: &metricObs{
+					name:      "threshold",
+					value:     threshold,
+					timestamp: s.endTimestamp,
+				},
+			})
+		}
+
+		// Update rolling window (after computing threshold, so current score
+		// doesn't influence its own threshold)
+		r.recentScores = append(r.recentScores, score)
+		if len(r.recentScores) > 100 {
+			r.recentScores = r.recentScores[1:]
+		}
+
+		if r.config.ThresholdSigma > 0 && threshold > 0 && score > threshold {
+			anomaly := observer.Anomaly{
+				Source:       "score",
+				DetectorName: r.Name(),
+				Title:        "RRCF multivariate anomaly",
+				Description:    fmt.Sprintf("Unusual system metric combination (CoDisp=%.1f, threshold=%.1f)", score, threshold),
+				Timestamp:      s.endTimestamp,
+				DebugInfo: &observer.AnomalyDebugInfo{
+					CurrentValue:   score,
+					Threshold:      threshold,
+					DeviationSigma: (score - r.rollingMean()) / math.Max(r.rollingStddev(), 1),
+				},
+			}
+			anomalies = append(anomalies, anomaly)
+		}
+	}
+
+	return observer.MultiSeriesDetectionResult{
+		Anomalies: anomalies,
+		Telemetry: telemetry,
+	}
+}
+
+// dynamicThreshold returns mean + ThresholdSigma*stddev of the recent score window.
+func (r *RRCFDetector) dynamicThreshold() float64 {
+	if len(r.recentScores) < 10 {
+		return 0 // not enough data yet
+	}
+	return r.rollingMean() + r.config.ThresholdSigma*r.rollingStddev()
+}
+
+func (r *RRCFDetector) rollingMean() float64 {
+	if len(r.recentScores) == 0 {
+		return 0
+	}
+	sum := 0.0
+	for _, v := range r.recentScores {
+		sum += v
+	}
+	return sum / float64(len(r.recentScores))
+}
+
+func (r *RRCFDetector) rollingStddev() float64 {
+	n := len(r.recentScores)
+	if n < 2 {
+		return 0
+	}
+	mean := r.rollingMean()
+	sumSq := 0.0
+	for _, v := range r.recentScores {
+		d := v - mean
+		sumSq += d * d
+	}
+	return math.Sqrt(sumSq / float64(n))
+}
+
+// scoreShingle computes the CoDisp (collusive displacement) score for a shingle.
+// Inserts the shingle into the RRCF forest and returns the average CoDisp score.
+func (r *RRCFDetector) scoreShingle(s shingle) float64 {
+	// Insert shingle into forest (handles eviction of oldest point if at capacity)
+	_, avgCodisp := r.forest.insertPoint(s.vector)
+	return avgCodisp
+}
+
+// Reset clears all state, useful for testing or after major regime changes.
+func (r *RRCFDetector) Reset() {
+	r.resolvedKeys = make(map[string]observer.SeriesKey)
+	r.cursors = make(map[string]int64)
+	r.shingleBuffer = make(map[string][]float64)
+	r.recentScores = r.recentScores[:0]
+	r.allScores = r.allScores[:0]
+	r.totalScored = 0
+	r.alignedCount = 0
+	r.shingleCount = 0
+	r.forest.reset()
+}
+
+// GetExtraData implements ComponentDataProvider, exposing score stats via /api/components/rrcf/data.
+func (r *RRCFDetector) GetExtraData() interface{} {
+	return r.GetScoreStats()
+}
+
+// GetScoreStats returns distribution statistics and full score history.
+func (r *RRCFDetector) GetScoreStats() RRCFScoreStats {
+	stats := RRCFScoreStats{
+		Enabled:       true,
+		SampleCount:   len(r.allScores),
+		AlignedPoints: r.alignedCount,
+		ShinglesBuilt: r.shingleCount,
+		Config: RRCFConfigSummary{
+			NumTrees:       r.config.NumTrees,
+			TreeSize:       r.config.TreeSize,
+			ShingleSize:    r.config.ShingleSize,
+			ShingleDim:     r.config.ShingleSize * len(r.metrics),
+			ThresholdSigma: r.config.ThresholdSigma,
+		},
+		Scores: r.allScores,
+	}
+
+	for _, m := range r.metrics {
+		stats.Metrics = append(stats.Metrics, m.Namespace+"|"+m.Name)
+	}
+
+	if len(r.allScores) == 0 {
+		return stats
+	}
+
+	// Compute distribution stats
+	sorted := make([]float64, len(r.allScores))
+	sum := 0.0
+	for i, sp := range r.allScores {
+		sorted[i] = sp.Score
+		sum += sp.Score
+	}
+	sort.Float64s(sorted)
+
+	n := float64(len(sorted))
+	stats.MinScore = sorted[0]
+	stats.MaxScore = sorted[len(sorted)-1]
+	stats.MeanScore = sum / n
+
+	// Stddev
+	sumSq := 0.0
+	for _, v := range sorted {
+		d := v - stats.MeanScore
+		sumSq += d * d
+	}
+	stats.StddevScore = math.Sqrt(sumSq / n)
+
+	// Percentiles (nearest-rank method)
+	pct := func(p float64) float64 {
+		idx := int(math.Ceil(p/100.0*n)) - 1
+		if idx < 0 {
+			idx = 0
+		}
+		if idx >= len(sorted) {
+			idx = len(sorted) - 1
+		}
+		return sorted[idx]
+	}
+	stats.P50 = pct(50)
+	stats.P75 = pct(75)
+	stats.P90 = pct(90)
+	stats.P95 = pct(95)
+	stats.P99 = pct(99)
+
+	return stats
+}

--- a/comp/observer/impl/notify.go
+++ b/comp/observer/impl/notify.go
@@ -1,0 +1,96 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+
+	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
+)
+
+// eventSender formats and dispatches one Datadog event per correlation.
+// When api is nil, send prints to stdout (dry-run mode) instead of calling the API.
+type eventSender struct {
+	api *datadogV2.EventsApi
+	ctx context.Context
+}
+
+// newEventSender creates an eventSender. When dryRun is true, api is left nil.
+func newEventSender(dryRun bool) (*eventSender, error) {
+	if dryRun {
+		return &eventSender{}, nil
+	}
+	apiKey := os.Getenv("DD_API_KEY")
+	if apiKey == "" {
+		return nil, fmt.Errorf("DD_API_KEY environment variable is not set")
+	}
+	ctx := context.WithValue(
+		datadog.NewDefaultContext(context.Background()),
+		datadog.ContextAPIKeys,
+		map[string]datadog.APIKey{"apiKeyAuth": {Key: apiKey}},
+	)
+	return &eventSender{
+		api: datadogV2.NewEventsApi(datadog.NewAPIClient(datadog.NewConfiguration())),
+		ctx: ctx,
+	}, nil
+}
+
+// send formats a correlation into an event and either prints or posts it.
+func (s *eventSender) send(c observerdef.ActiveCorrelation) error {
+	var lines []string
+	for _, a := range c.Anomalies {
+		if a.Description != "" {
+			lines = append(lines, "- "+a.Description)
+		}
+	}
+	intro := fmt.Sprintf("The following %d metric anomalies were detected and are likely related:", len(lines))
+	text := intro + "\n" + strings.Join(lines, "\n")
+	ts := time.Unix(c.FirstSeen, 0).UTC().Format(time.RFC3339)
+
+	if s.api == nil {
+		fmt.Printf("[dry-run] pattern=%s title=%q timestamp=%s\n%s\n\n", c.Pattern, c.Title, ts, text)
+		return nil
+	}
+
+	attrs := datadogV2.AlertEventCustomAttributesAsEventPayloadAttributes(
+		datadogV2.NewAlertEventCustomAttributes(datadogV2.ALERTEVENTCUSTOMATTRIBUTESSTATUS_ERROR),
+	)
+	payload := datadogV2.EventCreateRequestPayload{
+		Data: datadogV2.EventCreateRequest{
+			Type: datadogV2.EVENTCREATEREQUESTTYPE_EVENT,
+			Attributes: datadogV2.EventPayload{
+				Title:      c.Title,
+				Message:    datadog.PtrString(text),
+				Category:   datadogV2.EVENTCATEGORY_ALERT,
+				Tags:       []string{"source:agent-q-branch-observer", "pattern:" + c.Pattern},
+				Attributes: attrs,
+			},
+		},
+	}
+	_, _, err := s.api.CreateEvent(s.ctx, payload)
+	return err
+}
+
+// sendCorrelationEvents creates a sender and dispatches one event per correlation.
+func sendCorrelationEvents(correlations []observerdef.ActiveCorrelation, dryRun bool) error {
+	sender, err := newEventSender(dryRun)
+	if err != nil {
+		return err
+	}
+	for _, c := range correlations {
+		if err := sender.send(c); err != nil {
+			return fmt.Errorf("sending event for pattern %q: %w", c.Pattern, err)
+		}
+	}
+	return nil
+}

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -199,8 +199,12 @@ func NewComponent(deps Requires) Provides {
 			},
 			&ConnectionErrorExtractor{},
 		},
-		metricsDetectors: []observerdef.MetricsDetector{
-			NewCUSUMDetector(),
+		multiDetectors: []observerdef.MultiSeriesDetector{
+			newMetricsDetectorAdapter(NewCUSUMDetector(), []observerdef.Aggregate{
+				observerdef.AggregateAverage,
+				observerdef.AggregateCount,
+			}),
+			NewRRCFDetector(DefaultRRCFConfig()),
 		},
 		correlators: []observerdef.Correlator{
 			correlator,
@@ -351,13 +355,16 @@ func samplePass(rate float64, n uint64) bool {
 
 // observerImpl is the implementation of the observer component.
 type observerImpl struct {
-	logDetectors     []observerdef.LogDetector
-	metricsDetectors []observerdef.MetricsDetector
-	correlators      []observerdef.Correlator
-	reporters        []observerdef.Reporter
-	storage          *timeSeriesStorage
-	obsCh            chan observation
-	handleFunc       observerdef.HandleFunc // Handle factory (may wrap with recorder middleware)
+	logDetectors   []observerdef.LogDetector
+	multiDetectors []observerdef.MultiSeriesDetector
+	correlators    []observerdef.Correlator
+	reporters      []observerdef.Reporter
+	storage        *timeSeriesStorage
+	obsCh          chan observation
+	handleFunc     observerdef.HandleFunc // Handle factory (may wrap with recorder middleware)
+
+	// Deduplication layer (optional) - filters anomalies before correlation
+	deduplicator *AnomalyDeduplicator
 
 	// Raw anomaly tracking for test bench display
 	rawAnomalies     []observerdef.Anomaly
@@ -370,6 +377,9 @@ type observerImpl struct {
 	fetcher              *observerFetcher
 	totalAnomalyCount    int                             // total count of all anomalies ever detected (no cap)
 	uniqueAnomalySources map[observerdef.MetricName]bool // unique sources that had anomalies
+	dedupSkipped         int                             // count of anomalies skipped by dedup
+
+	lastAnalyzedDataTime int64 // data timestamp up to which we've analyzed
 }
 
 // run is the main dispatch loop, processing all observations sequentially.
@@ -390,88 +400,126 @@ func (o *observerImpl) run() {
 	}
 }
 
-// detectionAggregations defines which aggregations to run metrics detection on.
-// This allows detecting both value elevation (average) and frequency elevation (count).
-var detectionAggregations = []Aggregate{AggregateAverage, AggregateCount}
-
 // processMetric handles a metric observation.
 func (o *observerImpl) processMetric(source string, m *metricObs) {
-	// Add to storage
 	o.storage.Add(source, m.name, m.value, m.timestamp, m.tags)
-
-	// Run metrics detection on multiple aggregations
-	for _, agg := range detectionAggregations {
-		if series := o.storage.GetSeries(source, m.name, m.tags, agg); series != nil {
-			o.runMetricsDetectors(*series, agg)
-		}
-	}
-
-	o.flushAndReport()
+	o.maybeRunDetectors(m.timestamp)
 }
 
 // processLog handles a log observation.
 func (o *observerImpl) processLog(source string, l *logObs) {
-	// Create a view for log detectors
 	view := &logView{obs: l}
-
 	for _, detector := range o.logDetectors {
 		result := detector.Process(view)
-
-		// Add metrics from log processing to storage, then run metrics detection
 		for _, m := range result.Metrics {
 			// Virtual metrics coming from logs starts with _virtual.
 			o.storage.Add(source, "_virtual."+m.Name, m.Value, l.timestampMs/1000, m.Tags)
-			// Run metrics detection on multiple aggregations
-			for _, agg := range detectionAggregations {
-				if series := o.storage.GetSeries(source, m.Name, m.Tags, agg); series != nil {
-					o.runMetricsDetectors(*series, agg)
-				}
-			}
 		}
-
 		// Route directly emitted anomalies through the standard pipeline
 		for _, anomaly := range result.Anomalies {
 			o.captureRawAnomaly(anomaly)
 			o.processAnomaly(anomaly)
 		}
 	}
+	o.maybeRunDetectors(l.timestampMs / 1000)
+}
+
+// maybeRunDetectors checks if data time has advanced enough to trigger detection.
+// We only analyze complete seconds - when we see data at time T, we analyze up to T-1.
+// This ensures deterministic output regardless of batch vs streaming ingestion.
+func (o *observerImpl) maybeRunDetectors(dataTime int64) {
+	// Only analyze complete seconds (everything strictly before current second)
+	analyzeUpTo := dataTime - 1
+
+	if analyzeUpTo <= o.lastAnalyzedDataTime {
+		return
+	}
+
+	o.runDetectorsUpTo(analyzeUpTo)
+	o.lastAnalyzedDataTime = analyzeUpTo
+}
+
+// runDetectorsUpTo runs all multi-series detectors, providing them access to storage
+// and the data timestamp up to which they should analyze.
+func (o *observerImpl) runDetectorsUpTo(upTo int64) {
+	for _, detector := range o.multiDetectors {
+		result := detector.Detect(o.storage, upTo)
+		for _, anomaly := range result.Anomalies {
+			o.captureRawAnomaly(anomaly)
+			o.processAnomaly(anomaly)
+		}
+		// TODO: handle result.Telemetry in live observer (currently only used by testbench)
+	}
 
 	o.flushAndReport()
 }
 
-// runMetricsDetectors runs all metrics detectors on a series with the given aggregation.
-// It appends an aggregation suffix to the series name for distinct Source tracking.
-func (o *observerImpl) runMetricsDetectors(series observerdef.Series, agg Aggregate) {
-	// Append aggregation suffix to series name for distinct Source tracking
-	seriesWithAgg := series
-	seriesWithAgg.Name = series.Name + ":" + aggSuffix(agg)
+// metricsDetectorAdapter wraps a stateless MetricsDetector to implement MultiSeriesDetector.
+// It runs the wrapped detector on all series, handling aggregation suffixes.
+type metricsDetectorAdapter struct {
+	detector     observerdef.MetricsDetector
+	aggregations []observerdef.Aggregate
+}
 
-	for _, metricsDetector := range o.metricsDetectors {
-		result := metricsDetector.Detect(seriesWithAgg)
-		for _, anomaly := range result.Anomalies {
-			// Set the detector name so we can identify who produced this anomaly
-			anomaly.DetectorName = metricsDetector.Name()
-			anomaly.Source = observerdef.MetricName(seriesWithAgg.Name)
-			anomaly.SourceSeriesID = observerdef.SeriesID(seriesKey(series.Namespace, seriesWithAgg.Name, series.Tags))
-			// Capture raw anomaly before passing to correlators
-			o.captureRawAnomaly(anomaly)
-			o.processAnomaly(anomaly)
+func newMetricsDetectorAdapter(detector observerdef.MetricsDetector, aggregations []observerdef.Aggregate) *metricsDetectorAdapter {
+	return &metricsDetectorAdapter{
+		detector:     detector,
+		aggregations: aggregations,
+	}
+}
+
+func (a *metricsDetectorAdapter) Name() string {
+	return a.detector.Name()
+}
+
+func (a *metricsDetectorAdapter) Detect(storage observerdef.StorageReader, dataTime int64) observerdef.MultiSeriesDetectionResult {
+	var allAnomalies []observerdef.Anomaly
+	var allTelemetry []observerdef.ObserverTelemetry
+
+	// Get all series (no filter = everything)
+	seriesKeys := storage.ListSeries(observerdef.SeriesFilter{})
+
+	for _, key := range seriesKeys {
+		for _, agg := range a.aggregations {
+			// Get series up to dataTime
+			series := storage.GetSeriesRange(key, 0, dataTime, agg)
+			if series == nil || len(series.Points) == 0 {
+				continue
+			}
+
+			// Append aggregation suffix for distinct tracking
+			seriesWithAgg := *series
+			seriesWithAgg.Name = series.Name + ":" + aggSuffix(agg)
+
+			result := a.detector.Detect(seriesWithAgg)
+			for _, anomaly := range result.Anomalies {
+				anomaly.DetectorName = a.detector.Name()
+				anomaly.Source = observerdef.MetricName(seriesWithAgg.Name)
+				anomaly.SourceSeriesID = observerdef.SeriesID(seriesKey(series.Namespace, seriesWithAgg.Name, series.Tags))
+				allAnomalies = append(allAnomalies, anomaly)
+			}
+			allTelemetry = append(allTelemetry, result.Telemetry...)
 		}
+	}
+
+	return observerdef.MultiSeriesDetectionResult{
+		Anomalies: allAnomalies,
+		Telemetry: allTelemetry,
 	}
 }
 
 // aggSuffix returns a short suffix for the given aggregation type.
-func aggSuffix(agg Aggregate) string {
+func aggSuffix(agg observerdef.Aggregate) string {
 	switch agg {
-	case AggregateAverage:
+	case observerdef.AggregateAverage:
 		return "avg"
-	case AggregateSum:
+	case observerdef.AggregateSum:
 		return "sum"
-	case AggregateCount:
+	case observerdef.AggregateCount:
 		return "count"
-	case AggregateMin:
+	case observerdef.AggregateMin:
 		return "min"
-	case AggregateMax:
+	case observerdef.AggregateMax:
 		return "max"
 	default:
 		return "unknown"

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -361,10 +361,7 @@ type observerImpl struct {
 	reporters      []observerdef.Reporter
 	storage        *timeSeriesStorage
 	obsCh          chan observation
-	handleFunc     observerdef.HandleFunc // Handle factory (may wrap with recorder middleware)
-
-	// Deduplication layer (optional) - filters anomalies before correlation
-	deduplicator *AnomalyDeduplicator
+	handleFunc observerdef.HandleFunc // Handle factory (may wrap with recorder middleware)
 
 	// Raw anomaly tracking for test bench display
 	rawAnomalies     []observerdef.Anomaly
@@ -377,8 +374,6 @@ type observerImpl struct {
 	fetcher              *observerFetcher
 	totalAnomalyCount    int                             // total count of all anomalies ever detected (no cap)
 	uniqueAnomalySources map[observerdef.MetricName]bool // unique sources that had anomalies
-	dedupSkipped         int                             // count of anomalies skipped by dedup
-
 	lastAnalyzedDataTime int64 // data timestamp up to which we've analyzed
 }
 

--- a/comp/observer/impl/rrcf.go
+++ b/comp/observer/impl/rrcf.go
@@ -1,0 +1,625 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	"math"
+	"math/rand"
+)
+
+// node is the interface implemented by both branch and leaf nodes in an RCTree.
+type node interface {
+	isNode()
+	getParent() node
+	setParent(node)
+	leafCount() int
+	setLeafCount(int)
+	// boundingBox returns the bounding box as a flat slice:
+	// [min_d0, min_d1, ..., min_{ndim-1}, max_d0, max_d1, ..., max_{ndim-1}]
+	boundingBox() []float64
+	setBoundingBox([]float64)
+}
+
+// branch is an internal node in a random cut tree.
+type branch struct {
+	q int       // cut dimension
+	p float64   // cut value
+	l node      // left child
+	r node      // right child
+	u node      // parent (nil for root)
+	n int       // number of leaves under this branch
+	b []float64 // bounding box: [min_d0, ..., min_{ndim-1}, max_d0, ..., max_{ndim-1}]
+}
+
+func (b *branch) isNode()                     {}
+func (b *branch) getParent() node             { return b.u }
+func (b *branch) setParent(p node)            { b.u = p }
+func (b *branch) leafCount() int              { return b.n }
+func (b *branch) setLeafCount(n int)          { b.n = n }
+func (b *branch) boundingBox() []float64      { return b.b }
+func (b *branch) setBoundingBox(bb []float64) { b.b = bb }
+
+// leaf is a terminal node in a random cut tree.
+type leaf struct {
+	i int       // index/identifier
+	d int       // depth in tree
+	u node      // parent (nil if leaf is root)
+	x []float64 // the point (ndim values)
+	n int       // count (for duplicate handling, always 1 in our use case)
+}
+
+func (l *leaf) isNode()            {}
+func (l *leaf) getParent() node    { return l.u }
+func (l *leaf) setParent(p node)   { l.u = p }
+func (l *leaf) leafCount() int     { return l.n }
+func (l *leaf) setLeafCount(n int) { l.n = n }
+
+// boundingBox for a leaf returns the point as both min and max.
+func (l *leaf) boundingBox() []float64 {
+	ndim := len(l.x)
+	bb := make([]float64, 2*ndim)
+	copy(bb[:ndim], l.x)
+	copy(bb[ndim:], l.x)
+	return bb
+}
+
+func (l *leaf) setBoundingBox(_ []float64) {
+	// Leaf bounding box is always just its point, so this is a no-op.
+}
+
+// rcTree is a single random cut tree.
+type rcTree struct {
+	root   node
+	leaves map[int]*leaf // index -> leaf pointer
+	ndim   int           // dimensionality of points
+	rng    *rand.Rand    // random number generator
+}
+
+// newRCTree creates an empty random cut tree.
+func newRCTree(rng *rand.Rand) *rcTree {
+	return &rcTree{
+		root:   nil,
+		leaves: make(map[int]*leaf),
+		ndim:   0,
+		rng:    rng,
+	}
+}
+
+// insertPoint inserts a point into the tree with the given index.
+// Returns the created leaf.
+func (t *rcTree) insertPoint(point []float64, index int) *leaf {
+	// Validate dimensions match if tree is non-empty
+	if t.root != nil && len(point) != t.ndim {
+		panic("point dimension mismatch")
+	}
+	// Check index doesn't already exist
+	if _, exists := t.leaves[index]; exists {
+		panic("index already exists in tree")
+	}
+
+	// If tree is empty, create leaf as root
+	if t.root == nil {
+		newLeaf := &leaf{
+			i: index,
+			d: 0,
+			u: nil,
+			x: point,
+			n: 1,
+		}
+		t.root = newLeaf
+		t.ndim = len(point)
+		t.leaves[index] = newLeaf
+		return newLeaf
+	}
+
+	// Tree has existing nodes; insert using the RRCF algorithm
+	currentNode := t.root
+	var parent node
+	var side byte // 'l' or 'r' to track which child of parent we descended from
+	depth := 0
+
+	// Walk down tree, at each step decide if we create a cut above the current node
+	for {
+		nodeBbox := currentNode.boundingBox()
+		cutDim, cutVal := t.insertPointCut(point, nodeBbox)
+
+		minVal := nodeBbox[cutDim]        // min in cut dimension
+		maxVal := nodeBbox[t.ndim+cutDim] // max in cut dimension
+
+		// If cut separates point from current subtree (cut <= min or cut >= max),
+		// create a new branch here
+		if cutVal <= minVal {
+			// Point goes left, current subtree goes right
+			newLeaf := &leaf{
+				i: index,
+				d: depth,
+				u: nil,
+				x: point,
+				n: 1,
+			}
+			newBranch := &branch{
+				q: cutDim,
+				p: cutVal,
+				l: newLeaf,
+				r: currentNode,
+				u: parent,
+				n: newLeaf.n + currentNode.leafCount(),
+			}
+			newLeaf.u = newBranch
+			currentNode.setParent(newBranch)
+
+			t.linkBranchToParent(newBranch, parent, side)
+			t.incrementDepthsBelow(currentNode, 1)
+			t.updateLeafCountUpwards(parent, 1)
+			t.tightenBboxUpwards(newBranch)
+			t.leaves[index] = newLeaf
+			return newLeaf
+
+		} else if cutVal >= maxVal {
+			// Current subtree goes left, point goes right
+			newLeaf := &leaf{
+				i: index,
+				d: depth,
+				u: nil,
+				x: point,
+				n: 1,
+			}
+			newBranch := &branch{
+				q: cutDim,
+				p: cutVal,
+				l: currentNode,
+				r: newLeaf,
+				u: parent,
+				n: newLeaf.n + currentNode.leafCount(),
+			}
+			newLeaf.u = newBranch
+			currentNode.setParent(newBranch)
+
+			t.linkBranchToParent(newBranch, parent, side)
+			t.incrementDepthsBelow(currentNode, 1)
+			t.updateLeafCountUpwards(parent, 1)
+			t.tightenBboxUpwards(newBranch)
+			t.leaves[index] = newLeaf
+			return newLeaf
+		}
+
+		// Cut is inside current node's bbox; descend into tree
+		depth++
+		br, ok := currentNode.(*branch)
+		if !ok {
+			// Current node is a leaf but we didn't cut above it - this shouldn't happen
+			// with correct algorithm, but let's handle it defensively
+			panic("reached leaf without making a cut - algorithm error")
+		}
+
+		// Descend based on cut dimension/value of the current branch
+		parent = br
+		if point[br.q] <= br.p {
+			currentNode = br.l
+			side = 'l'
+		} else {
+			currentNode = br.r
+			side = 'r'
+		}
+	}
+}
+
+// linkBranchToParent links a new branch to its parent (or sets it as root).
+func (t *rcTree) linkBranchToParent(newBranch *branch, parent node, side byte) {
+	if parent == nil {
+		t.root = newBranch
+	} else {
+		parentBranch := parent.(*branch)
+		if side == 'l' {
+			parentBranch.l = newBranch
+		} else {
+			parentBranch.r = newBranch
+		}
+	}
+}
+
+// insertPointCut generates cut dimension and value for inserting a new point.
+// bbox is the bounding box of the current subtree in flat format.
+func (t *rcTree) insertPointCut(point []float64, bbox []float64) (cutDim int, cutVal float64) {
+	ndim := t.ndim
+
+	// Compute expanded bounding box including the new point
+	bboxHatMin := make([]float64, ndim)
+	bboxHatMax := make([]float64, ndim)
+
+	for d := 0; d < ndim; d++ {
+		bboxHatMin[d] = math.Min(bbox[d], point[d])
+		bboxHatMax[d] = math.Max(bbox[ndim+d], point[d])
+	}
+
+	// Compute span in each dimension and total range
+	spans := make([]float64, ndim)
+	totalRange := 0.0
+	for d := 0; d < ndim; d++ {
+		spans[d] = bboxHatMax[d] - bboxHatMin[d]
+		totalRange += spans[d]
+	}
+
+	// If all spans are zero (all points identical), pick dimension 0 arbitrarily
+	if totalRange == 0 {
+		return 0, point[0]
+	}
+
+	// Choose cut point uniformly over total range
+	r := t.rng.Float64() * totalRange
+
+	// Find which dimension the cut falls in
+	cumSum := 0.0
+	cutDim = ndim - 1 // default to last dimension
+	for d := 0; d < ndim; d++ {
+		cumSum += spans[d]
+		if cumSum >= r {
+			cutDim = d
+			break
+		}
+	}
+
+	// Cut value within that dimension
+	cutVal = bboxHatMin[cutDim] + cumSum - r
+
+	return cutDim, cutVal
+}
+
+// forgetPoint removes a point from the tree by its index.
+// Returns the removed leaf.
+func (t *rcTree) forgetPoint(index int) *leaf {
+	leafNode, exists := t.leaves[index]
+	if !exists {
+		panic("index does not exist in tree")
+	}
+
+	// Handle duplicate counts (not used in our case, but keeping for completeness)
+	if leafNode.n > 1 {
+		t.updateLeafCountUpwards(leafNode, -1)
+		delete(t.leaves, index)
+		return leafNode
+	}
+
+	// If leaf is root, tree becomes empty
+	if leafNode == t.root {
+		t.root = nil
+		t.ndim = 0
+		delete(t.leaves, index)
+		return leafNode
+	}
+
+	// Find parent and sibling
+	parent := leafNode.u.(*branch)
+	var sibling node
+	if leafNode == parent.l {
+		sibling = parent.r
+	} else {
+		sibling = parent.l
+	}
+
+	// If parent is root, sibling becomes new root
+	if parent == t.root {
+		sibling.setParent(nil)
+		t.root = sibling
+		t.incrementDepthsBelow(sibling, -1)
+		delete(t.leaves, index)
+		return leafNode
+	}
+
+	// General case: short-circuit grandparent to sibling
+	grandparent := parent.u.(*branch)
+	sibling.setParent(grandparent)
+
+	if parent == grandparent.l {
+		grandparent.l = sibling
+	} else {
+		grandparent.r = sibling
+	}
+
+	// Update depths below sibling (they decrease by 1)
+	t.incrementDepthsBelow(sibling, -1)
+
+	// Update leaf counts upwards from grandparent
+	t.updateLeafCountUpwards(grandparent, -1)
+
+	// Update bounding boxes upwards
+	t.relaxBboxUpwards(grandparent, leafNode.x)
+
+	delete(t.leaves, index)
+	return leafNode
+}
+
+// disp computes the displacement score for a leaf.
+// Displacement is the number of leaves in the sibling subtree.
+func (t *rcTree) disp(index int) int {
+	leafNode, exists := t.leaves[index]
+	if !exists {
+		panic("index does not exist in tree")
+	}
+
+	// If leaf is root, displacement is 0
+	if leafNode == t.root {
+		return 0
+	}
+
+	parent := leafNode.u.(*branch)
+	var sibling node
+	if leafNode == parent.l {
+		sibling = parent.r
+	} else {
+		sibling = parent.l
+	}
+
+	return sibling.leafCount()
+}
+
+// codisp computes the collusive displacement score for a leaf.
+// This is the primary anomaly score in RRCF - higher means more anomalous.
+func (t *rcTree) codisp(index int) float64 {
+	leafNode, exists := t.leaves[index]
+	if !exists {
+		panic("index does not exist in tree")
+	}
+
+	// If leaf is root, codisp is 0
+	if leafNode == t.root {
+		return 0
+	}
+
+	var maxResult float64
+	var currentNode node = leafNode
+
+	// Walk from leaf to root, computing displacement ratio at each level
+	for currentNode.getParent() != nil {
+		parent := currentNode.getParent().(*branch)
+
+		var sibling node
+		if currentNode == parent.l {
+			sibling = parent.r
+		} else {
+			sibling = parent.l
+		}
+
+		// Ratio: how many points would be displaced if we removed this subtree
+		numDeleted := currentNode.leafCount()
+		displacement := sibling.leafCount()
+		result := float64(displacement) / float64(numDeleted)
+
+		if result > maxResult {
+			maxResult = result
+		}
+
+		currentNode = parent
+	}
+
+	return maxResult
+}
+
+// updateLeafCountUpwards updates leaf counts going up the tree.
+func (t *rcTree) updateLeafCountUpwards(n node, inc int) {
+	for n != nil {
+		n.setLeafCount(n.leafCount() + inc)
+		n = n.getParent()
+	}
+}
+
+// incrementDepthsBelow recursively increments depth of all leaves below a node.
+func (t *rcTree) incrementDepthsBelow(n node, inc int) {
+	if leafNode, ok := n.(*leaf); ok {
+		leafNode.d += inc
+		return
+	}
+
+	br := n.(*branch)
+	t.incrementDepthsBelow(br.l, inc)
+	t.incrementDepthsBelow(br.r, inc)
+}
+
+// computeBranchBbox computes bounding box of a branch from its children.
+func (t *rcTree) computeBranchBbox(br *branch) []float64 {
+	lbox := br.l.boundingBox()
+	rbox := br.r.boundingBox()
+
+	ndim := t.ndim
+	bbox := make([]float64, 2*ndim)
+
+	// Min values
+	for d := 0; d < ndim; d++ {
+		bbox[d] = math.Min(lbox[d], rbox[d])
+	}
+	// Max values
+	for d := 0; d < ndim; d++ {
+		bbox[ndim+d] = math.Max(lbox[ndim+d], rbox[ndim+d])
+	}
+
+	return bbox
+}
+
+// tightenBboxUpwards expands bounding boxes going up after insertion.
+func (t *rcTree) tightenBboxUpwards(br *branch) {
+	// Set bbox of the new branch
+	bbox := t.computeBranchBbox(br)
+	br.b = bbox
+
+	// Walk up and expand parent bboxes if needed
+	n := br.getParent()
+	for n != nil {
+		parentBranch := n.(*branch)
+		parentBbox := parentBranch.b
+		if parentBbox == nil {
+			parentBranch.b = t.computeBranchBbox(parentBranch)
+			n = n.getParent()
+			continue
+		}
+
+		changed := false
+		ndim := t.ndim
+
+		// Check if we need to expand mins
+		for d := 0; d < ndim; d++ {
+			if bbox[d] < parentBbox[d] {
+				parentBbox[d] = bbox[d]
+				changed = true
+			}
+		}
+		// Check if we need to expand maxes
+		for d := 0; d < ndim; d++ {
+			if bbox[ndim+d] > parentBbox[ndim+d] {
+				parentBbox[ndim+d] = bbox[ndim+d]
+				changed = true
+			}
+		}
+
+		if !changed {
+			break // No need to continue if this bbox didn't change
+		}
+
+		n = n.getParent()
+	}
+}
+
+// relaxBboxUpwards contracts bounding boxes going up after deletion.
+func (t *rcTree) relaxBboxUpwards(n node, deletedPoint []float64) {
+	for n != nil {
+		br := n.(*branch)
+		oldBbox := br.b
+
+		// Check if deleted point was on the boundary
+		onBoundary := false
+		ndim := t.ndim
+		for d := 0; d < ndim; d++ {
+			if deletedPoint[d] == oldBbox[d] || deletedPoint[d] == oldBbox[ndim+d] {
+				onBoundary = true
+				break
+			}
+		}
+
+		if !onBoundary {
+			break // Point wasn't on boundary, bbox unchanged
+		}
+
+		// Recompute bbox from children
+		br.b = t.computeBranchBbox(br)
+		n = n.getParent()
+	}
+}
+
+// rcForest is a collection of random cut trees for anomaly detection.
+type rcForest struct {
+	trees      []*rcTree
+	numTrees   int
+	treeSize   int // max points per tree
+	ndim       int
+	rng        *rand.Rand
+	indexQueue []int // FIFO queue of point indices for sliding window
+	nextIndex  int   // next index to assign to new points
+}
+
+// newRCForest creates a new forest with the given parameters.
+func newRCForest(numTrees, treeSize, ndim int, seed int64) *rcForest {
+	rng := rand.New(rand.NewSource(seed))
+
+	trees := make([]*rcTree, numTrees)
+	for i := 0; i < numTrees; i++ {
+		// Each tree gets its own RNG seeded from the main RNG
+		treeSeed := rng.Int63()
+		treeRng := rand.New(rand.NewSource(treeSeed))
+		trees[i] = newRCTree(treeRng)
+	}
+
+	return &rcForest{
+		trees:      trees,
+		numTrees:   numTrees,
+		treeSize:   treeSize,
+		ndim:       ndim,
+		rng:        rng,
+		indexQueue: make([]int, 0, treeSize),
+		nextIndex:  0,
+	}
+}
+
+// insertPoint inserts a point into all trees and returns the index and average CoDisp score.
+// If at capacity, the oldest point is evicted first.
+func (f *rcForest) insertPoint(point []float64) (index int, avgCodisp float64) {
+	if len(point) != f.ndim {
+		panic("point dimension mismatch with forest")
+	}
+
+	// Evict oldest point if at capacity
+	if len(f.indexQueue) >= f.treeSize {
+		oldestIdx := f.indexQueue[0]
+		f.indexQueue = f.indexQueue[1:]
+		for _, tree := range f.trees {
+			tree.forgetPoint(oldestIdx)
+		}
+	}
+
+	// Insert point into all trees
+	index = f.nextIndex
+	f.nextIndex++
+
+	for _, tree := range f.trees {
+		tree.insertPoint(point, index)
+	}
+
+	f.indexQueue = append(f.indexQueue, index)
+
+	// Compute average CoDisp across all trees
+	totalCodisp := 0.0
+	for _, tree := range f.trees {
+		totalCodisp += tree.codisp(index)
+	}
+	avgCodisp = totalCodisp / float64(f.numTrees)
+
+	return index, avgCodisp
+}
+
+// score computes the anomaly score for a point without permanently adding it.
+// Inserts the point, computes score, then removes it.
+// Note: This does NOT evict old points, use insertPoint for streaming.
+func (f *rcForest) score(point []float64) float64 {
+	if len(point) != f.ndim {
+		panic("point dimension mismatch with forest")
+	}
+
+	// Use a temporary index that won't collide
+	tempIndex := -1 - f.nextIndex
+
+	// Insert into all trees
+	for _, tree := range f.trees {
+		tree.insertPoint(point, tempIndex)
+	}
+
+	// Compute average CoDisp
+	totalCodisp := 0.0
+	for _, tree := range f.trees {
+		totalCodisp += tree.codisp(tempIndex)
+	}
+	avgCodisp := totalCodisp / float64(f.numTrees)
+
+	// Remove from all trees
+	for _, tree := range f.trees {
+		tree.forgetPoint(tempIndex)
+	}
+
+	return avgCodisp
+}
+
+// reset clears all trees in the forest.
+func (f *rcForest) reset() {
+	for i := range f.trees {
+		treeSeed := f.rng.Int63()
+		treeRng := rand.New(rand.NewSource(treeSeed))
+		f.trees[i] = newRCTree(treeRng)
+	}
+	f.indexQueue = f.indexQueue[:0]
+	f.nextIndex = 0
+}
+
+// size returns the current number of points in the forest.
+func (f *rcForest) size() int {
+	return len(f.indexQueue)
+}

--- a/comp/observer/impl/rrcf_test.go
+++ b/comp/observer/impl/rrcf_test.go
@@ -1,0 +1,487 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+)
+
+func TestRCTree_EmptyTree(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+	tree := newRCTree(rng)
+
+	if tree.root != nil {
+		t.Error("expected nil root for empty tree")
+	}
+	if len(tree.leaves) != 0 {
+		t.Error("expected no leaves for empty tree")
+	}
+}
+
+func TestRCTree_InsertSinglePoint(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+	tree := newRCTree(rng)
+
+	point := []float64{1.0, 2.0, 3.0}
+	leaf := tree.insertPoint(point, 0)
+
+	if tree.root != leaf {
+		t.Error("single point should be root")
+	}
+	if tree.ndim != 3 {
+		t.Errorf("expected ndim=3, got %d", tree.ndim)
+	}
+	if leaf.n != 1 {
+		t.Errorf("expected leaf count=1, got %d", leaf.n)
+	}
+	if leaf.d != 0 {
+		t.Errorf("expected depth=0, got %d", leaf.d)
+	}
+
+	// Verify the point is stored correctly
+	for i, v := range point {
+		if leaf.x[i] != v {
+			t.Errorf("point mismatch at index %d: expected %f, got %f", i, v, leaf.x[i])
+		}
+	}
+
+	// Check leaves map
+	if tree.leaves[0] != leaf {
+		t.Error("leaf not in leaves map")
+	}
+}
+
+func TestRCTree_InsertMultiplePoints(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+	tree := newRCTree(rng)
+
+	points := [][]float64{
+		{1.0, 2.0},
+		{3.0, 4.0},
+		{5.0, 6.0},
+	}
+
+	for i, p := range points {
+		tree.insertPoint(p, i)
+	}
+
+	// Verify all points are in the tree
+	if len(tree.leaves) != 3 {
+		t.Errorf("expected 3 leaves, got %d", len(tree.leaves))
+	}
+
+	// Root should be a branch with 3 leaves under it
+	br, ok := tree.root.(*branch)
+	if !ok {
+		// If root is a leaf, that's wrong
+		if _, isLeaf := tree.root.(*leaf); isLeaf && len(points) > 1 {
+			t.Error("root should be branch with multiple points")
+		}
+	} else {
+		if br.n != 3 {
+			t.Errorf("expected root branch leaf count=3, got %d", br.n)
+		}
+	}
+}
+
+func TestRCTree_ForgetPoint(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+	tree := newRCTree(rng)
+
+	// Insert points
+	tree.insertPoint([]float64{1.0, 2.0}, 0)
+	tree.insertPoint([]float64{3.0, 4.0}, 1)
+	tree.insertPoint([]float64{5.0, 6.0}, 2)
+
+	// Forget middle point
+	tree.forgetPoint(1)
+
+	if len(tree.leaves) != 2 {
+		t.Errorf("expected 2 leaves after forget, got %d", len(tree.leaves))
+	}
+	if _, exists := tree.leaves[1]; exists {
+		t.Error("forgotten leaf should not be in leaves map")
+	}
+
+	// Root should still have correct count
+	if tree.root.leafCount() != 2 {
+		t.Errorf("expected root leaf count=2, got %d", tree.root.leafCount())
+	}
+}
+
+func TestRCTree_ForgetOnlyPoint(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+	tree := newRCTree(rng)
+
+	tree.insertPoint([]float64{1.0, 2.0}, 0)
+	tree.forgetPoint(0)
+
+	if tree.root != nil {
+		t.Error("expected nil root after forgetting only point")
+	}
+	if len(tree.leaves) != 0 {
+		t.Error("expected no leaves after forgetting only point")
+	}
+}
+
+func TestRCTree_Disp(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+	tree := newRCTree(rng)
+
+	// Single point - displacement should be 0
+	tree.insertPoint([]float64{1.0, 2.0}, 0)
+	disp := tree.disp(0)
+	if disp != 0 {
+		t.Errorf("single point disp should be 0, got %d", disp)
+	}
+
+	// Add more points
+	tree.insertPoint([]float64{100.0, 100.0}, 1) // outlier
+
+	// Displacement of the outlier should be 1 (the original point is the sibling)
+	disp = tree.disp(1)
+	if disp != 1 {
+		t.Errorf("outlier disp should be 1, got %d", disp)
+	}
+}
+
+func TestRCTree_Codisp(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+	tree := newRCTree(rng)
+
+	// Build a tree with some normal points and an outlier
+	normalPoints := [][]float64{
+		{0.1, 0.1},
+		{0.2, 0.2},
+		{0.3, 0.3},
+		{0.4, 0.4},
+	}
+
+	for i, p := range normalPoints {
+		tree.insertPoint(p, i)
+	}
+
+	// Add an outlier
+	tree.insertPoint([]float64{100.0, 100.0}, 100)
+
+	// The outlier should have a higher codisp than normal points
+	outlierCodisp := tree.codisp(100)
+
+	// Codisp should be positive
+	if outlierCodisp <= 0 {
+		t.Errorf("outlier codisp should be positive, got %f", outlierCodisp)
+	}
+
+	// At minimum, outlier codisp should be number of other points / 1 = 4
+	// (since removing the outlier would displace at least some of the normal points)
+	if outlierCodisp < 1.0 {
+		t.Errorf("outlier codisp should be >= 1, got %f", outlierCodisp)
+	}
+}
+
+func TestRCForest_Basic(t *testing.T) {
+	forest := newRCForest(10, 50, 3, 42)
+
+	if forest.size() != 0 {
+		t.Error("new forest should be empty")
+	}
+
+	// Insert a point
+	idx, score := forest.insertPoint([]float64{1.0, 2.0, 3.0})
+	if idx != 0 {
+		t.Errorf("first index should be 0, got %d", idx)
+	}
+	if forest.size() != 1 {
+		t.Errorf("forest size should be 1, got %d", forest.size())
+	}
+
+	// First point in empty tree has codisp 0
+	if score != 0 {
+		t.Errorf("first point score should be 0, got %f", score)
+	}
+
+	// Insert more points
+	for i := 1; i < 10; i++ {
+		forest.insertPoint([]float64{float64(i), float64(i), float64(i)})
+	}
+
+	if forest.size() != 10 {
+		t.Errorf("forest size should be 10, got %d", forest.size())
+	}
+}
+
+func TestRCForest_SlidingWindow(t *testing.T) {
+	// Small tree size to test eviction
+	forest := newRCForest(3, 5, 2, 42)
+
+	// Insert 5 points to fill the window
+	for i := 0; i < 5; i++ {
+		forest.insertPoint([]float64{float64(i), float64(i)})
+	}
+
+	if forest.size() != 5 {
+		t.Errorf("expected size 5, got %d", forest.size())
+	}
+
+	// Insert one more - should evict the oldest
+	forest.insertPoint([]float64{5.0, 5.0})
+
+	if forest.size() != 5 {
+		t.Errorf("expected size 5 after eviction, got %d", forest.size())
+	}
+
+	// Verify first tree doesn't have index 0 anymore
+	if _, exists := forest.trees[0].leaves[0]; exists {
+		t.Error("index 0 should have been evicted")
+	}
+
+	// But should have indices 1-5
+	for i := 1; i <= 5; i++ {
+		if _, exists := forest.trees[0].leaves[i]; !exists {
+			t.Errorf("index %d should exist", i)
+		}
+	}
+}
+
+func TestRCForest_OutlierDetection(t *testing.T) {
+	// Larger forest for more reliable scoring
+	forest := newRCForest(50, 100, 2, 42)
+
+	// Insert many normal points clustered around origin
+	for i := 0; i < 50; i++ {
+		x := float64(i%10) * 0.1
+		y := float64(i/10) * 0.1
+		forest.insertPoint([]float64{x, y})
+	}
+
+	// Insert an outlier far from the cluster
+	_, outlierScore := forest.insertPoint([]float64{100.0, 100.0})
+
+	// Insert another normal point
+	_, normalScore := forest.insertPoint([]float64{0.5, 0.5})
+
+	// Outlier should have higher score than normal point
+	if outlierScore <= normalScore {
+		t.Errorf("outlier score (%f) should be higher than normal score (%f)",
+			outlierScore, normalScore)
+	}
+}
+
+func TestRCForest_Score(t *testing.T) {
+	forest := newRCForest(10, 50, 2, 42)
+
+	// Build up the forest
+	for i := 0; i < 20; i++ {
+		forest.insertPoint([]float64{float64(i % 5), float64(i / 5)})
+	}
+
+	sizeBefore := forest.size()
+
+	// Score a point without adding it
+	score := forest.score([]float64{100.0, 100.0})
+
+	// Score should be positive for outlier
+	if score <= 0 {
+		t.Errorf("outlier score should be positive, got %f", score)
+	}
+
+	// Size should be unchanged
+	if forest.size() != sizeBefore {
+		t.Errorf("forest size should be unchanged after score(), was %d, now %d",
+			sizeBefore, forest.size())
+	}
+}
+
+func TestRCForest_Reset(t *testing.T) {
+	forest := newRCForest(5, 20, 2, 42)
+
+	// Insert some points
+	for i := 0; i < 10; i++ {
+		forest.insertPoint([]float64{float64(i), float64(i)})
+	}
+
+	if forest.size() != 10 {
+		t.Errorf("expected size 10, got %d", forest.size())
+	}
+
+	// Reset
+	forest.reset()
+
+	if forest.size() != 0 {
+		t.Errorf("expected size 0 after reset, got %d", forest.size())
+	}
+
+	// Should be able to insert again
+	forest.insertPoint([]float64{1.0, 2.0})
+	if forest.size() != 1 {
+		t.Errorf("expected size 1 after re-insert, got %d", forest.size())
+	}
+}
+
+func TestRCTree_BoundingBoxes(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+	tree := newRCTree(rng)
+
+	points := [][]float64{
+		{0.0, 0.0},
+		{1.0, 1.0},
+		{0.5, 0.5},
+	}
+
+	for i, p := range points {
+		tree.insertPoint(p, i)
+	}
+
+	// Root should be a branch
+	br, ok := tree.root.(*branch)
+	if !ok {
+		t.Fatal("root should be a branch")
+	}
+
+	// Check bounding box of root
+	bbox := br.b
+	ndim := tree.ndim
+
+	// Min should be (0, 0)
+	for d := 0; d < ndim; d++ {
+		if bbox[d] != 0.0 {
+			t.Errorf("min[%d] should be 0, got %f", d, bbox[d])
+		}
+	}
+
+	// Max should be (1, 1)
+	for d := 0; d < ndim; d++ {
+		if bbox[ndim+d] != 1.0 {
+			t.Errorf("max[%d] should be 1, got %f", d, bbox[ndim+d])
+		}
+	}
+}
+
+func TestRCTree_DimensionValidation(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+	tree := newRCTree(rng)
+
+	tree.insertPoint([]float64{1.0, 2.0}, 0)
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for dimension mismatch")
+		}
+	}()
+
+	// This should panic - wrong dimension
+	tree.insertPoint([]float64{1.0, 2.0, 3.0}, 1)
+}
+
+func TestRCTree_DuplicateIndexValidation(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+	tree := newRCTree(rng)
+
+	tree.insertPoint([]float64{1.0, 2.0}, 0)
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for duplicate index")
+		}
+	}()
+
+	// This should panic - duplicate index
+	tree.insertPoint([]float64{3.0, 4.0}, 0)
+}
+
+func TestRCTree_ForgetNonexistentValidation(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+	tree := newRCTree(rng)
+
+	tree.insertPoint([]float64{1.0, 2.0}, 0)
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for nonexistent index")
+		}
+	}()
+
+	// This should panic - index doesn't exist
+	tree.forgetPoint(999)
+}
+
+// TestRCTree_ManyInsertDelete tests the tree structure remains valid after many operations
+func TestRCTree_ManyInsertDelete(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+	tree := newRCTree(rng)
+
+	// Insert 100 points
+	for i := 0; i < 100; i++ {
+		tree.insertPoint([]float64{rng.Float64() * 10, rng.Float64() * 10}, i)
+	}
+
+	if len(tree.leaves) != 100 {
+		t.Errorf("expected 100 leaves, got %d", len(tree.leaves))
+	}
+
+	// Delete half
+	for i := 0; i < 50; i++ {
+		tree.forgetPoint(i)
+	}
+
+	if len(tree.leaves) != 50 {
+		t.Errorf("expected 50 leaves after deletion, got %d", len(tree.leaves))
+	}
+
+	// Verify remaining leaves are accessible
+	for i := 50; i < 100; i++ {
+		if _, exists := tree.leaves[i]; !exists {
+			t.Errorf("leaf %d should exist", i)
+		}
+		// Codisp should not panic
+		_ = tree.codisp(i)
+	}
+
+	// Insert more
+	for i := 100; i < 150; i++ {
+		tree.insertPoint([]float64{rng.Float64() * 10, rng.Float64() * 10}, i)
+	}
+
+	if len(tree.leaves) != 100 {
+		t.Errorf("expected 100 leaves, got %d", len(tree.leaves))
+	}
+
+	// Verify root count matches leaf count
+	if tree.root.leafCount() != 100 {
+		t.Errorf("root leaf count %d doesn't match actual leaves %d",
+			tree.root.leafCount(), len(tree.leaves))
+	}
+}
+
+// TestInsertPointCut tests the cut generation algorithm
+func TestInsertPointCut(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+	tree := newRCTree(rng)
+	tree.ndim = 2
+
+	// Bbox: min=(0,0), max=(1,1)
+	bbox := []float64{0.0, 0.0, 1.0, 1.0}
+	point := []float64{2.0, 0.5} // Outside bbox in dimension 0
+
+	// Run multiple cuts and verify they're valid
+	for i := 0; i < 100; i++ {
+		dim, val := tree.insertPointCut(point, bbox)
+
+		if dim < 0 || dim >= tree.ndim {
+			t.Errorf("cut dimension %d out of range", dim)
+		}
+
+		// Extended bbox should include the point
+		minD := math.Min(bbox[dim], point[dim])
+		maxD := math.Max(bbox[tree.ndim+dim], point[dim])
+
+		if val < minD || val > maxD {
+			t.Errorf("cut value %f outside extended bbox range [%f, %f]", val, minD, maxD)
+		}
+	}
+}

--- a/comp/observer/impl/storage.go
+++ b/comp/observer/impl/storage.go
@@ -46,15 +46,16 @@ type statPoint struct {
 	Max       float64
 }
 
-// Aggregate specifies which statistic to extract from summary stats.
-type Aggregate int
+// Aggregate is an alias to the definition in the observer component for internal use.
+type Aggregate = observer.Aggregate
 
+// Re-export aggregate constants for internal use.
 const (
-	AggregateAverage Aggregate = iota
-	AggregateSum
-	AggregateCount
-	AggregateMin
-	AggregateMax
+	AggregateAverage = observer.AggregateAverage
+	AggregateSum     = observer.AggregateSum
+	AggregateCount   = observer.AggregateCount
+	AggregateMin     = observer.AggregateMin
+	AggregateMax     = observer.AggregateMax
 )
 
 // aggregate extracts the specified statistic from this point.
@@ -86,6 +87,25 @@ func (s *seriesStats) toSeries(agg Aggregate) observer.Series {
 			Timestamp: p.Timestamp,
 			Value:     p.aggregate(agg),
 		})
+	}
+	return observer.Series{
+		Namespace: s.Namespace,
+		Name:      s.Name,
+		Tags:      s.Tags,
+		Points:    points,
+	}
+}
+
+// toSeriesUpTo returns a Series with only points where Timestamp <= upTo.
+func (s *seriesStats) toSeriesUpTo(agg Aggregate, upTo int64) observer.Series {
+	points := make([]observer.Point, 0, len(s.Points))
+	for _, p := range s.Points {
+		if p.Timestamp <= upTo {
+			points = append(points, observer.Point{
+				Timestamp: p.Timestamp,
+				Value:     p.aggregate(agg),
+			})
+		}
 	}
 	return observer.Series{
 		Namespace: s.Namespace,
@@ -316,6 +336,19 @@ func (s *timeSeriesStorage) TimeBounds() (minTs int64, maxTs int64, ok bool) {
 	return min, max, found
 }
 
+// MaxTimestamp returns the latest timestamp across all series in storage.
+func (s *timeSeriesStorage) MaxTimestamp() int64 {
+	var max int64
+	for _, stats := range s.series {
+		if n := len(stats.Points); n > 0 {
+			if t := stats.Points[n-1].Timestamp; t > max {
+				max = t
+			}
+		}
+	}
+	return max
+}
+
 // seriesKey creates a unique key for a series.
 func seriesKey(namespace, name string, tags []string) string {
 	sortedTags := copyTags(tags)
@@ -404,4 +437,119 @@ func (s *timeSeriesStorage) DumpToFile(path string) error {
 		return err
 	}
 	return os.WriteFile(path, data, 0644)
+}
+
+// StorageReader interface implementation
+
+// ListSeries returns keys of all series matching the filter.
+func (s *timeSeriesStorage) ListSeries(filter observer.SeriesFilter) []observer.SeriesKey {
+	var result []observer.SeriesKey
+	for _, stats := range s.series {
+		// Check namespace filter
+		if filter.Namespace != "" && stats.Namespace != filter.Namespace {
+			continue
+		}
+		// Check name pattern filter (prefix match)
+		if filter.NamePattern != "" && !strings.HasPrefix(stats.Name, filter.NamePattern) {
+			continue
+		}
+		// Check tag matchers
+		if !matchTags(stats.Tags, filter.TagMatchers) {
+			continue
+		}
+		result = append(result, observer.SeriesKey{
+			Namespace: stats.Namespace,
+			Name:      stats.Name,
+			Tags:      stats.Tags,
+		})
+	}
+	return result
+}
+
+// PointCount returns the number of raw data points for a series.
+func (s *timeSeriesStorage) PointCount(key observer.SeriesKey) int {
+	k := seriesKey(key.Namespace, key.Name, key.Tags)
+	if stats, ok := s.series[k]; ok {
+		return len(stats.Points)
+	}
+	return 0
+}
+
+// matchTags checks if tags contain all required key=value pairs.
+func matchTags(tags []string, matchers map[string]string) bool {
+	if len(matchers) == 0 {
+		return true
+	}
+	tagMap := make(map[string]string)
+	for _, t := range tags {
+		if idx := strings.Index(t, ":"); idx > 0 {
+			tagMap[t[:idx]] = t[idx+1:]
+		}
+	}
+	for k, v := range matchers {
+		if tagMap[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// GetSeriesByKey returns the full series for a key.
+func (s *timeSeriesStorage) GetSeriesByKey(key observer.SeriesKey, agg Aggregate) *observer.Series {
+	internalKey := seriesKey(key.Namespace, key.Name, key.Tags)
+	stats := s.series[internalKey]
+	if stats == nil {
+		return nil
+	}
+	series := stats.toSeries(agg)
+	return &series
+}
+
+// GetSeriesRange returns points within a time range [start, end].
+func (s *timeSeriesStorage) GetSeriesRange(key observer.SeriesKey, start, end int64, agg Aggregate) *observer.Series {
+	internalKey := seriesKey(key.Namespace, key.Name, key.Tags)
+	stats := s.series[internalKey]
+	if stats == nil {
+		return nil
+	}
+
+	points := make([]observer.Point, 0)
+	for _, p := range stats.Points {
+		if p.Timestamp >= start && p.Timestamp <= end {
+			points = append(points, observer.Point{
+				Timestamp: p.Timestamp,
+				Value:     p.aggregate(agg),
+			})
+		}
+	}
+	return &observer.Series{
+		Namespace: stats.Namespace,
+		Name:      stats.Name,
+		Tags:      stats.Tags,
+		Points:    points,
+	}
+}
+
+// ReadSince returns points with timestamp > cursor, plus the new cursor position.
+func (s *timeSeriesStorage) ReadSince(key observer.SeriesKey, cursor int64, agg Aggregate) ([]observer.Point, int64) {
+	internalKey := seriesKey(key.Namespace, key.Name, key.Tags)
+	stats := s.series[internalKey]
+	if stats == nil {
+		return nil, cursor
+	}
+
+	var points []observer.Point
+	newCursor := cursor
+	for _, p := range stats.Points {
+		if p.Timestamp > cursor {
+			points = append(points, observer.Point{
+				Timestamp: p.Timestamp,
+				Value:     p.aggregate(agg),
+			})
+			if p.Timestamp > newCursor {
+				newCursor = p.Timestamp
+			}
+		}
+	}
+	return points, newCursor
 }

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -278,7 +278,7 @@ func (tb *TestBench) LoadScenario(name string) error {
 	tb.ready = false
 	tb.loadedScenario = name
 
-	// Reset ALL correlators (not just enabled) so disabled ones clear stale state
+	// Reset ALL components so disabled ones clear stale state
 	tb.resetAllState()
 
 	// Load data from scenario
@@ -490,13 +490,13 @@ func (tb *TestBench) runLogDetectors() error {
 	return nil
 }
 
-// resetAllState resets all correlators.
+// resetAllState resets all registered components that support Reset().
 func (tb *TestBench) resetAllState() {
-	for _, proc := range tb.allCorrelators() {
-		if resetter, ok := proc.(interface{ Reset() }); ok {
+	for _, comp := range tb.components {
+		if resetter, ok := comp.Instance.(interface{ Reset() }); ok {
 			resetter.Reset()
-		} else {
-			proc.Flush()
+		} else if flusher, ok := comp.Instance.(interface{ Flush() }); ok {
+			flusher.Flush()
 		}
 	}
 }
@@ -577,7 +577,7 @@ func (tb *TestBench) rerunDetectorsLocked() {
 		delete(tb.metricsBySeriesID, k)
 	}
 
-	// Reset ALL correlators (not just enabled) so disabled ones clear stale state
+	// Reset ALL components (not just enabled) so disabled ones clear stale state
 	tb.resetAllState()
 
 	detectors := tb.enabledDetectors()
@@ -618,6 +618,31 @@ func (tb *TestBench) rerunDetectorsLocked() {
 				}
 			}
 		}
+	}
+
+	// Phase 1b (sync): Run multi-series detectors (pull-based, e.g. RRCF)
+	dataTime := tb.storage.MaxTimestamp()
+	for _, detector := range tb.enabledMultiDetectors() {
+		multiResult := detector.Detect(tb.storage, dataTime)
+		for _, anomaly := range multiResult.Anomalies {
+			// If the anomaly has a Source (telemetry metric name) but no SourceSeriesID,
+			// resolve it to the telemetry series using the same naming convention as handleTelemetry.
+			if anomaly.SourceSeriesID == "" && anomaly.Source != "" {
+				telemetryName := "telemetry." + detector.Name() + "." + string(anomaly.Source)
+				anomaly.SourceSeriesID = observerdef.SeriesID(seriesKey("telemetry", telemetryName+":avg", nil))
+			}
+			if dedup != nil {
+				if !dedup.ShouldProcess(string(anomaly.SourceSeriesID), anomaly.Timestamp) {
+					continue
+				}
+			}
+			tb.metricsAnomalies = append(tb.metricsAnomalies, anomaly)
+			tb.metricsByDetector[anomaly.DetectorName] = append(tb.metricsByDetector[anomaly.DetectorName], anomaly)
+			if anomaly.SourceSeriesID != "" {
+				tb.metricsBySeriesID[anomaly.SourceSeriesID] = append(tb.metricsBySeriesID[anomaly.SourceSeriesID], anomaly)
+			}
+		}
+		tb.handleTelemetry(multiResult.Telemetry, detector.Name(), dataTime)
 	}
 
 	// --- Correlations ---
@@ -857,11 +882,12 @@ func (tb *TestBench) GetDetectorComponentMap() map[string]string {
 		if comp.Registration.Category != "detector" {
 			continue
 		}
-		detector, ok := comp.Instance.(observerdef.MetricsDetector)
-		if !ok {
-			continue
+		if detector, ok := comp.Instance.(observerdef.MetricsDetector); ok {
+			result[detector.Name()] = componentName
 		}
-		result[detector.Name()] = componentName
+		if detector, ok := comp.Instance.(observerdef.MultiSeriesDetector); ok {
+			result[detector.Name()] = componentName
+		}
 	}
 	return result
 }
@@ -946,7 +972,7 @@ func (tb *TestBench) seriesCount() int {
 
 // GetLeadLagEdges returns lead-lag edges if the correlator is enabled.
 func (tb *TestBench) GetLeadLagEdges() ([]LeadLagEdge, bool) {
-	data, enabled := tb.GetCorrelatorData("lead_lag")
+	data, enabled := tb.GetComponentData("lead_lag")
 	if edges, ok := data.([]LeadLagEdge); ok {
 		return edges, enabled
 	}
@@ -955,7 +981,7 @@ func (tb *TestBench) GetLeadLagEdges() ([]LeadLagEdge, bool) {
 
 // GetSurpriseEdges returns surprise edges if the correlator is enabled.
 func (tb *TestBench) GetSurpriseEdges() ([]SurpriseEdge, bool) {
-	data, enabled := tb.GetCorrelatorData("surprise")
+	data, enabled := tb.GetComponentData("surprise")
 	if edges, ok := data.([]SurpriseEdge); ok {
 		return edges, enabled
 	}

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -57,7 +57,6 @@ type TestBenchConfig struct {
 	// If a name is present, its value overrides the registry DefaultEnabled.
 	// Components not listed use their registry default.
 	EnableOverrides map[string]bool
-
 }
 
 // TestBench is the main controller for the observer test bench.
@@ -1033,6 +1032,22 @@ func (tb *TestBench) RunHeadless(scenario, outputPath string, verbose bool) erro
 	}
 
 	return nil
+}
+
+// RunSendAnomalyEvents loads a scenario, waits for correlators to finish, then
+// delegates to notify.go to send one Datadog event per correlation.
+// When dryRun is true, events are printed to stdout instead of being sent.
+func (tb *TestBench) RunSendAnomalyEvents(scenario string, dryRun bool) error {
+	if err := tb.LoadScenario(scenario); err != nil {
+		return fmt.Errorf("loading scenario %q: %w", scenario, err)
+	}
+
+	tb.mu.RLock()
+	defer tb.mu.RUnlock()
+	for tb.correlatorsProcessing {
+		tb.correlatorsDone.Wait()
+	}
+	return sendCorrelationEvents(tb.correlations, dryRun)
 }
 
 // ToggleComponent toggles a component's enabled state and re-runs analyses if needed.

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -631,11 +631,6 @@ func (tb *TestBench) rerunDetectorsLocked() {
 				telemetryName := "telemetry." + detector.Name() + "." + string(anomaly.Source)
 				anomaly.SourceSeriesID = observerdef.SeriesID(seriesKey("telemetry", telemetryName+":avg", nil))
 			}
-			if dedup != nil {
-				if !dedup.ShouldProcess(string(anomaly.SourceSeriesID), anomaly.Timestamp) {
-					continue
-				}
-			}
 			tb.metricsAnomalies = append(tb.metricsAnomalies, anomaly)
 			tb.metricsByDetector[anomaly.DetectorName] = append(tb.metricsByDetector[anomaly.DetectorName], anomaly)
 			if anomaly.SourceSeriesID != "" {

--- a/comp/observer/impl/testbench_api.go
+++ b/comp/observer/impl/testbench_api.go
@@ -50,7 +50,6 @@ func (api *TestBenchAPI) Start(addr string) error {
 	mux.HandleFunc("/api/surprise", api.cors(api.handleSurprise))
 	mux.HandleFunc("/api/stats", api.cors(api.handleStats))
 	mux.HandleFunc("/api/components/", api.cors(api.handleComponentAction))
-	mux.HandleFunc("/api/correlators/", api.cors(api.handleCorrelatorData))
 	mux.HandleFunc("/api/correlations/compressed", api.cors(api.handleCompressedCorrelations))
 
 	api.server = &http.Server{
@@ -595,7 +594,7 @@ func (api *TestBenchAPI) handleStats(w http.ResponseWriter, r *http.Request) {
 	api.writeJSON(w, stats)
 }
 
-// handleComponentAction handles POST /api/components/{name}/toggle.
+// handleComponentAction handles /api/components/{name}/{action} (toggle, data).
 func (api *TestBenchAPI) handleComponentAction(w http.ResponseWriter, r *http.Request) {
 	path := strings.TrimPrefix(r.URL.Path, "/api/components/")
 	parts := strings.Split(path, "/")
@@ -618,19 +617,19 @@ func (api *TestBenchAPI) handleComponentAction(w http.ResponseWriter, r *http.Re
 			return
 		}
 		api.writeJSON(w, api.tb.GetStatus())
+	case "data":
+		if r.Method != "GET" {
+			api.writeError(w, http.StatusMethodNotAllowed, "use GET for component data")
+			return
+		}
+		data, enabled := api.tb.GetComponentData(name)
+		api.writeJSON(w, map[string]interface{}{
+			"enabled": enabled,
+			"data":    data,
+		})
 	default:
 		api.writeError(w, http.StatusBadRequest, "unknown action: "+action)
 	}
-}
-
-// handleCorrelatorData handles GET /api/correlators/{name}.
-func (api *TestBenchAPI) handleCorrelatorData(w http.ResponseWriter, r *http.Request) {
-	name := strings.TrimPrefix(r.URL.Path, "/api/correlators/")
-	data, enabled := api.tb.GetCorrelatorData(name)
-	api.writeJSON(w, map[string]interface{}{
-		"enabled": enabled,
-		"data":    data,
-	})
 }
 
 // handleCompressedCorrelations returns compressed group descriptions.

--- a/comp/observer/impl/testbench_registry.go
+++ b/comp/observer/impl/testbench_registry.go
@@ -23,9 +23,9 @@ type registeredComponent struct {
 	Enabled      bool
 }
 
-// CorrelatorDataProvider is implemented by correlators that expose extra data
-// beyond what the Correlator interface provides (e.g. edges, clusters).
-type CorrelatorDataProvider interface {
+// ComponentDataProvider is implemented by components that expose extra data
+// beyond what their primary interface provides (e.g. edges, clusters, scores).
+type ComponentDataProvider interface {
 	GetExtraData() interface{}
 }
 
@@ -50,6 +50,17 @@ var defaultRegistry = []ComponentRegistration{
 			return NewBOCPDDetector()
 		},
 	},
+	{
+		Name:           "rrcf",
+		DisplayName:    "RRCF",
+		Category:       "detector",
+		DefaultEnabled: false,
+		Factory: func(_ *TestBench) interface{} {
+			config := DefaultRRCFConfig()
+			config.Metrics = TestBenchRRCFMetrics()
+			return NewRRCFDetector(config)
+		},
+	},
 	// Correlators
 	{
 		Name:           "time_cluster",
@@ -59,7 +70,6 @@ var defaultRegistry = []ComponentRegistration{
 		Factory: func(_ *TestBench) interface{} {
 			return NewTimeClusterCorrelator(TimeClusterConfig{
 				ProximitySeconds: 10,
-				MinClusterSize:   2,
 				WindowSeconds:    120,
 			})
 		},
@@ -93,13 +103,26 @@ var defaultRegistry = []ComponentRegistration{
 	},
 }
 
-// enabledDetectors returns all enabled MetricsDetector instances.
+// enabledDetectors returns all enabled MetricsDetector instances (per-series detectors).
 func (tb *TestBench) enabledDetectors() []observerdef.MetricsDetector {
 	var result []observerdef.MetricsDetector
 	for _, comp := range tb.components {
 		if comp.Enabled && comp.Registration.Category == "detector" {
 			if a, ok := comp.Instance.(observerdef.MetricsDetector); ok {
 				result = append(result, a)
+			}
+		}
+	}
+	return result
+}
+
+// enabledMultiDetectors returns all enabled MultiSeriesDetector instances (pull-based).
+func (tb *TestBench) enabledMultiDetectors() []observerdef.MultiSeriesDetector {
+	var result []observerdef.MultiSeriesDetector
+	for _, comp := range tb.components {
+		if comp.Enabled && comp.Registration.Category == "detector" {
+			if d, ok := comp.Instance.(observerdef.MultiSeriesDetector); ok {
+				result = append(result, d)
 			}
 		}
 	}
@@ -132,15 +155,27 @@ func (tb *TestBench) allCorrelators() []observerdef.Correlator {
 	return result
 }
 
-// GetCorrelatorData returns the extra data and enabled status for a named correlator.
-func (tb *TestBench) GetCorrelatorData(name string) (data interface{}, enabled bool) {
+// getDeduplicator returns the deduplicator if it is enabled, or nil.
+func (tb *TestBench) getDeduplicator() *AnomalyDeduplicator {
+	comp, ok := tb.components["dedup"]
+	if !ok || !comp.Enabled {
+		return nil
+	}
+	if d, ok := comp.Instance.(*AnomalyDeduplicator); ok {
+		return d
+	}
+	return nil
+}
+
+// GetComponentData returns the extra data and enabled status for a named component.
+func (tb *TestBench) GetComponentData(name string) (data interface{}, enabled bool) {
 	tb.mu.RLock()
 	defer tb.mu.RUnlock()
 	comp, ok := tb.components[name]
 	if !ok {
 		return nil, false
 	}
-	if provider, ok := comp.Instance.(CorrelatorDataProvider); ok {
+	if provider, ok := comp.Instance.(ComponentDataProvider); ok {
 		return provider.GetExtraData(), comp.Enabled
 	}
 	return nil, comp.Enabled

--- a/comp/observer/impl/testbench_registry.go
+++ b/comp/observer/impl/testbench_registry.go
@@ -155,18 +155,6 @@ func (tb *TestBench) allCorrelators() []observerdef.Correlator {
 	return result
 }
 
-// getDeduplicator returns the deduplicator if it is enabled, or nil.
-func (tb *TestBench) getDeduplicator() *AnomalyDeduplicator {
-	comp, ok := tb.components["dedup"]
-	if !ok || !comp.Enabled {
-		return nil
-	}
-	if d, ok := comp.Instance.(*AnomalyDeduplicator); ok {
-		return d
-	}
-	return nil
-}
-
 // GetComponentData returns the extra data and enabled status for a named component.
 func (tb *TestBench) GetComponentData(name string) (data interface{}, enabled bool) {
 	tb.mu.RLock()

--- a/go.mod
+++ b/go.mod
@@ -482,7 +482,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/buf v0.76.0-devel // indirect
 	github.com/DataDog/datadog-agent/pkg/util/statstracker v0.64.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/system/socket v0.76.0-devel
-	github.com/DataDog/datadog-api-client-go/v2 v2.54.0 // indirect
+	github.com/DataDog/datadog-api-client-go/v2 v2.54.0
 	github.com/DataDog/go-tuf v1.1.1-0.5.2 // indirect
 	github.com/DataDog/gohai v0.0.0-20230524154621-4316413895ee // indirect
 	github.com/DataDog/gostackparse v0.7.0 // indirect


### PR DESCRIPTION
## Summary
- Adds `--send-anomaly-event <scenario>` flag to the observer testbench that runs a scenario and sends one Datadog event per active correlation via the Datadog Events v2 API
- Adds `--dry-run` flag to print events to stdout instead of sending them (useful for testing without an API key)
- Introduces `comp/observer/impl/notify.go` with an `eventSender` that formats correlation data into event payloads and dispatches them
<img width="1251" height="651" alt="Screenshot 2026-03-05 at 22 30 47" src="https://github.com/user-attachments/assets/6ad61712-2fb5-47ea-b6a0-613f9bb02f3f" />

## Test plan
- [ ] Run with `--dry-run` to verify event formatting without an API key
- [ ] Run with a valid `DD_API_KEY` and `--send-anomaly-event <scenario>` to verify events appear in Datadog

🤖 Generated with [Claude Code](https://claude.com/claude-code)