### PR TITLE
Add shell test scenarios from yash_posix_tests

### DIFF
--- a/pkg/shell/tests/scenarios/cmd/exit/basic/override_prev_failure.yaml
+++ b/pkg/shell/tests/scenarios/cmd/exit/basic/override_prev_failure.yaml
@@ -1,0 +1,10 @@
+description: Exit with explicit zero overrides a previous failed command.
+input:
+  # language=bash
+  script: |+
+    false
+    exit 0
+expect:
+  stdout: ""
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/brace_group/with_and_chain.yaml
+++ b/pkg/shell/tests/scenarios/shell/brace_group/with_and_chain.yaml
@@ -1,0 +1,11 @@
+description: Brace groups can be chained with the AND operator.
+input:
+  # language=bash
+  script: |+
+    { echo 1; } && { echo 2; }
+expect:
+  stdout: |+
+    1
+    2
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/brace_group/with_or_chain.yaml
+++ b/pkg/shell/tests/scenarios/shell/brace_group/with_or_chain.yaml
@@ -1,0 +1,10 @@
+description: Brace group failure triggers the OR fallback brace group.
+input:
+  # language=bash
+  script: |+
+    { false; } || { echo fallback; }
+expect:
+  stdout: |+
+    fallback
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/comments/only_comments.yaml
+++ b/pkg/shell/tests/scenarios/shell/comments/only_comments.yaml
@@ -1,0 +1,11 @@
+description: A script with only comments produces no output and exits zero.
+input:
+  # language=bash
+  script: |+
+    #
+    # foo
+    #	bar
+expect:
+  stdout: ""
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/for_clause/basic/newline_do.yaml
+++ b/pkg/shell/tests/scenarios/shell/for_clause/basic/newline_do.yaml
@@ -1,0 +1,15 @@
+description: For loop with do on a separate line from the word list.
+input:
+  # language=bash
+  script: |+
+    for i in a b c
+    do
+      echo $i
+    done
+expect:
+  stdout: |+
+    a
+    b
+    c
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/for_clause/break_cont/break_with_negation.yaml
+++ b/pkg/shell/tests/scenarios/shell/for_clause/break_cont/break_with_negation.yaml
@@ -1,0 +1,14 @@
+description: Break preceded by negation still exits the loop.
+input:
+  # language=bash
+  script: |+
+    for i in 1 2 3; do
+      ! break
+      echo not reached
+    done
+    echo done
+expect:
+  stdout: |+
+    done
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/for_clause/break_cont/continue_with_negation.yaml
+++ b/pkg/shell/tests/scenarios/shell/for_clause/break_cont/continue_with_negation.yaml
@@ -1,0 +1,14 @@
+description: Continue preceded by negation still skips the rest of the loop body.
+input:
+  # language=bash
+  script: |+
+    for i in a b c; do
+      ! continue
+      echo not reached
+    done
+    echo done
+expect:
+  stdout: |+
+    done
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/for_clause/exit_code/break_after_false.yaml
+++ b/pkg/shell/tests/scenarios/shell/for_clause/exit_code/break_after_false.yaml
@@ -1,0 +1,14 @@
+description: Break resets exit status to zero even after a failed command.
+input:
+  # language=bash
+  script: |+
+    for i in 1; do
+      false
+      break
+    done
+    echo $?
+expect:
+  stdout: |+
+    0
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/for_clause/exit_code/last_iteration_cmd.yaml
+++ b/pkg/shell/tests/scenarios/shell/for_clause/exit_code/last_iteration_cmd.yaml
@@ -1,0 +1,14 @@
+description: Exit status of for loop is from the last command of the last iteration.
+input:
+  # language=bash
+  script: |+
+    for i in a b c; do
+      false
+      true
+    done
+    echo $?
+expect:
+  stdout: |+
+    0
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/for_clause/var_scoping/var_last_value_after_loop.yaml
+++ b/pkg/shell/tests/scenarios/shell/for_clause/var_scoping/var_last_value_after_loop.yaml
@@ -1,0 +1,13 @@
+description: Loop variable retains the value from the last iteration after loop ends.
+input:
+  # language=bash
+  script: |+
+    for i in a b c; do
+      true
+    done
+    echo $i
+expect:
+  stdout: |+
+    c
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/heredoc/blank_line_only.yaml
+++ b/pkg/shell/tests/scenarios/shell/heredoc/blank_line_only.yaml
@@ -1,0 +1,11 @@
+description: Heredoc with only a blank line between delimiters outputs the blank line.
+input:
+  # language=bash
+  script: |+
+    cat <<EOF
+
+    EOF
+expect:
+  stdout: "\n"
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/heredoc/in_brace_group.yaml
+++ b/pkg/shell/tests/scenarios/shell/heredoc/in_brace_group.yaml
@@ -1,0 +1,14 @@
+description: Heredoc works inside a brace group.
+input:
+  # language=bash
+  script: |+
+    {
+      cat <<EOF
+    hello
+    EOF
+    }
+expect:
+  stdout: |+
+    hello
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/heredoc/in_for_loop.yaml
+++ b/pkg/shell/tests/scenarios/shell/heredoc/in_for_loop.yaml
@@ -1,0 +1,15 @@
+description: Heredocs can be used inside a for loop body.
+input:
+  # language=bash
+  script: |+
+    for i in a b; do
+      cat <<EOF
+    $i
+    EOF
+    done
+expect:
+  stdout: |+
+    a
+    b
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/line_continuation/in_for_keywords.yaml
+++ b/pkg/shell/tests/scenarios/shell/line_continuation/in_for_keywords.yaml
@@ -1,0 +1,16 @@
+description: Line continuation works across for loop keywords.
+input:
+  # language=bash
+  script: |+
+    for i \
+    in a b c; \
+    do \
+    echo $i; \
+    done
+expect:
+  stdout: |+
+    a
+    b
+    c
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/logic_ops/mixed/negation_in_and_or.yaml
+++ b/pkg/shell/tests/scenarios/shell/logic_ops/mixed/negation_in_and_or.yaml
@@ -1,0 +1,10 @@
+description: Negated pipelines interact correctly with and-or lists.
+input:
+  # language=bash
+  script: |+
+    ! false && echo foo | cat
+expect:
+  stdout: |+
+    foo
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/logic_ops/mixed/or_fallback_to_and.yaml
+++ b/pkg/shell/tests/scenarios/shell/logic_ops/mixed/or_fallback_to_and.yaml
@@ -1,0 +1,12 @@
+description: Three-command list with failure then or-fallback then and-continuation.
+input:
+  # language=bash
+  script: |+
+    false && echo foo || echo bar
+    true || echo foo && echo bar
+expect:
+  stdout: |+
+    bar
+    bar
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/logic_ops/mixed/pipe_in_and_or.yaml
+++ b/pkg/shell/tests/scenarios/shell/logic_ops/mixed/pipe_in_and_or.yaml
@@ -1,0 +1,11 @@
+description: Pipelines can be used as components of and-or lists.
+input:
+  # language=bash
+  script: |+
+    echo hello | cat && echo world
+expect:
+  stdout: |+
+    hello
+    world
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/negation/exit_code/negate_captures_status.yaml
+++ b/pkg/shell/tests/scenarios/shell/negation/exit_code/negate_captures_status.yaml
@@ -1,0 +1,14 @@
+description: Negation captures the exit status in $? as 0 or 1.
+input:
+  # language=bash
+  script: |+
+    ! false
+    echo $?
+    ! true
+    echo $?
+expect:
+  stdout: |+
+    0
+    1
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/pipe/basic/brace_in_pipeline.yaml
+++ b/pkg/shell/tests/scenarios/shell/pipe/basic/brace_in_pipeline.yaml
@@ -1,0 +1,11 @@
+description: Brace groups can be used as pipeline components.
+input:
+  # language=bash
+  script: |+
+    { echo foo; echo bar; } | cat
+expect:
+  stdout: |+
+    foo
+    bar
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/pipe/exit_code/three_stage_last_wins.yaml
+++ b/pkg/shell/tests/scenarios/shell/pipe/exit_code/three_stage_last_wins.yaml
@@ -1,0 +1,11 @@
+description: In a three-stage pipeline the exit status comes from the last command.
+input:
+  # language=bash
+  script: |+
+    false | true | false
+    echo $?
+expect:
+  stdout: |+
+    1
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/var_expand/basic/adjacent_vars.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/basic/adjacent_vars.yaml
@@ -1,0 +1,12 @@
+description: Adjacent variable expansions are concatenated without spaces.
+input:
+  # language=bash
+  script: |+
+    A=hello
+    B=world
+    echo $A$B
+expect:
+  stdout: |+
+    helloworld
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/var_expand/basic/underscore_name.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/basic/underscore_name.yaml
@@ -1,0 +1,11 @@
+description: Variable names can start with an underscore.
+input:
+  # language=bash
+  script: |+
+    _foo=bar
+    echo $_foo
+expect:
+  stdout: |+
+    bar
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/var_expand/quoting/backslash_outside_quotes.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/quoting/backslash_outside_quotes.yaml
@@ -1,0 +1,12 @@
+description: Backslash outside quotes escapes the following character literally.
+input:
+  # language=bash
+  script: |+
+    echo \$HOME
+    echo hello\ world
+expect:
+  stdout: |+
+    $HOME
+    hello world
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/var_expand/quoting/double_quote_backslash.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/quoting/double_quote_backslash.yaml
@@ -1,0 +1,10 @@
+description: Backslash-backslash inside double quotes produces a single literal backslash.
+input:
+  # language=bash
+  script: |+
+    echo "a\\b"
+expect:
+  stdout: |+
+    a\b
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/var_expand/quoting/double_quote_multiline.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/quoting/double_quote_multiline.yaml
@@ -1,0 +1,12 @@
+description: Double quotes can span multiple lines preserving the literal newline.
+input:
+  # language=bash
+  script: |+
+    echo "line1
+    line2"
+expect:
+  stdout: |+
+    line1
+    line2
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/var_expand/quoting/double_quote_preserves_spaces.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/quoting/double_quote_preserves_spaces.yaml
@@ -1,0 +1,11 @@
+description: Double-quoted expansion preserves internal whitespace without field splitting.
+input:
+  # language=bash
+  script: |+
+    a='hello   world'
+    echo "$a"
+expect:
+  stdout: |+
+    hello   world
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/var_expand/quoting/line_continuation_in_dquotes.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/quoting/line_continuation_in_dquotes.yaml
@@ -1,0 +1,11 @@
+description: Backslash-newline inside double quotes joins the lines.
+input:
+  # language=bash
+  script: |+
+    echo "hello\
+    world"
+expect:
+  stdout: |+
+    helloworld
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/var_expand/quoting/mixed_quotes.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/quoting/mixed_quotes.yaml
@@ -1,0 +1,11 @@
+description: Adjacent single-quoted and double-quoted strings are concatenated into one word.
+input:
+  # language=bash
+  script: |+
+    a=world
+    echo 'hello '"$a"
+expect:
+  stdout: |+
+    hello world
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/var_expand/quoting/single_quote_multiline.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/quoting/single_quote_multiline.yaml
@@ -1,0 +1,12 @@
+description: Single quotes can span multiple lines preserving the literal newline.
+input:
+  # language=bash
+  script: |+
+    echo 'line1
+    line2'
+expect:
+  stdout: |+
+    line1
+    line2
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/var_expand/quoting/single_quote_preserves_dollar.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/quoting/single_quote_preserves_dollar.yaml
@@ -1,0 +1,11 @@
+description: Single quotes prevent variable expansion, preserving the literal dollar sign.
+input:
+  # language=bash
+  script: |+
+    a=hello
+    echo '$a'
+expect:
+  stdout: |+
+    $a
+  stderr: ""
+  exit_code: 0


