### PR TITLE
Expand pkg/shell control flow test coverage

### DIFF
--- a/pkg/shell/tests/scenarios/shell/brace_group/chained_with_and.yaml
+++ b/pkg/shell/tests/scenarios/shell/brace_group/chained_with_and.yaml
@@ -1,0 +1,10 @@
+description: Brace group exit code propagates through && chain.
+input:
+  script: |+
+    { true; } && { echo "step2"; } && { echo "step3"; }
+expect:
+  stdout: |+
+    step2
+    step3
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/brace_group/chained_with_or.yaml
+++ b/pkg/shell/tests/scenarios/shell/brace_group/chained_with_or.yaml
@@ -1,0 +1,9 @@
+description: Brace group exit code propagates through || chain.
+input:
+  script: |+
+    { false; } || { echo "recovered"; }
+expect:
+  stdout: |+
+    recovered
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/brace_group/deeply_nested.yaml
+++ b/pkg/shell/tests/scenarios/shell/brace_group/deeply_nested.yaml
@@ -1,0 +1,11 @@
+description: Three levels of nested brace groups execute correctly.
+input:
+  script: |+
+    { { { echo deep; }; echo mid; }; echo outer; }
+expect:
+  stdout: |+
+    deep
+    mid
+    outer
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/brace_group/exit_code_tracking.yaml
+++ b/pkg/shell/tests/scenarios/shell/brace_group/exit_code_tracking.yaml
@@ -1,0 +1,13 @@
+description: Exit code from brace group is captured by $? on the next line.
+input:
+  script: |+
+    { true; false; }
+    echo $?
+    { false; true; }
+    echo $?
+expect:
+  stdout: |+
+    1
+    0
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/brace_group/multiple_sequential.yaml
+++ b/pkg/shell/tests/scenarios/shell/brace_group/multiple_sequential.yaml
@@ -1,0 +1,11 @@
+description: Multiple sequential brace groups separated by semicolons execute independently.
+input:
+  script: |+
+    { echo a; }; { echo b; }; { echo c; }
+expect:
+  stdout: |+
+    a
+    b
+    c
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/brace_group/multiple_sequential_newlines.yaml
+++ b/pkg/shell/tests/scenarios/shell/brace_group/multiple_sequential_newlines.yaml
@@ -1,0 +1,19 @@
+description: Multiple sequential brace groups on separate lines.
+input:
+  script: |+
+    {
+      echo first
+    }
+    {
+      echo second
+    }
+    {
+      echo third
+    }
+expect:
+  stdout: |+
+    first
+    second
+    third
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/brace_group/nested_var_scope.yaml
+++ b/pkg/shell/tests/scenarios/shell/brace_group/nested_var_scope.yaml
@@ -1,0 +1,20 @@
+description: Variables flow through nested brace groups in shared scope.
+input:
+  script: |+
+    A=1
+    {
+      B=2
+      {
+        C=3
+        echo "$A $B $C"
+      }
+      echo "$A $B $C"
+    }
+    echo "$A $B $C"
+expect:
+  stdout: |+
+    1 2 3
+    1 2 3
+    1 2 3
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/brace_group/only_false.yaml
+++ b/pkg/shell/tests/scenarios/shell/brace_group/only_false.yaml
@@ -1,0 +1,8 @@
+description: Brace group containing only false has exit code 1.
+input:
+  script: |+
+    { false; }
+expect:
+  stdout: ""
+  stderr: ""
+  exit_code: 1

