### PR TITLE
Fix shell negation of exit and enable tests

### DIFF
--- a/pkg/shell/interp/runner.go
+++ b/pkg/shell/interp/runner.go
@@ -151,7 +151,7 @@ func (r *Runner) stmtSync(ctx context.Context, st *syntax.Stmt) {
 	if r.exit.ok() && st.Cmd != nil {
 		r.cmd(ctx, st.Cmd)
 	}
-	if st.Negated {
+	if st.Negated && !r.exit.exiting {
 		wasOk := r.exit.ok()
 		r.exit = exitStatus{}
 		r.exit.oneIf(wasOk)

--- a/pkg/shell/tests/scenarios/shell/field_splitting/double_quotes_prevent_globbing.yaml
+++ b/pkg/shell/tests/scenarios/shell/field_splitting/double_quotes_prevent_globbing.yaml
@@ -1,5 +1,4 @@
 description: Double-quoted variable expansion prevents pathname (glob) expansion.
-test_against_local_shell: false
 setup:
   files:
     - path: "abc.txt"

--- a/pkg/shell/tests/scenarios/shell/field_splitting/double_quotes_prevent_splitting.yaml
+++ b/pkg/shell/tests/scenarios/shell/field_splitting/double_quotes_prevent_splitting.yaml
@@ -1,5 +1,4 @@
 description: Double-quoted variable expansion prevents field splitting.
-test_against_local_shell: false
 input:
   script: |+
     A="hello world foo"

--- a/pkg/shell/tests/scenarios/shell/field_splitting/echo_args_custom_ifs.yaml
+++ b/pkg/shell/tests/scenarios/shell/field_splitting/echo_args_custom_ifs.yaml
@@ -1,5 +1,4 @@
 description: "Field splitting in echo args with custom IFS"
-test_against_local_shell: false
 input:
   script: |
     IFS=:

--- a/pkg/shell/tests/scenarios/shell/field_splitting/empty_ifs_no_split_any.yaml
+++ b/pkg/shell/tests/scenarios/shell/field_splitting/empty_ifs_no_split_any.yaml
@@ -1,5 +1,4 @@
 description: "Empty IFS means no splitting happens on any character"
-test_against_local_shell: false
 input:
   script: |
     IFS=

--- a/pkg/shell/tests/scenarios/shell/field_splitting/empty_quoted_preserved.yaml
+++ b/pkg/shell/tests/scenarios/shell/field_splitting/empty_quoted_preserved.yaml
@@ -1,5 +1,4 @@
 description: Empty quoted variable expansion is preserved as an empty field.
-test_against_local_shell: false
 input:
   script: |+
     A=""

--- a/pkg/shell/tests/scenarios/shell/field_splitting/empty_unquoted_removed.yaml
+++ b/pkg/shell/tests/scenarios/shell/field_splitting/empty_unquoted_removed.yaml
@@ -1,5 +1,4 @@
 description: Empty unquoted variable expansion produces no fields and is removed.
-test_against_local_shell: false
 input:
   script: |+
     A=""

--- a/pkg/shell/tests/scenarios/shell/field_splitting/ifs_change_affects_later.yaml
+++ b/pkg/shell/tests/scenarios/shell/field_splitting/ifs_change_affects_later.yaml
@@ -1,5 +1,4 @@
 description: "IFS change affects splitting of subsequent expansions in the same script"
-test_against_local_shell: false
 input:
   script: |
     A="a:b:c"

--- a/pkg/shell/tests/scenarios/shell/field_splitting/ifs_colon_separator.yaml
+++ b/pkg/shell/tests/scenarios/shell/field_splitting/ifs_colon_separator.yaml
@@ -1,5 +1,4 @@
 description: Custom IFS splits variable expansion on the specified delimiter.
-test_against_local_shell: false
 input:
   script: |+
     IFS=:

--- a/pkg/shell/tests/scenarios/shell/field_splitting/ifs_equals_sign.yaml
+++ b/pkg/shell/tests/scenarios/shell/field_splitting/ifs_equals_sign.yaml
@@ -1,5 +1,4 @@
 description: "IFS with equals sign splits correctly"
-test_against_local_shell: false
 input:
   script: |
     IFS==

--- a/pkg/shell/tests/scenarios/shell/field_splitting/ifs_pipe_char.yaml
+++ b/pkg/shell/tests/scenarios/shell/field_splitting/ifs_pipe_char.yaml
@@ -1,5 +1,4 @@
 description: "IFS with pipe character splits correctly"
-test_against_local_shell: false
 input:
   script: |
     IFS="|"

--- a/pkg/shell/tests/scenarios/shell/field_splitting/ifs_whitespace_coalescing.yaml
+++ b/pkg/shell/tests/scenarios/shell/field_splitting/ifs_whitespace_coalescing.yaml
@@ -1,5 +1,4 @@
 description: Consecutive whitespace characters in IFS are coalesced into a single delimiter.
-test_against_local_shell: false
 input:
   script: |+
     A="hello   world"

--- a/pkg/shell/tests/scenarios/shell/field_splitting/leading_nonws_ifs_empty_field.yaml
+++ b/pkg/shell/tests/scenarios/shell/field_splitting/leading_nonws_ifs_empty_field.yaml
@@ -1,5 +1,4 @@
 description: "Non-whitespace IFS splits correctly on values starting with data"
-test_against_local_shell: false
 input:
   script: |
     IFS=:

--- a/pkg/shell/tests/scenarios/shell/field_splitting/leading_trailing_ws_trimmed.yaml
+++ b/pkg/shell/tests/scenarios/shell/field_splitting/leading_trailing_ws_trimmed.yaml
@@ -1,5 +1,4 @@
 description: "Leading whitespace in IFS is trimmed during splitting"
-test_against_local_shell: false
 input:
   script: |
     A="  hello  world  "

--- a/pkg/shell/tests/scenarios/shell/field_splitting/literal_not_split.yaml
+++ b/pkg/shell/tests/scenarios/shell/field_splitting/literal_not_split.yaml
@@ -1,5 +1,4 @@
 description: "Literal text is not subject to field splitting regardless of IFS"
-test_against_local_shell: false
 input:
   script: |
     IFS=" 0"

--- a/pkg/shell/tests/scenarios/shell/field_splitting/mixed_tabs_spaces_coalesce.yaml
+++ b/pkg/shell/tests/scenarios/shell/field_splitting/mixed_tabs_spaces_coalesce.yaml
@@ -1,5 +1,4 @@
 description: "Tabs and spaces mixed in value are coalesced by default IFS"
-test_against_local_shell: false
 input:
   script: "A=\"one \t two \t three\"\nfor w in $A; do echo \"[$w]\"; done\n"
 expect:

--- a/pkg/shell/tests/scenarios/shell/field_splitting/mixed_ws_nonws_ifs.yaml
+++ b/pkg/shell/tests/scenarios/shell/field_splitting/mixed_ws_nonws_ifs.yaml
@@ -1,5 +1,4 @@
 description: "Whitespace IFS characters coalesce, non-whitespace splits"
-test_against_local_shell: false
 input:
   script: |
     IFS=" -"

--- a/pkg/shell/tests/scenarios/shell/field_splitting/multiple_consecutive_nonws_ifs.yaml
+++ b/pkg/shell/tests/scenarios/shell/field_splitting/multiple_consecutive_nonws_ifs.yaml
@@ -1,5 +1,4 @@
 description: "IFS with colon splits on each colon delimiter"
-test_against_local_shell: false
 input:
   script: |
     IFS=:

--- a/pkg/shell/tests/scenarios/shell/field_splitting/newline_splitting_default_ifs.yaml
+++ b/pkg/shell/tests/scenarios/shell/field_splitting/newline_splitting_default_ifs.yaml
@@ -1,5 +1,4 @@
 description: "Newlines in variable value are split by default IFS"
-test_against_local_shell: false
 input:
   script: "A=\"line1\nline2\nline3\"\nfor w in $A; do echo \"[$w]\"; done\n"
 expect:

--- a/pkg/shell/tests/scenarios/shell/field_splitting/nonws_ifs_empty_fields.yaml
+++ b/pkg/shell/tests/scenarios/shell/field_splitting/nonws_ifs_empty_fields.yaml
@@ -1,5 +1,4 @@
 description: "Non-whitespace IFS characters split on each delimiter"
-test_against_local_shell: false
 input:
   script: |
     IFS=-

--- a/pkg/shell/tests/scenarios/shell/field_splitting/quoted_empty_preserved_multiple.yaml
+++ b/pkg/shell/tests/scenarios/shell/field_splitting/quoted_empty_preserved_multiple.yaml
@@ -1,5 +1,4 @@
 description: "Quoted double expansion preserves empty fields in for loop"
-test_against_local_shell: false
 input:
   script: |
     A=""

--- a/pkg/shell/tests/scenarios/shell/field_splitting/single_quoted_no_expand.yaml
+++ b/pkg/shell/tests/scenarios/shell/field_splitting/single_quoted_no_expand.yaml
@@ -1,5 +1,4 @@
 description: "Single-quoted strings prevent variable expansion, keeping literal dollar sign"
-test_against_local_shell: false
 input:
   script: |
     A="hello world"

--- a/pkg/shell/tests/scenarios/shell/field_splitting/unquoted_var_splits.yaml
+++ b/pkg/shell/tests/scenarios/shell/field_splitting/unquoted_var_splits.yaml
@@ -1,5 +1,4 @@
 description: Unquoted variable expansion is split on default IFS whitespace.
-test_against_local_shell: false
 input:
   script: |+
     A="hello world foo"

--- a/pkg/shell/tests/scenarios/shell/field_splitting/var_in_for_items.yaml
+++ b/pkg/shell/tests/scenarios/shell/field_splitting/var_in_for_items.yaml
@@ -1,5 +1,4 @@
 description: Variable expansion in for loop word list respects field splitting.
-test_against_local_shell: false
 input:
   script: |+
     ITEMS="a b c"

--- a/pkg/shell/tests/scenarios/shell/for_clause/break_cont/break_exceeds_depth.yaml
+++ b/pkg/shell/tests/scenarios/shell/for_clause/break_cont/break_exceeds_depth.yaml
@@ -1,4 +1,3 @@
-test_against_local_shell: false
 description: Break with argument exceeding nesting depth breaks all loops.
 input:
   script: |+

--- a/pkg/shell/tests/scenarios/shell/for_clause/break_cont/break_mid_body.yaml
+++ b/pkg/shell/tests/scenarios/shell/for_clause/break_cont/break_mid_body.yaml
@@ -1,4 +1,3 @@
-test_against_local_shell: false
 description: Break in the middle of the loop body stops execution.
 input:
   script: |+

--- a/pkg/shell/tests/scenarios/shell/for_clause/break_cont/break_simple.yaml
+++ b/pkg/shell/tests/scenarios/shell/for_clause/break_cont/break_simple.yaml
@@ -1,4 +1,3 @@
-test_against_local_shell: false
 description: Break exits the for loop early.
 input:
   script: |+

--- a/pkg/shell/tests/scenarios/shell/for_clause/break_cont/break_with_arg.yaml
+++ b/pkg/shell/tests/scenarios/shell/for_clause/break_cont/break_with_arg.yaml
@@ -1,4 +1,3 @@
-test_against_local_shell: false
 description: Break with argument 1 breaks one level (same as simple break).
 input:
   script: |+

--- a/pkg/shell/tests/scenarios/shell/for_clause/break_cont/continue_simple.yaml
+++ b/pkg/shell/tests/scenarios/shell/for_clause/break_cont/continue_simple.yaml
@@ -1,4 +1,3 @@
-test_against_local_shell: false
 description: Continue skips the rest of the loop body and goes to the next iteration.
 input:
   script: |+

--- a/pkg/shell/tests/scenarios/shell/for_clause/break_cont/continue_with_arg.yaml
+++ b/pkg/shell/tests/scenarios/shell/for_clause/break_cont/continue_with_arg.yaml
@@ -1,4 +1,3 @@
-test_against_local_shell: false
 description: Continue with argument 1 continues one level (same as simple continue).
 input:
   script: |+

--- a/pkg/shell/tests/scenarios/shell/inline_var/persistent_on_empty_expansion.yaml
+++ b/pkg/shell/tests/scenarios/shell/inline_var/persistent_on_empty_expansion.yaml
@@ -1,7 +1,6 @@
 description: >-
   When the command word expands to nothing (unquoted unset variable),
   the assignment becomes persistent (inspired by yash simple-p.tst).
-test_against_local_shell: false
 input:
   script: |+
     A=hello $___NONEXISTENT_VAR___

--- a/pkg/shell/tests/scenarios/shell/negation/exit_code/negate_exit_one.yaml
+++ b/pkg/shell/tests/scenarios/shell/negation/exit_code/negate_exit_one.yaml
@@ -1,9 +1,8 @@
-test_against_local_shell: false
-description: Negating exit 1 produces exit code 0.
+description: Exit inside negation still exits with the specified code (negation does not apply).
 input:
   script: |+
     ! exit 1
 expect:
   stdout: ""
   stderr: ""
-  exit_code: 0
+  exit_code: 1

--- a/pkg/shell/tests/scenarios/shell/negation/exit_code/negate_exit_zero.yaml
+++ b/pkg/shell/tests/scenarios/shell/negation/exit_code/negate_exit_zero.yaml
@@ -1,9 +1,8 @@
-test_against_local_shell: false
-description: Negating exit 0 produces exit code 1.
+description: Exit inside negation still exits with the specified code (negation does not apply).
 input:
   script: |+
     ! exit 0
 expect:
   stdout: ""
   stderr: ""
-  exit_code: 1
+  exit_code: 0


### PR DESCRIPTION
<!-- dd-meta {"pullId":"e0cc6cdc-522f-47ff-a808-f01f062bd7ab","source":"chat","resourceId":"126d3d00-17ee-4896-a095-aa38bc2f357c","workflowId":"6906c781-fd38-4e23-a284-44b3b8352be8","codeChangeId":"6906c781-fd38-4e23-a284-44b3b8352be8","sourceType":"chat"} -->
### What does this PR do?

Fixes a bug where `! exit N` incorrectly negated the exit code in the restricted shell (producing 1 for `! exit 0` instead of 0), and enables `test_against_local_shell` for 32 scenarios that already match bash behavior.

### Motivation

Audited all scenarios with `test_against_local_shell: false` to find cases disabled due to restricted shell bugs rather than intentional design differences. Found one bug (negation of exit) and 30 scenarios unnecessarily excluded from bash comparison testing.

**Bug fixed:** In `runner.go`, the negation handler (`st.Negated`) was resetting the entire `exitStatus` struct — including the `exiting` flag — and inverting the code. In bash, `exit` terminates the shell before negation applies, so `! exit 0` exits with code 0. The fix skips negation when `r.exit.exiting` is true.

**Tests re-enabled against bash:**
- 23 field_splitting scenarios (standard POSIX field splitting)
- 6 break/continue basic scenarios (break_simple, break_mid_body, break_exceeds_depth, break_with_arg, continue_simple, continue_with_arg)
- 2 negation/exit_code scenarios (with corrected expectations)
- 1 inline_var/persistent_on_empty_expansion scenario

### Describe how you validated your changes

- Verified bash behavior for all re-enabled scenarios
- Ran `TestShellScenarios` (restricted shell) — all pass
- Ran `TestShellScenariosAgainstBash` (bash comparison) — all pass including newly enabled tests

### Additional Notes

Scenarios that remain `test_against_local_shell: false` are legitimately disabled because the restricted shell intentionally differs from bash (blocked commands/redirects/variables, different error messages, restricted echo flags, path access controls, empty environment).

---

PR by Bits
[View session in Datadog](https://app.datadoghq.com/code/126d3d00-17ee-4896-a095-aa38bc2f357c)

Comment @datadog to request changes