### PR DESCRIPTION
<!-- dd-meta {"pullId":"758e0162-80b6-4779-a877-3b6c03ed63a0","source":"chat","resourceId":"1e0842fc-c738-4d85-9901-893d696f7bc7","workflowId":"26250444-e48e-4439-9647-3b3499f4b067","codeChangeId":"26250444-e48e-4439-9647-3b3499f4b067","sourceType":"chat"} -->
### What does this PR do?

Adds 30 new test scenario YAML files to `pkg/shell/tests/scenarios/` to improve coverage of the shell interpreter. These tests are inspired by the POSIX compliance tests in `pkg/shell/yash_posix_tests/` (andor-p, pipeline-p, for-p, break-p, grouping-p, comment-p, quote-p, exit-p, redir-p, param-p).

### Motivation

The existing test scenarios had gaps in coverage for several supported shell features. By drawing inspiration from the yash POSIX test suite, this PR fills those gaps while carefully avoiding duplicate coverage with existing tests.

**New coverage areas:**
- **Logic ops**: Pipelines within and-or lists, negation in and-or lists, 3-command or-fallback-to-and chains
- **For clause**: Newline-separated `do`, break after `false` resets exit status, last iteration exit status, loop variable last value, break/continue with `!` negation
- **Brace group**: Chaining with `&&` and `||` operators
- **Pipe**: 3-stage pipeline exit status, brace groups in pipelines
- **Negation**: Exit status capture via `$?`
- **Comments**: Script with only comments
- **Quoting**: Backslash in/outside double quotes, single-quote dollar preservation, multiline single/double quotes, line continuation inside double quotes, mixed quote concatenation
- **Variable expansion**: Adjacent variables, underscore-prefixed names
- **Heredoc**: Blank-line-only content, heredoc in brace group and for loop
- **Line continuation**: Across for loop keywords
- **Exit**: Override previous failure with explicit `exit 0`

### Describe how you validated your changes

- All 30 new scenarios pass `TestShellScenarios` (interpreter)
- All new scenarios pass `TestShellScenariosAgainstBash` (bash comparison)

### Additional Notes

No code changes to the interpreter — only new test YAML files.

---

PR by Bits
[View session in Datadog](https://app.datadoghq.com/code/1e0842fc-c738-4d85-9901-893d696f7bc7)

Comment @datadog to request changes