--- a/pkg/shell/tests/scenarios/shell/brace_group/only_true.yaml
+++ b/pkg/shell/tests/scenarios/shell/brace_group/only_true.yaml
@@ -1,0 +1,8 @@
+description: Brace group containing only true has exit code 0.
+input:
+  script: |+
+    { true; }
+expect:
+  stdout: ""
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/brace_group/single_command.yaml
+++ b/pkg/shell/tests/scenarios/shell/brace_group/single_command.yaml
@@ -1,0 +1,9 @@
+description: A brace group containing a single command executes correctly.
+input:
+  script: |+
+    { echo only; }
+expect:
+  stdout: |+
+    only
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/brace_group/with_logic_exit_code.yaml
+++ b/pkg/shell/tests/scenarios/shell/brace_group/with_logic_exit_code.yaml
@@ -1,0 +1,13 @@
+description: Logic operators inside brace group affect the group exit code.
+input:
+  script: |+
+    { true && false; }
+    echo $?
+    { false || true; }
+    echo $?
+expect:
+  stdout: |+
+    1
+    0
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/cmd_separator/basic/long_semicolon_chain.yaml
+++ b/pkg/shell/tests/scenarios/shell/cmd_separator/basic/long_semicolon_chain.yaml
@@ -1,0 +1,18 @@
+description: A long chain of ten semicolon-separated commands all execute in order.
+input:
+  script: |+
+    echo 1; echo 2; echo 3; echo 4; echo 5; echo 6; echo 7; echo 8; echo 9; echo 10
+expect:
+  stdout: |+
+    1
+    2
+    3
+    4
+    5
+    6
+    7
+    8
+    9
+    10
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/cmd_separator/basic/only_empty_lines.yaml
+++ b/pkg/shell/tests/scenarios/shell/cmd_separator/basic/only_empty_lines.yaml
@@ -1,0 +1,9 @@
+description: A script consisting only of empty lines produces no output and exits 0.
+input:
+  script: |+
+
+
+expect:
+  stdout: ""
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/cmd_separator/control_flow/and_or_with_semicolons.yaml
+++ b/pkg/shell/tests/scenarios/shell/cmd_separator/control_flow/and_or_with_semicolons.yaml
@@ -1,0 +1,11 @@
+description: And-or lists separated by semicolons on the same line are independent.
+input:
+  script: |+
+    true && echo a; false || echo b; true && echo c
+expect:
+  stdout: |+
+    a
+    b
+    c
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/cmd_separator/control_flow/braces_and_for_mixed.yaml
+++ b/pkg/shell/tests/scenarios/shell/cmd_separator/control_flow/braces_and_for_mixed.yaml
@@ -1,0 +1,16 @@
+description: Brace groups and for loops mixed with semicolons and newlines.
+input:
+  script: |+
+    { echo a; echo b; }
+    for i in 1 2; do echo $i; done
+    { echo c; }; echo d
+expect:
+  stdout: |+
+    a
+    b
+    1
+    2
+    c
+    d
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/cmd_separator/control_flow/multiple_for_semicolons.yaml
+++ b/pkg/shell/tests/scenarios/shell/cmd_separator/control_flow/multiple_for_semicolons.yaml
@@ -1,0 +1,12 @@
+description: Multiple for loops separated by semicolons on the same line execute sequentially.
+input:
+  script: |+
+    for i in a b; do echo $i; done; for j in 1 2; do echo $j; done
+expect:
+  stdout: |+
+    a
+    b
+    1
+    2
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/cmd_separator/exit_code/exit_code_last_of_many.yaml
+++ b/pkg/shell/tests/scenarios/shell/cmd_separator/exit_code/exit_code_last_of_many.yaml
@@ -1,0 +1,8 @@
+description: Exit code of last command in a long chain is preserved.
+input:
+  script: |+
+    true; true; true; true; false
+expect:
+  stdout: ""
+  stderr: ""
+  exit_code: 1

