### PR TITLE
[CONTP-1353] Add Remote Configuration status to cluster agent 

### DIFF
--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -79,6 +79,7 @@ import (
 	privateactionrunner "github.com/DataDog/datadog-agent/comp/privateactionrunner/impl"
 	rccomp "github.com/DataDog/datadog-agent/comp/remote-config/rcservice"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcservice/rcserviceimpl"
+	"github.com/DataDog/datadog-agent/comp/remote-config/rcstatus/rcstatusimpl"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rctelemetryreporter/rctelemetryreporterimpl"
 	logscompression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/def"
 	logscompressionfx "github.com/DataDog/datadog-agent/comp/serializer/logscompression/fx"
@@ -207,6 +208,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				}),
 				autodiscoveryimpl.Module(),
 				rcserviceimpl.Module(),
+				rcstatusimpl.Module(),
 				rctelemetryreporterimpl.Module(),
 				fx.Provide(func(config config.Component) healthprobe.Options {
 					return healthprobe.Options{

--- a/releasenotes-dca/notes/cluster-agent-rc-status-bf239f2afab4ed57.yaml
+++ b/releasenotes-dca/notes/cluster-agent-rc-status-bf239f2afab4ed57.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Add Remote Configuration status section to ``datadog-cluster-agent status`` output and flares.
+    This displays whether RC is enabled for the organization, whether the API key is authorized
+    for Remote Configuration, and any last errors, matching the node agent's existing behavior.

--- a/test/static/static_quality_gates.yml
+++ b/test/static/static_quality_gates.yml
@@ -47,10 +47,10 @@ static_quality_gate_docker_agent_jmx_arm64:
   max_on_disk_size: 999.17 MiB
   max_on_wire_size: 324.39 MiB
 static_quality_gate_docker_cluster_agent_amd64:
-  max_on_disk_size: 204.27 MiB
+  max_on_disk_size: 204.45 MiB
   max_on_wire_size: 71.92 MiB
 static_quality_gate_docker_cluster_agent_arm64:
-  max_on_disk_size: 218.0 MiB
+  max_on_disk_size: 218.03 MiB
   max_on_wire_size: 67.22 MiB
 static_quality_gate_docker_cws_instrumentation_amd64:
   max_on_disk_size: 7.18 MiB

--- a/test/static/static_quality_gates.yml
+++ b/test/static/static_quality_gates.yml
@@ -47,10 +47,10 @@ static_quality_gate_docker_agent_jmx_arm64:
   max_on_disk_size: 999.17 MiB
   max_on_wire_size: 324.39 MiB
 static_quality_gate_docker_cluster_agent_amd64:
-  max_on_disk_size: 204.45 MiB
+  max_on_disk_size: 204.27 MiB
   max_on_wire_size: 71.92 MiB
 static_quality_gate_docker_cluster_agent_arm64:
-  max_on_disk_size: 218.03 MiB
+  max_on_disk_size: 218.0 MiB
   max_on_wire_size: 67.22 MiB
 static_quality_gate_docker_cws_instrumentation_amd64:
   max_on_disk_size: 7.18 MiB


### PR DESCRIPTION
### What does this PR do?
 Adds the Remote Configuration status section to datadog-cluster-agent status output and flares by registering rcstatusimpl.Module() in the cluster agent.
Previously, only the node agent displayed RC status. This made it difficult for customers to diagnose issues where their API key lacked RC permissions — the information was only available in logs.

### Motivation
CONTP-1353

### Describe how you validated your changes
Run cluster-agent status, enabled
```
  Remote Configuration
  ====================

  Organization enabled: True
  API Key: Authorized
  Last error: None
```

  When the API key lacks RC permissions:
  Remote Configuration
```
  ====================

  Organization enabled: True
  API Key: Not authorized, add the Remote Configuration Read permission to enable it for this agent.
  Last error: None
```

  When RC is disabled:
```
  Remote Configuration
  ====================

  Remote Configuration is disabled because it is explicitly disabled in the agent configuration. (`remote_configuration.enabled: false`)
```

### Additional Notes
