### PR TITLE
Match bash for exit/cat/echo builtins

### DIFF
--- a/pkg/shell/interp/builtins/builtins.go
+++ b/pkg/shell/interp/builtins/builtins.go
@@ -5,9 +5,13 @@ package builtins
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
+	"syscall"
+	"unicode"
+	"unicode/utf8"
 )
 
 // HandlerFunc is the signature for a builtin command implementation.
@@ -76,3 +80,33 @@ func Lookup(name string) (HandlerFunc, bool) {
 	return fn, ok
 }
 
+// FormatOSError extracts the underlying syscall error from a wrapped error
+// (e.g., *os.PathError) and capitalizes the first letter to match the
+// format used by coreutils and bash. Non-syscall errors (such as path
+// escape or custom permission errors) are returned unchanged.
+func FormatOSError(err error) string {
+	var pathErr *os.PathError
+	if errors.As(err, &pathErr) {
+		if _, ok := pathErr.Err.(syscall.Errno); ok {
+			msg := pathErr.Err.Error()
+			r, size := utf8.DecodeRuneInString(msg)
+			if size > 0 && unicode.IsLower(r) {
+				msg = string(unicode.ToUpper(r)) + msg[size:]
+			}
+			return msg
+		}
+	}
+	return err.Error()
+}
+
+// IsSyscallPathError reports whether err is an *os.PathError wrapping
+// a syscall.Errno. This is used to decide whether to reformat the
+// error message (e.g., for redirects) or keep the original.
+func IsSyscallPathError(err error) bool {
+	var pathErr *os.PathError
+	if errors.As(err, &pathErr) {
+		_, ok := pathErr.Err.(syscall.Errno)
+		return ok
+	}
+	return false
+}

--- a/pkg/shell/interp/builtins/cat.go
+++ b/pkg/shell/interp/builtins/cat.go
@@ -16,7 +16,7 @@ func builtinCat(ctx context.Context, callCtx *CallContext, args []string) Result
 	var failed bool
 	for _, arg := range args {
 		if err := catFile(ctx, callCtx, arg); err != nil {
-			callCtx.Errf("cat: %s: %v\n", arg, err)
+			callCtx.Errf("cat: %s: %s\n", arg, FormatOSError(err))
 			failed = true
 		}
 	}

--- a/pkg/shell/interp/builtins/echo.go
+++ b/pkg/shell/interp/builtins/echo.go
@@ -3,15 +3,131 @@
 
 package builtins
 