--- a/pkg/shell/tests/scenarios/shell/cmd_separator/exit_code/exit_status_chain.yaml
+++ b/pkg/shell/tests/scenarios/shell/cmd_separator/exit_code/exit_status_chain.yaml
@@ -1,0 +1,11 @@
+description: Each command's exit status is independently tracked via $?.
+input:
+  script: |+
+    false; echo $?; true; echo $?; false; echo $?
+expect:
+  stdout: |+
+    1
+    0
+    1
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/cmd_separator/var_sharing/var_from_brace_group.yaml
+++ b/pkg/shell/tests/scenarios/shell/cmd_separator/var_sharing/var_from_brace_group.yaml
@@ -1,0 +1,9 @@
+description: Variables set in brace groups are visible after the group.
+input:
+  script: |+
+    { X=hello; }; echo $X
+expect:
+  stdout: |+
+    hello
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/cmd_separator/var_sharing/var_from_for_loop.yaml
+++ b/pkg/shell/tests/scenarios/shell/cmd_separator/var_sharing/var_from_for_loop.yaml
@@ -1,0 +1,9 @@
+description: Variable set inside a for loop body is visible after the loop via separator.
+input:
+  script: |+
+    for i in a b c; do LAST=$i; done; echo $LAST
+expect:
+  stdout: |+
+    c
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/cmd_separator/with_ops/complex_all_features.yaml
+++ b/pkg/shell/tests/scenarios/shell/cmd_separator/with_ops/complex_all_features.yaml
@@ -1,0 +1,16 @@
+description: Complex script mixing assignments, control flow, and separators.
+input:
+  script: |+
+    A=1; B=2
+    for i in $A $B; do echo "loop:$i"; done
+    { echo "brace:$A"; echo "brace:$B"; }
+    true && echo "and:ok" || echo "or:skip"
+expect:
+  stdout: |+
+    loop:1
+    loop:2
+    brace:1
+    brace:2
+    and:ok
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/cmd_separator/with_ops/multiple_lists_newlines.yaml
+++ b/pkg/shell/tests/scenarios/shell/cmd_separator/with_ops/multiple_lists_newlines.yaml
@@ -1,0 +1,16 @@
+description: Multiple statements each with their own and-or operators separated by newlines.
+input:
+  script: |+
+    echo one && echo two
+    false || echo three
+    true && false || echo four
+    echo five
+expect:
+  stdout: |+
+    one
+    two
+    three
+    four
+    five
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/for_clause/basic/exit_in_body.yaml
+++ b/pkg/shell/tests/scenarios/shell/for_clause/basic/exit_in_body.yaml
@@ -1,0 +1,14 @@
+description: Exit inside for loop body terminates the entire script immediately.
+input:
+  script: |+
+    for i in a b c; do
+      echo $i
+      exit 0
+      echo not reached
+    done
+    echo also not reached
+expect:
+  stdout: |+
+    a
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/for_clause/basic/exit_nonzero_in_body.yaml
+++ b/pkg/shell/tests/scenarios/shell/for_clause/basic/exit_nonzero_in_body.yaml
@@ -1,0 +1,12 @@
+description: Exit with non-zero code inside for loop body terminates with that code.
+input:
+  script: |+
+    for i in a b c; do
+      echo $i
+      exit 5
+    done
+expect:
+  stdout: |+
+    a
+  stderr: ""
+  exit_code: 5

--- a/pkg/shell/tests/scenarios/shell/for_clause/basic/loop_var_overwrite.yaml
+++ b/pkg/shell/tests/scenarios/shell/for_clause/basic/loop_var_overwrite.yaml
@@ -1,0 +1,18 @@
+description: Reassigning the loop variable inside the body does not affect iteration.
+input:
+  script: |+
+    for i in a b c; do
+      echo "before:$i"
+      i=overwritten
+      echo "after:$i"
+    done
+expect:
+  stdout: |+
+    before:a
+    after:overwritten
+    before:b
+    after:overwritten
+    before:c
+    after:overwritten
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/for_clause/basic/multiple_loops_sequence.yaml
+++ b/pkg/shell/tests/scenarios/shell/for_clause/basic/multiple_loops_sequence.yaml
@@ -1,0 +1,15 @@
+description: Multiple for loops in sequence execute one after another.
+input:
+  script: |+
+    for i in a b; do echo "first:$i"; done
+    for j in 1 2; do echo "second:$j"; done
+    for k in x; do echo "third:$k"; done
+expect:
+  stdout: |+
+    first:a
+    first:b
+    second:1
+    second:2
+    third:x
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/for_clause/basic/single_line_compact.yaml
+++ b/pkg/shell/tests/scenarios/shell/for_clause/basic/single_line_compact.yaml
@@ -1,0 +1,14 @@
+description: For loop written entirely on one line with semicolons.
+input:
+  script: |+
+    for i in a b c; do echo $i; echo --; done
+expect:
+  stdout: |+
+    a
+    --
+    b
+    --
+    c
+    --
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/for_clause/basic/tab_separated_tokens.yaml
+++ b/pkg/shell/tests/scenarios/shell/for_clause/basic/tab_separated_tokens.yaml
@@ -1,0 +1,9 @@
+description: For loop tokens can be separated by tabs instead of spaces.
+input:
+  script: "for\ti\tin\ta\tb; do echo $i; done\n"
+expect:
+  stdout: |+
+    a
+    b
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/for_clause/exit_code/exit_code_body_mixed.yaml
+++ b/pkg/shell/tests/scenarios/shell/for_clause/exit_code/exit_code_body_mixed.yaml
@@ -1,0 +1,14 @@
+description: For loop exit code comes from the very last command of the final iteration regardless of earlier commands.
+input:
+  script: |+
+    for i in a b c; do
+      false
+      echo $i
+    done
+expect:
+  stdout: |+
+    a
+    b
+    c
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/for_clause/exit_code/exit_code_last_iteration.yaml
+++ b/pkg/shell/tests/scenarios/shell/for_clause/exit_code/exit_code_last_iteration.yaml
@@ -1,0 +1,15 @@
+description: For loop exit code is from the last command in the last iteration.
+input:
+  script: |+
+    for x in 1 2 3; do
+      true
+    done
+    echo $?
+    for x in 1 2 3; do
+      false
+    done
+expect:
+  stdout: |+
+    0
+  stderr: ""
+  exit_code: 1

