### PR TITLE
pkg/dyninst: Improve testing to allow architecture specific expectation, integration test skipping

### DIFF
--- a/pkg/dyninst/integration_test.go
+++ b/pkg/dyninst/integration_test.go
@@ -339,47 +339,90 @@ func runIntegrationTestSuite(
 	for _, cfg := range cfgs {
 		probes := testprogs.MustGetProbeDefinitions(t, service)
 		probes = slices.DeleteFunc(probes, testprogs.HasIssueTag)
-		// Some probes have different output in different versions, due to
-		// compiler changes. We rename the probes to organize output into different files.
+
+		// For each probe, resolve which output file name applies to the
+		// current config (stored in resultNames) and which names belong
+		// to other configs (stored in otherVariantNames). The latter is
+		// needed because output files for all configs live in the same
+		// directory — without tracking them, the "unexpected probes"
+		// check would flag files belonging to other configs as errors.
+		//
+		// otherVariantNames is populated from two sources:
+		//  1. Probes skipped entirely for this config — all their
+		//     variant names (base + version_diff + config_diff) go here.
+		//  2. Non-matching variants of kept probes — e.g. a probe kept
+		//     with result name "foo_geq_1.23" still has "foo" on disk
+		//     for older toolchains; that name goes here.
+		otherVariantNames := make(map[string]struct{})
 		resultNames := make(map[string]string)
-		otherVersionNames := make(map[string]struct{})
+		var keptProbes []ir.ProbeDefinition
 		for _, p := range probes {
+			skipped := testprogs.IsIntegrationConfigSkipped(t, p, cfg)
+			if !skipped {
+				keptProbes = append(keptProbes, p)
+			}
+
+			// Resolve version_diff tags to pick the base result name.
+			// Skipped probes still go through resolution so all their
+			// variant names land in otherVariantNames.
 			var versions []string
 			for _, tag := range p.GetTags() {
 				if strings.HasPrefix(tag, "version_diff:") {
 					versionDiff := strings.TrimPrefix(tag, "version_diff:")
 					versions = append(versions, versionDiff)
-					if cfg.GOTOOLCHAIN >= versionDiff {
-						resultNames[p.GetID()] = p.GetID() + "_geq_" + versionDiff
-						break
-					}
 				}
 			}
 			if versions == nil {
-				resultNames[p.GetID()] = p.GetID()
-				continue
-			}
-			// Find the largest version diff tag that applies to the version we are running with.
-			// Save other variants to recognize unexpected outputs.
-			slices.Sort(versions)
-			slices.Reverse(versions)
-			versions = append(versions, "")
-			found := false
-			for _, version := range versions {
-				var resultName string
-				if version == "" {
-					resultName = p.GetID()
+				if skipped {
+					otherVariantNames[p.GetID()] = struct{}{}
 				} else {
-					resultName = p.GetID() + "_geq_" + version
+					resultNames[p.GetID()] = p.GetID()
 				}
-				if !found && cfg.GOTOOLCHAIN >= version {
-					resultNames[p.GetID()] = resultName
-					found = true
+			} else {
+				// Find the largest version diff tag that applies to the
+				// version we are running with. Save other variants to
+				// recognize unexpected outputs.
+				slices.Sort(versions)
+				slices.Reverse(versions)
+				versions = append(versions, "")
+				found := false
+				for _, version := range versions {
+					var resultName string
+					if version == "" {
+						resultName = p.GetID()
+					} else {
+						resultName = p.GetID() + "_geq_" + version
+					}
+					if !skipped && !found && cfg.GOTOOLCHAIN >= version {
+						resultNames[p.GetID()] = resultName
+						found = true
+					} else {
+						otherVariantNames[resultName] = struct{}{}
+					}
+				}
+			}
+
+			// config_diff tags override the version_diff result for a
+			// specific arch+toolchain pair. The tag value is a Config
+			// string (arch=ARCH,toolchain=VERSION) parsed by parseConfig.
+			for _, tag := range p.GetTags() {
+				if !strings.HasPrefix(tag, "config_diff:") {
+					continue
+				}
+				diffCfg, err := testprogs.ParseConfig(tag[len("config_diff:"):])
+				require.NoError(t, err, "invalid config_diff tag %q on probe %s", tag, p.GetID())
+				configName := p.GetID() + "_config_" + diffCfg.String()
+				if !skipped && diffCfg == cfg {
+					if prev := resultNames[p.GetID()]; prev != "" {
+						otherVariantNames[prev] = struct{}{}
+					}
+					resultNames[p.GetID()] = configName
 				} else {
-					otherVersionNames[resultName] = struct{}{}
+					otherVariantNames[configName] = struct{}{}
 				}
 			}
 		}
+		probes = keptProbes
 		t.Run(cfg.String(), func(t *testing.T) {
 			if cfg.GOARCH != runtime.GOARCH {
 				t.Skipf("cross-execution is not supported, running on %s, skipping %s", runtime.GOARCH, cfg.GOARCH)
@@ -421,7 +464,7 @@ func runIntegrationTestSuite(
 								if _, ok := got[id]; ok {
 									return true
 								}
-								if _, ok := otherVersionNames[id]; ok {
+								if _, ok := otherVariantNames[id]; ok {
 									return true
 								}
 								return false

--- a/pkg/dyninst/testprogs/probes.go
+++ b/pkg/dyninst/testprogs/probes.go
@@ -79,6 +79,11 @@ func getProbeDefinitions(name string) ([]ir.ProbeDefinition, error) {
 // IssueTagPrefix is the prefix of the issue tag.
 const IssueTagPrefix = "issue:"
 
+// SkipIntegrationTagPrefix is the prefix for skipping probes in integration tests.
+// The value after the prefix is a Config string (arch=ARCH,toolchain=VERSION)
+// parsed by parseConfig. Matching is exact on both fields.
+const SkipIntegrationTagPrefix = "skip_integration:"
+
 // GetIssueTag returns the issue tag for a probe definition.
 func GetIssueTag(p ir.ProbeDefinition) (string, bool) {
 	tags := p.GetTags()
@@ -95,4 +100,21 @@ func GetIssueTag(p ir.ProbeDefinition) (string, bool) {
 func HasIssueTag(p ir.ProbeDefinition) bool {
 	_, ok := GetIssueTag(p)
 	return ok
+}
+
+// IsIntegrationConfigSkipped returns true if the probe should be skipped for
+// the given Config. Each skip_integration: tag value is parsed as a Config
+// string via parseConfig and compared with exact equality.
+func IsIntegrationConfigSkipped(t testing.TB, p ir.ProbeDefinition, cfg Config) bool {
+	for _, tag := range p.GetTags() {
+		if !strings.HasPrefix(tag, SkipIntegrationTagPrefix) {
+			continue
+		}
+		skipCfg, err := ParseConfig(tag[len(SkipIntegrationTagPrefix):])
+		require.NoError(t, err, "invalid skip_integration tag %q on probe %s", tag, p.GetID())
+		if skipCfg == cfg {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/dyninst/testprogs/test_progs.go
+++ b/pkg/dyninst/testprogs/test_progs.go
@@ -177,7 +177,7 @@ found:
 		if !file.IsDir() {
 			continue
 		}
-		cfg, err := parseConfig(file.Name())
+		cfg, err := ParseConfig(file.Name())
 		if err != nil {
 			return state{}, fmt.Errorf("failed to parse config from directory name: %w", err)
 		}
@@ -338,7 +338,8 @@ func (m *Config) Validate() error {
 	return nil
 }
 
-func parseConfig(s string) (Config, error) {
+// ParseConfig parses a Config string of the form "arch=ARCH,toolchain=VERSION".
+func ParseConfig(s string) (Config, error) {
 	parts := strings.Split(s, ",")
 	var cfg Config
 	for _, part := range parts {

--- a/pkg/dyninst/testprogs/test_progs_test.go
+++ b/pkg/dyninst/testprogs/test_progs_test.go
@@ -17,6 +17,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/dyninst/ir"
 )
 
 const inSubprocessEnvVar = "DD_DYNINST_TESTPROGS_IN_SUBPROCESS"
@@ -132,4 +134,74 @@ func testInitFromBinariesInSubprocess(t *testing.T) {
 	}
 	_, err = os.Stderr.Write(out)
 	require.NoError(t, err)
+}
+
+// mockProbe implements ir.ProbeDefinition for testing issue tag functions.
+type mockProbe struct {
+	tags []string
+}
+
+func (m *mockProbe) GetID() string                        { return "test" }
+func (m *mockProbe) GetVersion() int                      { return 0 }
+func (m *mockProbe) GetTags() []string                    { return m.tags }
+func (m *mockProbe) GetKind() ir.ProbeKind                { return ir.ProbeKindLog }
+func (m *mockProbe) GetWhere() ir.Where                   { return nil }
+func (m *mockProbe) GetCaptureConfig() ir.CaptureConfig   { return nil }
+func (m *mockProbe) GetThrottleConfig() ir.ThrottleConfig { return nil }
+func (m *mockProbe) GetTemplate() ir.TemplateDefinition   { return nil }
+func (m *mockProbe) GetCaptureExpressions() []ir.CaptureExpressionDefinition {
+	return nil
+}
+
+func TestIsIntegrationConfigSkipped(t *testing.T) {
+	cases := []struct {
+		name     string
+		tags     []string
+		cfg      Config
+		expected bool
+	}{
+		{
+			name:     "no tags",
+			tags:     nil,
+			cfg:      Config{GOARCH: "amd64", GOTOOLCHAIN: "go1.24.3"},
+			expected: false,
+		},
+		{
+			name:     "exact match",
+			tags:     []string{"skip_integration:arch=arm64,toolchain=go1.25.0"},
+			cfg:      Config{GOARCH: "arm64", GOTOOLCHAIN: "go1.25.0"},
+			expected: true,
+		},
+		{
+			name:     "arch does not match",
+			tags:     []string{"skip_integration:arch=arm64,toolchain=go1.25.0"},
+			cfg:      Config{GOARCH: "amd64", GOTOOLCHAIN: "go1.25.0"},
+			expected: false,
+		},
+		{
+			name:     "toolchain does not match",
+			tags:     []string{"skip_integration:arch=arm64,toolchain=go1.25.0"},
+			cfg:      Config{GOARCH: "arm64", GOTOOLCHAIN: "go1.24.3"},
+			expected: false,
+		},
+		{
+			name:     "issue tag is not matched",
+			tags:     []string{"issue:UnsupportedFeature"},
+			cfg:      Config{GOARCH: "amd64", GOTOOLCHAIN: "go1.24.3"},
+			expected: false,
+		},
+		{
+			name:     "multiple skip tags one matches",
+			tags:     []string{"skip_integration:arch=amd64,toolchain=go1.24.3", "skip_integration:arch=arm64,toolchain=go1.24.3"},
+			cfg:      Config{GOARCH: "arm64", GOTOOLCHAIN: "go1.24.3"},
+			expected: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &mockProbe{tags: tc.tags}
+			require.Equal(t, tc.expected, IsIntegrationConfigSkipped(t, p, tc.cfg))
+		})
+	}
 }


### PR DESCRIPTION
# What does this PR do?

Adds `config_diff` and `skip_integration` tags for integration tests. Both tags use the existing config string format (`arch=ARCH,toolchain=VERSION`).

### `config_diff:` tag

New tag for probes whose integration test output differs on a specific architecture and toolchain combination. Overrides the `version_diff` result with an exact config match.

- `config_diff:arch=ARCH,toolchain=VERSION` -> use a different expected output file for this exact config
- File naming: `probeID_config_arch=ARCH,toolchain=VERSION.json`
- Multiple `config_diff` tags can be added for different configs

Resolution order: `version_diff` resolves first (picking the base file via range matching), then `config_diff` overrides the result if an exact match exists.

### `skip_integration:` tag

New tag for skipping probes in integration tests without declaring an irgen issue. Uses the same string format as `config_diff`:

- `skip_integration:arch=ARCH,toolchain=VERSION` -> skip for this exact config

The distinction: `issue:` means "irgen will report this issue kind when processing this probe" (expected output verified by the snapshot test). `skip_integration:` means "don't run this probe in the integration test on this config" (test filter only). Other test suites (compiler, gosym, irgen issues) ignore `skip_integration:`.

### Motivation

#47281 exposed discrepancies between how Go 1.26rc1 generates DWARF across different architectures. The existing `version_diff` tag system couldn't handle architecture-specific differences. Additionally, some probes fail only on specific arch+toolchain combinations due to compiler bugs, requiring conditional skipping rather than unconditional exclusion.

### Describe how you validated your changes

- `go vet` passes on all affected packages
- New unit tests: `TestIsIntegrationConfigSkipped`
- Ran integration tests across all supported arch/toolchain combinations and verified correct file resolution and skipping behavior.