-import "context"
+import (
+	"context"
+	"strings"
+)
 
 func builtinEcho(_ context.Context, callCtx *CallContext, args []string) Result {
-	for i, arg := range args {
-		if i > 0 {
+	noNewline := false
+	interpretEscapes := false
+
+	i := 0
+	for i < len(args) {
+		arg := args[i]
+		if len(arg) < 2 || arg[0] != '-' {
+			break
+		}
+		valid := true
+		for _, c := range arg[1:] {
+			if c != 'n' && c != 'e' && c != 'E' {
+				valid = false
+				break
+			}
+		}
+		if !valid {
+			break
+		}
+		for _, c := range arg[1:] {
+			switch c {
+			case 'n':
+				noNewline = true
+			case 'e':
+				interpretEscapes = true
+			case 'E':
+				interpretEscapes = false
+			}
+		}
+		i++
+	}
+	args = args[i:]
+
+	for j, arg := range args {
+		if j > 0 {
 			callCtx.Out(" ")
 		}
-		callCtx.Out(arg)
+		if interpretEscapes {
+			if !echoEscape(callCtx, arg) {
+				return Result{}
+			}
+		} else {
+			callCtx.Out(arg)
+		}
 	}
-	callCtx.Out("\n")
+	if !noNewline {
+		callCtx.Out("\n")
+	}
 	return Result{}
+}
+
+func echoEscape(callCtx *CallContext, s string) bool {
+	var buf strings.Builder
+	for i := 0; i < len(s); i++ {
+		if s[i] != '\\' || i+1 >= len(s) {
+			buf.WriteByte(s[i])
+			continue
+		}
+		i++
+		switch s[i] {
+		case 'a':
+			buf.WriteByte('\a')
+		case 'b':
+			buf.WriteByte('\b')
+		case 'c':
+			callCtx.Out(buf.String())
+			return false
+		case 'e', 'E':
+			buf.WriteByte(0x1b)
+		case 'f':
+			buf.WriteByte('\f')
+		case 'n':
+			buf.WriteByte('\n')
+		case 'r':
+			buf.WriteByte('\r')
+		case 't':
+			buf.WriteByte('\t')
+		case 'v':
+			buf.WriteByte('\v')
+		case '\\':
+			buf.WriteByte('\\')
+		case '0':
+			val := 0
+			j := 0
+			for j < 3 && i+1+j < len(s) && s[i+1+j] >= '0' && s[i+1+j] <= '7' {
+				val = val*8 + int(s[i+1+j]-'0')
+				j++
+			}
+			i += j
+			buf.WriteByte(byte(val))
+		case 'x':
+			val, j := 0, 0
+			for j < 2 && i+1+j < len(s) {
+				c := s[i+1+j]
+				switch {
+				case c >= '0' && c <= '9':
+					val = val*16 + int(c-'0')
+				case c >= 'a' && c <= 'f':
+					val = val*16 + int(c-'a'+10)
+				case c >= 'A' && c <= 'F':
+					val = val*16 + int(c-'A'+10)
+				default:
+					goto doneHex
+				}
+				j++
+			}
+		doneHex:
+			if j == 0 {
+				buf.WriteByte('\\')
+				buf.WriteByte('x')
+			} else {
+				i += j
+				buf.WriteByte(byte(val))
+			}
+		default:
+			buf.WriteByte('\\')
+			buf.WriteByte(s[i])
+		}
+	}
+	callCtx.Out(buf.String())
+	return true
 }

--- a/pkg/shell/interp/builtins/echo_test.go
+++ b/pkg/shell/interp/builtins/echo_test.go
@@ -1,0 +1,219 @@
+// Copyright (c) Datadog, Inc.
+// See LICENSE for licensing information
+
+package builtins
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func runEcho(args []string) (stdout string, r Result) {
+	var out bytes.Buffer
+	callCtx := &CallContext{Stdout: &out, Stderr: &bytes.Buffer{}}
+	r = builtinEcho(context.Background(), callCtx, args)
+	return out.String(), r
+}
+
+func TestEcho_NoArgs(t *testing.T) {
+	out, r := runEcho(nil)
+	assert.Equal(t, "\n", out)
+	assert.Equal(t, uint8(0), r.Code)
+}
+
+func TestEcho_Simple(t *testing.T) {
+	out, _ := runEcho([]string{"hello"})
+	assert.Equal(t, "hello\n", out)
+}
+
+func TestEcho_MultipleArgs(t *testing.T) {
+	out, _ := runEcho([]string{"hello", "world"})
+	assert.Equal(t, "hello world\n", out)
+}
+
+func TestEcho_EmptyStringArg(t *testing.T) {
+	out, _ := runEcho([]string{""})
+	assert.Equal(t, "\n", out)
+}
+
+// --- Flag parsing ---
+
+func TestEcho_FlagN(t *testing.T) {
+	out, _ := runEcho([]string{"-n", "hello"})
+	assert.Equal(t, "hello", out)
+}
+
+func TestEcho_FlagE(t *testing.T) {
+	out, _ := runEcho([]string{"-e", "hello"})
+	assert.Equal(t, "hello\n", out)
+}
+
+func TestEcho_FlagE_WithEscape(t *testing.T) {
+	out, _ := runEcho([]string{"-e", `hello\nworld`})
+	assert.Equal(t, "hello\nworld\n", out)
+}
+
+func TestEcho_FlagBigE(t *testing.T) {
+	out, _ := runEcho([]string{"-E", "hello"})
+	assert.Equal(t, "hello\n", out)
+}
+
+func TestEcho_FlagNE(t *testing.T) {
+	out, _ := runEcho([]string{"-ne", `hello\tworld`})
+	assert.Equal(t, "hello\tworld", out)
+}
+
+func TestEcho_FlagEN(t *testing.T) {
+	out, _ := runEcho([]string{"-en", `a\nb`})
+	assert.Equal(t, "a\nb", out)
+}
+
+func TestEcho_FlagEE_DisablesEscapes(t *testing.T) {
+	out, _ := runEcho([]string{"-eE", `hello\nworld`})
+	assert.Equal(t, `hello\nworld`+"\n", out)
+}
+
+func TestEcho_FlagNEE(t *testing.T) {
+	out, _ := runEcho([]string{"-nEe", `a\tb`})
+	assert.Equal(t, "a\tb", out)
+}
+
+func TestEcho_MultipleFlagArgs(t *testing.T) {
+	out, _ := runEcho([]string{"-n", "-e", `a\nb`})
+	assert.Equal(t, "a\nb", out)
+}
+
+func TestEcho_InvalidFlagTreatedAsLiteral(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"dash_a", []string{"-a", "hello"}, "-a hello\n"},
+		{"dash_dash", []string{"--", "hello"}, "-- hello\n"},
+		{"single_dash", []string{"-", "hello"}, "- hello\n"},
+		{"dash_nx", []string{"-nx", "hello"}, "-nx hello\n"},
+		{"empty_dash", []string{"-"}, "-\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, _ := runEcho(tt.args)
+			assert.Equal(t, tt.want, out)
+		})
+	}
+}
+
+func TestEcho_FlagAfterNonFlag(t *testing.T) {
+	out, _ := runEcho([]string{"hello", "-n", "world"})
+	assert.Equal(t, "hello -n world\n", out)
+}
+
+// --- Escape sequences (with -e) ---
+
+func TestEcho_Escapes(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"alert", `\a`, "\a"},
+		{"backspace", `\b`, "\b"},
+		{"escape_lower", `\e`, "\x1b"},
+		{"escape_upper", `\E`, "\x1b"},
+		{"formfeed", `\f`, "\f"},
+		{"newline", `\n`, "\n"},
+		{"carriage_return", `\r`, "\r"},
+		{"tab", `\t`, "\t"},
+		{"vertical_tab", `\v`, "\v"},
+		{"backslash", `\\`, "\\"},
+		{"multiple", `a\tb\nc`, "a\tb\nc"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, _ := runEcho([]string{"-ne", tt.input})
+			assert.Equal(t, tt.want, out)
+		})
+	}
+}
+
+func TestEcho_EscapeC_StopsOutput(t *testing.T) {
+	out, _ := runEcho([]string{"-e", `hello\cworld`})
+	assert.Equal(t, "hello", out)
+}
+
+func TestEcho_EscapeC_StopsBeforeNextArg(t *testing.T) {
+	out, _ := runEcho([]string{"-e", `first\c`, "second"})
+	assert.Equal(t, "first", out)
+}
+
+func TestEcho_UnknownEscape(t *testing.T) {
+	out, _ := runEcho([]string{"-ne", `\z`})
+	assert.Equal(t, `\z`, out)
+}
+
+func TestEcho_TrailingBackslash(t *testing.T) {
+	out, _ := runEcho([]string{"-ne", `hello\`})
+	assert.Equal(t, `hello\`, out)
+}
+
+func TestEcho_NoEscapesWithoutFlag(t *testing.T) {
+	out, _ := runEcho([]string{`hello\nworld`})
+	assert.Equal(t, `hello\nworld`+"\n", out)
+}
+
+// --- Octal escapes ---
+
+func TestEcho_Octal(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"null", `\0`, "\x00"},
+		{"one_digit", `\01`, "\x01"},
+		{"two_digits", `\012`, "\n"},
+		{"three_digits", `\0101`, "A"},
+		{"max_three_digits", `\0377`, "\xff"},
+		{"octal_with_trailing", `\0101B`, "AB"},
+		{"no_octal_digits", `\0hello`, "\x00hello"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, _ := runEcho([]string{"-ne", tt.input})
+			assert.Equal(t, tt.want, out)
+		})
+	}
+}
+
+// --- Hex escapes ---
+
+func TestEcho_Hex(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"one_digit", `\x41`, "A"},
+		{"lowercase", `\x6f`, "o"},
+		{"uppercase", `\x6F`, "o"},
+		{"two_digit", `\xff`, "\xff"},
+		{"single_digit", `\xA`, "\n"},
+		{"with_trailing", `\x41BC`, "ABC"},
+		{"no_hex_digits", `\xzz`, `\xzz`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, _ := runEcho([]string{"-ne", tt.input})
+			assert.Equal(t, tt.want, out)
+		})
+	}
+}
+
+func TestEcho_AlwaysReturnsZero(t *testing.T) {
+	_, r := runEcho([]string{"-e", `\c`})
+	assert.Equal(t, uint8(0), r.Code)
+	assert.False(t, r.Exiting)
+}

--- a/pkg/shell/interp/builtins/exit.go
+++ b/pkg/shell/interp/builtins/exit.go
@@ -19,15 +19,16 @@ func builtinExit(_ context.Context, callCtx *CallContext, args []string) Result 
 	case 1:
 		n, err := strconv.Atoi(args[0])
 		if err != nil {
-			callCtx.Errf("invalid exit status code: %q\n", args[0])
-			r.Code = 255
+			callCtx.Errf("exit: %s: numeric argument required\n", args[0])
+			r.Code = 2
 			r.Exiting = true
 			return r
 		}
 		r.Code = uint8(n)
 	default:
-		callCtx.Errf("exit cannot take multiple arguments\n")
+		callCtx.Errf("exit: too many arguments\n")
 		r.Code = 1
+		r.Exiting = true
 		return r
 	}
 	r.Exiting = true

--- a/pkg/shell/interp/builtins/exit.go
+++ b/pkg/shell/interp/builtins/exit.go
@@ -20,8 +20,7 @@ func builtinExit(_ context.Context, callCtx *CallContext, args []string) Result 
 		n, err := strconv.Atoi(args[0])
 		if err != nil {
 			callCtx.Errf("invalid exit status code: %q\n", args[0])
-			r.Code = 2
-			// In bash, exit with invalid args still terminates the shell.
+			r.Code = 255
 			r.Exiting = true
 			return r
 		}
@@ -29,8 +28,6 @@ func builtinExit(_ context.Context, callCtx *CallContext, args []string) Result 
 	default:
 		callCtx.Errf("exit cannot take multiple arguments\n")
 		r.Code = 1
-		// In bash, exit with too many args still terminates the shell.
-		r.Exiting = true
 		return r
 	}
 	r.Exiting = true

--- a/pkg/shell/interp/runner.go
+++ b/pkg/shell/interp/runner.go
@@ -473,13 +473,16 @@ func (r *Runner) exec(ctx context.Context, pos syntax.Pos, args []string) {
 
 func (r *Runner) open(ctx context.Context, path string, flags int, mode os.FileMode, print bool) (io.ReadWriteCloser, error) {
 	f, err := r.openHandler(r.handlerCtx(ctx, todoPos), path, flags, mode)
-	// TODO: support wrapped PathError returned from openHandler.
 	switch err.(type) {
 	case nil:
 		return f, nil
 	case *os.PathError:
 		if print {
-			r.errf("%v\n", err)
+			if builtins.IsSyscallPathError(err) {
+				r.errf("%s: %s\n", path, builtins.FormatOSError(err))
+			} else {
+				r.errf("%v\n", err)
+			}
 		}
 	default: // handler's custom fatal error
 		r.exit.fatal(err)

--- a/pkg/shell/tests/scenarios/cmd/cat/errors/is_directory.yaml
+++ b/pkg/shell/tests/scenarios/cmd/cat/errors/is_directory.yaml
@@ -1,4 +1,3 @@
-test_against_local_shell: false
 description: Cat on a directory fails with "is a directory" error and exits with code 1.
 target_os: [linux, darwin]
 setup:
@@ -14,5 +13,5 @@ expect:
   stdout: ""
   stderr_contains:
     - "cat: mydir:"
-    - "is a directory"
+    - "Is a directory"
   exit_code: 1

--- a/pkg/shell/tests/scenarios/cmd/cat/errors/multiple_all_fail.yaml
+++ b/pkg/shell/tests/scenarios/cmd/cat/errors/multiple_all_fail.yaml
@@ -1,4 +1,3 @@
-test_against_local_shell: false
 description: When all files are missing, cat reports errors for each file.
 target_os: [linux, darwin]
 input:
@@ -10,5 +9,5 @@ expect:
   stderr_contains:
     - "cat: missing1.txt:"
     - "cat: missing2.txt:"
-    - "no such file or directory"
+    - "No such file or directory"
   exit_code: 1

--- a/pkg/shell/tests/scenarios/cmd/cat/errors/multiple_first_fails.yaml
+++ b/pkg/shell/tests/scenarios/cmd/cat/errors/multiple_first_fails.yaml
@@ -1,4 +1,3 @@
-test_against_local_shell: false
 description: When the first of multiple files fails, cat continues and processes remaining files.
 target_os: [linux, darwin]
 setup:
@@ -16,5 +15,5 @@ expect:
     hello world
   stderr_contains:
     - "cat: nonexistent.txt:"
-    - "no such file or directory"
+    - "No such file or directory"
   exit_code: 1

--- a/pkg/shell/tests/scenarios/cmd/cat/errors/multiple_second_fails.yaml
+++ b/pkg/shell/tests/scenarios/cmd/cat/errors/multiple_second_fails.yaml
@@ -1,4 +1,3 @@
-test_against_local_shell: false
 description: When the second of multiple files fails, the first file is output before the error.
 target_os: [linux, darwin]
 setup:
@@ -16,5 +15,5 @@ expect:
     hello world
   stderr_contains:
     - "cat: nonexistent.txt:"
-    - "no such file or directory"
+    - "No such file or directory"
   exit_code: 1

--- a/pkg/shell/tests/scenarios/cmd/cat/errors/nonexistent_continues.yaml
+++ b/pkg/shell/tests/scenarios/cmd/cat/errors/nonexistent_continues.yaml
@@ -1,4 +1,3 @@
-test_against_local_shell: false
 description: Cat failure does not stop script execution; the exit code is from the last command.
 target_os: [linux, darwin]
 input:
@@ -11,5 +10,5 @@ expect:
     hello
   stderr_contains:
     - "cat: nonexistent.txt:"
-    - "no such file or directory"
+    - "No such file or directory"
   exit_code: 0

--- a/pkg/shell/tests/scenarios/cmd/cat/errors/nonexistent_file.yaml
+++ b/pkg/shell/tests/scenarios/cmd/cat/errors/nonexistent_file.yaml
@@ -1,4 +1,3 @@
-test_against_local_shell: false
 description: Cat on a nonexistent file prints an error to stderr and exits with code 1.
 target_os: [linux, darwin]
 input:
@@ -9,5 +8,5 @@ expect:
   stdout: ""
   stderr_contains:
     - "cat: nonexistent.txt:"
-    - "no such file or directory"
+    - "No such file or directory"
   exit_code: 1

--- a/pkg/shell/tests/scenarios/cmd/cat/errors/redirect_nonexistent.yaml
+++ b/pkg/shell/tests/scenarios/cmd/cat/errors/redirect_nonexistent.yaml
@@ -1,4 +1,3 @@
-test_against_local_shell: false
 description: Input redirect from a nonexistent file fails at the redirect level, not cat itself, so the error has no "cat:" prefix.
 target_os: [linux, darwin]
 input:
@@ -9,5 +8,5 @@ expect:
   stdout: ""
   stderr_contains:
     - "nonexistent.txt"
-    - "no such file or directory"
+    - "No such file or directory"
   exit_code: 1

--- a/pkg/shell/tests/scenarios/cmd/echo/literal/dash_E_is_literal.yaml
+++ b/pkg/shell/tests/scenarios/cmd/echo/literal/dash_E_is_literal.yaml
@@ -1,11 +1,9 @@
-# Our echo intentionally ignores all flags; bash interprets -E to disable escapes.
-test_against_local_shell: false
-description: Echo treats -E as a literal argument, not as an option.
+description: Echo with -E disables escape interpretation (the default).
 input:
   script: |+
     echo -E hello
 expect:
   stdout: |+
-    -E hello
+    hello
   stderr: ""
   exit_code: 0

--- a/pkg/shell/tests/scenarios/cmd/echo/literal/dash_e_is_literal.yaml
+++ b/pkg/shell/tests/scenarios/cmd/echo/literal/dash_e_is_literal.yaml
@@ -1,10 +1,9 @@
-test_against_local_shell: false
-description: Echo treats -e as a literal argument, not as an option.
+description: Echo with -e enables escape interpretation (no escapes in this input).
 input:
   script: |+
     echo -e hello
 expect:
   stdout: |+
-    -e hello
+    hello
   stderr: ""
   exit_code: 0

--- a/pkg/shell/tests/scenarios/cmd/echo/literal/dash_n_is_literal.yaml
+++ b/pkg/shell/tests/scenarios/cmd/echo/literal/dash_n_is_literal.yaml
@@ -1,10 +1,8 @@
-test_against_local_shell: false
-description: Echo treats -n as a literal argument, not as an option.
+description: Echo with -n suppresses the trailing newline.
 input:
   script: |+
     echo -n hello
 expect:
-  stdout: |+
-    -n hello
+  stdout: "hello"
   stderr: ""
   exit_code: 0

--- a/pkg/shell/tests/scenarios/cmd/echo/literal/double_quote_escapes.yaml
+++ b/pkg/shell/tests/scenarios/cmd/echo/literal/double_quote_escapes.yaml
@@ -1,4 +1,3 @@
-test_against_local_shell: false
 description: Backslash escape sequences in double-quoted echo are passed literally.
 input:
   script: |+

--- a/pkg/shell/tests/scenarios/cmd/echo/literal/mixed_flags_literal.yaml
+++ b/pkg/shell/tests/scenarios/cmd/echo/literal/mixed_flags_literal.yaml
@@ -1,13 +1,10 @@
-# Our echo intentionally ignores all flags; bash interprets -ne, -eE, etc.
-test_against_local_shell: false
-description: Echo treats combined flag-like arguments as literal strings.
+description: Echo handles combined flags like -ne and -eE correctly.
 input:
   script: |+
     echo -ne hello
     echo -eE world
 expect:
   stdout: |+
-    -ne hello
-    -eE world
+    helloworld
   stderr: ""
   exit_code: 0

--- a/pkg/shell/tests/scenarios/cmd/echo/literal/special_chars.yaml
+++ b/pkg/shell/tests/scenarios/cmd/echo/literal/special_chars.yaml
@@ -1,4 +1,3 @@
-test_against_local_shell: false
 description: Echo outputs special characters verbatim without interpreting escape sequences.
 input:
   script: |+

--- a/pkg/shell/tests/scenarios/cmd/exit/errors/float.yaml
+++ b/pkg/shell/tests/scenarios/cmd/exit/errors/float.yaml
@@ -1,10 +1,9 @@
-test_against_local_shell: false
 description: Exit with a floating-point argument is invalid.
 input:
   script: |+
     exit 1.5
 expect:
   stdout: ""
-  stderr: |+
-    invalid exit status code: "1.5"
-  exit_code: 255
+  stderr_contains:
+    - "exit: 1.5: numeric argument required"
+  exit_code: 2

--- a/pkg/shell/tests/scenarios/cmd/exit/errors/float.yaml
+++ b/pkg/shell/tests/scenarios/cmd/exit/errors/float.yaml
@@ -7,4 +7,4 @@ expect:
   stdout: ""
   stderr: |+
     invalid exit status code: "1.5"
-  exit_code: 2
+  exit_code: 255

--- a/pkg/shell/tests/scenarios/cmd/exit/errors/invalid_continues.yaml
+++ b/pkg/shell/tests/scenarios/cmd/exit/errors/invalid_continues.yaml
@@ -7,4 +7,4 @@ expect:
   stdout: ""
   stderr: |+
     invalid exit status code: "abc"
-  exit_code: 2
+  exit_code: 255

--- a/pkg/shell/tests/scenarios/cmd/exit/errors/invalid_continues.yaml
+++ b/pkg/shell/tests/scenarios/cmd/exit/errors/invalid_continues.yaml
@@ -1,10 +1,9 @@
-test_against_local_shell: false
 description: An invalid exit argument exits the shell; subsequent commands do not run.
 input:
   script: |+
     exit abc; echo still running
 expect:
   stdout: ""
-  stderr: |+
-    invalid exit status code: "abc"
-  exit_code: 255
+  stderr_contains:
+    - "exit: abc: numeric argument required"
+  exit_code: 2

--- a/pkg/shell/tests/scenarios/cmd/exit/errors/invalid_string.yaml
+++ b/pkg/shell/tests/scenarios/cmd/exit/errors/invalid_string.yaml
@@ -7,4 +7,4 @@ expect:
   stdout: ""
   stderr: |+
     invalid exit status code: "abc"
-  exit_code: 2
+  exit_code: 255

--- a/pkg/shell/tests/scenarios/cmd/exit/errors/invalid_string.yaml
+++ b/pkg/shell/tests/scenarios/cmd/exit/errors/invalid_string.yaml
@@ -1,10 +1,9 @@
-test_against_local_shell: false
 description: Exit with a non-numeric string argument produces an error and exits.
 input:
   script: |+
     exit abc
 expect:
   stdout: ""
-  stderr: |+
-    invalid exit status code: "abc"
-  exit_code: 255
+  stderr_contains:
+    - "exit: abc: numeric argument required"
+  exit_code: 2

--- a/pkg/shell/tests/scenarios/cmd/exit/errors/multiple_args.yaml
+++ b/pkg/shell/tests/scenarios/cmd/exit/errors/multiple_args.yaml
@@ -1,5 +1,5 @@
 test_against_local_shell: false
-description: Exit with multiple arguments produces an error and exits.
+description: Exit with multiple arguments produces an error but does not exit the shell.
 input:
   script: |+
     exit 1 2

--- a/pkg/shell/tests/scenarios/cmd/exit/errors/multiple_args.yaml
+++ b/pkg/shell/tests/scenarios/cmd/exit/errors/multiple_args.yaml
@@ -1,10 +1,9 @@
-test_against_local_shell: false
-description: Exit with multiple arguments produces an error but does not exit the shell.
+description: Exit with multiple arguments produces an error and exits.
 input:
   script: |+
     exit 1 2
 expect:
   stdout: ""
-  stderr: |+
-    exit cannot take multiple arguments
+  stderr_contains:
+    - "exit: too many arguments"
   exit_code: 1

--- a/pkg/shell/tests/scenarios/cmd/exit/errors/multiple_args_continues.yaml
+++ b/pkg/shell/tests/scenarios/cmd/exit/errors/multiple_args_continues.yaml
@@ -1,11 +1,9 @@
-test_against_local_shell: false
-description: Exit with multiple arguments does not exit the shell; subsequent commands still run.
+description: Exit with multiple arguments exits the shell; subsequent commands do not run.
 input:
   script: |+
     exit 1 2; echo still running
 expect:
-  stdout: |+
-    still running
-  stderr: |+
-    exit cannot take multiple arguments
-  exit_code: 0
+  stdout: ""
+  stderr_contains:
+    - "exit: too many arguments"
+  exit_code: 1

--- a/pkg/shell/tests/scenarios/cmd/exit/errors/multiple_args_continues.yaml
+++ b/pkg/shell/tests/scenarios/cmd/exit/errors/multiple_args_continues.yaml
@@ -1,10 +1,11 @@
 test_against_local_shell: false
-description: Exit with multiple arguments exits the shell; subsequent commands do not run.
+description: Exit with multiple arguments does not exit the shell; subsequent commands still run.
 input:
   script: |+
     exit 1 2; echo still running
 expect:
-  stdout: ""
+  stdout: |+
+    still running
   stderr: |+
     exit cannot take multiple arguments
-  exit_code: 1
+  exit_code: 0

--- a/pkg/shell/tests/scenarios/shell/allowed_paths/nonexistent_file_in_allowed.yaml
+++ b/pkg/shell/tests/scenarios/shell/allowed_paths/nonexistent_file_in_allowed.yaml
@@ -11,5 +11,5 @@ input:
     - "data"
 expect:
   stderr_contains:
-    - "no such file or directory"
+    - "No such file or directory"
   exit_code: 1


### PR DESCRIPTION
<!-- dd-meta {"pullId":"c98260f9-724a-4e0a-95f9-1eb2d3b377d6","source":"chat","resourceId":"608c6a6d-73a0-4f3e-bd0a-0d89364739ae","workflowId":"845ebc76-bfd6-4b64-88bc-77f07c59cb0e","codeChangeId":"845ebc76-bfd6-4b64-88bc-77f07c59cb0e","sourceType":"chat"} -->
### What does this PR do?

Fixes the restricted shell's `exit`, `cat`, and `echo` builtins to match bash behavior, and updates error formatting for redirects. Removes `test_against_local_shell: false` from 18 test scenarios that now pass against real `/bin/bash`.

**Changes:**
- **exit**: Error messages now match bash format (`exit: too many arguments`, `exit: abc: numeric argument required`)
- **cat**: Error messages unwrap `*os.PathError` and capitalize to match coreutils (`No such file or directory`, `Is a directory`)
- **echo**: Implements `-n` (suppress newline), `-e` (interpret escapes), `-E` (disable escapes) flags, matching bash
- **redirects**: File-not-found errors now format as `path: No such file or directory` instead of raw Go PathError

### Motivation

These builtins had `test_against_local_shell: false` on 18 scenarios due to behavioral differences with bash. By matching bash's error message format and implementing echo flags, these scenarios now validate against both the restricted shell and real `/bin/bash`.

### Describe how you validated your changes

- `go test ./pkg/shell/...` — all tests pass (both `TestShellScenarios` and `TestShellScenariosAgainstBash`)
- `go build ./pkg/shell/...` — compiles cleanly

### Additional Notes

- `FormatOSError` only unwraps `syscall.Errno` errors (not `os.ErrPermission` or custom errors), preserving the existing format for `allowed_paths` security errors and `os.Root` path-escape errors.
- Windows cat error tests (`*_windows.yaml`) and `unknown_cmd/common_progs` tests retain `test_against_local_shell: false` — these are intentional differences by design.

---

PR by Bits
[View session in Datadog](https://app.datadoghq.com/code/608c6a6d-73a0-4f3e-bd0a-0d89364739ae)

Comment @datadog to request changes