--- a/pkg/shell/tests/scenarios/shell/for_clause/var_scoping/loop_var_reused.yaml
+++ b/pkg/shell/tests/scenarios/shell/for_clause/var_scoping/loop_var_reused.yaml
@@ -1,0 +1,18 @@
+description: Same loop variable name reused across multiple for loops takes value from last loop.
+input:
+  script: |+
+    for i in a b; do echo $i; done
+    echo "after first: $i"
+    for i in x y z; do echo $i; done
+    echo "after second: $i"
+expect:
+  stdout: |+
+    a
+    b
+    after first: b
+    x
+    y
+    z
+    after second: z
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/for_clause/var_scoping/nested_inner_var_visible.yaml
+++ b/pkg/shell/tests/scenarios/shell/for_clause/var_scoping/nested_inner_var_visible.yaml
@@ -1,0 +1,14 @@
+description: Loop variable from inner nested for loop is visible after both loops complete.
+input:
+  script: |+
+    for i in a b; do
+      for j in 1 2; do
+        true
+      done
+    done
+    echo "i=$i j=$j"
+expect:
+  stdout: |+
+    i=b j=2
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/for_clause/var_scoping/unset_var_empty_expansion.yaml
+++ b/pkg/shell/tests/scenarios/shell/for_clause/var_scoping/unset_var_empty_expansion.yaml
@@ -1,0 +1,12 @@
+description: Expanding an unset variable in for loop items produces an empty list.
+input:
+  script: |+
+    for i in $UNDEFINED_VAR; do
+      echo "got: $i"
+    done
+    echo done
+expect:
+  stdout: |+
+    done
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/logic_ops/and_basic_behavior/chain_fails_at_fourth.yaml
+++ b/pkg/shell/tests/scenarios/shell/logic_ops/and_basic_behavior/chain_fails_at_fourth.yaml
@@ -1,0 +1,11 @@
+description: A && chain stops at the fourth command when it fails.
+input:
+  script: |+
+    echo one && echo two && echo three && false && echo five
+expect:
+  stdout: |+
+    one
+    two
+    three
+  stderr: ""
+  exit_code: 1

