### PR TITLE
observer: propagate MetricType through pipeline to parquet

### DIFF
--- a/comp/anomalydetection/recorder/def/component.go
+++ b/comp/anomalydetection/recorder/def/component.go
@@ -50,11 +50,12 @@ type Component interface {
 // MetricData represents a single metric read from parquet files.
 // Used by ReadAllMetrics for batch loading scenarios.
 type MetricData struct {
-	Source    string   // Source/namespace (RunID in parquet)
-	Name      string   // Metric name
-	Value     float64  // Metric value
-	Timestamp int64    // Unix timestamp in seconds
-	Tags      []string // Tags in "key:value" format
+	Source     string   // Source/namespace (RunID in parquet)
+	Name       string   // Metric name
+	MetricType string   // Metric type (e.g. "Gauge", "Count", "MonotonicCount", "Rate", "Histogram")
+	Value      float64  // Metric value
+	Timestamp  int64    // Unix timestamp in seconds
+	Tags       []string // Tags in "key:value" format
 }
 
 // TraceData represents a trace read from parquet files.

--- a/comp/anomalydetection/recorder/impl/parquet_bloom_test.go
+++ b/comp/anomalydetection/recorder/impl/parquet_bloom_test.go
@@ -23,9 +23,9 @@ func TestParquetBloomFilterOnListColumn(t *testing.T) {
 	require.NoError(t, err)
 
 	// Write metrics with different tag combinations
-	writer.WriteMetric("test", "metric.a", 1.0, []string{"host:server1", "env:prod"}, 1000)
-	writer.WriteMetric("test", "metric.b", 2.0, []string{"host:server2", "env:dev"}, 2000)
-	writer.WriteMetric("test", "metric.c", 3.0, []string{"host:server3", "env:staging"}, 3000)
+	writer.WriteMetric("test", "metric.a", "Gauge", 1.0, []string{"host:server1", "env:prod"}, 1000)
+	writer.WriteMetric("test", "metric.b", "Gauge", 2.0, []string{"host:server2", "env:dev"}, 2000)
+	writer.WriteMetric("test", "metric.c", "Gauge", 3.0, []string{"host:server3", "env:staging"}, 3000)
 
 	// Close to flush and finalize the file
 	require.NoError(t, writer.Close())
@@ -85,7 +85,7 @@ func TestParquetWriteReadMultipleMetrics(t *testing.T) {
 			"env:prod",
 			"index:" + strconv.Itoa(i),
 		}
-		writer.WriteMetric("test", "metric.test", float64(i), tags, int64(i*1000))
+		writer.WriteMetric("test", "metric.test", "Gauge", float64(i), tags, int64(i*1000))
 	}
 	require.NoError(t, writer.Close())
 

--- a/comp/anomalydetection/recorder/impl/parquet_metric_reader.go
+++ b/comp/anomalydetection/recorder/impl/parquet_metric_reader.go
@@ -25,6 +25,7 @@ type FGMMetric struct {
 	RunID      string
 	Time       int64 // milliseconds
 	MetricName string
+	MetricType string // e.g. "Gauge", "Count", "MonotonicCount", "Rate", "Histogram"
 	ValueInt   *uint64
 	ValueFloat *float64
 	Tags       map[string]string
@@ -206,6 +207,11 @@ func extractMetricsFromRecord(record arrow.Record) ([]FGMMetric, error) {
 	runIDIdx := findColumnIndexInSchema(schema, "runid")
 	timeIdx := findColumnIndexInSchema(schema, "time")
 	metricNameIdx := findColumnIndexInSchema(schema, "metricname")
+	// BACKCOMPAT: MetricType column was added 2026-03-05. Parquet files written before
+	// this date won't have it, so metricTypeIdx will be -1 and MetricType will be "".
+	// DELETEME: Safe to make this required (and remove the -1 guard) after 2026-04-01,
+	// when no pre-MetricType parquet files should still be in use.
+	metricTypeIdx := findColumnIndexInSchema(schema, "metrictype")
 	valueFloatIdx := findColumnIndexInSchema(schema, "valuefloat")
 	tagsIdx := findColumnIndexInSchema(schema, "tags")
 
@@ -227,6 +233,7 @@ func extractMetricsFromRecord(record arrow.Record) ([]FGMMetric, error) {
 	// Get typed column references (safe type switches)
 	var runIDCol *array.String
 	var metricNameCol *array.String
+	var metricTypeCol *array.String
 	var valueFloatCol *array.Float64
 	var tagsCol *array.List
 	var timeColRaw arrow.Array
@@ -242,6 +249,11 @@ func extractMetricsFromRecord(record arrow.Record) ([]FGMMetric, error) {
 	if metricNameIdx >= 0 {
 		if c, ok := record.Column(metricNameIdx).(*array.String); ok {
 			metricNameCol = c
+		}
+	}
+	if metricTypeIdx >= 0 {
+		if c, ok := record.Column(metricTypeIdx).(*array.String); ok {
+			metricTypeCol = c
 		}
 	}
 	if valueFloatIdx >= 0 {
@@ -275,7 +287,7 @@ func extractMetricsFromRecord(record arrow.Record) ([]FGMMetric, error) {
 	// Build metrics
 	metrics := make([]FGMMetric, numRows)
 	for i := 0; i < numRows; i++ {
-		var runID, metricName string
+		var runID, metricName, metricType string
 		var timestamp int64
 		var valueFloat *float64
 		tags := make(map[string]string)
@@ -288,6 +300,9 @@ func extractMetricsFromRecord(record arrow.Record) ([]FGMMetric, error) {
 		}
 		if metricNameCol != nil && !metricNameCol.IsNull(i) {
 			metricName = metricNameCol.Value(i)
+		}
+		if metricTypeCol != nil && !metricTypeCol.IsNull(i) {
+			metricType = metricTypeCol.Value(i)
 		}
 		if valueFloatCol != nil && !valueFloatCol.IsNull(i) {
 			v := valueFloatCol.Value(i)
@@ -324,6 +339,7 @@ func extractMetricsFromRecord(record arrow.Record) ([]FGMMetric, error) {
 			RunID:      runID,
 			Time:       timestamp,
 			MetricName: metricName,
+			MetricType: metricType,
 			ValueFloat: valueFloat,
 			Tags:       tags,
 		}

--- a/comp/anomalydetection/recorder/impl/parquet_metric_writer.go
+++ b/comp/anomalydetection/recorder/impl/parquet_metric_writer.go
@@ -42,6 +42,7 @@ func newMetricParquetWriter(outputDir string, flushInterval, retentionDuration t
 			{Name: "RunID", Type: arrow.BinaryTypes.String},              // Source/namespace
 			{Name: "Time", Type: arrow.PrimitiveTypes.Int64},             // milliseconds since epoch
 			{Name: "MetricName", Type: arrow.BinaryTypes.String},         // metric name
+			{Name: "MetricType", Type: arrow.BinaryTypes.String},         // e.g. "Gauge", "Count", "MonotonicCount"
 			{Name: "ValueFloat", Type: arrow.PrimitiveTypes.Float64},     // metric value
 			{Name: "Tags", Type: arrow.ListOf(arrow.BinaryTypes.String)}, // tags as list of strings
 		},
@@ -82,11 +83,11 @@ func newMetricParquetWriter(outputDir string, flushInterval, retentionDuration t
 }
 
 // WriteMetric adds a metric to the batch (will be flushed on interval).
-func (pw *metricParquetWriter) WriteMetric(source, name string, value float64, tags []string, timestamp int64) {
+func (pw *metricParquetWriter) WriteMetric(source, name, metricType string, value float64, tags []string, timestamp int64) {
 	pw.mu.Lock()
 	defer pw.mu.Unlock()
 
-	pw.typedBuilder.add(source, name, value, tags, timestamp)
+	pw.typedBuilder.add(source, name, metricType, value, tags, timestamp)
 }
 
 // metricBatchBuilder accumulates metrics into Arrow record batches using RecordBuilder
@@ -96,6 +97,7 @@ type metricBatchBuilder struct {
 	runIDs      []string
 	times       []int64
 	metricNames []string
+	metricTypes []string
 	valueFloats []float64
 	tags        [][]string
 }
@@ -104,10 +106,11 @@ func newMetricBatchBuilder(schema *arrow.Schema) *metricBatchBuilder {
 	return &metricBatchBuilder{schema: schema}
 }
 
-func (b *metricBatchBuilder) add(source, name string, value float64, tags []string, timestamp int64) {
+func (b *metricBatchBuilder) add(source, name, metricType string, value float64, tags []string, timestamp int64) {
 	b.runIDs = append(b.runIDs, source)
 	b.times = append(b.times, timestamp*1000) // Convert to milliseconds
 	b.metricNames = append(b.metricNames, name)
+	b.metricTypes = append(b.metricTypes, metricType)
 	b.valueFloats = append(b.valueFloats, value)
 
 	// Copy tags to avoid mutation
@@ -127,8 +130,9 @@ func (b *metricBatchBuilder) build() arrow.Record {
 	runIDBuilder := recordBuilder.Field(0).(*array.StringBuilder)
 	timeBuilder := recordBuilder.Field(1).(*array.Int64Builder)
 	nameBuilder := recordBuilder.Field(2).(*array.StringBuilder)
-	valueBuilder := recordBuilder.Field(3).(*array.Float64Builder)
-	tagsBuilder := recordBuilder.Field(4).(*array.ListBuilder)
+	typeBuilder := recordBuilder.Field(3).(*array.StringBuilder)
+	valueBuilder := recordBuilder.Field(4).(*array.Float64Builder)
+	tagsBuilder := recordBuilder.Field(5).(*array.ListBuilder)
 	tagsValueBuilder := tagsBuilder.ValueBuilder().(*array.StringBuilder)
 
 	for _, id := range b.runIDs {
@@ -137,6 +141,9 @@ func (b *metricBatchBuilder) build() arrow.Record {
 	timeBuilder.AppendValues(b.times, nil)
 	for _, name := range b.metricNames {
 		nameBuilder.Append(name)
+	}
+	for _, mt := range b.metricTypes {
+		typeBuilder.Append(mt)
 	}
 	valueBuilder.AppendValues(b.valueFloats, nil)
 
@@ -154,6 +161,7 @@ func (b *metricBatchBuilder) build() arrow.Record {
 	b.runIDs = nil
 	b.times = nil
 	b.metricNames = nil
+	b.metricTypes = nil
 	b.valueFloats = nil
 	b.tags = nil
 

--- a/comp/anomalydetection/recorder/impl/recorder.go
+++ b/comp/anomalydetection/recorder/impl/recorder.go
@@ -166,11 +166,12 @@ func (r *recorderImpl) ReadAllMetrics(inputDir string) ([]recorderdef.MetricData
 		timestamp := metric.Time / 1000
 
 		metrics = append(metrics, recorderdef.MetricData{
-			Source:    metric.RunID,
-			Name:      metric.MetricName,
-			Value:     value,
-			Timestamp: timestamp,
-			Tags:      tags,
+			Source:     metric.RunID,
+			Name:       metric.MetricName,
+			MetricType: metric.MetricType,
+			Value:      value,
+			Timestamp:  timestamp,
+			Tags:       tags,
 		})
 	}
 
@@ -259,6 +260,7 @@ func (h *recordingHandle) ObserveMetric(sample observer.MetricView) {
 	h.recorder.metricParquetWriter.WriteMetric(
 		h.name,
 		sample.GetName(),
+		sample.GetMetricTypeName(),
 		sample.GetValue(),
 		sample.GetRawTags(),
 		timestamp,

--- a/comp/observer/README.md
+++ b/comp/observer/README.md
@@ -54,9 +54,10 @@ func (m *MyLogDetector) Process(log observer.LogView) observer.LogDetectionResul
     // Return metrics and/or anomalies
     return observer.LogDetectionResult{
         Metrics: []observer.MetricOutput{{
-            Name:  "my.metric",
-            Value: 1,
-            Tags:  log.GetTags(),
+            Name:       "my.metric",
+            Value:      1,
+            Tags:       log.GetTags(),
+            MetricType: observer.MetricTypeDeltaCount,
         }},
     }
 }

--- a/comp/observer/def/component.go
+++ b/comp/observer/def/component.go
@@ -55,6 +55,7 @@ type MetricView interface {
 	GetRawTags() []string
 	GetTimestamp() float64
 	GetSampleRate() float64
+	GetMetricTypeName() string
 }
 
 // LogView provides read-only access to a log message.

--- a/comp/observer/def/component.go
+++ b/comp/observer/def/component.go
@@ -12,6 +12,74 @@ package observer
 
 // team: agent-metric-pipelines
 
+// MetricType represents the type of a metric in the observer pipeline.
+// This is a uint8 enum to minimize memory usage in per-series storage.
+type MetricType uint8
+
+const (
+	// MetricTypeUnknown indicates the metric type could not be determined.
+	MetricTypeUnknown MetricType = iota
+	// MetricTypeGauge is an instantaneous measurement (e.g. cpu.percent, heap.used_mb).
+	MetricTypeGauge
+	// MetricTypeRate is a per-second rate computed by the agent.
+	MetricTypeRate
+	// MetricTypeDeltaCount is a count of events in a flush interval (resets each interval).
+	MetricTypeDeltaCount
+	// MetricTypeMonotonicCount is a cumulative counter that only increases (resets to zero on restart).
+	MetricTypeMonotonicCount
+	// MetricTypeHistogram is a client-side aggregated distribution.
+	MetricTypeHistogram
+	// MetricTypeDistribution is a distribution sent to the backend for server-side aggregation.
+	MetricTypeDistribution
+	// MetricTypeSet tracks unique values.
+	MetricTypeSet
+)
+
+// String returns the canonical string representation of a MetricType.
+func (m MetricType) String() string {
+	switch m {
+	case MetricTypeGauge:
+		return "Gauge"
+	case MetricTypeRate:
+		return "Rate"
+	case MetricTypeDeltaCount:
+		return "DeltaCount"
+	case MetricTypeMonotonicCount:
+		return "MonotonicCount"
+	case MetricTypeHistogram:
+		return "Histogram"
+	case MetricTypeDistribution:
+		return "Distribution"
+	case MetricTypeSet:
+		return "Set"
+	default:
+		return "Unknown"
+	}
+}
+
+// ParseMetricType converts a string (from MetricView.GetMetricTypeName or parquet)
+// to a MetricType. Unrecognized strings return MetricTypeUnknown.
+func ParseMetricType(s string) MetricType {
+	switch s {
+	case "Gauge", "GaugeWithTimestamp":
+		return MetricTypeGauge
+	case "Rate":
+		return MetricTypeRate
+	case "Count", "DeltaCount", "Counter", "CountWithTimestamp":
+		return MetricTypeDeltaCount
+	case "MonotonicCount":
+		return MetricTypeMonotonicCount
+	case "Histogram", "Historate":
+		return MetricTypeHistogram
+	case "Distribution":
+		return MetricTypeDistribution
+	case "Set":
+		return MetricTypeSet
+	default:
+		return MetricTypeUnknown
+	}
+}
+
 // Component is the central observer that receives data via handles.
 type Component interface {
 	// GetHandle returns a lightweight handle for a named source.
@@ -252,9 +320,10 @@ type LogDetectionResult struct {
 // The storage keeps full summaries (min/max/sum/count) so aggregation
 // is specified at read time, not write time.
 type MetricOutput struct {
-	Name  string
-	Value float64
-	Tags  []string
+	Name       string
+	Value      float64
+	Tags       []string
+	MetricType MetricType
 }
 
 // MetricName is a human-readable metric identifier (e.g., "cpu.user:avg").

--- a/comp/observer/impl/log_detector_connection_errors.go
+++ b/comp/observer/impl/log_detector_connection_errors.go
@@ -39,9 +39,10 @@ func (c *ConnectionErrorExtractor) Process(log observer.LogView) observer.LogDet
 		if strings.Contains(content, pattern) {
 			return observer.LogDetectionResult{
 				Metrics: []observer.MetricOutput{{
-					Name:  "connection.errors",
-					Value: 1.0,
-					Tags:  log.GetTags(),
+					Name:       "connection.errors",
+					Value:      1.0,
+					Tags:       log.GetTags(),
+					MetricType: observer.MetricTypeDeltaCount,
 				}},
 			}
 		}

--- a/comp/observer/impl/log_metrics_extractor.go
+++ b/comp/observer/impl/log_metrics_extractor.go
@@ -44,9 +44,10 @@ func (a *LogMetricsExtractor) Process(log observer.LogView) observer.LogDetectio
 	}
 
 	metrics := []observer.MetricOutput{{
-		Name:  patternCountMetricName(patternSig),
-		Value: 1,
-		Tags:  tags,
+		Name:       patternCountMetricName(patternSig),
+		Value:      1,
+		Tags:       tags,
+		MetricType: observer.MetricTypeDeltaCount,
 	}}
 
 	// For JSON logs, also extract numeric field metrics
@@ -92,9 +93,10 @@ func (a *LogMetricsExtractor) extractJSONFieldMetrics(content []byte, tags []str
 		}
 
 		out = append(out, observer.MetricOutput{
-			Name:  "log.field." + sanitizeMetricFragment(k),
-			Value: f,
-			Tags:  tags,
+			Name:       "log.field." + sanitizeMetricFragment(k),
+			Value:      f,
+			Tags:       tags,
+			MetricType: observer.MetricTypeGauge,
 		})
 	}
 

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -65,7 +65,7 @@ type metricObs struct {
 	value      float64
 	tags       []string
 	timestamp  int64
-	metricType string
+	metricType observerdef.MetricType
 }
 
 // Ensure metricObs implements observerdef.MetricView
@@ -93,7 +93,7 @@ func (m *metricObs) GetSampleRate() float64 {
 }
 
 func (m *metricObs) GetMetricTypeName() string {
-	return m.metricType
+	return m.metricType.String()
 }
 
 // logObs contains copied log data and implements observerdef.LogView.
@@ -402,7 +402,7 @@ func (o *observerImpl) run() {
 
 // processMetric handles a metric observation.
 func (o *observerImpl) processMetric(source string, m *metricObs) {
-	o.storage.Add(source, m.name, m.value, m.timestamp, m.tags)
+	o.storage.Add(source, m.name, m.value, m.timestamp, m.tags, m.metricType)
 	o.maybeRunDetectors(m.timestamp)
 }
 
@@ -413,7 +413,7 @@ func (o *observerImpl) processLog(source string, l *logObs) {
 		result := detector.Process(view)
 		for _, m := range result.Metrics {
 			// Virtual metrics coming from logs starts with _virtual.
-			o.storage.Add(source, "_virtual."+m.Name, m.Value, l.timestampMs/1000, m.Tags)
+			o.storage.Add(source, "_virtual."+m.Name, m.Value, l.timestampMs/1000, m.Tags, m.MetricType)
 		}
 		// Route directly emitted anomalies through the standard pipeline
 		for _, anomaly := range result.Anomalies {
@@ -707,7 +707,7 @@ func (h *handle) ObserveMetric(sample observerdef.MetricView) {
 			value:      sample.GetValue(),
 			tags:       copyTags(sample.GetRawTags()),
 			timestamp:  timestamp,
-			metricType: sample.GetMetricTypeName(),
+			metricType: observerdef.ParseMetricType(sample.GetMetricTypeName()),
 		},
 	}
 

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -61,10 +61,11 @@ type observation struct {
 
 // metricObs contains copied metric data and implements observerdef.MetricView.
 type metricObs struct {
-	name      string
-	value     float64
-	tags      []string
-	timestamp int64
+	name       string
+	value      float64
+	tags       []string
+	timestamp  int64
+	metricType string
 }
 
 // Ensure metricObs implements observerdef.MetricView
@@ -89,6 +90,10 @@ func (m *metricObs) GetTimestamp() float64 {
 // Observer does not store samplerate; just return 1.0
 func (m *metricObs) GetSampleRate() float64 {
 	return 1.0
+}
+
+func (m *metricObs) GetMetricTypeName() string {
+	return m.metricType
 }
 
 // logObs contains copied log data and implements observerdef.LogView.
@@ -361,7 +366,7 @@ type observerImpl struct {
 	reporters      []observerdef.Reporter
 	storage        *timeSeriesStorage
 	obsCh          chan observation
-	handleFunc observerdef.HandleFunc // Handle factory (may wrap with recorder middleware)
+	handleFunc     observerdef.HandleFunc // Handle factory (may wrap with recorder middleware)
 
 	// Raw anomaly tracking for test bench display
 	rawAnomalies     []observerdef.Anomaly
@@ -374,7 +379,7 @@ type observerImpl struct {
 	fetcher              *observerFetcher
 	totalAnomalyCount    int                             // total count of all anomalies ever detected (no cap)
 	uniqueAnomalySources map[observerdef.MetricName]bool // unique sources that had anomalies
-	lastAnalyzedDataTime int64 // data timestamp up to which we've analyzed
+	lastAnalyzedDataTime int64                           // data timestamp up to which we've analyzed
 }
 
 // run is the main dispatch loop, processing all observations sequentially.
@@ -698,10 +703,11 @@ func (h *handle) ObserveMetric(sample observerdef.MetricView) {
 	obs := observation{
 		source: h.source,
 		metric: &metricObs{
-			name:      sample.GetName(),
-			value:     sample.GetValue(),
-			tags:      copyTags(sample.GetRawTags()),
-			timestamp: timestamp,
+			name:       sample.GetName(),
+			value:      sample.GetValue(),
+			tags:       copyTags(sample.GetRawTags()),
+			timestamp:  timestamp,
+			metricType: sample.GetMetricTypeName(),
 		},
 	}
 

--- a/comp/observer/impl/output_test.go
+++ b/comp/observer/impl/output_test.go
@@ -79,8 +79,8 @@ func TestWriteObserverOutput_EmptyScenario(t *testing.T) {
 func TestWriteObserverOutput_NonVerbose(t *testing.T) {
 	tb := newTestBenchForOutput()
 	tb.loadedScenario = "test_scenario"
-	tb.storage.Add("parquet", "cpu.user", 1.0, 1000, []string{"host:a"})
-	tb.storage.Add("parquet", "cpu.user", 2.0, 2000, []string{"host:a"})
+	tb.storage.Add("parquet", "cpu.user", 1.0, 1000, []string{"host:a"}, observerdef.MetricTypeGauge)
+	tb.storage.Add("parquet", "cpu.user", 2.0, 2000, []string{"host:a"}, observerdef.MetricTypeGauge)
 	tb.correlations = []observerdef.ActiveCorrelation{testCorrelation()}
 	tb.components["cusum"] = &registeredComponent{
 		Registration: ComponentRegistration{Name: "cusum", Category: "detector"},
@@ -113,8 +113,8 @@ func TestWriteObserverOutput_NonVerbose(t *testing.T) {
 func TestWriteObserverOutput_Verbose(t *testing.T) {
 	tb := newTestBenchForOutput()
 	tb.loadedScenario = "test_scenario"
-	tb.storage.Add("parquet", "cpu.user", 1.0, 1000, []string{"host:a"})
-	tb.storage.Add("parquet", "cpu.user", 2.0, 2000, []string{"host:a"})
+	tb.storage.Add("parquet", "cpu.user", 1.0, 1000, []string{"host:a"}, observerdef.MetricTypeGauge)
+	tb.storage.Add("parquet", "cpu.user", 2.0, 2000, []string{"host:a"}, observerdef.MetricTypeGauge)
 	tb.correlations = []observerdef.ActiveCorrelation{testCorrelation()}
 	tb.components["cusum"] = &registeredComponent{
 		Registration: ComponentRegistration{Name: "cusum", Category: "detector"},
@@ -169,8 +169,8 @@ func TestWriteObserverOutput_Verbose(t *testing.T) {
 
 func TestWriteObserverOutput_TimelineBoundsFromStorage(t *testing.T) {
 	tb := newTestBenchForOutput()
-	tb.storage.Add("parquet", "disk.io", 10.0, 5000, []string{"device:sda"})
-	tb.storage.Add("parquet", "disk.io", 20.0, 9000, []string{"device:sda"})
+	tb.storage.Add("parquet", "disk.io", 10.0, 5000, []string{"device:sda"}, observerdef.MetricTypeGauge)
+	tb.storage.Add("parquet", "disk.io", 20.0, 9000, []string{"device:sda"}, observerdef.MetricTypeGauge)
 
 	outPath := filepath.Join(t.TempDir(), "results.json")
 	require.NoError(t, tb.WriteObserverOutput(outPath, false))

--- a/comp/observer/impl/reporter_html_test.go
+++ b/comp/observer/impl/reporter_html_test.go
@@ -192,8 +192,8 @@ func TestHTMLReporter_APISeries_ReturnsJSON(t *testing.T) {
 	r := NewHTMLReporter()
 
 	storage := newTimeSeriesStorage()
-	storage.Add("test", "my.metric", 10.5, 1000, nil)
-	storage.Add("test", "my.metric", 20.5, 1001, nil)
+	storage.Add("test", "my.metric", 10.5, 1000, nil, observer.MetricTypeGauge)
+	storage.Add("test", "my.metric", 20.5, 1001, nil, observer.MetricTypeGauge)
 	r.SetStorage(storage)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/series?namespace=test&name=my.metric&agg=avg", nil)
@@ -297,7 +297,7 @@ func TestHTMLReporter_IntegrationWithHTTPServer(t *testing.T) {
 	})
 
 	storage := newTimeSeriesStorage()
-	storage.Add("demo", "cpu.usage", 50.0, 1000, nil)
+	storage.Add("demo", "cpu.usage", 50.0, 1000, nil, observer.MetricTypeGauge)
 	r.SetStorage(storage)
 
 	// Create test server using the handler
@@ -354,8 +354,8 @@ func TestHTMLReporter_APISeriesList_ReturnsJSON(t *testing.T) {
 	r := NewHTMLReporter()
 
 	storage := newTimeSeriesStorage()
-	storage.Add("demo", "cpu.usage", 50.0, 1000, nil)
-	storage.Add("demo", "memory.usage", 75.0, 1000, nil)
+	storage.Add("demo", "cpu.usage", 50.0, 1000, nil, observer.MetricTypeGauge)
+	storage.Add("demo", "memory.usage", 75.0, 1000, nil, observer.MetricTypeGauge)
 	r.SetStorage(storage)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/series/list?namespace=demo", nil)

--- a/comp/observer/impl/stats_metrics.go
+++ b/comp/observer/impl/stats_metrics.go
@@ -41,10 +41,10 @@ func processStatsView(handle observerdef.Handle, stats observerdef.TraceStatsVie
 		timestamp := float64(row.GetBucketStart()) / 1e9
 		tags := buildStatsTagsFromRow(agentHostname, agentEnv, row)
 
-		handle.ObserveMetric(&statsMetricView{name: "trace.hits", value: float64(row.GetHits()), tags: tags, timestamp: timestamp})
-		handle.ObserveMetric(&statsMetricView{name: "trace.errors", value: float64(row.GetErrors()), tags: tags, timestamp: timestamp})
-		handle.ObserveMetric(&statsMetricView{name: "trace.duration", value: float64(row.GetDuration()), tags: tags, timestamp: timestamp})
-		handle.ObserveMetric(&statsMetricView{name: "trace.top_level_hits", value: float64(row.GetTopLevelHits()), tags: tags, timestamp: timestamp})
+		handle.ObserveMetric(&statsMetricView{name: "trace.hits", value: float64(row.GetHits()), tags: tags, timestamp: timestamp, metricType: "Count"})
+		handle.ObserveMetric(&statsMetricView{name: "trace.errors", value: float64(row.GetErrors()), tags: tags, timestamp: timestamp, metricType: "Count"})
+		handle.ObserveMetric(&statsMetricView{name: "trace.duration", value: float64(row.GetDuration()), tags: tags, timestamp: timestamp, metricType: "Count"})
+		handle.ObserveMetric(&statsMetricView{name: "trace.top_level_hits", value: float64(row.GetTopLevelHits()), tags: tags, timestamp: timestamp, metricType: "Count"})
 
 		if okSummary := row.GetOkSummary(); len(okSummary) > 0 {
 			emitPercentiles(handle, "trace.latency.ok", okSummary, tags, timestamp)
@@ -75,10 +75,11 @@ func emitPercentiles(handle observerdef.Handle, metricPrefix string, sketchBytes
 
 		metricName := fmt.Sprintf("%s.%s", metricPrefix, pq.suffix)
 		handle.ObserveMetric(&statsMetricView{
-			name:      metricName,
-			value:     value,
-			tags:      tags,
-			timestamp: timestamp,
+			name:       metricName,
+			value:      value,
+			tags:       tags,
+			timestamp:  timestamp,
+			metricType: "Gauge",
 		})
 	}
 }
@@ -149,17 +150,19 @@ func buildStatsTagsFromRow(agentHostname, agentEnv string, row observerdef.Trace
 
 // statsMetricView implements the MetricView interface for stats-derived metrics.
 type statsMetricView struct {
-	name      string
-	value     float64
-	tags      []string
-	timestamp float64
+	name       string
+	value      float64
+	tags       []string
+	timestamp  float64
+	metricType string
 }
 
-func (m *statsMetricView) GetName() string        { return m.name }
-func (m *statsMetricView) GetValue() float64      { return m.value }
-func (m *statsMetricView) GetRawTags() []string   { return m.tags }
-func (m *statsMetricView) GetTimestamp() float64  { return m.timestamp }
-func (m *statsMetricView) GetSampleRate() float64 { return 1.0 }
+func (m *statsMetricView) GetName() string           { return m.name }
+func (m *statsMetricView) GetValue() float64         { return m.value }
+func (m *statsMetricView) GetRawTags() []string      { return m.tags }
+func (m *statsMetricView) GetTimestamp() float64     { return m.timestamp }
+func (m *statsMetricView) GetSampleRate() float64    { return 1.0 }
+func (m *statsMetricView) GetMetricTypeName() string { return m.metricType }
 
 // statsPayloadView adapts a *pb.StatsPayload to the TraceStatsView interface.
 type statsPayloadView struct {

--- a/comp/observer/impl/stats_metrics.go
+++ b/comp/observer/impl/stats_metrics.go
@@ -41,10 +41,10 @@ func processStatsView(handle observerdef.Handle, stats observerdef.TraceStatsVie
 		timestamp := float64(row.GetBucketStart()) / 1e9
 		tags := buildStatsTagsFromRow(agentHostname, agentEnv, row)
 
-		handle.ObserveMetric(&statsMetricView{name: "trace.hits", value: float64(row.GetHits()), tags: tags, timestamp: timestamp, metricType: "Count"})
-		handle.ObserveMetric(&statsMetricView{name: "trace.errors", value: float64(row.GetErrors()), tags: tags, timestamp: timestamp, metricType: "Count"})
-		handle.ObserveMetric(&statsMetricView{name: "trace.duration", value: float64(row.GetDuration()), tags: tags, timestamp: timestamp, metricType: "Count"})
-		handle.ObserveMetric(&statsMetricView{name: "trace.top_level_hits", value: float64(row.GetTopLevelHits()), tags: tags, timestamp: timestamp, metricType: "Count"})
+		handle.ObserveMetric(&statsMetricView{name: "trace.hits", value: float64(row.GetHits()), tags: tags, timestamp: timestamp, metricType: observerdef.MetricTypeDeltaCount})
+		handle.ObserveMetric(&statsMetricView{name: "trace.errors", value: float64(row.GetErrors()), tags: tags, timestamp: timestamp, metricType: observerdef.MetricTypeDeltaCount})
+		handle.ObserveMetric(&statsMetricView{name: "trace.duration", value: float64(row.GetDuration()), tags: tags, timestamp: timestamp, metricType: observerdef.MetricTypeDeltaCount})
+		handle.ObserveMetric(&statsMetricView{name: "trace.top_level_hits", value: float64(row.GetTopLevelHits()), tags: tags, timestamp: timestamp, metricType: observerdef.MetricTypeDeltaCount})
 
 		if okSummary := row.GetOkSummary(); len(okSummary) > 0 {
 			emitPercentiles(handle, "trace.latency.ok", okSummary, tags, timestamp)
@@ -79,7 +79,7 @@ func emitPercentiles(handle observerdef.Handle, metricPrefix string, sketchBytes
 			value:      value,
 			tags:       tags,
 			timestamp:  timestamp,
-			metricType: "Gauge",
+			metricType: observerdef.MetricTypeGauge,
 		})
 	}
 }
@@ -154,7 +154,7 @@ type statsMetricView struct {
 	value      float64
 	tags       []string
 	timestamp  float64
-	metricType string
+	metricType observerdef.MetricType
 }
 
 func (m *statsMetricView) GetName() string           { return m.name }
@@ -162,7 +162,7 @@ func (m *statsMetricView) GetValue() float64         { return m.value }
 func (m *statsMetricView) GetRawTags() []string      { return m.tags }
 func (m *statsMetricView) GetTimestamp() float64     { return m.timestamp }
 func (m *statsMetricView) GetSampleRate() float64    { return 1.0 }
-func (m *statsMetricView) GetMetricTypeName() string { return m.metricType }
+func (m *statsMetricView) GetMetricTypeName() string { return m.metricType.String() }
 
 // statsPayloadView adapts a *pb.StatsPayload to the TraceStatsView interface.
 type statsPayloadView struct {

--- a/comp/observer/impl/storage.go
+++ b/comp/observer/impl/storage.go
@@ -22,6 +22,12 @@ type timeSeriesStorage struct {
 	mu     sync.RWMutex
 	series map[string]*seriesStats
 
+	// metricTypes enforces one metric type per metric name.
+	// Key is metric name (not series key), value is the first-observed type.
+	metricTypes          map[string]observer.MetricType
+	metricTypeConflicts  map[string]int // sampled conflict count per metric name
+	metricTypeConflicted int64          // total conflict count
+
 	// Drop accounting for invalid/unsafe input values.
 	droppedNonFinite int64
 	droppedExtreme   int64
@@ -31,10 +37,11 @@ type timeSeriesStorage struct {
 
 // seriesStats contains accumulated statistics for a time series (internal).
 type seriesStats struct {
-	Namespace string
-	Name      string
-	Tags      []string
-	Points    []statPoint
+	Namespace  string
+	Name       string
+	MetricType observer.MetricType
+	Tags       []string
+	Points     []statPoint
 }
 
 // statPoint holds summary statistics for a single time bucket (internal).
@@ -118,15 +125,22 @@ func (s *seriesStats) toSeriesUpTo(agg Aggregate, upTo int64) observer.Series {
 // newTimeSeriesStorage creates a new time series storage.
 func newTimeSeriesStorage() *timeSeriesStorage {
 	return &timeSeriesStorage{
-		series:          make(map[string]*seriesStats),
-		droppedByMetric: make(map[string]int64),
-		sampledDrops:    make(map[string]int),
+		series:              make(map[string]*seriesStats),
+		metricTypes:         make(map[string]observer.MetricType),
+		metricTypeConflicts: make(map[string]int),
+		droppedByMetric:     make(map[string]int64),
+		sampledDrops:        make(map[string]int),
 	}
 }
 
 // Add records a data point for a named metric in a namespace.
 // Invalid values are dropped at ingest with accounting and sampled logging.
-func (s *timeSeriesStorage) Add(namespace, name string, value float64, timestamp int64, tags []string) {
+// metricType is required; panics if MetricTypeUnknown.
+func (s *timeSeriesStorage) Add(namespace, name string, value float64, timestamp int64, tags []string, metricType observer.MetricType) {
+	if metricType == observer.MetricTypeUnknown {
+		panic("[observer] storage.Add called with MetricTypeUnknown for metric " + name)
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -140,15 +154,32 @@ func (s *timeSeriesStorage) Add(namespace, name string, value float64, timestamp
 		s.recordDroppedValue("extreme", namespace, name, value, timestamp, tags)
 		return
 	}
+
+	// Enforce one metric type per metric name.
+	if existing, ok := s.metricTypes[name]; ok {
+		if existing != metricType {
+			s.metricTypeConflicted++
+			sampled := s.metricTypeConflicts[name]
+			if sampled < 3 {
+				s.metricTypeConflicts[name] = sampled + 1
+				log.Printf("[observer] metric type conflict for %q: first seen %s, now %s (sample %d)",
+					name, existing, metricType, sampled+1)
+			}
+		}
+	} else {
+		s.metricTypes[name] = metricType
+	}
+
 	key := seriesKey(namespace, name, tags)
 
 	stats, exists := s.series[key]
 	if !exists {
 		stats = &seriesStats{
-			Namespace: namespace,
-			Name:      name,
-			Tags:      copyTags(tags),
-			Points:    nil,
+			Namespace:  namespace,
+			Name:       name,
+			MetricType: metricType,
+			Tags:       copyTags(tags),
+			Points:     nil,
 		}
 		s.series[key] = stats
 	}

--- a/comp/observer/impl/storage_test.go
+++ b/comp/observer/impl/storage_test.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"testing"
 
+	observer "github.com/DataDog/datadog-agent/comp/observer/def"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -17,7 +18,7 @@ func TestTimeSeriesStorage_Add(t *testing.T) {
 	s := newTimeSeriesStorage()
 
 	// Add first point
-	s.Add("test", "my.metric", 10.0, 1000, []string{"env:prod"})
+	s.Add("test", "my.metric", 10.0, 1000, []string{"env:prod"}, observer.MetricTypeGauge)
 	series := s.GetSeries("test", "my.metric", []string{"env:prod"}, AggregateAverage)
 
 	require.NotNil(t, series)
@@ -33,9 +34,9 @@ func TestTimeSeriesStorage_AddSameBucket_Average(t *testing.T) {
 	s := newTimeSeriesStorage()
 
 	// Add multiple points to same bucket
-	s.Add("test", "my.metric", 10.0, 1000, []string{"env:prod"})
-	s.Add("test", "my.metric", 20.0, 1000, []string{"env:prod"})
-	s.Add("test", "my.metric", 5.0, 1000, []string{"env:prod"})
+	s.Add("test", "my.metric", 10.0, 1000, []string{"env:prod"}, observer.MetricTypeGauge)
+	s.Add("test", "my.metric", 20.0, 1000, []string{"env:prod"}, observer.MetricTypeGauge)
+	s.Add("test", "my.metric", 5.0, 1000, []string{"env:prod"}, observer.MetricTypeGauge)
 	series := s.GetSeries("test", "my.metric", []string{"env:prod"}, AggregateAverage)
 
 	require.NotNil(t, series)
@@ -47,9 +48,9 @@ func TestTimeSeriesStorage_AddSameBucket_Average(t *testing.T) {
 func TestTimeSeriesStorage_AddSameBucket_Sum(t *testing.T) {
 	s := newTimeSeriesStorage()
 
-	s.Add("test", "my.metric", 10.0, 1000, nil)
-	s.Add("test", "my.metric", 20.0, 1000, nil)
-	s.Add("test", "my.metric", 5.0, 1000, nil)
+	s.Add("test", "my.metric", 10.0, 1000, nil, observer.MetricTypeGauge)
+	s.Add("test", "my.metric", 20.0, 1000, nil, observer.MetricTypeGauge)
+	s.Add("test", "my.metric", 5.0, 1000, nil, observer.MetricTypeGauge)
 	series := s.GetSeries("test", "my.metric", nil, AggregateSum)
 
 	require.NotNil(t, series)
@@ -60,9 +61,9 @@ func TestTimeSeriesStorage_AddSameBucket_Sum(t *testing.T) {
 func TestTimeSeriesStorage_AddSameBucket_Count(t *testing.T) {
 	s := newTimeSeriesStorage()
 
-	s.Add("test", "my.metric", 10.0, 1000, nil)
-	s.Add("test", "my.metric", 20.0, 1000, nil)
-	s.Add("test", "my.metric", 5.0, 1000, nil)
+	s.Add("test", "my.metric", 10.0, 1000, nil, observer.MetricTypeGauge)
+	s.Add("test", "my.metric", 20.0, 1000, nil, observer.MetricTypeGauge)
+	s.Add("test", "my.metric", 5.0, 1000, nil, observer.MetricTypeGauge)
 	series := s.GetSeries("test", "my.metric", nil, AggregateCount)
 
 	require.NotNil(t, series)
@@ -73,9 +74,9 @@ func TestTimeSeriesStorage_AddSameBucket_Count(t *testing.T) {
 func TestTimeSeriesStorage_AddSameBucket_MinMax(t *testing.T) {
 	s := newTimeSeriesStorage()
 
-	s.Add("test", "my.metric", 10.0, 1000, nil)
-	s.Add("test", "my.metric", 20.0, 1000, nil)
-	s.Add("test", "my.metric", 5.0, 1000, nil)
+	s.Add("test", "my.metric", 10.0, 1000, nil, observer.MetricTypeGauge)
+	s.Add("test", "my.metric", 20.0, 1000, nil, observer.MetricTypeGauge)
+	s.Add("test", "my.metric", 5.0, 1000, nil, observer.MetricTypeGauge)
 
 	minSeries := s.GetSeries("test", "my.metric", nil, AggregateMin)
 	maxSeries := s.GetSeries("test", "my.metric", nil, AggregateMax)
@@ -90,9 +91,9 @@ func TestTimeSeriesStorage_AddDifferentBuckets(t *testing.T) {
 	s := newTimeSeriesStorage()
 
 	// Add points to different buckets
-	s.Add("test", "my.metric", 10.0, 1000, []string{"env:prod"})
-	s.Add("test", "my.metric", 20.0, 1001, []string{"env:prod"})
-	s.Add("test", "my.metric", 30.0, 1002, []string{"env:prod"})
+	s.Add("test", "my.metric", 10.0, 1000, []string{"env:prod"}, observer.MetricTypeGauge)
+	s.Add("test", "my.metric", 20.0, 1001, []string{"env:prod"}, observer.MetricTypeGauge)
+	s.Add("test", "my.metric", 30.0, 1002, []string{"env:prod"}, observer.MetricTypeGauge)
 	series := s.GetSeries("test", "my.metric", []string{"env:prod"}, AggregateAverage)
 
 	require.NotNil(t, series)
@@ -110,8 +111,8 @@ func TestTimeSeriesStorage_DifferentTags(t *testing.T) {
 	s := newTimeSeriesStorage()
 
 	// Different tags = different series
-	s.Add("test", "my.metric", 10.0, 1000, []string{"env:prod"})
-	s.Add("test", "my.metric", 20.0, 1000, []string{"env:staging"})
+	s.Add("test", "my.metric", 10.0, 1000, []string{"env:prod"}, observer.MetricTypeGauge)
+	s.Add("test", "my.metric", 20.0, 1000, []string{"env:staging"}, observer.MetricTypeGauge)
 
 	prodSeries := s.GetSeries("test", "my.metric", []string{"env:prod"}, AggregateAverage)
 	stagingSeries := s.GetSeries("test", "my.metric", []string{"env:staging"}, AggregateAverage)
@@ -126,8 +127,8 @@ func TestTimeSeriesStorage_TagOrderDoesNotMatter(t *testing.T) {
 	s := newTimeSeriesStorage()
 
 	// Tags in different order should be same series
-	s.Add("test", "my.metric", 10.0, 1000, []string{"a:1", "b:2"})
-	s.Add("test", "my.metric", 20.0, 1000, []string{"b:2", "a:1"})
+	s.Add("test", "my.metric", 10.0, 1000, []string{"a:1", "b:2"}, observer.MetricTypeGauge)
+	s.Add("test", "my.metric", 20.0, 1000, []string{"b:2", "a:1"}, observer.MetricTypeGauge)
 
 	series := s.GetSeries("test", "my.metric", []string{"a:1", "b:2"}, AggregateAverage)
 	require.NotNil(t, series)
@@ -146,9 +147,9 @@ func TestTimeSeriesStorage_AllSeries(t *testing.T) {
 	s := newTimeSeriesStorage()
 
 	// Add series to different namespaces
-	s.Add("ns1", "metric1", 10.0, 1000, nil)
-	s.Add("ns1", "metric2", 20.0, 1000, nil)
-	s.Add("ns2", "metric3", 30.0, 1000, nil)
+	s.Add("ns1", "metric1", 10.0, 1000, nil, observer.MetricTypeGauge)
+	s.Add("ns1", "metric2", 20.0, 1000, nil, observer.MetricTypeGauge)
+	s.Add("ns2", "metric3", 30.0, 1000, nil, observer.MetricTypeGauge)
 
 	ns1Series := s.AllSeries("ns1", AggregateAverage)
 	ns2Series := s.AllSeries("ns2", AggregateAverage)
@@ -191,8 +192,8 @@ func TestAggSuffix(t *testing.T) {
 func TestTimeSeriesStorage_DropsNonFiniteValuesWithStats(t *testing.T) {
 	s := newTimeSeriesStorage()
 
-	s.Add("test", "my.metric", math.Inf(1), 1000, nil)
-	s.Add("test", "my.metric", math.NaN(), 1001, nil)
+	s.Add("test", "my.metric", math.Inf(1), 1000, nil, observer.MetricTypeGauge)
+	s.Add("test", "my.metric", math.NaN(), 1001, nil, observer.MetricTypeGauge)
 
 	series := s.GetSeries("test", "my.metric", nil, AggregateAverage)
 	assert.Nil(t, series)
@@ -206,8 +207,8 @@ func TestTimeSeriesStorage_DropsNonFiniteValuesWithStats(t *testing.T) {
 func TestTimeSeriesStorage_DropsExtremeFiniteValuesWithStats(t *testing.T) {
 	s := newTimeSeriesStorage()
 
-	s.Add("test", "my.metric", math.MaxFloat64, 1000, nil)
-	s.Add("test", "my.metric", math.MaxFloat64/4, 1001, nil)
+	s.Add("test", "my.metric", math.MaxFloat64, 1000, nil, observer.MetricTypeGauge)
+	s.Add("test", "my.metric", math.MaxFloat64/4, 1001, nil, observer.MetricTypeGauge)
 
 	series := s.GetSeries("test", "my.metric", nil, AggregateAverage)
 	require.NotNil(t, series)

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -385,6 +385,7 @@ func (tb *TestBench) loadParquetDir(dir string) error {
 			m.Value,
 			m.Timestamp,
 			m.Tags,
+			observerdef.ParseMetricType(m.MetricType),
 		)
 	}
 
@@ -433,7 +434,7 @@ type storageHandle struct {
 }
 
 func (h *storageHandle) ObserveMetric(sample observerdef.MetricView) {
-	h.storage.Add(h.namespace, sample.GetName(), sample.GetValue(), int64(sample.GetTimestamp()), sample.GetRawTags())
+	h.storage.Add(h.namespace, sample.GetName(), sample.GetValue(), int64(sample.GetTimestamp()), sample.GetRawTags(), observerdef.ParseMetricType(sample.GetMetricTypeName()))
 }
 func (h *storageHandle) ObserveLog(_ observerdef.LogView)               {}
 func (h *storageHandle) ObserveTrace(_ observerdef.TraceView)           {}
@@ -502,7 +503,7 @@ func (tb *TestBench) runLogDetectors() error {
 			result := detector.Process(log)
 			ts := log.GetTimestampMs()
 			for _, m := range result.Metrics {
-				tb.storage.Add("logs", "_virtual."+m.Name, m.Value, ts/1000, m.Tags)
+				tb.storage.Add("logs", "_virtual."+m.Name, m.Value, ts/1000, m.Tags, m.MetricType)
 			}
 			for _, anomaly := range result.Anomalies {
 				// Fill in fields the detector may not have set
@@ -778,7 +779,7 @@ func (tb *TestBench) handleTelemetry(telemetry []observerdef.ObserverTelemetry, 
 				value:      telemetryEvent.Metric.GetValue(),
 				tags:       telemetryEvent.Metric.GetRawTags(),
 				timestamp:  int64(telemetryEvent.Metric.GetTimestamp()),
-				metricType: telemetryEvent.Metric.GetMetricTypeName(),
+				metricType: observerdef.ParseMetricType(telemetryEvent.Metric.GetMetricTypeName()),
 			}
 			if metric.timestamp == 0 {
 				metric.timestamp = baseTimestampMs / 1000
@@ -787,7 +788,7 @@ func (tb *TestBench) handleTelemetry(telemetry []observerdef.ObserverTelemetry, 
 				telemetryEvent.DetectorName = detectorName
 			}
 			// Save this for UI
-			tb.storage.Add("telemetry", "telemetry."+telemetryEvent.DetectorName+"."+metric.name, metric.value, metric.timestamp, metric.tags)
+			tb.storage.Add("telemetry", "telemetry."+telemetryEvent.DetectorName+"."+metric.name, metric.value, metric.timestamp, metric.tags, metric.metricType)
 		}
 
 		if telemetryEvent.Log != nil {
@@ -1130,44 +1131,44 @@ func (tb *TestBench) loadDemoScenario() error {
 
 		// Heap usage (host:web-1)
 		heapValue := getDemoHeapValue(elapsed)
-		tb.storage.Add("demo", "runtime.heap.used_mb", heapValue, timestamp, []string{"host:web-1"})
+		tb.storage.Add("demo", "runtime.heap.used_mb", heapValue, timestamp, []string{"host:web-1"}, observerdef.MetricTypeGauge)
 
 		// GC pause time (host:web-1)
 		gcValue := getDemoGCPauseValue(elapsed)
-		tb.storage.Add("demo", "runtime.gc.pause_ms", gcValue, timestamp, []string{"host:web-1"})
+		tb.storage.Add("demo", "runtime.gc.pause_ms", gcValue, timestamp, []string{"host:web-1"}, observerdef.MetricTypeGauge)
 
 		// CPU usage (host:web-1)
 		cpuValue := getDemoCPUValue(elapsed)
-		tb.storage.Add("demo", "system.cpu.user_percent", cpuValue, timestamp, []string{"host:web-1"})
+		tb.storage.Add("demo", "system.cpu.user_percent", cpuValue, timestamp, []string{"host:web-1"}, observerdef.MetricTypeGauge)
 
 		// Request latency — two service variants
 		latencyValue := getDemoLatencyValue(elapsed)
-		tb.storage.Add("demo", "app.request.latency_p99_ms", latencyValue*1.2, timestamp, []string{"service:api"})
-		tb.storage.Add("demo", "app.request.latency_p99_ms", latencyValue*0.8, timestamp, []string{"service:worker"})
+		tb.storage.Add("demo", "app.request.latency_p99_ms", latencyValue*1.2, timestamp, []string{"service:api"}, observerdef.MetricTypeGauge)
+		tb.storage.Add("demo", "app.request.latency_p99_ms", latencyValue*0.8, timestamp, []string{"service:worker"}, observerdef.MetricTypeGauge)
 
 		// Error rate — two service variants
 		errorValue := getDemoErrorRateValue(elapsed)
-		tb.storage.Add("demo", "app.request.error_rate", errorValue*1.5, timestamp, []string{"service:api"})
-		tb.storage.Add("demo", "app.request.error_rate", errorValue*0.7, timestamp, []string{"service:worker"})
+		tb.storage.Add("demo", "app.request.error_rate", errorValue*1.5, timestamp, []string{"service:api"}, observerdef.MetricTypeGauge)
+		tb.storage.Add("demo", "app.request.error_rate", errorValue*0.7, timestamp, []string{"service:worker"}, observerdef.MetricTypeGauge)
 
 		// Throughput — two service variants
 		throughputValue := getDemoThroughputValue(elapsed)
-		tb.storage.Add("demo", "app.request.throughput_rps", throughputValue*1.4, timestamp, []string{"service:api"})
-		tb.storage.Add("demo", "app.request.throughput_rps", throughputValue*0.6, timestamp, []string{"service:worker"})
+		tb.storage.Add("demo", "app.request.throughput_rps", throughputValue*1.4, timestamp, []string{"service:api"}, observerdef.MetricTypeGauge)
+		tb.storage.Add("demo", "app.request.throughput_rps", throughputValue*0.6, timestamp, []string{"service:worker"}, observerdef.MetricTypeGauge)
 
 		// Correlator-targeted metrics (trigger kernel_bottleneck / network_degradation patterns)
 		// network.retransmits → analyzed as "network.retransmits:avg" — host-level
 		retransmits := getDemoNetworkRetransmitsValue(elapsed)
-		tb.storage.Add("demo", "network.retransmits", retransmits, timestamp, []string{"host:web-1"})
+		tb.storage.Add("demo", "network.retransmits", retransmits, timestamp, []string{"host:web-1"}, observerdef.MetricTypeDeltaCount)
 
 		// ebpf.lock_contention_ns → analyzed as "ebpf.lock_contention_ns:avg" — host-level
 		lockContention := getDemoLockContentionValue(elapsed)
-		tb.storage.Add("demo", "ebpf.lock_contention_ns", lockContention, timestamp, []string{"host:web-1"})
+		tb.storage.Add("demo", "ebpf.lock_contention_ns", lockContention, timestamp, []string{"host:web-1"}, observerdef.MetricTypeDeltaCount)
 
 		// connection.errors → analyzed as "connection.errors:count" — two service variants
 		connErrors := getDemoConnectionErrorsValue(elapsed)
-		tb.storage.Add("demo", "connection.errors", connErrors, timestamp, []string{"service:api"})
-		tb.storage.Add("demo", "connection.errors", connErrors*0.6, timestamp, []string{"service:worker"})
+		tb.storage.Add("demo", "connection.errors", connErrors, timestamp, []string{"service:api"}, observerdef.MetricTypeDeltaCount)
+		tb.storage.Add("demo", "connection.errors", connErrors*0.6, timestamp, []string{"service:worker"}, observerdef.MetricTypeDeltaCount)
 	}
 
 	fmt.Printf("  Generated %d seconds of demo data\n", totalSeconds)

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -774,10 +774,11 @@ func (tb *TestBench) handleTelemetry(telemetry []observerdef.ObserverTelemetry, 
 		// Generate missing fields if needed
 		if telemetryEvent.Metric != nil {
 			metric := &metricObs{
-				name:      telemetryEvent.Metric.GetName(),
-				value:     telemetryEvent.Metric.GetValue(),
-				tags:      telemetryEvent.Metric.GetRawTags(),
-				timestamp: int64(telemetryEvent.Metric.GetTimestamp()),
+				name:       telemetryEvent.Metric.GetName(),
+				value:      telemetryEvent.Metric.GetValue(),
+				tags:       telemetryEvent.Metric.GetRawTags(),
+				timestamp:  int64(telemetryEvent.Metric.GetTimestamp()),
+				metricType: telemetryEvent.Metric.GetMetricTypeName(),
 			}
 			if metric.timestamp == 0 {
 				metric.timestamp = baseTimestampMs / 1000

--- a/pkg/metrics/metric_sample.go
+++ b/pkg/metrics/metric_sample.go
@@ -171,3 +171,8 @@ func (m *MetricSample) GetTimestamp() float64 {
 func (m *MetricSample) GetSampleRate() float64 {
 	return m.SampleRate
 }
+
+// GetMetricTypeName returns the metric type as a string (e.g. "Gauge", "Count", "MonotonicCount").
+func (m *MetricSample) GetMetricTypeName() string {
+	return m.Mtype.String()
+}


### PR DESCRIPTION
## The Problem

Parquet files written by the observer/recorder pipeline didn't include metric type information. Every metric -- whether a gauge, a monotonic counter, or a rate -- looked identical in the output. This made downstream analysis unreliable: monotonic counters (whose raw values are cumulative) were being compared as if they were gauges, producing nonsensical phase-over-phase deltas in gensim scenarios.

## The Fix

`MetricType` is already available on `MetricSample.Mtype` at the point where the observer taps the pipeline. This change threads it through:

1. **`MetricView` interface** -- added `GetMetricTypeName() string`
2. **`MetricSample`** -- implements the new method, delegating to `Mtype.String()`
3. **Recorder `WriteMetric`** -- accepts and writes a `metric_type` column to parquet
4. **Parquet readers** (both observer and recorder) -- read the new column with backward-compat guards for older files that lack it

The parquet readers have `BACKCOMPAT` / `DELETEME` markers for the optional-column handling -- safe to remove after 2026-04-01 when no pre-MetricType files should still be in use.

## Test Plan

- [x] Existing `parquet_bloom_test.go` updated and passing with new `WriteMetric` signature
- [ ] Verify round-trip: write metrics with known types, read back, confirm `MetricType` populated
- [ ] Run gensim scenario and confirm parquet output includes `metric_type` column