### PR TITLE
Add taskmd task tracking and file pre-push hook issues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,9 +215,9 @@ tasks.
 Tasks are tracked with [taskmd](https://github.com/scottopell/taskmd) in `taskmd/`.
 
 ```bash
-taskmd validate taskmd   # check consistency
-taskmd fix taskmd        # auto-repair filenames/frontmatter
-taskmd next taskmd       # get next task number
+taskmd validate   # check consistency
+taskmd fix        # auto-repair filenames/frontmatter
+taskmd next       # get next task number
 ```
 
 ## Troubleshooting Development Issues

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,6 +210,16 @@ tasks.
 4. **Update documentation**: Keep docs in sync with code changes
 6. **Check for security implications**: Review security-sensitive changes carefully
 
+## Task Tracking
+
+Tasks are tracked with [taskmd](https://github.com/scottopell/taskmd) in `taskmd/`.
+
+```bash
+taskmd validate taskmd   # check consistency
+taskmd fix taskmd        # auto-repair filenames/frontmatter
+taskmd next taskmd       # get next task number
+```
+
 ## Troubleshooting Development Issues
 
 ### Common Build Issues

--- a/taskmd/0001-p2-ready--pre-push-rtloader-link-failures.md
+++ b/taskmd/0001-p2-ready--pre-push-rtloader-link-failures.md
@@ -1,0 +1,25 @@
+---
+created: 2026-03-05
+priority: p2
+status: ready
+---
+
+# Pre-push hook: rtloader link failures
+
+## Summary
+
+The `go-test` pre-push hook fails because three packages can't link against
+`libdatadog-agent-rtloader`:
+
+- `cmd/agent/subcommands/run`
+- `cmd/dogstatsd/subcommands/start`
+- `comp/metadata/inventorychecks/inventorychecksimpl`
+
+The hook runs `dda inv test --only-modified-packages`, which picks up these
+packages transitively. They require `dda inv rtloader.build` to have been run
+first, but that isn't part of the normal dev loop.
+
+## Acceptance Criteria
+
+- [ ] Pre-push `go-test` hook passes on a fresh worktree without manual rtloader build
+- [ ] Either exclude rtloader-dependent packages from the hook, build rtloader as a prerequisite, or use `--build-exclude` tags

--- a/taskmd/0002-p3-ready--pre-push-uds-test-flake.md
+++ b/taskmd/0002-p3-ready--pre-push-uds-test-flake.md
@@ -1,0 +1,20 @@
+---
+created: 2026-03-05
+priority: p3
+status: ready
+---
+
+# Pre-push hook: UDS test flake
+
+## Summary
+
+`pkg/trace/api.TestUDS` and `TestUDS/uds_permission_err` fail intermittently
+during the `go-test` pre-push hook. These are Unix domain socket tests that
+appear to be timing-sensitive.
+
+Observed on clean `q-branch-observer` checkout with no local modifications.
+
+## Acceptance Criteria
+
+- [ ] Identify root cause of flakiness (permission race, socket cleanup, timeout)
+- [ ] Fix or mark as known flake so it doesn't block pre-push hooks


### PR DESCRIPTION
## Summary

- Set up [taskmd](https://github.com/scottopell/taskmd) in `taskmd/` for lightweight task tracking
- Added taskmd usage instructions to `AGENTS.md`
- Filed two tasks for pre-existing pre-push hook failures:
  - **0001** (p2): rtloader link failures — `go-test` hook fails because three packages need `libdatadog-agent-rtloader` built first
  - **0002** (p3): UDS test flake — `pkg/trace/api.TestUDS` fails intermittently