--- a/pkg/shell/tests/scenarios/shell/logic_ops/and_basic_behavior/chain_five_succeed.yaml
+++ b/pkg/shell/tests/scenarios/shell/logic_ops/and_basic_behavior/chain_five_succeed.yaml
@@ -1,0 +1,13 @@
+description: A long && chain of five commands succeeds when all succeed.
+input:
+  script: |+
+    echo one && echo two && echo three && echo four && echo five
+expect:
+  stdout: |+
+    one
+    two
+    three
+    four
+    five
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/logic_ops/and_basic_behavior/with_assignment.yaml
+++ b/pkg/shell/tests/scenarios/shell/logic_ops/and_basic_behavior/with_assignment.yaml
@@ -1,0 +1,9 @@
+description: Variable set in an assignment command is visible on the right side of &&.
+input:
+  script: |+
+    X=hello && echo $X
+expect:
+  stdout: |+
+    hello
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/logic_ops/mixed/brace_left_operand_fails.yaml
+++ b/pkg/shell/tests/scenarios/shell/logic_ops/mixed/brace_left_operand_fails.yaml
@@ -1,0 +1,10 @@
+description: Brace group as the left operand of && fails, right side is skipped.
+input:
+  script: |+
+    { false; } && echo skipped
+    echo done
+expect:
+  stdout: |+
+    done
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/logic_ops/mixed/long_alternating_chain.yaml
+++ b/pkg/shell/tests/scenarios/shell/logic_ops/mixed/long_alternating_chain.yaml
@@ -1,0 +1,10 @@
+description: A long alternating chain of six operators evaluates left to right.
+input:
+  script: |+
+    true && false || true && echo step4 || echo step5 && echo step6
+expect:
+  stdout: |+
+    step4
+    step6
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/logic_ops/mixed/multiple_independent_lists.yaml
+++ b/pkg/shell/tests/scenarios/shell/logic_ops/mixed/multiple_independent_lists.yaml
@@ -1,0 +1,15 @@
+description: Multiple independent and-or lists on separate lines.
+input:
+  script: |+
+    true && echo "line1"
+    false || echo "line2"
+    true && false || echo "line3"
+    false && echo "skip" || true && echo "line4"
+expect:
+  stdout: |+
+    line1
+    line2
+    line3
+    line4
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/logic_ops/mixed/recovery_with_braces.yaml
+++ b/pkg/shell/tests/scenarios/shell/logic_ops/mixed/recovery_with_braces.yaml
@@ -1,0 +1,10 @@
+description: Error recovery pattern using brace group after || operator.
+input:
+  script: |+
+    false || { echo "recovered"; true; } && echo "continued"
+expect:
+  stdout: |+
+    recovered
+    continued
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/logic_ops/mixed/semicolons_separate_lists.yaml
+++ b/pkg/shell/tests/scenarios/shell/logic_ops/mixed/semicolons_separate_lists.yaml
@@ -1,0 +1,10 @@
+description: Semicolons separate independent and-or lists on the same line.
+input:
+  script: |+
+    false && echo no; true && echo yes; false || echo fallback
+expect:
+  stdout: |+
+    yes
+    fallback
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/logic_ops/or_basic_behavior/chain_five_all_fail.yaml
+++ b/pkg/shell/tests/scenarios/shell/logic_ops/or_basic_behavior/chain_five_all_fail.yaml
@@ -1,0 +1,8 @@
+description: A long || chain of five commands all fail with exit code from the last.
+input:
+  script: |+
+    false || false || false || false || false
+expect:
+  stdout: ""
+  stderr: ""
+  exit_code: 1

