### PR TITLE
Expand pkg/shell test scenario coverage

### DIFF
--- a/pkg/shell/interp/runner.go
+++ b/pkg/shell/interp/runner.go
@@ -31,7 +31,6 @@ func (r *Runner) fillExpandConfig(ctx context.Context) {
 	r.updateExpandOpts()
 }
 
-
 func (r *Runner) updateExpandOpts() {
 	r.ecfg.ReadDir2 = func(s string) ([]fs.DirEntry, error) {
 		return r.readDirHandler(r.handlerCtx(r.ectx, todoPos), s)
@@ -58,7 +57,6 @@ func (r *Runner) expandErr(err error) {
 	r.exit.code = 1
 	r.exit.exiting = true
 }
-
 
 func (r *Runner) fields(words ...*syntax.Word) []string {
 	strs, err := expand.Fields(r.ecfg, words...)
@@ -337,6 +335,15 @@ func (r *Runner) redir(ctx context.Context, rd *syntax.Redirect) (io.Closer, err
 		r.stdin = pr
 		return pr, nil
 	}
+	if rd.Op == syntax.Hdoc || rd.Op == syntax.DashHdoc {
+		pr, pw, err := os.Pipe()
+		if err != nil {
+			return nil, err
+		}
+		go func() { pw.Close() }()
+		r.stdin = pr
+		return pr, nil
+	}
 
 	arg := r.literal(rd.Word)
 	switch rd.Op {
@@ -420,4 +427,3 @@ func (r *Runner) open(ctx context.Context, path string, flags int, mode os.FileM
 	}
 	return nil, err
 }
-

--- a/pkg/shell/tests/scenarios/cmd/false/basic/with_arguments.yaml
+++ b/pkg/shell/tests/scenarios/cmd/false/basic/with_arguments.yaml
@@ -1,0 +1,8 @@
+description: The false builtin ignores any arguments passed to it.
+input:
+  script: |+
+    false unused ignored arguments
+expect:
+  stdout: ""
+  stderr: ""
+  exit_code: 1

--- a/pkg/shell/tests/scenarios/cmd/true/basic/with_arguments.yaml
+++ b/pkg/shell/tests/scenarios/cmd/true/basic/with_arguments.yaml
@@ -1,0 +1,8 @@
+description: The true builtin ignores any arguments passed to it.
+input:
+  script: |+
+    true unused ignored arguments
+expect:
+  stdout: ""
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/brace_group/as_and_operand.yaml
+++ b/pkg/shell/tests/scenarios/shell/brace_group/as_and_operand.yaml
@@ -1,0 +1,9 @@
+description: Brace group can be used as the right operand of an && operator.
+input:
+  script: |+
+    true && { echo "inside"; }
+expect:
+  stdout: |+
+    inside
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/brace_group/as_or_operand.yaml
+++ b/pkg/shell/tests/scenarios/shell/brace_group/as_or_operand.yaml
@@ -1,0 +1,9 @@
+description: Brace group can be used as the right operand of an || operator.
+input:
+  script: |+
+    false || { echo "fallback"; }
+expect:
+  stdout: |+
+    fallback
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/brace_group/with_and_or.yaml
+++ b/pkg/shell/tests/scenarios/shell/brace_group/with_and_or.yaml
@@ -1,0 +1,10 @@
+description: And-or operators work inside brace groups.
+input:
+  script: |+
+    { true && echo "and-ok"; false || echo "or-ok"; }
+expect:
+  stdout: |+
+    and-ok
+    or-ok
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/brace_group/with_for_loop.yaml
+++ b/pkg/shell/tests/scenarios/shell/brace_group/with_for_loop.yaml
@@ -1,0 +1,15 @@
+description: For loop can be used inside a brace group.
+input:
+  script: |+
+    {
+      for i in x y z; do
+        echo "$i"
+      done
+    }
+expect:
+  stdout: |+
+    x
+    y
+    z
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/comments/after_assignment.yaml
+++ b/pkg/shell/tests/scenarios/shell/comments/after_assignment.yaml
@@ -1,0 +1,10 @@
+description: Comment after variable assignment is ignored and assignment still takes effect.
+input:
+  script: |+
+    A=hello # comment after assignment
+    echo "$A"
+expect:
+  stdout: |+
+    hello
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/comments/after_semicolon.yaml
+++ b/pkg/shell/tests/scenarios/shell/comments/after_semicolon.yaml
@@ -1,0 +1,11 @@
+description: Comment after a semicolon separator is ignored.
+input:
+  script: |+
+    echo first; # comment after semicolon
+    echo second
+expect:
+  stdout: |+
+    first
+    second
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/comments/multiple_consecutive.yaml
+++ b/pkg/shell/tests/scenarios/shell/comments/multiple_consecutive.yaml
@@ -1,0 +1,14 @@
+description: Multiple consecutive comment lines are all ignored.
+input:
+  script: |+
+    # comment 1
+    # comment 2
+    # comment 3
+    echo ok
+    # comment 4
+    # comment 5
+expect:
+  stdout: |+
+    ok
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/comments/standalone_between_commands.yaml
+++ b/pkg/shell/tests/scenarios/shell/comments/standalone_between_commands.yaml
@@ -1,0 +1,13 @@
+description: Standalone comment lines between commands are ignored.
+input:
+  script: |+
+    echo first
+    # this is a standalone comment
+    # another standalone comment
+    echo second
+expect:
+  stdout: |+
+    first
+    second
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/field_splitting/double_quotes_prevent_globbing.yaml
+++ b/pkg/shell/tests/scenarios/shell/field_splitting/double_quotes_prevent_globbing.yaml
@@ -1,0 +1,15 @@
+description: Double-quoted variable expansion prevents pathname (glob) expansion.
+test_against_local_shell: false
+setup:
+  files:
+    - path: "abc.txt"
+      content: "test"
+input:
+  script: |+
+    A="*.txt"
+    echo "$A"
+expect:
+  stdout: |+
+    *.txt
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/field_splitting/double_quotes_prevent_splitting.yaml
+++ b/pkg/shell/tests/scenarios/shell/field_splitting/double_quotes_prevent_splitting.yaml
@@ -1,0 +1,11 @@
+description: Double-quoted variable expansion prevents field splitting.
+test_against_local_shell: false
+input:
+  script: |+
+    A="hello world foo"
+    for w in "$A"; do echo "[$w]"; done
+expect:
+  stdout: |+
+    [hello world foo]
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/field_splitting/empty_quoted_preserved.yaml
+++ b/pkg/shell/tests/scenarios/shell/field_splitting/empty_quoted_preserved.yaml
@@ -1,0 +1,11 @@
+description: Empty quoted variable expansion is preserved as an empty field.
+test_against_local_shell: false
+input:
+  script: |+
+    A=""
+    for w in "$A"; do echo "[$w]"; done
+expect:
+  stdout: |+
+    []
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/field_splitting/empty_unquoted_removed.yaml
+++ b/pkg/shell/tests/scenarios/shell/field_splitting/empty_unquoted_removed.yaml
@@ -1,0 +1,12 @@
+description: Empty unquoted variable expansion produces no fields and is removed.
+test_against_local_shell: false
+input:
+  script: |+
+    A=""
+    for w in $A; do echo "word: $w"; done
+    echo "done"
+expect:
+  stdout: |+
+    done
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/field_splitting/ifs_colon_separator.yaml
+++ b/pkg/shell/tests/scenarios/shell/field_splitting/ifs_colon_separator.yaml
@@ -1,0 +1,14 @@
+description: Custom IFS splits variable expansion on the specified delimiter.
+test_against_local_shell: false
+input:
+  script: |+
+    IFS=:
+    A="one:two:three"
+    for w in $A; do echo "$w"; done
+expect:
+  stdout: |+
+    one
+    two
+    three
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/field_splitting/ifs_whitespace_coalescing.yaml
+++ b/pkg/shell/tests/scenarios/shell/field_splitting/ifs_whitespace_coalescing.yaml
@@ -1,0 +1,12 @@
+description: Consecutive whitespace characters in IFS are coalesced into a single delimiter.
+test_against_local_shell: false
+input:
+  script: |+
+    A="hello   world"
+    for w in $A; do echo "[$w]"; done
+expect:
+  stdout: |+
+    [hello]
+    [world]
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/field_splitting/unquoted_var_splits.yaml
+++ b/pkg/shell/tests/scenarios/shell/field_splitting/unquoted_var_splits.yaml
@@ -1,0 +1,13 @@
+description: Unquoted variable expansion is split on default IFS whitespace.
+test_against_local_shell: false
+input:
+  script: |+
+    A="hello world foo"
+    for w in $A; do echo "[$w]"; done
+expect:
+  stdout: |+
+    [hello]
+    [world]
+    [foo]
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/field_splitting/var_in_for_items.yaml
+++ b/pkg/shell/tests/scenarios/shell/field_splitting/var_in_for_items.yaml
@@ -1,0 +1,13 @@
+description: Variable expansion in for loop word list respects field splitting.
+test_against_local_shell: false
+input:
+  script: |+
+    ITEMS="a b c"
+    for i in $ITEMS; do echo "$i"; done
+expect:
+  stdout: |+
+    a
+    b
+    c
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/for_clause/basic/and_or_in_body.yaml
+++ b/pkg/shell/tests/scenarios/shell/for_clause/basic/and_or_in_body.yaml
@@ -1,0 +1,17 @@
+description: And-or lists work correctly inside for loop body.
+input:
+  script: |+
+    for i in a b c; do
+      true && echo "ok:$i"
+    done
+    for i in x; do
+      false && echo "skip" || echo "fallback:$i"
+    done
+expect:
+  stdout: |+
+    ok:a
+    ok:b
+    ok:c
+    fallback:x
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/for_clause/basic/brace_in_body.yaml
+++ b/pkg/shell/tests/scenarios/shell/for_clause/basic/brace_in_body.yaml
@@ -1,0 +1,14 @@
+description: Brace group can be used inside for loop body.
+input:
+  script: |+
+    for i in 1 2; do
+      { echo "a:$i"; echo "b:$i"; }
+    done
+expect:
+  stdout: |+
+    a:1
+    b:1
+    a:2
+    b:2
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/for_clause/basic/negation_in_body.yaml
+++ b/pkg/shell/tests/scenarios/shell/for_clause/basic/negation_in_body.yaml
@@ -1,0 +1,13 @@
+description: Negation works inside for loop body.
+input:
+  script: |+
+    for i in a b; do
+      ! false
+      echo "$i:$?"
+    done
+expect:
+  stdout: |+
+    a:0
+    b:0
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/for_clause/basic/pipe_in_body.yaml
+++ b/pkg/shell/tests/scenarios/shell/for_clause/basic/pipe_in_body.yaml
@@ -1,0 +1,12 @@
+description: Pipe command inside a for loop body pipes each iteration independently.
+input:
+  script: |+
+    for i in hello world; do
+      echo ">>$i" | cat
+    done
+expect:
+  stdout: |+
+    >>hello
+    >>world
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/for_clause/basic/reserved_words_as_items.yaml
+++ b/pkg/shell/tests/scenarios/shell/for_clause/basic/reserved_words_as_items.yaml
@@ -1,0 +1,12 @@
+description: Shell reserved words used as for loop item values are treated as plain strings.
+input:
+  script: |+
+    for w in for do done in; do echo "$w"; done
+expect:
+  stdout: |+
+    for
+    do
+    done
+    in
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/for_clause/nested/with_pipe.yaml
+++ b/pkg/shell/tests/scenarios/shell/for_clause/nested/with_pipe.yaml
@@ -1,0 +1,16 @@
+description: Nested for loops can use pipes to pass output between stages.
+input:
+  script: |+
+    for i in a b; do
+      for j in 1 2; do
+        echo "$i$j"
+      done
+    done | cat
+expect:
+  stdout: |+
+    a1
+    a2
+    b1
+    b2
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/heredoc/empty_content.yaml
+++ b/pkg/shell/tests/scenarios/shell/heredoc/empty_content.yaml
@@ -1,0 +1,9 @@
+description: Heredoc with no content lines produces an empty output.
+input:
+  script: |+
+    cat <<EOF
+    EOF
+expect:
+  stdout: ""
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/heredoc/in_brace_group.yaml
+++ b/pkg/shell/tests/scenarios/shell/heredoc/in_brace_group.yaml
@@ -1,0 +1,13 @@
+description: Heredoc can be used inside a brace group.
+input:
+  script: |+
+    {
+      cat <<EOF
+    hello from brace
+    EOF
+    }
+expect:
+  stdout: |+
+    hello from brace
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/heredoc/in_for_loop.yaml
+++ b/pkg/shell/tests/scenarios/shell/heredoc/in_for_loop.yaml
@@ -1,0 +1,14 @@
+description: Heredoc can be used inside a for loop body.
+input:
+  script: |+
+    for i in 1 2; do
+      cat <<EOF
+    item:$i
+    EOF
+    done
+expect:
+  stdout: |+
+    item:1
+    item:2
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/heredoc/tabs_preserved.yaml
+++ b/pkg/shell/tests/scenarios/shell/heredoc/tabs_preserved.yaml
@@ -1,0 +1,7 @@
+description: Regular heredoc (without dash) preserves leading tabs in content.
+input:
+  script: "cat <<EOF\n\ttabbed line\n\tanother tabbed\nEOF\n"
+expect:
+  stdout: "\ttabbed line\n\tanother tabbed\n"
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/heredoc_dash/spaces_not_stripped.yaml
+++ b/pkg/shell/tests/scenarios/shell/heredoc_dash/spaces_not_stripped.yaml
@@ -1,0 +1,7 @@
+description: Heredoc-dash strips only leading tabs, not spaces.
+input:
+  script: "cat <<-EOF\n\ttab-indented\n  space-indented\n\tEOF\n"
+expect:
+  stdout: "tab-indented\n  space-indented\n"
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/line_continuation/in_echo_args.yaml
+++ b/pkg/shell/tests/scenarios/shell/line_continuation/in_echo_args.yaml
@@ -1,0 +1,11 @@
+description: Line continuation between echo arguments continues on next line.
+input:
+  script: |+
+    echo foo \
+    bar \
+    baz
+expect:
+  stdout: |+
+    foo bar baz
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/line_continuation/in_for_items.yaml
+++ b/pkg/shell/tests/scenarios/shell/line_continuation/in_for_items.yaml
@@ -1,0 +1,13 @@
+description: Line continuation works within the for loop item list.
+input:
+  script: |+
+    for i in a \
+    b \
+    c; do echo $i; done
+expect:
+  stdout: |+
+    a
+    b
+    c
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/line_continuation/multiple_consecutive.yaml
+++ b/pkg/shell/tests/scenarios/shell/line_continuation/multiple_consecutive.yaml
@@ -1,0 +1,11 @@
+description: Multiple consecutive line continuations join several lines into one word.
+input:
+  script: |+
+    echo hel\
+    l\
+    o
+expect:
+  stdout: |+
+    hello
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/negation/basic/exit_status_captured.yaml
+++ b/pkg/shell/tests/scenarios/shell/negation/basic/exit_status_captured.yaml
@@ -1,0 +1,15 @@
+description: Negated exit status is captured correctly in a variable via $?.
+input:
+  script: |+
+    ! true
+    A=$?
+    echo $A
+    ! false
+    B=$?
+    echo $B
+expect:
+  stdout: |+
+    1
+    0
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/negation/compound/negate_brace_group.yaml
+++ b/pkg/shell/tests/scenarios/shell/negation/compound/negate_brace_group.yaml
@@ -1,0 +1,8 @@
+description: Negation can be applied to a brace group to invert its exit code.
+input:
+  script: |+
+    ! { true; }
+expect:
+  stdout: ""
+  stderr: ""
+  exit_code: 1

--- a/pkg/shell/tests/scenarios/shell/negation/compound/negate_for_loop.yaml
+++ b/pkg/shell/tests/scenarios/shell/negation/compound/negate_for_loop.yaml
@@ -1,0 +1,8 @@
+description: Negation can be applied to a for loop to invert its exit code.
+input:
+  script: |+
+    ! for i in a; do true; done
+expect:
+  stdout: ""
+  stderr: ""
+  exit_code: 1

--- a/pkg/shell/tests/scenarios/shell/pipe/basic/brace_both_sides.yaml
+++ b/pkg/shell/tests/scenarios/shell/pipe/basic/brace_both_sides.yaml
@@ -1,0 +1,10 @@
+description: Brace groups can be used on both sides of a pipeline.
+input:
+  script: |+
+    { echo first; echo second; } | { cat; }
+expect:
+  stdout: |+
+    first
+    second
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/pipe/basic/for_loop_right.yaml
+++ b/pkg/shell/tests/scenarios/shell/pipe/basic/for_loop_right.yaml
@@ -1,0 +1,9 @@
+description: For loop can receive input on the right side of a pipeline.
+input:
+  script: |+
+    echo "hello" | for w in x; do cat; done
+expect:
+  stdout: |+
+    hello
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/pipe/basic/linebreak.yaml
+++ b/pkg/shell/tests/scenarios/shell/pipe/basic/linebreak.yaml
@@ -1,0 +1,11 @@
+description: A linebreak after the pipe operator continues the pipeline on the next line.
+input:
+  script: |+
+    echo hello |
+    cat |
+    cat
+expect:
+  stdout: |+
+    hello
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/var_expand/basic/concatenation.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/basic/concatenation.yaml
@@ -1,0 +1,13 @@
+description: Variable concatenation with adjacent expansions in double quotes.
+input:
+  script: |+
+    A=hello
+    B=world
+    echo "$A$B"
+    echo "${A}_${B}"
+expect:
+  stdout: |+
+    helloworld
+    hello_world
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/var_expand/basic/dollar_question_updates.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/basic/dollar_question_updates.yaml
@@ -1,0 +1,16 @@
+description: The $? variable updates after each command to reflect its exit code.
+input:
+  script: |+
+    true
+    echo $?
+    false
+    echo $?
+    true
+    echo $?
+expect:
+  stdout: |+
+    0
+    1
+    0
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/var_expand/basic/underscore_in_name.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/basic/underscore_in_name.yaml
@@ -1,0 +1,12 @@
+description: Variable names with underscores and digits work correctly.
+input:
+  script: |+
+    my_var_1=alpha
+    _leading=beta
+    A_B_C=gamma
+    echo $my_var_1 $_leading $A_B_C
+expect:
+  stdout: |+
+    alpha beta gamma
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/var_expand/quoting/backslash_dquote_in_dquotes.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/quoting/backslash_dquote_in_dquotes.yaml
@@ -1,0 +1,9 @@
+description: Escaped double quote inside double quotes produces a literal double quote.
+input:
+  script: |+
+    echo "a\"b\"c"
+expect:
+  stdout: |+
+    a"b"c
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/var_expand/quoting/backslash_nonspecial_in_dquotes.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/quoting/backslash_nonspecial_in_dquotes.yaml
@@ -1,0 +1,9 @@
+description: Backslash before a non-special character inside double quotes is preserved literally.
+input:
+  script: |+
+    echo "a\nb\tc"
+expect:
+  stdout: |+
+    a\nb\tc
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/var_expand/quoting/double_quote_multiline.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/quoting/double_quote_multiline.yaml
@@ -1,0 +1,13 @@
+description: Double-quoted string can span multiple lines preserving newlines.
+input:
+  script: |+
+    echo "line1
+    line2
+    line3"
+expect:
+  stdout: |+
+    line1
+    line2
+    line3
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/var_expand/quoting/empty_quoted_args_preserved.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/quoting/empty_quoted_args_preserved.yaml
@@ -1,0 +1,11 @@
+description: Empty quoted strings are preserved as arguments in for loop iteration.
+input:
+  script: |+
+    for w in "" "a" ""; do echo "[$w]"; done
+expect:
+  stdout: |+
+    []
+    [a]
+    []
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/var_expand/quoting/single_quote_multiline.yaml
+++ b/pkg/shell/tests/scenarios/shell/var_expand/quoting/single_quote_multiline.yaml
@@ -1,0 +1,13 @@
+description: Single-quoted string can span multiple lines preserving newlines literally.
+input:
+  script: |+
+    echo 'line1
+    line2
+    line3'
+expect:
+  stdout: |+
+    line1
+    line2
+    line3
+  stderr: ""
+  exit_code: 0


### PR DESCRIPTION
<!-- dd-meta {"pullId":"b0ebb585-7e33-4028-9bc7-634495920e4e","source":"chat","resourceId":"ae9b7d7b-d769-4ddd-bd5b-7669f55e8526","workflowId":"e6c7f67f-dc02-48bd-9dac-299e0366c875","codeChangeId":"e6c7f67f-dc02-48bd-9dac-299e0366c875","sourceType":"chat"} -->
### What does this PR do?

Adds 40 new test scenarios to `pkg/shell/tests/scenarios/` covering gaps identified by comparing with `pkg/shell/yash_posix_tests`. Also fixes a bug where empty heredocs (`cat <<EOF\nEOF`) returned exit code 1 instead of 0.

**New test scenarios by category:**

- **Quoting** (5): backslash-escaped double quote in double quotes, backslash before non-special char in double quotes, single/double quote multiline strings, empty quoted args preserved
- **Field splitting** (8): unquoted var splits, double quotes prevent splitting/globbing, IFS colon separator, whitespace coalescing, empty unquoted removed, empty quoted preserved, var in for items
- **Pipeline** (3): for loop as pipe receiver, brace groups on both sides, linebreak after pipe operator
- **For loop** (6): pipe/and-or/negation/brace in body, reserved words as items, nested for with pipe
- **Brace group** (4): with and-or, as and/or operand, with for loop
- **Heredoc** (5): empty content, in for loop, in brace group, tabs preserved, heredoc-dash spaces not stripped
- **Comments** (4): after semicolon, standalone between commands, after assignment, multiple consecutive
- **Negation** (3): exit status captured in variable, negate brace group, negate for loop
- **Line continuation** (3): multiple consecutive, in echo args, in for items
- **True/False** (2): with arguments (ignored)
- **Variable expansion** (3): concatenation, $? updates per command, underscore in name

### Motivation

Improve test coverage for `pkg/shell` by taking inspiration from the POSIX compliance tests in `pkg/shell/yash_posix_tests`. Each new scenario is non-overlapping with existing tests and validates real shell behavior patterns.

### Describe how you validated your changes

- All 40 new scenarios pass `TestShellScenarios` (restricted interpreter)
- All bash-comparable scenarios pass `TestShellScenariosAgainstBash`
- Full `go test ./pkg/shell/...` passes
- `go vet` and `gofmt` pass on changed Go files

### Additional Notes

The implementation fix in `runner.go` handles empty heredocs (where the parser sets `Hdoc` to `nil`). Previously this fell through to the "unhandled redirect op" error path. Now it correctly provides empty stdin via an immediately-closed pipe.

---

PR by Bits
[View session in Datadog](https://app.datadoghq.com/code/ae9b7d7b-d769-4ddd-bd5b-7669f55e8526)

Comment @datadog to request changes