### PR TITLE
Enable bash comparison for shell env tests

### DIFF
--- a/pkg/shell/tests/scenarios/shell/environment/builtin_ifs_set.yaml
+++ b/pkg/shell/tests/scenarios/shell/environment/builtin_ifs_set.yaml
@@ -1,4 +1,3 @@
-test_against_local_shell: false
 description: The IFS builtin variable is set by the interpreter and controls word splitting.
 input:
   script: |+

--- a/pkg/shell/tests/scenarios/shell/environment/empty_var_vs_unset.yaml
+++ b/pkg/shell/tests/scenarios/shell/environment/empty_var_vs_unset.yaml
@@ -1,5 +1,4 @@
 description: "Explicitly empty variable (VAR=) differs from unset variable"
-test_against_local_shell: false
 input:
   script: |
     EMPTY=

--- a/pkg/shell/tests/scenarios/shell/environment/ifs_default_tab.yaml
+++ b/pkg/shell/tests/scenarios/shell/environment/ifs_default_tab.yaml
@@ -1,4 +1,3 @@
-test_against_local_shell: false
 description: Default IFS splits on spaces, tabs, and newlines.
 input:
   script: |+

--- a/pkg/shell/tests/scenarios/shell/environment/ifs_empty_no_split.yaml
+++ b/pkg/shell/tests/scenarios/shell/environment/ifs_empty_no_split.yaml
@@ -1,4 +1,3 @@
-test_against_local_shell: false
 description: Empty IFS disables word splitting.
 input:
   script: |+

--- a/pkg/shell/tests/scenarios/shell/environment/ifs_multiple_custom_chars.yaml
+++ b/pkg/shell/tests/scenarios/shell/environment/ifs_multiple_custom_chars.yaml
@@ -1,5 +1,4 @@
 description: "IFS set to multiple non-whitespace characters splits on each"
-test_against_local_shell: false
 input:
   script: |
     IFS=:,

--- a/pkg/shell/tests/scenarios/shell/environment/ifs_tab_only.yaml
+++ b/pkg/shell/tests/scenarios/shell/environment/ifs_tab_only.yaml
@@ -1,5 +1,4 @@
 description: "IFS set to tab only splits on tabs, not spaces"
-test_against_local_shell: false
 input:
   script: "IFS=\"\t\"\nA=\"hello world\tfoo\"\nfor w in $A; do echo \"[$w]\"; done\n"
 expect:

--- a/pkg/shell/tests/scenarios/shell/environment/inline_assignment.yaml
+++ b/pkg/shell/tests/scenarios/shell/environment/inline_assignment.yaml
@@ -1,4 +1,3 @@
-test_against_local_shell: false
 description: Variables assigned in the script are accessible, even without input.envs.
 input:
   script: |+

--- a/pkg/shell/tests/scenarios/shell/environment/inline_assignment_temporary.yaml
+++ b/pkg/shell/tests/scenarios/shell/environment/inline_assignment_temporary.yaml
@@ -1,5 +1,4 @@
 description: "Inline var assignment is temporary and does not persist past the command"
-test_against_local_shell: false
 input:
   script: |
     X=before

--- a/pkg/shell/tests/scenarios/shell/environment/multiple_assignments.yaml
+++ b/pkg/shell/tests/scenarios/shell/environment/multiple_assignments.yaml
@@ -1,5 +1,4 @@
 description: "Multiple variables assigned in sequence are all accessible"
-test_against_local_shell: false
 input:
   script: |
     A=one

--- a/pkg/shell/tests/scenarios/shell/environment/optind_set_to_one.yaml
+++ b/pkg/shell/tests/scenarios/shell/environment/optind_set_to_one.yaml
@@ -1,5 +1,4 @@
 description: "OPTIND is set to 1 by default"
-test_against_local_shell: false
 input:
   script: |
     echo "$OPTIND"

--- a/pkg/shell/tests/scenarios/shell/environment/pwd_is_set.yaml
+++ b/pkg/shell/tests/scenarios/shell/environment/pwd_is_set.yaml
@@ -1,5 +1,4 @@
 description: "PWD is set to the working directory"
-test_against_local_shell: false
 input:
   script: |
     echo "$PWD"

--- a/pkg/shell/tests/scenarios/shell/environment/variable_overwrite.yaml
+++ b/pkg/shell/tests/scenarios/shell/environment/variable_overwrite.yaml
@@ -1,5 +1,4 @@
 description: "Assigning the same variable twice uses the last value"
-test_against_local_shell: false
 input:
   script: |
     X=first

--- a/pkg/shell/tests/scenarios/shell/environment/variable_with_spaces.yaml
+++ b/pkg/shell/tests/scenarios/shell/environment/variable_with_spaces.yaml
@@ -1,5 +1,4 @@
 description: "Variable values can contain spaces"
-test_against_local_shell: false
 input:
   script: |
     MSG="hello world foo"


### PR DESCRIPTION
<!-- dd-meta {"pullId":"3f6529b1-8bed-46e3-b857-b3d68ebf4cd6","source":"chat","resourceId":"cdb306ed-a0ef-4cd7-add3-df8f7c90ed5d","workflowId":"eca9cfa2-a9b5-4926-939f-1e1d7136d123","codeChangeId":"eca9cfa2-a9b5-4926-939f-1e1d7136d123","sourceType":"chat"} -->
### What does this PR do?

Enables `test_against_local_shell` for 13 environment test scenarios that test standard POSIX-compliant shell behavior (variable assignment, IFS splitting, PWD, OPTIND). These were unnecessarily disabled despite the restricted shell already producing bash-compatible output for these features.

### Motivation

Per `pkg/shell/AGENTS.md`, `test_against_local_shell` should only be `false` for features that intentionally diverge from bash (blocked commands, restricted redirects, etc.). These 13 tests cover standard shell behavior (variable assignment, IFS word splitting, builtins like PWD/OPTIND) that matches bash exactly, so they should be validated against bash.

The remaining 19 disabled tests are legitimately disabled because they test either:
- Intentional security restrictions (empty env, no HOME/PATH/USER/SHELL/TERM/LANG, no tilde expansion, no parent env propagation)
- The `interpreter_env` API which has no bash equivalent

### Describe how you validated your changes

- Ran `TestShellScenarios` (restricted shell) — all pass
- Ran `TestShellScenariosAgainstBash` (bash comparison) — all 13 newly enabled tests pass against real `/bin/bash`
- Full test suite passes

### Additional Notes

Tests re-enabled:
- `variable_with_spaces`, `variable_overwrite`, `multiple_assignments`, `empty_var_vs_unset`
- `inline_assignment`, `inline_assignment_temporary`
- `ifs_default_tab`, `ifs_empty_no_split`, `ifs_multiple_custom_chars`, `ifs_tab_only`, `builtin_ifs_set`
- `optind_set_to_one`, `pwd_is_set`

---

PR by Bits
[View session in Datadog](https://app.datadoghq.com/code/cdb306ed-a0ef-4cd7-add3-df8f7c90ed5d)

Comment @datadog to request changes