--- a/pkg/shell/tests/scenarios/shell/logic_ops/or_basic_behavior/chain_middle_succeeds.yaml
+++ b/pkg/shell/tests/scenarios/shell/logic_ops/or_basic_behavior/chain_middle_succeeds.yaml
@@ -1,0 +1,9 @@
+description: In a || chain the middle command succeeds so the rest are skipped.
+input:
+  script: |+
+    false || echo middle || echo skipped
+expect:
+  stdout: |+
+    middle
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/logic_ops/or_basic_behavior/with_assignment.yaml
+++ b/pkg/shell/tests/scenarios/shell/logic_ops/or_basic_behavior/with_assignment.yaml
@@ -1,0 +1,10 @@
+description: Variable set in left side of || is visible in fallback.
+input:
+  script: |+
+    X=hello || echo $X
+    echo $X
+expect:
+  stdout: |+
+    hello
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/logic_ops/var_interact/chain_var_propagation.yaml
+++ b/pkg/shell/tests/scenarios/shell/logic_ops/var_interact/chain_var_propagation.yaml
@@ -1,0 +1,9 @@
+description: Variable propagation through an and-or chain with assignments.
+input:
+  script: |+
+    A=1 && B=2 && C=3 && echo "$A $B $C"
+expect:
+  stdout: |+
+    1 2 3
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/logic_ops/var_interact/exit_status_through_chain.yaml
+++ b/pkg/shell/tests/scenarios/shell/logic_ops/var_interact/exit_status_through_chain.yaml
@@ -1,0 +1,13 @@
+description: The $? variable tracks exit status correctly through an and-or chain.
+input:
+  script: |+
+    true && echo $?
+    false || echo $?
+    true && false || echo $?
+expect:
+  stdout: |+
+    0
+    1
+    1
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/logic_ops/var_interact/or_assignment_persists.yaml
+++ b/pkg/shell/tests/scenarios/shell/logic_ops/var_interact/or_assignment_persists.yaml
@@ -1,0 +1,10 @@
+description: Variable set in || left side is visible even when left succeeds and right is skipped.
+input:
+  script: |+
+    V=set || echo "fallback"
+    echo "$V"
+expect:
+  stdout: |+
+    set
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/negation/basic/multiple_negations_sequence.yaml
+++ b/pkg/shell/tests/scenarios/shell/negation/basic/multiple_negations_sequence.yaml
@@ -1,0 +1,16 @@
+description: Multiple negated commands separated by semicolons track $? independently.
+input:
+  script: |+
+    ! false
+    echo $?
+    ! true
+    echo $?
+    ! false
+    echo $?
+expect:
+  stdout: |+
+    0
+    1
+    0
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/negation/compound/negate_brace_multi_cmd.yaml
+++ b/pkg/shell/tests/scenarios/shell/negation/compound/negate_brace_multi_cmd.yaml
@@ -1,0 +1,17 @@
+description: Negation of a brace group with multiple commands inverts the exit code of the last command.
+input:
+  script: |+
+    ! { echo a; echo b; true; }
+    echo $?
+    ! { echo c; echo d; false; }
+    echo $?
+expect:
+  stdout: |+
+    a
+    b
+    1
+    c
+    d
+    0
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/negation/compound/negate_brace_with_false.yaml
+++ b/pkg/shell/tests/scenarios/shell/negation/compound/negate_brace_with_false.yaml
@@ -1,0 +1,9 @@
+description: Negation of a brace group where the last command fails produces exit code 0.
+input:
+  script: |+
+    ! { echo hello; false; }
+expect:
+  stdout: |+
+    hello
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/negation/compound/negate_for_empty_list.yaml
+++ b/pkg/shell/tests/scenarios/shell/negation/compound/negate_for_empty_list.yaml
@@ -1,0 +1,8 @@
+description: Negation of a for loop with an empty word list inverts exit code 0 to 1.
+input:
+  script: |+
+    ! for i in; do echo never; done
+expect:
+  stdout: ""
+  stderr: ""
+  exit_code: 1

--- a/pkg/shell/tests/scenarios/shell/negation/compound/negate_for_false_body.yaml
+++ b/pkg/shell/tests/scenarios/shell/negation/compound/negate_for_false_body.yaml
@@ -1,0 +1,8 @@
+description: Negation of a for loop where the body evaluates to false produces exit code 0.
+input:
+  script: |+
+    ! for i in a b; do false; done
+expect:
+  stdout: ""
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/negation/compound/negate_nested_brace.yaml
+++ b/pkg/shell/tests/scenarios/shell/negation/compound/negate_nested_brace.yaml
@@ -1,0 +1,8 @@
+description: Negation of nested brace groups inverts the exit code of the innermost last command.
+input:
+  script: |+
+    ! { { true; }; }
+expect:
+  stdout: ""
+  stderr: ""
+  exit_code: 1

