### PR TITLE
Fix break/continue invalid arg exit code

### DIFF
--- a/pkg/shell/interp/builtins/break_continue.go
+++ b/pkg/shell/interp/builtins/break_continue.go
@@ -29,8 +29,7 @@ func loopControl(callCtx *CallContext, name string, args []string) Result {
 		parsed, err := strconv.Atoi(args[0])
 		if err != nil {
 			callCtx.Errf("%s: %s: numeric argument required\n", name, args[0])
-			// In bash, invalid args still break the loop.
-			return Result{Code: 2, BreakN: 1}
+			return Result{Code: 128, Exiting: true}
 		}
 		if parsed < 1 {
 			callCtx.Errf("%s: %s: loop count out of range\n", name, args[0])

--- a/pkg/shell/tests/scenarios/shell/for_clause/break_cont/break_invalid_arg.yaml
+++ b/pkg/shell/tests/scenarios/shell/for_clause/break_cont/break_invalid_arg.yaml
@@ -1,6 +1,4 @@
-# Our shell exits 2 for non-numeric args; bash exits 128 (special builtin fatal error).
-test_against_local_shell: false
-description: Break with non-numeric argument breaks the loop and produces an error.
+description: Break with non-numeric argument exits the shell and produces an error.
 input:
   script: |+
     for i in a b c; do
@@ -8,6 +6,6 @@ input:
     done
 expect:
   stdout: ""
-  stderr: |+
-    break: abc: numeric argument required
-  exit_code: 2
+  stderr_contains:
+    - "break: abc: numeric argument required"
+  exit_code: 128

--- a/pkg/shell/tests/scenarios/shell/for_clause/break_cont/continue_invalid_arg.yaml
+++ b/pkg/shell/tests/scenarios/shell/for_clause/break_cont/continue_invalid_arg.yaml
@@ -1,6 +1,4 @@
-# Our shell exits 2 for non-numeric args; bash exits 128 (special builtin fatal error).
-test_against_local_shell: false
-description: Continue with non-numeric argument breaks the loop and produces an error.
+description: Continue with non-numeric argument exits the shell and produces an error.
 input:
   script: |+
     for i in a b c; do
@@ -8,6 +6,6 @@ input:
     done
 expect:
   stdout: ""
-  stderr: |+
-    continue: abc: numeric argument required
-  exit_code: 2
+  stderr_contains:
+    - "continue: abc: numeric argument required"
+  exit_code: 128


### PR DESCRIPTION
<!-- dd-meta {"pullId":"846312e5-3a4c-401d-b4aa-d8fea707717b","source":"chat","resourceId":"4cd150fa-a839-4e39-b2e8-657307705f61","workflowId":"ab2873a7-550d-46fa-aacc-3b22aad5f224","codeChangeId":"ab2873a7-550d-46fa-aacc-3b22aad5f224","sourceType":"chat"} -->
### What does this PR do?

Fixes the restricted shell's `break`/`continue` builtins to exit the shell with code 128 when given a non-numeric argument, matching bash's behavior for special builtin fatal errors.

### Motivation

The restricted shell was returning exit code 2 and only breaking the loop when `break abc` or `continue abc` was used with an invalid non-numeric argument. Bash treats this as a special builtin fatal error, terminating the entire script with exit code 128. This was a bug causing the restricted shell to behave differently from bash.

Two other disabled scenarios (`break_outside_loop`, `continue_outside_loop`) were examined and confirmed to be intentional differences (different error message wording, same behavior).

### Describe how you validated your changes

- Ran `TestShellScenarios` for all 5 target scenario directories (globbing, heredoc, line_continuation, for_clause, heredoc_dash) — all pass
- Ran `TestShellScenariosAgainstBash` for `break_cont` group — `break_invalid_arg` and `continue_invalid_arg` now pass against bash
- Verified bash behavior: `bash -c 'for i in a b c; do break abc; done'` exits 128

### Additional Notes

**Changes:**
- `pkg/shell/interp/builtins/break_continue.go`: Changed invalid-arg return from `{Code: 2, BreakN: 1}` to `{Code: 128, Exiting: true}`
- `break_invalid_arg.yaml` / `continue_invalid_arg.yaml`: Updated exit_code to 128, switched to `stderr_contains`, removed `test_against_local_shell: false` to enable bash comparison

---

PR by Bits
[View session in Datadog](https://app.datadoghq.com/code/4cd150fa-a839-4e39-b2e8-657307705f61)

Comment @datadog to request changes