--- a/pkg/shell/tests/scenarios/shell/negation/with_logic_ops/multiple_negations_in_and_chain.yaml
+++ b/pkg/shell/tests/scenarios/shell/negation/with_logic_ops/multiple_negations_in_and_chain.yaml
@@ -1,0 +1,9 @@
+description: Multiple negated pipelines chained with && all succeed when negation inverts failure to success.
+input:
+  script: |+
+    ! false && ! false && echo "all ok"
+expect:
+  stdout: |+
+    all ok
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/negation/with_logic_ops/negate_false_then_and.yaml
+++ b/pkg/shell/tests/scenarios/shell/negation/with_logic_ops/negate_false_then_and.yaml
@@ -1,0 +1,9 @@
+description: Negation applies to the pipeline only; the successful negation feeds into && which continues.
+input:
+  script: |+
+    ! false && echo "continued"
+expect:
+  stdout: |+
+    continued
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/negation/with_logic_ops/negate_true_then_or.yaml
+++ b/pkg/shell/tests/scenarios/shell/negation/with_logic_ops/negate_true_then_or.yaml
@@ -1,0 +1,9 @@
+description: Negation of true fails, triggering the || fallback.
+input:
+  script: |+
+    ! true || echo "fallback"
+expect:
+  stdout: |+
+    fallback
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/negation/with_pipe/negate_pipe_last_fails.yaml
+++ b/pkg/shell/tests/scenarios/shell/negation/with_pipe/negate_pipe_last_fails.yaml
@@ -1,0 +1,8 @@
+description: Negation of a pipeline where the last command fails produces exit code 0.
+input:
+  script: |+
+    ! echo hello | false
+expect:
+  stdout: ""
+  stderr: ""
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/negation/with_pipe/negate_three_stage_pipe.yaml
+++ b/pkg/shell/tests/scenarios/shell/negation/with_pipe/negate_three_stage_pipe.yaml
@@ -1,0 +1,9 @@
+description: Negation of a three-stage pipeline inverts the exit code of the last command.
+input:
+  script: |+
+    ! echo hello | cat | cat
+expect:
+  stdout: |+
+    hello
+  stderr: ""
+  exit_code: 1


### PR DESCRIPTION
<!-- dd-meta {"pullId":"0d9e8fb7-8aef-4a63-8052-006c689cff72","source":"chat","resourceId":"31b13b04-fe2f-4b4b-9284-03fb12b87413","workflowId":"6d227a10-0541-40f6-a95e-5162fe3eafe5","codeChangeId":"6d227a10-0541-40f6-a95e-5162fe3eafe5","sourceType":"chat"} -->
### What does this PR do?

Adds 47 new YAML test scenarios for `pkg/shell/tests/scenarios` covering control flow features, inspired by patterns from `pkg/shell/yash_posix_tests`.

### Motivation

Improve test coverage for supported shell control flow features: `for` loops, `&&`/`||` lists, `!` negation, `{ }` brace groups, and `;`/newline command separators.

New scenarios per feature area:
- **for_clause** (11 new): exit in body, multiple sequential loops, loop variable overwrite, tab-separated tokens, single-line compact, exit code across iterations, unset var expansion, reused loop var, nested inner var visibility
- **logic_ops** (14 new): long chains (5+ commands), variable assignments in chains, recovery with braces, brace as left operand, alternating operators, semicolon-separated lists, independent lists, variable propagation, `$?` tracking
- **negation** (11 new): multiple negations in sequence, negation of brace group with false/multiple commands/nested, negation of for loop with false/empty list, negation + `&&`/`||` combinations, three-stage pipeline negation
- **brace_group** (11 new): deep nesting (3+ levels), sequential groups, exit code tracking with `$?`, logic ops exit code, single command, nested variable scope, chained with `&&`/`||`, only true/false
- **cmd_separator** (11 new): long chains, empty-lines-only script, multiple for loops with semicolons, mixed braces/for, and-or with semicolons, exit status chains, variables from loops/braces, complex all-features mix

### Describe how you validated your changes

- All 47 new scenarios pass against `TestShellScenarios` (restricted interpreter)
- All new scenarios pass against `TestShellScenariosAgainstBash` (real `/bin/bash` comparison)

### Additional Notes

Removed 3 initially created double/triple negation tests (`! ! true`, `! ! false`, `! ! ! true`) because the underlying `mvdan.cc/sh/v3/syntax` parser does not support multiple consecutive negation operators.

---

PR by Bits
[View session in Datadog](https://app.datadoghq.com/code/31b13b04-fe2f-4b4b-9284-03fb12b87413)

Comment @datadog to request changes