### PR TITLE
[observer] Unify detector interfaces and rewrite README

### DIFF
--- a/comp/observer/README.md
+++ b/comp/observer/README.md
@@ -9,23 +9,29 @@ Observes data flowing through the agent for sampling and analysis.
 **Handle** is the lightweight interface passed to data pipelines. It has two methods:
 
 - `ObserveMetric(MetricView)` — adds the metric to storage, then runs metrics detection on the updated series.
-- `ObserveLog(LogView)` — runs all log detectors. Any metrics they produce are added to storage and trigger metrics detection.
+- `ObserveLog(LogView)` — runs all log extractors. Any metrics they produce are added to storage and trigger detection.
 
 **MetricView / LogView** are read-only interfaces to avoid data races. The underlying data may be reused after the call returns, so copy any values you need synchronously.
 
 **Storage** accumulates metrics into per-second buckets, tracking sum/count/min/max for each series. When retrieved, you specify an aggregation (average, sum, count, min, max) to collapse each bucket to a single value.
 
-**LogDetector** transforms logs into metrics and anomaly events:
+**LogMetricsExtractor** transforms logs into metrics:
 ```
-Process(log LogView) → LogDetectionResult{Metrics[], Anomalies[]}
+ProcessLog(log LogView) → []MetricOutput
 ```
 Implementations should be stateless and fast since they run synchronously on every log.
 
-**MetricsDetector** detects anomalies from accumulated time series:
+**SeriesDetector** detects anomalies from a single time series:
 ```
-Detect(Series) → MetricsDetectionResult{Anomalies[]}
+Detect(Series) → DetectionResult{Anomalies[]}
 ```
 Receives a series of aggregated points. Implementations should be stateless and just do math on the points.
+
+**Detector** is the flexible detection interface that pulls data from storage:
+```
+Detect(StorageReader, dataTime int64) → DetectionResult{Anomalies[]}
+```
+Supports multivariate detection across multiple series. SeriesDetector implementations are automatically wrapped into Detectors via `seriesDetectorAdapter`.
 
 **Correlator** receives and accumulates anomaly events from all analyses:
 ```
@@ -38,27 +44,25 @@ Unlike analyses, correlators are stateful. They accumulate events and produce re
 
 Handles are the only concurrent part. They copy data and send it over a channel. Everything else (storage, analyses, consumers) runs in a single dispatch goroutine, so no locks are needed in component implementations.
 
-## Writing a New Log Detector
+## Writing a New Log Extractor
 
-Implement `LogDetector` or `MetricsDetector`:
+Implement `LogMetricsExtractor`:
 
 ```go
-type MyLogDetector struct{}
+type MyExtractor struct{}
 
-func (m *MyLogDetector) Name() string { return "my_detector" }
+func (m *MyExtractor) Name() string { return "my_extractor" }
 
-func (m *MyLogDetector) Process(log observer.LogView) observer.LogDetectionResult {
+func (m *MyExtractor) ProcessLog(log observer.LogView) []observer.MetricOutput {
     // Extract what you need synchronously - don't store the view
     content := string(log.GetContent())
 
-    // Return metrics and/or anomalies
-    return observer.LogDetectionResult{
-        Metrics: []observer.MetricOutput{{
-            Name:  "my.metric",
-            Value: 1,
-            Tags:  log.GetTags(),
-        }},
-    }
+    // Return derived metrics
+    return []observer.MetricOutput{{
+        Name:  "my.metric",
+        Value: 1,
+        Tags:  log.GetTags(),
+    }}
 }
 ```
 
@@ -66,8 +70,8 @@ Register in `observer.go`:
 
 ```go
 obs := &observerImpl{
-    logDetectors: []observerdef.LogDetector{
-        &MyLogDetector{},  // add here
+    extractors: []observerdef.LogMetricsExtractor{
+        &MyExtractor{},  // add here
     },
     // ...
 }

--- a/comp/observer/README.md
+++ b/comp/observer/README.md
@@ -28,7 +28,7 @@ The observer watches data flowing through the agent — metrics, logs, traces, p
                       └─────────────────────────────────────────────────────────────────────┘
 ```
 
-Data enters through lightweight **Handles** that copy and send observations over a channel. The framework handles scheduling, threading, and data flow — individual components (detectors, extractors, correlators) are just functions that receive data and return results, with no need to worry about concurrency or how they get called.
+Data enters through lightweight **Handles** that copy and send observations over a channel. The framework handles scheduling, threading, and data flow — individual components (detectors, extractors, correlators) currently run sequentially in a single goroutine, so they don't need to be thread-safe or manage shared state. This may evolve (e.g. parallelizing independent detectors), but component implementations should not depend on the threading model.
 
 ## Pipeline Stages
 
@@ -52,7 +52,11 @@ Each method copies the data synchronously, then does a **non-blocking send** to 
 
 ### 2. Store
 
-**Storage** accumulates metrics into per-second buckets. Each bucket tracks sum, count, min, and max for the series. Aggregation (average, sum, count, min, max) is chosen at **read time**, not write time — storage always keeps the full summary.
+**Storage** accumulates metrics into a sketch-like (but simplified) summary representation. Each metric series is bucketed into **one-second intervals**, and each bucket records four values: sum, count, min, and max. Multiple samples arriving within the same second are merged into a single bucket. This is lossy — we discard individual sample values — but it's compact and gives us five useful aggregation options at read time: **average** (sum/count), **sum**, **count**, **min**, and **max**.
+
+Aggregation is chosen at **read time**, not write time. Storage always keeps the full summary, so detectors and queries can pick whichever aggregation is appropriate without needing to re-ingest data.
+
+The observer is currently **metric-type agnostic** — it does not distinguish between Count, Gauge, Rate, etc. All metrics are treated uniformly as samples to be summarized. This is a bet on a simpler unified model; we'll see over time whether there's a good reason to introduce type-specific logic.
 
 Metrics from logs are stored with a `_virtual.` prefix (e.g. `_virtual.log.field.duration`) to distinguish them from directly observed metrics.
 
@@ -68,13 +72,13 @@ There are two detector interfaces, from simple to flexible:
 ```
 Detect(Series) → DetectionResult{Anomalies[]}
 ```
-Receives aggregated points for one series. Implementations should be stateless — just do math on the points. Examples: CUSUM (change-point detection), BOCPD (Bayesian changepoint detection).
+Called once per series per detection cycle. Currently receives the **full accumulated history** for that series — all points from the beginning up to the current data time. We will need to develop a windowing strategy so this doesn't grow unboundedly; that's an open question. Each point is one second (matching the storage buckets), with timestamps in Unix seconds. There may be gaps where no data arrived — we currently do no fill (zero-fill, last-value hold, etc.). This could become important for metrics like monotonic counts that are reported at wider intervals than our one-second bucket size. Implementations should be stateless — just do math on the points you're given. Examples: CUSUM (change-point detection), BOCPD (Bayesian changepoint detection).
 
 **Detector** pulls whatever it needs from storage:
 ```
 Detect(StorageReader, dataTime int64) → DetectionResult{Anomalies[]}
 ```
-Supports multivariate detection across multiple series. Example: RRCF (Robust Random Cut Forest) reads several metrics, aligns them by timestamp, and scores the combined signal.
+`dataTime` is the current detection time in Unix seconds. The detector can query storage for any series and any time range it needs. Supports multivariate detection across multiple series. Example: RRCF (Robust Random Cut Forest) reads several metrics, aligns them by timestamp, and scores the combined signal.
 
 **How they connect:** SeriesDetector implementations are automatically wrapped into Detectors via `seriesDetectorAdapter`. The adapter iterates all series in storage × a set of aggregations (avg, count by default), runs the SeriesDetector on each, and appends an aggregation suffix (`:avg`, `:count`) to the metric name. If you need per-series detection, implement SeriesDetector. If you need cross-series detection, implement Detector directly.
 
@@ -132,11 +136,11 @@ The observer separates **framework concerns** from **component logic**. If you'r
 - Do your math or logic on the data you're given
 - Return results — the framework takes it from there
 
-Currently the framework runs everything in a single dispatch goroutine, but this is an implementation detail that could evolve (e.g. parallelizing independent detectors). Component implementations shouldn't depend on or worry about the threading model.
+Currently the framework runs everything in a single dispatch goroutine, but this is an implementation detail that could evolve (e.g. parallelizing independent detectors). Component implementations shouldn't depend on or worry about the threading model, but they are expected not to block — detectors should be doing local computation on the data points they're given, not making network calls or similar.
 
 ### Threading Details (for framework contributors)
 
-Handles are the only concurrent part. They copy data and do a **non-blocking send** to a buffered channel (capacity 1000). If the buffer is full, observations are silently dropped — analysis should never back-pressure data ingestion.
+Handles are the only concurrent part. They copy data and do a **non-blocking send** to a buffered channel (capacity 1000). If the buffer is full, observations are dropped — analysis should never back-pressure data ingestion. Drops are not yet tracked; we should add telemetry for this so we have visibility into when it happens. The buffer capacity could also become a useful knob for controlling resource usage.
 
 Everything after the channel — storage, extractors, detectors, correlators, reporters — currently runs in a single dispatch goroutine:
 ```go

--- a/comp/observer/README.md
+++ b/comp/observer/README.md
@@ -1,52 +1,219 @@
 # Observer Component
 
-Observes data flowing through the agent for sampling and analysis.
+The observer watches data flowing through the agent — metrics, logs, traces, profiles — and runs anomaly detection on it. The core idea is a pipeline:
 
-## Components
-
-**Component** is the entry point. Call `GetHandle(name)` to get a handle scoped to a named source (e.g. "dogstatsd", "otlp").
-
-**Handle** is the lightweight interface passed to data pipelines. It has two methods:
-
-- `ObserveMetric(MetricView)` — adds the metric to storage, then runs metrics detection on the updated series.
-- `ObserveLog(LogView)` — runs all log extractors. Any metrics they produce are added to storage and trigger detection.
-
-**MetricView / LogView** are read-only interfaces to avoid data races. The underlying data may be reused after the call returns, so copy any values you need synchronously.
-
-**Storage** accumulates metrics into per-second buckets, tracking sum/count/min/max for each series. When retrieved, you specify an aggregation (average, sum, count, min, max) to collapse each bucket to a single value.
-
-**LogMetricsExtractor** transforms logs into metrics:
 ```
-ProcessLog(log LogView) → []MetricOutput
+                      ┌─────────────────────────────────────────────────────────────────────┐
+                      │                                                                     │
+┌────────────┐        │    ┌───────────────────────┐    ┌───────────────────────────┐       │
+│   Handle   ├─Logs───┼─┬──▶  LogMetricExtractors  │    │         Detectors         │       │
+└──────┬─────┘        │ │  └───────────┬───────────┘    │                           │       │
+       │              │ │              │                │  ┌─────────────────────┐  │       │
+       │              │ └──────────────┼────────────────┼──▶     LogObserver     │  ├───┐   │
+       │              │                │                │  └─────────────────────┘  │   │   │
+       │              │                │                │                           │   │   │
+       │              │    ┌───────────▼───────────┐    │  ┌─────────────────────┐  │   │   │
+       └───Metrics────┼────▶     MetricStorage     ├────▶  │   SeriesDetector    │  │   │   │
+                      │    └───────────────────────┘    │  └─────────────────────┘  │   │   │
+                      │                                 └───────────────────────────┘   │   │
+                      │                                                                 │   │
+                      │        ┌──────────────────┐                                     │   │
+                      │        │   Correlators    ◀─────────────Anomalies───────────────┘   │
+                      │        └────────┬─────────┘                                         │
+                      │                 │                                                   │
+                      │        ┌────────▼─────────┐                                         │
+                      │        │    Reporters     │                                         │
+                      │        └──────────────────┘                                         │
+                      │                                                                     │
+                      └─────────────────────────────────────────────────────────────────────┘
 ```
-Implementations should be stateless and fast since they run synchronously on every log.
 
-**SeriesDetector** detects anomalies from a single time series:
+Data enters through lightweight **Handles** that copy and send observations over a channel. The framework handles scheduling, threading, and data flow — individual components (detectors, extractors, correlators) are just functions that receive data and return results, with no need to worry about concurrency or how they get called.
+
+## Pipeline Stages
+
+### 1. Observe (Handles)
+
+**Component** is the entry point. Call `GetHandle(name)` to get a handle scoped to a named source (e.g. "dogstatsd", "otlp", "trace-agent").
+
+**Handle** is the lightweight interface passed to data pipelines. It accepts five signal types:
+
+- `ObserveMetric(MetricView)` — a DogStatsD metric sample
+- `ObserveLog(LogView)` — a log message
+- `ObserveTrace(TraceView)` — a trace (collection of spans)
+- `ObserveTraceStats(TraceStatsView)` — aggregated APM stats (decomposed into metrics at the handle layer)
+- `ObserveProfile(ProfileView)` — a profiling sample
+
+Each method copies the data synchronously, then does a **non-blocking send** to a buffered channel (capacity 1000). If the channel is full, the observation is silently dropped. This ensures the observer never blocks data ingestion, even if analysis is slow.
+
+> **Note:** Trace and profile observation are wired up but analysis is not yet implemented — they are recorded but not yet used for detection. A fetcher periodically pulls traces and profiles from remote trace-agents via gRPC.
+
+**View interfaces** (`MetricView`, `LogView`, `TraceView`, etc.) provide read-only access to prevent data races. The underlying data may be reused after the call returns, so handles copy everything before sending.
+
+### 2. Store
+
+**Storage** accumulates metrics into per-second buckets. Each bucket tracks sum, count, min, and max for the series. Aggregation (average, sum, count, min, max) is chosen at **read time**, not write time — storage always keeps the full summary.
+
+Metrics from logs are stored with a `_virtual.` prefix (e.g. `_virtual.log.field.duration`) to distinguish them from directly observed metrics.
+
+### 3. Detect
+
+Detection is **not** scheduled on a timer. It's triggered by data arrival: when data at time T arrives, detectors run on data up to T-1. This "complete seconds" rule ensures deterministic results whether data arrives in batch or streaming.
+
+**Why determinism matters:** Because detection is driven entirely by data timestamps (not wall-clock time), replaying the same data always produces the same anomalies. This makes it cheap to simulate the full detection pipeline offline, which is key to iterating quickly on algorithms. The testbench leverages this — it loads a parquet file of recorded metrics, runs them through the same pipeline that runs live, and produces identical results every time. This gives us fast, repeatable iteration loops: change a detector, re-run the scenario, compare results.
+
+There are two detector interfaces, from simple to flexible:
+
+**SeriesDetector** analyzes a single time series:
 ```
 Detect(Series) → DetectionResult{Anomalies[]}
 ```
-Receives a series of aggregated points. Implementations should be stateless and just do math on the points.
+Receives aggregated points for one series. Implementations should be stateless — just do math on the points. Examples: CUSUM (change-point detection), BOCPD (Bayesian changepoint detection).
 
-**Detector** is the flexible detection interface that pulls data from storage:
+**Detector** pulls whatever it needs from storage:
 ```
 Detect(StorageReader, dataTime int64) → DetectionResult{Anomalies[]}
 ```
-Supports multivariate detection across multiple series. SeriesDetector implementations are automatically wrapped into Detectors via `seriesDetectorAdapter`.
+Supports multivariate detection across multiple series. Example: RRCF (Robust Random Cut Forest) reads several metrics, aligns them by timestamp, and scores the combined signal.
 
-**Correlator** receives and accumulates anomaly events from all analyses:
+**How they connect:** SeriesDetector implementations are automatically wrapped into Detectors via `seriesDetectorAdapter`. The adapter iterates all series in storage × a set of aggregations (avg, count by default), runs the SeriesDetector on each, and appends an aggregation suffix (`:avg`, `:count`) to the metric name. If you need per-series detection, implement SeriesDetector. If you need cross-series detection, implement Detector directly.
+
+**LogObserver** is an optional interface that Detectors can implement to receive raw log observations directly, without going through the metrics extraction path:
+```go
+type LogObserver interface {
+    ProcessLog(log LogView)
+}
+```
+
+### 4. Correlate
+
+**Correlator** accumulates anomaly events and looks for patterns:
 ```
 Process(anomaly Anomaly)
-Flush() []ReportOutput
+Flush() → []ReportOutput
 ```
-Unlike analyses, correlators are stateful. They accumulate events and produce reports when `Flush()` is called.
+Correlators are stateful. They receive individual anomalies, accumulate them over a time window, and produce reports when patterns are detected. Example: `TimeClusterCorrelator` groups anomalies that occur close together in time into clusters, surfacing correlated bursts of anomalous behavior across different series.
 
-## Threading Model
+### 5. Report
 
-Handles are the only concurrent part. They copy data and send it over a channel. Everything else (storage, analyses, consumers) runs in a single dispatch goroutine, so no locks are needed in component implementations.
+**Reporter** delivers results to their destination:
+```
+Report(report ReportOutput)
+```
+Reporters query state interfaces like `CorrelationState` and `RawAnomalyState` to access current system state, rather than relying solely on the report argument. Example: `StdoutReporter` queries the correlator's `ActiveCorrelations()` to print changes.
 
-## Writing a New Log Extractor
+> **Note:** The Reporter interface hasn't seen much focus yet and may need some evolution as we learn more about what reporting needs look like in practice.
 
-Implement `LogMetricsExtractor`:
+## Log Processing
+
+When a log is observed, two things happen:
+
+1. **LogMetricsExtractors** run synchronously, transforming the log into metrics:
+   ```
+   ProcessLog(log LogView) → []MetricOutput
+   ```
+   Each returned metric is stored as `_virtual.{name}` and flows through normal detection. Implementations should be stateless and fast.
+
+2. **Detectors implementing LogObserver** receive the raw log directly, allowing log-based anomaly detection without the metrics extraction step.
+
+## Framework vs. Component Responsibilities
+
+The observer separates **framework concerns** from **component logic**. If you're writing a detector, extractor, or correlator, you don't need to think about threading, scheduling, or data flow — the framework handles all of that. Your code is just a function that receives data and returns results.
+
+**The framework's job:**
+- Copying data from handles and dispatching it to the right place
+- Storing metrics and managing time series buckets
+- Deciding when to run detectors (data-driven, not timer-based)
+- Routing anomalies to correlators and flushing reports to reporters
+- All threading and concurrency
+
+**Your job as a component author:**
+- Implement a simple interface (e.g. `Detect(Series) → DetectionResult`)
+- Do your math or logic on the data you're given
+- Return results — the framework takes it from there
+
+Currently the framework runs everything in a single dispatch goroutine, but this is an implementation detail that could evolve (e.g. parallelizing independent detectors). Component implementations shouldn't depend on or worry about the threading model.
+
+### Threading Details (for framework contributors)
+
+Handles are the only concurrent part. They copy data and do a **non-blocking send** to a buffered channel (capacity 1000). If the buffer is full, observations are silently dropped — analysis should never back-pressure data ingestion.
+
+Everything after the channel — storage, extractors, detectors, correlators, reporters — currently runs in a single dispatch goroutine:
+```go
+for obs := range o.obsCh {
+    if obs.metric != nil { processMetric() }
+    if obs.log != nil    { processLog() }
+    if obs.trace != nil  { processTrace() }
+    if obs.profile != nil { processProfile() }
+}
+```
+
+## Writing Extensions
+
+### New SeriesDetector
+
+Implement `SeriesDetector` for stateless per-series anomaly detection. The adapter will automatically run it across all series and aggregations.
+
+```go
+type MyDetector struct{}
+
+func (d *MyDetector) Name() string { return "my_detector" }
+
+func (d *MyDetector) Detect(series observer.Series) observer.DetectionResult {
+    // Analyze series.Points (already aggregated to one value per second)
+    for _, p := range series.Points {
+        if p.Value > 100 {
+            return observer.DetectionResult{
+                Anomalies: []observer.Anomaly{{
+                    Title:     "Spike detected",
+                    Timestamp: p.Timestamp,
+                }},
+            }
+        }
+    }
+    return observer.DetectionResult{}
+}
+```
+
+Register in `observer.go`:
+```go
+detectors: []observerdef.Detector{
+    newSeriesDetectorAdapter(&MyDetector{}, defaultAggregations),
+    // ...
+},
+```
+
+### New Detector (Multivariate)
+
+Implement `Detector` for cross-series analysis. You pull data from storage directly.
+
+```go
+type MyDetector struct{}
+
+func (d *MyDetector) Name() string { return "my_detector" }
+
+func (d *MyDetector) Detect(storage observer.StorageReader, dataTime int64) observer.DetectionResult {
+    // Find series you care about
+    keys := storage.ListSeries(observer.SeriesFilter{NamePattern: "cpu"})
+
+    // Read their data
+    for _, key := range keys {
+        series := storage.GetSeriesRange(key, 0, dataTime, observer.AggregateAverage)
+        // ... analyze across series
+    }
+    return observer.DetectionResult{}
+}
+```
+
+Register in `observer.go`:
+```go
+detectors: []observerdef.Detector{
+    &MyDetector{},
+    // ...
+},
+```
+
+### New LogMetricsExtractor
 
 ```go
 type MyExtractor struct{}
@@ -54,12 +221,10 @@ type MyExtractor struct{}
 func (m *MyExtractor) Name() string { return "my_extractor" }
 
 func (m *MyExtractor) ProcessLog(log observer.LogView) []observer.MetricOutput {
-    // Extract what you need synchronously - don't store the view
     content := string(log.GetContent())
-
-    // Return derived metrics
+    // Extract what you need synchronously — don't store the view
     return []observer.MetricOutput{{
-        Name:  "my.metric",
+        Name:  "my.metric",    // stored as _virtual.my.metric
         Value: 1,
         Tags:  log.GetTags(),
     }}
@@ -67,19 +232,14 @@ func (m *MyExtractor) ProcessLog(log observer.LogView) []observer.MetricOutput {
 ```
 
 Register in `observer.go`:
-
 ```go
-obs := &observerImpl{
-    extractors: []observerdef.LogMetricsExtractor{
-        &MyExtractor{},  // add here
-    },
+extractors: []observerdef.LogMetricsExtractor{
+    &MyExtractor{},
     // ...
-}
+},
 ```
 
-## Writing a New Correlator
-
-Implement `Correlator`:
+### New Correlator
 
 ```go
 type MyCorrelator struct {
@@ -93,7 +253,6 @@ func (c *MyCorrelator) Process(anomaly observer.Anomaly) {
 }
 
 func (c *MyCorrelator) Flush() []observer.ReportOutput {
-    // Do something with accumulated events
     var reports []observer.ReportOutput
     for _, e := range c.events {
         reports = append(reports, observer.ReportOutput{Title: e.Title})
@@ -104,34 +263,43 @@ func (c *MyCorrelator) Flush() []observer.ReportOutput {
 ```
 
 Register in `observer.go`:
-
 ```go
-obs := &observerImpl{
-    correlators: []observerdef.Correlator{
-        &MemoryCorrelator{},
-        &MyCorrelator{},  // add here
-    },
+correlators: []observerdef.Correlator{
+    &MyCorrelator{},
     // ...
-}
+},
+```
+
+## Configuration
+
+```yaml
+observer:
+  # Main switches
+  analysis:
+    enabled: true                    # Enable the anomaly detection pipeline
+
+  # Agent internal log capture
+  capture_agent_internal_logs:
+    enabled: true
+    sample_rate_info: 0.1            # Sample 10% of info logs
+    sample_rate_debug: 0.0           # Drop debug logs
+    sample_rate_trace: 0.0           # Drop trace logs
+
+  # Parquet metric recording
+  capture_metrics:
+    enabled: true
+  parquet_output_dir: "/var/log/datadog/observer-metrics"
+  parquet_flush_interval: 60s        # File rotation interval
+  parquet_retention: 24h             # Automatic cleanup (0 = disabled)
+
+  # Debug
+  debug_dump_path: "/tmp/observer-dump.json"
+  debug_dump_interval: 30s
 ```
 
 ## Metric Recording to Parquet Files
 
 The observer can record all observed metrics to Parquet files for long-term storage and analysis.
-
-### Configuration
-
-Enable Parquet recording in `datadog.yaml`:
-
-```yaml
-observer:
-  capture_metrics.enabled: true
-  parquet_output_dir: "/var/log/datadog/observer-metrics"
-  parquet_flush_interval: 60s  # File rotation interval
-  parquet_retention: 24h        # Automatic cleanup (0 = disabled)
-```
-
-### File Format
 
 Files are rotated at the flush interval with UTC-timestamped names:
 
@@ -158,20 +326,7 @@ Schema is compatible with **FGM (Flare Graph Metrics)** format:
 | `ValueFloat` | `float64`      | Metric value                                     |
 | `Tags`       | `list<string>` | Array of tags in "key:value" format              |
 
-**Arrow Schema Definition:**
-
-```go
-arrow.NewSchema([]arrow.Field{
-    {Name: "RunID", Type: arrow.BinaryTypes.String},
-    {Name: "Time", Type: arrow.PrimitiveTypes.Int64},
-    {Name: "MetricName", Type: arrow.BinaryTypes.String},
-    {Name: "ValueFloat", Type: arrow.PrimitiveTypes.Float64},
-    {Name: "Tags", Type: arrow.ListOf(arrow.BinaryTypes.String)},
-}, nil)
-```
-
-**Important Notes:**
 - Time is in **milliseconds** (divide by 1000 for seconds)
 - Tags format: `["host:server1", "env:prod"]`
 - All timestamps are UTC
-- **Bloom filters enabled** on Tags and MetricName for fast queries
+- Bloom filters enabled on Tags and MetricName for fast queries

--- a/comp/observer/def/component.go
+++ b/comp/observer/def/component.go
@@ -227,24 +227,21 @@ type ProfileView interface {
 	GetExternalPath() string
 }
 
-// LogDetector transforms observed logs into metrics and anomaly events.
+// LogMetricsExtractor transforms observed logs into metrics.
 // Implementations should be stateless and fast since they run synchronously
 // on every observed log.
-type LogDetector interface {
-	// Name returns the detector name for debugging and logging.
+type LogMetricsExtractor interface {
+	// Name returns the extractor name for debugging and logging.
 	Name() string
-	// Process examines a log and returns any detected signals.
-	Process(log LogView) LogDetectionResult
+	// ProcessLog examines a log and returns any derived metrics.
+	ProcessLog(log LogView) []MetricOutput
 }
 
-// LogDetectionResult contains outputs from processing a log.
-type LogDetectionResult struct {
-	// Metrics are timeseries values derived from the log.
-	Metrics []MetricOutput
-	// Anomalies are directly detected anomalies (bypassing the metrics→MetricsDetector path).
-	Anomalies []Anomaly
-	// Used to debug anomaly detectors
-	Telemetry []ObserverTelemetry
+// LogObserver is an optional interface that Detectors can implement to
+// receive log observations. This allows detectors to incorporate log signals
+// without going through the metrics extraction path.
+type LogObserver interface {
+	ProcessLog(log LogView)
 }
 
 // MetricOutput is a timeseries value derived from log analysis.
@@ -267,10 +264,10 @@ type SeriesID string
 type AnomalyType string
 
 const (
-	// AnomalyTypeMetric is a metric-based anomaly detected by a MetricsDetector.
+	// AnomalyTypeMetric is a metric-based anomaly detected by a detector.
 	AnomalyTypeMetric AnomalyType = "metric"
-	// AnomalyTypeLog is a log-based anomaly emitted directly by a log detector,
-	// bypassing the metrics→MetricsDetector pipeline.
+	// AnomalyTypeLog is a log-based anomaly emitted directly by a log observer,
+	// bypassing the metrics extraction pipeline.
 	AnomalyTypeLog AnomalyType = "log"
 )
 
@@ -287,7 +284,7 @@ type Anomaly struct {
 	// SourceSeriesID uniquely identifies the source series (namespace + name + tags).
 	// Empty for log anomalies.
 	SourceSeriesID SeriesID
-	// DetectorName identifies which MetricsDetector or LogDetector produced this anomaly.
+	// DetectorName identifies which detector produced this anomaly.
 	DetectorName string
 	Title        string
 	Description  string
@@ -327,7 +324,7 @@ type ReportOutput struct {
 }
 
 // Series is a time series with simple timestamp/value points.
-// This is the simplified view passed to MetricsDetector.
+// This is the simplified view passed to SeriesDetector.
 type Series struct {
 	Namespace string
 	Name      string
@@ -349,20 +346,20 @@ type ObserverTelemetry struct {
 	Log          LogView
 }
 
-// MetricsDetector analyzes a time series for anomalies.
-// Implementations should be stateless and just do math on the points.
-type MetricsDetector interface {
-	// Name returns the analysis name for debugging.
-	Name() string
-	// Detect examines a series and returns any detected anomalies.
-	Detect(series Series) MetricsDetectionResult
-}
-
-// MetricsDetectionResult contains outputs from metrics detection.
-type MetricsDetectionResult struct {
+// DetectionResult contains outputs from anomaly detection.
+type DetectionResult struct {
 	Anomalies []Anomaly
 	// Used to debug anomaly detectors
 	Telemetry []ObserverTelemetry
+}
+
+// SeriesDetector analyzes a time series for anomalies.
+// Implementations should be stateless and just do math on the points.
+type SeriesDetector interface {
+	// Name returns the analysis name for debugging.
+	Name() string
+	// Detect examines a series and returns any detected anomalies.
+	Detect(series Series) DetectionResult
 }
 
 // Correlator accumulates anomaly events and produces reports.
@@ -407,7 +404,7 @@ type ActiveCorrelation struct {
 // RawAnomalyState provides read access to raw anomalies before correlation processing.
 // Used by test bench reporters to display individual detector outputs.
 type RawAnomalyState interface {
-	// RawAnomalies returns all anomalies detected by MetricsDetector implementations.
+	// RawAnomalies returns all anomalies detected by detector implementations.
 	RawAnomalies() []Anomaly
 }
 
@@ -451,20 +448,13 @@ type StorageReader interface {
 	PointCount(key SeriesKey) int
 }
 
-// MultiSeriesDetectionResult contains outputs from multi-series detection.
-type MultiSeriesDetectionResult struct {
-	Anomalies []Anomaly
-	// Used to debug anomaly detectors
-	Telemetry []ObserverTelemetry
-}
-
-// MultiSeriesDetector is the flexible detection interface where detectors pull data from storage.
+// Detector is the flexible detection interface where detectors pull data from storage.
 // This supports multivariate detection across multiple series.
-type MultiSeriesDetector interface {
+type Detector interface {
 	Name() string
 
 	// Detect is called periodically by the scheduler.
 	// The detector queries storage for whatever data it needs.
 	// dataTime is the current data timestamp (for determinism - only read data <= dataTime).
-	Detect(storage StorageReader, dataTime int64) MultiSeriesDetectionResult
+	Detect(storage StorageReader, dataTime int64) DetectionResult
 }

--- a/comp/observer/def/component.go
+++ b/comp/observer/def/component.go
@@ -53,7 +53,8 @@ type MetricView interface {
 	GetName() string
 	GetValue() float64
 	GetRawTags() []string
-	GetTimestamp() float64
+	// GetTimestampUnix returns the sample timestamp in Unix seconds.
+	GetTimestampUnix() int64
 	GetSampleRate() float64
 }
 
@@ -66,7 +67,8 @@ type LogView interface {
 	GetStatus() string
 	GetTags() []string
 	GetHostname() string
-	GetTimestampMs() int64
+	// GetTimestampUnixMilli returns the log timestamp in Unix milliseconds.
+	GetTimestampUnixMilli() int64
 }
 
 // TraceView provides read-only access to a trace (collection of spans with the same trace ID).
@@ -87,10 +89,10 @@ type TraceView interface {
 	GetHostname() string
 	// GetContainerID returns the container ID where the trace originated.
 	GetContainerID() string
-	// GetTimestamp returns the trace start time in nanoseconds since epoch.
-	GetTimestamp() int64
-	// GetDuration returns the trace duration in nanoseconds.
-	GetDuration() int64
+	// GetTimestampUnixNano returns the trace start time in Unix nanoseconds.
+	GetTimestampUnixNano() int64
+	// GetDurationNano returns the trace duration in nanoseconds.
+	GetDurationNano() int64
 	// GetPriority returns the sampling priority.
 	GetPriority() int32
 	// IsError returns true if this trace contains an error.
@@ -125,10 +127,10 @@ type SpanView interface {
 	GetResource() string
 	// GetType returns the span type (e.g., "web", "db", "cache").
 	GetType() string
-	// GetStart returns the span start time in nanoseconds since epoch.
-	GetStart() int64
-	// GetDuration returns the span duration in nanoseconds.
-	GetDuration() int64
+	// GetStartUnixNano returns the span start time in Unix nanoseconds.
+	GetStartUnixNano() int64
+	// GetDurationNano returns the span duration in nanoseconds.
+	GetDurationNano() int64
 	// GetError returns the error code (0 = no error, 1 = error).
 	GetError() int32
 	// GetMeta returns string tags/metadata for this span.
@@ -171,8 +173,8 @@ type TraceStatRow interface {
 	GetClientVersion() string
 	GetClientContainerID() string
 	// Time bucket window (from ClientStatsBucket)
-	GetBucketStart() uint64    // nanoseconds since epoch
-	GetBucketDuration() uint64 // nanoseconds
+	GetBucketStartUnixNano() uint64 // Unix nanoseconds
+	GetBucketDurationNano() uint64  // nanoseconds
 	// Aggregation dimensions (from ClientGroupedStats)
 	GetService() string
 	GetName() string // operation name
@@ -186,7 +188,7 @@ type TraceStatRow interface {
 	GetHits() uint64
 	GetErrors() uint64
 	GetTopLevelHits() uint64
-	GetDuration() uint64     // total duration in nanoseconds
+	GetDurationNano() uint64 // total duration in nanoseconds
 	GetOkSummary() []byte    // DDSketch encoded latency distribution for ok spans
 	GetErrorSummary() []byte // DDSketch encoded latency distribution for error spans
 	GetPeerTags() []string
@@ -213,10 +215,10 @@ type ProfileView interface {
 	GetHostname() string
 	// GetContainerID returns the container ID where the profile was collected.
 	GetContainerID() string
-	// GetTimestamp returns the profile timestamp in nanoseconds since epoch.
-	GetTimestamp() int64
-	// GetDuration returns the profile duration in nanoseconds.
-	GetDuration() int64
+	// GetTimestampUnixNano returns the profile timestamp in Unix nanoseconds.
+	GetTimestampUnixNano() int64
+	// GetDurationNano returns the profile duration in nanoseconds.
+	GetDurationNano() int64
 	// GetTags returns profile tags.
 	GetTags() map[string]string
 	// GetContentType returns the original Content-Type header (profile format is language-specific).

--- a/comp/observer/impl/fetcher.go
+++ b/comp/observer/impl/fetcher.go
@@ -257,12 +257,12 @@ func (v *tracerPayloadView) Reset() {
 	v.spanIdx = -1
 }
 
-func (v *tracerPayloadView) GetEnv() string         { return v.payload.Env }
-func (v *tracerPayloadView) GetService() string     { return "" } // Service is per-span
-func (v *tracerPayloadView) GetHostname() string    { return v.payload.Hostname }
-func (v *tracerPayloadView) GetContainerID() string { return v.payload.ContainerID }
-func (v *tracerPayloadView) GetTimestamp() int64    { return v.receivedAt }
-func (v *tracerPayloadView) GetDuration() int64     { return 0 } // Would need to calculate
+func (v *tracerPayloadView) GetEnv() string              { return v.payload.Env }
+func (v *tracerPayloadView) GetService() string          { return "" } // Service is per-span
+func (v *tracerPayloadView) GetHostname() string         { return v.payload.Hostname }
+func (v *tracerPayloadView) GetContainerID() string      { return v.payload.ContainerID }
+func (v *tracerPayloadView) GetTimestampUnixNano() int64 { return v.receivedAt }
+func (v *tracerPayloadView) GetDurationNano() int64      { return 0 } // TODO(agent-q-anomaly-detection): Would need to calculate
 func (v *tracerPayloadView) GetPriority() int32 {
 	if len(v.payload.Chunks) > 0 {
 		return v.payload.Chunks[0].Priority
@@ -292,8 +292,8 @@ func (v *spanView) GetService() string             { return v.span.Service }
 func (v *spanView) GetName() string                { return v.span.Name }
 func (v *spanView) GetResource() string            { return v.span.Resource }
 func (v *spanView) GetType() string                { return v.span.Type }
-func (v *spanView) GetStart() int64                { return v.span.Start }
-func (v *spanView) GetDuration() int64             { return v.span.Duration }
+func (v *spanView) GetStartUnixNano() int64        { return v.span.Start }
+func (v *spanView) GetDurationNano() int64         { return v.span.Duration }
 func (v *spanView) GetError() int32                { return v.span.Error }
 func (v *spanView) GetMeta() map[string]string     { return v.span.Meta }
 func (v *spanView) GetMetrics() map[string]float64 { return v.span.Metrics }
@@ -303,16 +303,16 @@ type profileDataView struct {
 	data *pbcore.ProfileData
 }
 
-func (v *profileDataView) GetProfileID() string       { return v.data.ProfileId }
-func (v *profileDataView) GetProfileType() string     { return v.data.ProfileType }
-func (v *profileDataView) GetService() string         { return v.data.Service }
-func (v *profileDataView) GetEnv() string             { return v.data.Env }
-func (v *profileDataView) GetVersion() string         { return v.data.Version }
-func (v *profileDataView) GetHostname() string        { return v.data.Hostname }
-func (v *profileDataView) GetContainerID() string     { return v.data.ContainerId }
-func (v *profileDataView) GetTimestamp() int64        { return v.data.TimestampNs }
-func (v *profileDataView) GetDuration() int64         { return v.data.DurationNs }
-func (v *profileDataView) GetTags() map[string]string { return v.data.Tags }
-func (v *profileDataView) GetContentType() string     { return v.data.ContentType }
-func (v *profileDataView) GetRawData() []byte         { return v.data.InlineData }
-func (v *profileDataView) GetExternalPath() string    { return "" }
+func (v *profileDataView) GetProfileID() string        { return v.data.ProfileId }
+func (v *profileDataView) GetProfileType() string      { return v.data.ProfileType }
+func (v *profileDataView) GetService() string          { return v.data.Service }
+func (v *profileDataView) GetEnv() string              { return v.data.Env }
+func (v *profileDataView) GetVersion() string          { return v.data.Version }
+func (v *profileDataView) GetHostname() string         { return v.data.Hostname }
+func (v *profileDataView) GetContainerID() string      { return v.data.ContainerId }
+func (v *profileDataView) GetTimestampUnixNano() int64 { return v.data.TimestampNs }
+func (v *profileDataView) GetDurationNano() int64      { return v.data.DurationNs }
+func (v *profileDataView) GetTags() map[string]string  { return v.data.Tags }
+func (v *profileDataView) GetContentType() string      { return v.data.ContentType }
+func (v *profileDataView) GetRawData() []byte          { return v.data.InlineData }
+func (v *profileDataView) GetExternalPath() string     { return "" }

--- a/comp/observer/impl/log_detector_connection_errors.go
+++ b/comp/observer/impl/log_detector_connection_errors.go
@@ -30,22 +30,20 @@ func (c *ConnectionErrorExtractor) Name() string {
 	return "connection_error_extractor"
 }
 
-// Process checks if a log contains connection error patterns and returns a metric if so.
+// ProcessLog checks if a log contains connection error patterns and returns a metric if so.
 // Anomaly detection is handled by metrics detection on the count aggregation of the emitted metric.
-func (c *ConnectionErrorExtractor) Process(log observer.LogView) observer.LogDetectionResult {
+func (c *ConnectionErrorExtractor) ProcessLog(log observer.LogView) []observer.MetricOutput {
 	content := strings.ToLower(string(log.GetContent()))
 
 	for _, pattern := range connectionErrorPatterns {
 		if strings.Contains(content, pattern) {
-			return observer.LogDetectionResult{
-				Metrics: []observer.MetricOutput{{
-					Name:  "connection.errors",
-					Value: 1.0,
-					Tags:  log.GetTags(),
-				}},
-			}
+			return []observer.MetricOutput{{
+				Name:  "connection.errors",
+				Value: 1.0,
+				Tags:  log.GetTags(),
+			}}
 		}
 	}
 
-	return observer.LogDetectionResult{}
+	return nil
 }

--- a/comp/observer/impl/log_detector_connection_errors_test.go
+++ b/comp/observer/impl/log_detector_connection_errors_test.go
@@ -23,12 +23,12 @@ func TestConnectionErrorExtractor_Process_ConnectionRefused(t *testing.T) {
 		tags:    []string{"env:prod", "service:api"},
 	}
 
-	result := e.Process(log)
+	result := e.ProcessLog(log)
 
-	assert.Len(t, result.Metrics, 1)
-	assert.Equal(t, "connection.errors", result.Metrics[0].Name)
-	assert.Equal(t, 1.0, result.Metrics[0].Value)
-	assert.Equal(t, []string{"env:prod", "service:api"}, result.Metrics[0].Tags)
+	assert.Len(t, result, 1)
+	assert.Equal(t, "connection.errors", result[0].Name)
+	assert.Equal(t, 1.0, result[0].Value)
+	assert.Equal(t, []string{"env:prod", "service:api"}, result[0].Tags)
 }
 
 func TestConnectionErrorExtractor_Process_ECONNRESET(t *testing.T) {
@@ -38,12 +38,12 @@ func TestConnectionErrorExtractor_Process_ECONNRESET(t *testing.T) {
 		tags:    []string{"env:staging"},
 	}
 
-	result := e.Process(log)
+	result := e.ProcessLog(log)
 
-	assert.Len(t, result.Metrics, 1)
-	assert.Equal(t, "connection.errors", result.Metrics[0].Name)
-	assert.Equal(t, 1.0, result.Metrics[0].Value)
-	assert.Equal(t, []string{"env:staging"}, result.Metrics[0].Tags)
+	assert.Len(t, result, 1)
+	assert.Equal(t, "connection.errors", result[0].Name)
+	assert.Equal(t, 1.0, result[0].Value)
+	assert.Equal(t, []string{"env:staging"}, result[0].Tags)
 }
 
 func TestConnectionErrorExtractor_Process_NoMatch(t *testing.T) {
@@ -53,9 +53,9 @@ func TestConnectionErrorExtractor_Process_NoMatch(t *testing.T) {
 		tags:    []string{"env:test"},
 	}
 
-	result := e.Process(log)
+	result := e.ProcessLog(log)
 
-	assert.Empty(t, result.Metrics)
+	assert.Empty(t, result)
 }
 
 func TestConnectionErrorExtractor_Process_CaseInsensitive(t *testing.T) {
@@ -65,12 +65,12 @@ func TestConnectionErrorExtractor_Process_CaseInsensitive(t *testing.T) {
 		tags:    []string{"env:prod"},
 	}
 
-	result := e.Process(log)
+	result := e.ProcessLog(log)
 
-	assert.Len(t, result.Metrics, 1)
-	assert.Equal(t, "connection.errors", result.Metrics[0].Name)
-	assert.Equal(t, 1.0, result.Metrics[0].Value)
-	assert.Equal(t, []string{"env:prod"}, result.Metrics[0].Tags)
+	assert.Len(t, result, 1)
+	assert.Equal(t, "connection.errors", result[0].Name)
+	assert.Equal(t, 1.0, result[0].Value)
+	assert.Equal(t, []string{"env:prod"}, result[0].Tags)
 }
 
 func TestConnectionErrorExtractor_Process_TagsCopied(t *testing.T) {
@@ -81,10 +81,10 @@ func TestConnectionErrorExtractor_Process_TagsCopied(t *testing.T) {
 		tags:    inputTags,
 	}
 
-	result := e.Process(log)
+	result := e.ProcessLog(log)
 
-	assert.Len(t, result.Metrics, 1)
-	assert.Equal(t, inputTags, result.Metrics[0].Tags)
+	assert.Len(t, result, 1)
+	assert.Equal(t, inputTags, result[0].Tags)
 }
 
 func TestConnectionErrorExtractor_Process_AllPatterns(t *testing.T) {
@@ -109,11 +109,11 @@ func TestConnectionErrorExtractor_Process_AllPatterns(t *testing.T) {
 				tags:    []string{"test:pattern"},
 			}
 
-			result := e.Process(log)
+			result := e.ProcessLog(log)
 
-			assert.Len(t, result.Metrics, 1, "Expected metric for pattern: %s", tc.name)
-			assert.Equal(t, "connection.errors", result.Metrics[0].Name)
-			assert.Equal(t, 1.0, result.Metrics[0].Value)
+			assert.Len(t, result, 1, "Expected metric for pattern: %s", tc.name)
+			assert.Equal(t, "connection.errors", result[0].Name)
+			assert.Equal(t, 1.0, result[0].Value)
 		})
 	}
 }

--- a/comp/observer/impl/log_metrics_extractor.go
+++ b/comp/observer/impl/log_metrics_extractor.go
@@ -33,14 +33,14 @@ type LogMetricsExtractor struct {
 
 func (a *LogMetricsExtractor) Name() string { return "log_metrics_extractor" }
 
-func (a *LogMetricsExtractor) Process(log observer.LogView) observer.LogDetectionResult {
+func (a *LogMetricsExtractor) ProcessLog(log observer.LogView) []observer.MetricOutput {
 	content := log.GetContent()
 	tags := log.GetTags()
 
 	// Always emit pattern frequency metric for all logs
 	patternSig := logSignature(content, a.MaxEvalBytes)
 	if patternSig == "" {
-		return observer.LogDetectionResult{}
+		return nil
 	}
 
 	metrics := []observer.MetricOutput{{
@@ -54,7 +54,7 @@ func (a *LogMetricsExtractor) Process(log observer.LogView) observer.LogDetectio
 		metrics = append(metrics, a.extractJSONFieldMetrics(content, tags)...)
 	}
 
-	return observer.LogDetectionResult{Metrics: metrics}
+	return metrics
 }
 
 func isJSONObject(b []byte) bool {

--- a/comp/observer/impl/log_metrics_extractor_test.go
+++ b/comp/observer/impl/log_metrics_extractor_test.go
@@ -28,12 +28,12 @@ func TestLogMetricsExtractor_JSONNumericExtraction(t *testing.T) {
 		tags:    []string{"service:api"},
 	}
 
-	res := a.Process(log)
-	assert.Len(t, res.Metrics, 3) // 2 numeric fields + pattern count
+	res := a.ProcessLog(log)
+	assert.Len(t, res, 3) // 2 numeric fields + pattern count
 
 	// Order is map iteration dependent; just assert set membership.
 	got := map[string]observer.MetricOutput{}
-	for _, m := range res.Metrics {
+	for _, m := range res {
 		got[m.Name] = m
 	}
 
@@ -65,16 +65,16 @@ func TestLogMetricsExtractor_UnstructuredPatternCount(t *testing.T) {
 		tags:    []string{"service:web"},
 	}
 
-	res := a.Process(log)
-	assert.Len(t, res.Metrics, 1)
-	assert.Equal(t, float64(1), res.Metrics[0].Value)
-	assert.Equal(t, []string{"service:web"}, res.Metrics[0].Tags)
+	res := a.ProcessLog(log)
+	assert.Len(t, res, 1)
+	assert.Equal(t, float64(1), res[0].Value)
+	assert.Equal(t, []string{"service:web"}, res[0].Tags)
 
 	// Compute expected metric name (hash of signature).
 	sig := logSignature([]byte("Request completed in 45ms"), 0)
 	h := fnv.New64a()
 	_, _ = h.Write([]byte(sig))
-	assert.Equal(t, fmt.Sprintf("log.pattern.%x.count", h.Sum64()), res.Metrics[0].Name)
+	assert.Equal(t, fmt.Sprintf("log.pattern.%x.count", h.Sum64()), res[0].Name)
 }
 
 func TestLogMetricsExtractor_JSONIncludeFields(t *testing.T) {
@@ -89,11 +89,11 @@ func TestLogMetricsExtractor_JSONIncludeFields(t *testing.T) {
 		tags:    []string{"service:api"},
 	}
 
-	res := a.Process(log)
-	require.Len(t, res.Metrics, 2) // selected numeric field + pattern count
+	res := a.ProcessLog(log)
+	require.Len(t, res, 2) // selected numeric field + pattern count
 
 	got := map[string]observer.MetricOutput{}
-	for _, m := range res.Metrics {
+	for _, m := range res {
 		got[m.Name] = m
 	}
 
@@ -117,11 +117,11 @@ func TestLogMetricsExtractor_InvalidJSONFallsBackToUnstructured(t *testing.T) {
 	input := []byte(`{"duration_ms":45,`)
 	log := &mockLogView{content: input, tags: []string{"service:api"}}
 
-	res := a.Process(log)
-	require.Len(t, res.Metrics, 1)
+	res := a.ProcessLog(log)
+	require.Len(t, res, 1)
 
 	sig := logSignature(input, 0)
 	h := fnv.New64a()
 	_, _ = h.Write([]byte(sig))
-	assert.Equal(t, fmt.Sprintf("log.pattern.%x.count", h.Sum64()), res.Metrics[0].Name)
+	assert.Equal(t, fmt.Sprintf("log.pattern.%x.count", h.Sum64()), res[0].Name)
 }

--- a/comp/observer/impl/metrics_detector_bocpd.go
+++ b/comp/observer/impl/metrics_detector_bocpd.go
@@ -71,7 +71,7 @@ func (b *BOCPDDetector) Name() string {
 }
 
 // Analyze runs BOCPD and emits the first changepoint crossing CPThreshold.
-func (b *BOCPDDetector) Detect(series observer.Series) observer.MetricsDetectionResult {
+func (b *BOCPDDetector) Detect(series observer.Series) observer.DetectionResult {
 	minPoints := b.MinPoints
 	if minPoints <= 0 {
 		minPoints = 10
@@ -107,7 +107,7 @@ func (b *BOCPDDetector) Detect(series observer.Series) observer.MetricsDetection
 
 	n := len(series.Points)
 	if n < minPoints {
-		return observer.MetricsDetectionResult{}
+		return observer.DetectionResult{}
 	}
 
 	baselineEnd := int(float64(n) * baselineFrac)
@@ -126,7 +126,7 @@ func (b *BOCPDDetector) Detect(series observer.Series) observer.MetricsDetection
 		if math.Abs(baselineMean) > epsilon {
 			baselineStddev = math.Abs(baselineMean) * 0.1
 		} else {
-			return observer.MetricsDetectionResult{}
+			return observer.DetectionResult{}
 		}
 	}
 
@@ -182,7 +182,7 @@ func (b *BOCPDDetector) Detect(series observer.Series) observer.MetricsDetection
 					DeviationSigma: deviation,
 				},
 			}
-			return observer.MetricsDetectionResult{Anomalies: []observer.Anomaly{anomaly}}
+			return observer.DetectionResult{Anomalies: []observer.Anomaly{anomaly}}
 		}
 
 		newMeans := make([]float64, len(newRunProbs))
@@ -207,7 +207,7 @@ func (b *BOCPDDetector) Detect(series observer.Series) observer.MetricsDetection
 		precisions = newPrecisions
 	}
 
-	return observer.MetricsDetectionResult{}
+	return observer.DetectionResult{}
 }
 
 func shortRunLengthMass(runProbs []float64, shortRunLength int) float64 {

--- a/comp/observer/impl/metrics_detector_cusum.go
+++ b/comp/observer/impl/metrics_detector_cusum.go
@@ -60,7 +60,7 @@ func (c *CUSUMDetector) Name() string {
 
 // Analyze runs CUSUM on the series and returns an anomaly if a shift is detected.
 // The anomaly's Timestamp indicates when the shift was first detected (threshold crossing).
-func (c *CUSUMDetector) Detect(series observer.Series) observer.MetricsDetectionResult {
+func (c *CUSUMDetector) Detect(series observer.Series) observer.DetectionResult {
 	minPoints := c.MinPoints
 	if minPoints <= 0 {
 		minPoints = 5
@@ -80,7 +80,7 @@ func (c *CUSUMDetector) Detect(series observer.Series) observer.MetricsDetection
 
 	n := len(series.Points)
 	if n < minPoints {
-		return observer.MetricsDetectionResult{}
+		return observer.DetectionResult{}
 	}
 
 	// Estimate baseline from first portion of data
@@ -105,7 +105,7 @@ func (c *CUSUMDetector) Detect(series observer.Series) observer.MetricsDetection
 			baselineStddev = baselineMean * 0.1
 		} else {
 			// Can't establish meaningful baseline
-			return observer.MetricsDetectionResult{}
+			return observer.DetectionResult{}
 		}
 	}
 
@@ -126,10 +126,10 @@ func (c *CUSUMDetector) Detect(series observer.Series) observer.MetricsDetection
 	// Run CUSUM and detect threshold crossing
 	anomaly := runCUSUM(series, baselineMean, baselineStddev, k, h, debugInfo)
 	if anomaly == nil {
-		return observer.MetricsDetectionResult{}
+		return observer.DetectionResult{}
 	}
 
-	return observer.MetricsDetectionResult{Anomalies: []observer.Anomaly{*anomaly}}
+	return observer.DetectionResult{Anomalies: []observer.Anomaly{*anomaly}}
 }
 
 // runCUSUM executes a two-sided CUSUM algorithm and returns an anomaly at the first threshold crossing.

--- a/comp/observer/impl/metrics_detector_rrcf.go
+++ b/comp/observer/impl/metrics_detector_rrcf.go
@@ -179,24 +179,24 @@ func (r *RRCFDetector) Name() string {
 	return "rrcf"
 }
 
-// Detect implements MultiSeriesDetector. It queries storage for system metrics,
+// Detect implements Detector. It queries storage for system metrics,
 // builds multivariate shingles, and detects anomalies using RRCF.
-func (r *RRCFDetector) Detect(storage observer.StorageReader, dataTime int64) observer.MultiSeriesDetectionResult {
+func (r *RRCFDetector) Detect(storage observer.StorageReader, dataTime int64) observer.DetectionResult {
 	// Step 0: Resolve all metric keys to the same tag set (on first call)
 	if !r.resolveAllKeys(storage) {
-		return observer.MultiSeriesDetectionResult{}
+		return observer.DetectionResult{}
 	}
 
 	// Step 1: Read new points for each metric since last cursor
 	newPointsByMetric := r.readNewPoints(storage, dataTime)
 	if len(newPointsByMetric) == 0 {
-		return observer.MultiSeriesDetectionResult{}
+		return observer.DetectionResult{}
 	}
 
 	// Step 2: Align points by timestamp and build multivariate vectors
 	alignedPoints := r.alignByTimestamp(newPointsByMetric)
 	if len(alignedPoints) == 0 {
-		return observer.MultiSeriesDetectionResult{}
+		return observer.DetectionResult{}
 	}
 
 	r.alignedCount += len(alignedPoints)
@@ -204,7 +204,7 @@ func (r *RRCFDetector) Detect(storage observer.StorageReader, dataTime int64) ob
 	// Step 3: Build shingles from aligned points
 	shingles := r.buildShingles(alignedPoints)
 	if len(shingles) == 0 {
-		return observer.MultiSeriesDetectionResult{}
+		return observer.DetectionResult{}
 	}
 
 	r.shingleCount += len(shingles)
@@ -434,7 +434,7 @@ func (r *RRCFDetector) buildShingles(aligned []timestampedVector) []shingle {
 // scoreAndDetect scores shingles using RRCF and returns anomalies and telemetry.
 // Uses rolling z-score thresholding: after a warmup period (TreeSize points), a point
 // is anomalous if its score exceeds mean + ThresholdSigma*stddev of the recent window.
-func (r *RRCFDetector) scoreAndDetect(shingles []shingle, _ int64) observer.MultiSeriesDetectionResult {
+func (r *RRCFDetector) scoreAndDetect(shingles []shingle, _ int64) observer.DetectionResult {
 	var anomalies []observer.Anomaly
 	var telemetry []observer.ObserverTelemetry
 	warmup := r.config.TreeSize
@@ -503,7 +503,7 @@ func (r *RRCFDetector) scoreAndDetect(shingles []shingle, _ int64) observer.Mult
 		}
 	}
 
-	return observer.MultiSeriesDetectionResult{
+	return observer.DetectionResult{
 		Anomalies: anomalies,
 		Telemetry: telemetry,
 	}

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -82,9 +82,7 @@ func (m *metricObs) GetRawTags() []string {
 	return m.tags
 }
 
-func (m *metricObs) GetTimestamp() float64 {
-	return float64(m.timestamp)
-}
+func (m *metricObs) GetTimestampUnix() int64 { return m.timestamp }
 
 // Observer does not store samplerate; just return 1.0
 func (m *metricObs) GetSampleRate() float64 {
@@ -169,7 +167,7 @@ func (l *logObs) GetHostname() string {
 }
 
 // Optionally, for logs that provide timestamp interface (if needed elsewhere)
-func (l *logObs) GetTimestampMs() int64 {
+func (l *logObs) GetTimestampUnixMilli() int64 {
 	return l.timestampMs
 }
 
@@ -353,13 +351,13 @@ func samplePass(rate float64, n uint64) bool {
 
 // observerImpl is the implementation of the observer component.
 type observerImpl struct {
-	extractors []observerdef.LogMetricsExtractor
-	detectors  []observerdef.Detector
-	correlators    []observerdef.Correlator
-	reporters      []observerdef.Reporter
-	storage        *timeSeriesStorage
-	obsCh          chan observation
-	handleFunc observerdef.HandleFunc // Handle factory (may wrap with recorder middleware)
+	extractors  []observerdef.LogMetricsExtractor
+	detectors   []observerdef.Detector
+	correlators []observerdef.Correlator
+	reporters   []observerdef.Reporter
+	storage     *timeSeriesStorage
+	obsCh       chan observation
+	handleFunc  observerdef.HandleFunc // Handle factory (may wrap with recorder middleware)
 
 	// Raw anomaly tracking for test bench display
 	rawAnomalies     []observerdef.Anomaly
@@ -372,7 +370,7 @@ type observerImpl struct {
 	fetcher              *observerFetcher
 	totalAnomalyCount    int                             // total count of all anomalies ever detected (no cap)
 	uniqueAnomalySources map[observerdef.MetricName]bool // unique sources that had anomalies
-	lastAnalyzedDataTime int64 // data timestamp up to which we've analyzed
+	lastAnalyzedDataTime int64                           // data timestamp up to which we've analyzed
 }
 
 // run is the main dispatch loop, processing all observations sequentially.
@@ -697,7 +695,7 @@ type handle struct {
 
 // ObserveMetric observes a DogStatsD metric sample.
 func (h *handle) ObserveMetric(sample observerdef.MetricView) {
-	timestamp := int64(sample.GetTimestamp())
+	timestamp := sample.GetTimestampUnix()
 	if timestamp == 0 {
 		timestamp = time.Now().Unix()
 	}
@@ -724,7 +722,7 @@ func (h *handle) ObserveMetric(sample observerdef.MetricView) {
 // ObserveLog observes a log message.
 func (h *handle) ObserveLog(msg observerdef.LogView) {
 	// Use provided timestampMs if available, otherwise use current time
-	timestampMs := msg.GetTimestampMs()
+	timestampMs := msg.GetTimestampUnixMilli()
 
 	obs := observation{
 		source: h.source,
@@ -760,8 +758,8 @@ func (h *handle) ObserveTrace(trace observerdef.TraceView) {
 			name:     sv.GetName(),
 			resource: sv.GetResource(),
 			spanType: sv.GetType(),
-			start:    sv.GetStart(),
-			duration: sv.GetDuration(),
+			start:    sv.GetStartUnixNano(),
+			duration: sv.GetDurationNano(),
 			error:    sv.GetError(),
 			meta:     copyStringMap(sv.GetMeta()),
 			metrics:  copyFloat64Map(sv.GetMetrics()),
@@ -778,8 +776,8 @@ func (h *handle) ObserveTrace(trace observerdef.TraceView) {
 			service:      trace.GetService(),
 			hostname:     trace.GetHostname(),
 			containerID:  trace.GetContainerID(),
-			timestamp:    trace.GetTimestamp(),
-			duration:     trace.GetDuration(),
+			timestamp:    trace.GetTimestampUnixNano(),
+			duration:     trace.GetDurationNano(),
 			priority:     trace.GetPriority(),
 			isError:      trace.IsError(),
 			tags:         copyStringMap(trace.GetTags()),
@@ -814,8 +812,8 @@ func (h *handle) ObserveProfile(profile observerdef.ProfileView) {
 			version:      profile.GetVersion(),
 			hostname:     profile.GetHostname(),
 			containerID:  profile.GetContainerID(),
-			timestamp:    profile.GetTimestamp(),
-			duration:     profile.GetDuration(),
+			timestamp:    profile.GetTimestampUnixNano(),
+			duration:     profile.GetDurationNano(),
 			tags:         copyStringMap(profile.GetTags()),
 			contentType:  profile.GetContentType(),
 			rawData:      copyBytes(profile.GetRawData()),
@@ -835,11 +833,11 @@ type logView struct {
 	obs *logObs
 }
 
-func (v *logView) GetContent() []byte    { return v.obs.content }
-func (v *logView) GetStatus() string     { return v.obs.status }
-func (v *logView) GetTags() []string     { return v.obs.tags }
-func (v *logView) GetHostname() string   { return v.obs.hostname }
-func (v *logView) GetTimestampMs() int64 { return v.obs.timestampMs }
+func (v *logView) GetContent() []byte           { return v.obs.content }
+func (v *logView) GetStatus() string            { return v.obs.status }
+func (v *logView) GetTags() []string            { return v.obs.tags }
+func (v *logView) GetHostname() string          { return v.obs.hostname }
+func (v *logView) GetTimestampUnixMilli() int64 { return v.obs.timestampMs }
 
 // agentLogView is a minimal LogView implementation for agent-internal logs.
 // It is immediately copied by the observer handle, so it must not be retained.
@@ -851,11 +849,11 @@ type agentLogView struct {
 	timestampMs int64
 }
 
-func (v *agentLogView) GetContent() []byte    { return v.content }
-func (v *agentLogView) GetStatus() string     { return v.status }
-func (v *agentLogView) GetTags() []string     { return v.tags }
-func (v *agentLogView) GetHostname() string   { return v.hostname }
-func (v *agentLogView) GetTimestampMs() int64 { return v.timestampMs }
+func (v *agentLogView) GetContent() []byte           { return v.content }
+func (v *agentLogView) GetStatus() string            { return v.status }
+func (v *agentLogView) GetTags() []string            { return v.tags }
+func (v *agentLogView) GetHostname() string          { return v.hostname }
+func (v *agentLogView) GetTimestampUnixMilli() int64 { return v.timestampMs }
 
 // copyBytes creates a copy of a byte slice.
 func copyBytes(b []byte) []byte {

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -201,6 +201,7 @@ func NewComponent(deps Requires) Provides {
 		},
 		detectors: []observerdef.Detector{
 			newSeriesDetectorAdapter(NewCUSUMDetector(), defaultAggregations),
+			newSeriesDetectorAdapter(NewBOCPDDetector(), defaultAggregations),
 			NewRRCFDetector(DefaultRRCFConfig()),
 		},
 		correlators: []observerdef.Correlator{

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -182,7 +182,7 @@ func NewComponent(deps Requires) Provides {
 	reporter.SetCorrelationState(correlator)
 
 	obs := &observerImpl{
-		logDetectors: []observerdef.LogDetector{
+		extractors: []observerdef.LogMetricsExtractor{
 			&LogMetricsExtractor{
 				MaxEvalBytes: 4096,
 				// Exclude metadata fields that shouldn't be metrics.
@@ -199,11 +199,8 @@ func NewComponent(deps Requires) Provides {
 			},
 			&ConnectionErrorExtractor{},
 		},
-		multiDetectors: []observerdef.MultiSeriesDetector{
-			newMetricsDetectorAdapter(NewCUSUMDetector(), []observerdef.Aggregate{
-				observerdef.AggregateAverage,
-				observerdef.AggregateCount,
-			}),
+		detectors: []observerdef.Detector{
+			newSeriesDetectorAdapter(NewCUSUMDetector(), defaultAggregations),
 			NewRRCFDetector(DefaultRRCFConfig()),
 		},
 		correlators: []observerdef.Correlator{
@@ -355,8 +352,8 @@ func samplePass(rate float64, n uint64) bool {
 
 // observerImpl is the implementation of the observer component.
 type observerImpl struct {
-	logDetectors   []observerdef.LogDetector
-	multiDetectors []observerdef.MultiSeriesDetector
+	extractors []observerdef.LogMetricsExtractor
+	detectors  []observerdef.Detector
 	correlators    []observerdef.Correlator
 	reporters      []observerdef.Reporter
 	storage        *timeSeriesStorage
@@ -404,16 +401,17 @@ func (o *observerImpl) processMetric(source string, m *metricObs) {
 // processLog handles a log observation.
 func (o *observerImpl) processLog(source string, l *logObs) {
 	view := &logView{obs: l}
-	for _, detector := range o.logDetectors {
-		result := detector.Process(view)
-		for _, m := range result.Metrics {
+	for _, extractor := range o.extractors {
+		metrics := extractor.ProcessLog(view)
+		for _, m := range metrics {
 			// Virtual metrics coming from logs starts with _virtual.
 			o.storage.Add(source, "_virtual."+m.Name, m.Value, l.timestampMs/1000, m.Tags)
 		}
-		// Route directly emitted anomalies through the standard pipeline
-		for _, anomaly := range result.Anomalies {
-			o.captureRawAnomaly(anomaly)
-			o.processAnomaly(anomaly)
+	}
+	// Allow detectors to observe logs directly
+	for _, d := range o.detectors {
+		if lo, ok := d.(observerdef.LogObserver); ok {
+			lo.ProcessLog(view)
 		}
 	}
 	o.maybeRunDetectors(l.timestampMs / 1000)
@@ -437,7 +435,7 @@ func (o *observerImpl) maybeRunDetectors(dataTime int64) {
 // runDetectorsUpTo runs all multi-series detectors, providing them access to storage
 // and the data timestamp up to which they should analyze.
 func (o *observerImpl) runDetectorsUpTo(upTo int64) {
-	for _, detector := range o.multiDetectors {
+	for _, detector := range o.detectors {
 		result := detector.Detect(o.storage, upTo)
 		for _, anomaly := range result.Anomalies {
 			o.captureRawAnomaly(anomaly)
@@ -449,25 +447,32 @@ func (o *observerImpl) runDetectorsUpTo(upTo int64) {
 	o.flushAndReport()
 }
 
-// metricsDetectorAdapter wraps a stateless MetricsDetector to implement MultiSeriesDetector.
+// defaultAggregations is the standard set of aggregations used when adapting
+// a SeriesDetector into a Detector.
+var defaultAggregations = []observerdef.Aggregate{
+	observerdef.AggregateAverage,
+	observerdef.AggregateCount,
+}
+
+// seriesDetectorAdapter wraps a stateless SeriesDetector to implement Detector.
 // It runs the wrapped detector on all series, handling aggregation suffixes.
-type metricsDetectorAdapter struct {
-	detector     observerdef.MetricsDetector
+type seriesDetectorAdapter struct {
+	detector     observerdef.SeriesDetector
 	aggregations []observerdef.Aggregate
 }
 
-func newMetricsDetectorAdapter(detector observerdef.MetricsDetector, aggregations []observerdef.Aggregate) *metricsDetectorAdapter {
-	return &metricsDetectorAdapter{
+func newSeriesDetectorAdapter(detector observerdef.SeriesDetector, aggregations []observerdef.Aggregate) *seriesDetectorAdapter {
+	return &seriesDetectorAdapter{
 		detector:     detector,
 		aggregations: aggregations,
 	}
 }
 
-func (a *metricsDetectorAdapter) Name() string {
+func (a *seriesDetectorAdapter) Name() string {
 	return a.detector.Name()
 }
 
-func (a *metricsDetectorAdapter) Detect(storage observerdef.StorageReader, dataTime int64) observerdef.MultiSeriesDetectionResult {
+func (a *seriesDetectorAdapter) Detect(storage observerdef.StorageReader, dataTime int64) observerdef.DetectionResult {
 	var allAnomalies []observerdef.Anomaly
 	var allTelemetry []observerdef.ObserverTelemetry
 
@@ -488,6 +493,7 @@ func (a *metricsDetectorAdapter) Detect(storage observerdef.StorageReader, dataT
 
 			result := a.detector.Detect(seriesWithAgg)
 			for _, anomaly := range result.Anomalies {
+				anomaly.Type = observerdef.AnomalyTypeMetric
 				anomaly.DetectorName = a.detector.Name()
 				anomaly.Source = observerdef.MetricName(seriesWithAgg.Name)
 				anomaly.SourceSeriesID = observerdef.SeriesID(seriesKey(series.Namespace, seriesWithAgg.Name, series.Tags))
@@ -497,7 +503,7 @@ func (a *metricsDetectorAdapter) Detect(storage observerdef.StorageReader, dataT
 		}
 	}
 
-	return observerdef.MultiSeriesDetectionResult{
+	return observerdef.DetectionResult{
 		Anomalies: allAnomalies,
 		Telemetry: allTelemetry,
 	}

--- a/comp/observer/impl/reporter_html.go
+++ b/comp/observer/impl/reporter_html.go
@@ -1161,7 +1161,7 @@ func seriesIDsToStringSlice(ids []observer.SeriesID) []string {
 	return out
 }
 
-// handleAPIRawAnomalies returns all raw anomalies from MetricsDetector implementations.
+// handleAPIRawAnomalies returns all raw anomalies from detector implementations.
 func (r *HTMLReporter) handleAPIRawAnomalies(w http.ResponseWriter, req *http.Request) {
 	r.mu.RLock()
 	rawState := r.rawAnomalyState

--- a/comp/observer/impl/stats_metrics.go
+++ b/comp/observer/impl/stats_metrics.go
@@ -37,26 +37,26 @@ func processStatsView(handle observerdef.Handle, stats observerdef.TraceStatsVie
 	rows := stats.GetRows()
 	for rows.Next() {
 		row := rows.Row()
-		// Convert bucket start from nanoseconds to seconds for metric timestamp
-		timestamp := float64(row.GetBucketStart()) / 1e9
+		// Metrics storage uses Unix seconds.
+		timestampUnix := int64(row.GetBucketStartUnixNano() / 1e9)
 		tags := buildStatsTagsFromRow(agentHostname, agentEnv, row)
 
-		handle.ObserveMetric(&statsMetricView{name: "trace.hits", value: float64(row.GetHits()), tags: tags, timestamp: timestamp})
-		handle.ObserveMetric(&statsMetricView{name: "trace.errors", value: float64(row.GetErrors()), tags: tags, timestamp: timestamp})
-		handle.ObserveMetric(&statsMetricView{name: "trace.duration", value: float64(row.GetDuration()), tags: tags, timestamp: timestamp})
-		handle.ObserveMetric(&statsMetricView{name: "trace.top_level_hits", value: float64(row.GetTopLevelHits()), tags: tags, timestamp: timestamp})
+		handle.ObserveMetric(&statsMetricView{name: "trace.hits", value: float64(row.GetHits()), tags: tags, timestampUnix: timestampUnix})
+		handle.ObserveMetric(&statsMetricView{name: "trace.errors", value: float64(row.GetErrors()), tags: tags, timestampUnix: timestampUnix})
+		handle.ObserveMetric(&statsMetricView{name: "trace.duration", value: float64(row.GetDurationNano()), tags: tags, timestampUnix: timestampUnix})
+		handle.ObserveMetric(&statsMetricView{name: "trace.top_level_hits", value: float64(row.GetTopLevelHits()), tags: tags, timestampUnix: timestampUnix})
 
 		if okSummary := row.GetOkSummary(); len(okSummary) > 0 {
-			emitPercentiles(handle, "trace.latency.ok", okSummary, tags, timestamp)
+			emitPercentiles(handle, "trace.latency.ok", okSummary, tags, timestampUnix)
 		}
 		if errSummary := row.GetErrorSummary(); len(errSummary) > 0 {
-			emitPercentiles(handle, "trace.latency.error", errSummary, tags, timestamp)
+			emitPercentiles(handle, "trace.latency.error", errSummary, tags, timestampUnix)
 		}
 	}
 }
 
 // emitPercentiles extracts percentiles from a DDSketch and emits them as metrics.
-func emitPercentiles(handle observerdef.Handle, metricPrefix string, sketchBytes []byte, tags []string, timestamp float64) {
+func emitPercentiles(handle observerdef.Handle, metricPrefix string, sketchBytes []byte, tags []string, timestampUnix int64) {
 	sketch, err := decodeSketch(sketchBytes)
 	if err != nil {
 		pkglog.Debugf("[observer] failed to decode ddsketch: %v", err)
@@ -75,10 +75,10 @@ func emitPercentiles(handle observerdef.Handle, metricPrefix string, sketchBytes
 
 		metricName := fmt.Sprintf("%s.%s", metricPrefix, pq.suffix)
 		handle.ObserveMetric(&statsMetricView{
-			name:      metricName,
-			value:     value,
-			tags:      tags,
-			timestamp: timestamp,
+			name:          metricName,
+			value:         value,
+			tags:          tags,
+			timestampUnix: timestampUnix,
 		})
 	}
 }
@@ -149,16 +149,18 @@ func buildStatsTagsFromRow(agentHostname, agentEnv string, row observerdef.Trace
 
 // statsMetricView implements the MetricView interface for stats-derived metrics.
 type statsMetricView struct {
-	name      string
-	value     float64
-	tags      []string
-	timestamp float64
+	name          string
+	value         float64
+	tags          []string
+	timestampUnix int64
 }
 
-func (m *statsMetricView) GetName() string        { return m.name }
-func (m *statsMetricView) GetValue() float64      { return m.value }
-func (m *statsMetricView) GetRawTags() []string   { return m.tags }
-func (m *statsMetricView) GetTimestamp() float64  { return m.timestamp }
+func (m *statsMetricView) GetName() string      { return m.name }
+func (m *statsMetricView) GetValue() float64    { return m.value }
+func (m *statsMetricView) GetRawTags() []string { return m.tags }
+func (m *statsMetricView) GetTimestampUnix() int64 {
+	return m.timestampUnix
+}
 func (m *statsMetricView) GetSampleRate() float64 { return 1.0 }
 
 // statsPayloadView adapts a *pb.StatsPayload to the TraceStatsView interface.
@@ -215,24 +217,24 @@ type statsRowView struct {
 	group  *pb.ClientGroupedStats
 }
 
-func (r *statsRowView) GetClientHostname() string    { return r.client.Hostname }
-func (r *statsRowView) GetClientEnv() string         { return r.client.Env }
-func (r *statsRowView) GetClientVersion() string     { return r.client.Version }
-func (r *statsRowView) GetClientContainerID() string { return r.client.ContainerID }
-func (r *statsRowView) GetBucketStart() uint64       { return r.bucket.Start }
-func (r *statsRowView) GetBucketDuration() uint64    { return r.bucket.Duration }
-func (r *statsRowView) GetService() string           { return r.group.Service }
-func (r *statsRowView) GetName() string              { return r.group.Name }
-func (r *statsRowView) GetResource() string          { return r.group.Resource }
-func (r *statsRowView) GetType() string              { return r.group.Type }
-func (r *statsRowView) GetHTTPStatusCode() uint32    { return r.group.HTTPStatusCode }
-func (r *statsRowView) GetSpanKind() string          { return r.group.SpanKind }
-func (r *statsRowView) GetIsTraceRoot() int32        { return int32(r.group.IsTraceRoot) }
-func (r *statsRowView) GetSynthetics() bool          { return r.group.Synthetics }
-func (r *statsRowView) GetHits() uint64              { return r.group.Hits }
-func (r *statsRowView) GetErrors() uint64            { return r.group.Errors }
-func (r *statsRowView) GetTopLevelHits() uint64      { return r.group.TopLevelHits }
-func (r *statsRowView) GetDuration() uint64          { return r.group.Duration }
-func (r *statsRowView) GetOkSummary() []byte         { return r.group.OkSummary }
-func (r *statsRowView) GetErrorSummary() []byte      { return r.group.ErrorSummary }
-func (r *statsRowView) GetPeerTags() []string        { return r.group.PeerTags }
+func (r *statsRowView) GetClientHostname() string      { return r.client.Hostname }
+func (r *statsRowView) GetClientEnv() string           { return r.client.Env }
+func (r *statsRowView) GetClientVersion() string       { return r.client.Version }
+func (r *statsRowView) GetClientContainerID() string   { return r.client.ContainerID }
+func (r *statsRowView) GetBucketStartUnixNano() uint64 { return r.bucket.Start }
+func (r *statsRowView) GetBucketDurationNano() uint64  { return r.bucket.Duration }
+func (r *statsRowView) GetService() string             { return r.group.Service }
+func (r *statsRowView) GetName() string                { return r.group.Name }
+func (r *statsRowView) GetResource() string            { return r.group.Resource }
+func (r *statsRowView) GetType() string                { return r.group.Type }
+func (r *statsRowView) GetHTTPStatusCode() uint32      { return r.group.HTTPStatusCode }
+func (r *statsRowView) GetSpanKind() string            { return r.group.SpanKind }
+func (r *statsRowView) GetIsTraceRoot() int32          { return int32(r.group.IsTraceRoot) }
+func (r *statsRowView) GetSynthetics() bool            { return r.group.Synthetics }
+func (r *statsRowView) GetHits() uint64                { return r.group.Hits }
+func (r *statsRowView) GetErrors() uint64              { return r.group.Errors }
+func (r *statsRowView) GetTopLevelHits() uint64        { return r.group.TopLevelHits }
+func (r *statsRowView) GetDurationNano() uint64        { return r.group.Duration }
+func (r *statsRowView) GetOkSummary() []byte           { return r.group.OkSummary }
+func (r *statsRowView) GetErrorSummary() []byte        { return r.group.ErrorSummary }
+func (r *statsRowView) GetPeerTags() []string          { return r.group.PeerTags }

--- a/comp/observer/impl/test_helpers_test.go
+++ b/comp/observer/impl/test_helpers_test.go
@@ -14,8 +14,8 @@ type mockLogView struct {
 	timestampMs int64
 }
 
-func (m *mockLogView) GetContent() []byte    { return m.content }
-func (m *mockLogView) GetStatus() string     { return m.status }
-func (m *mockLogView) GetTags() []string     { return m.tags }
-func (m *mockLogView) GetHostname() string   { return m.hostname }
-func (m *mockLogView) GetTimestampMs() int64 { return m.timestampMs }
+func (m *mockLogView) GetContent() []byte           { return m.content }
+func (m *mockLogView) GetStatus() string            { return m.status }
+func (m *mockLogView) GetTags() []string            { return m.tags }
+func (m *mockLogView) GetHostname() string          { return m.hostname }
+func (m *mockLogView) GetTimestampUnixMilli() int64 { return m.timestampMs }

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -101,8 +101,8 @@ type TestBench struct {
 	ready          bool
 	episodeInfo    *EpisodeInfo
 
-	// Components (log detectors are not registry-managed)
-	logDetectors []observerdef.LogDetector
+	// Components (log extractors are not registry-managed)
+	extractors []observerdef.LogMetricsExtractor
 
 	// Registry-managed components
 	components map[string]*registeredComponent
@@ -184,8 +184,8 @@ func NewTestBench(config TestBenchConfig) (*TestBench, error) {
 		config:  config,
 		storage: newTimeSeriesStorage(),
 
-		// Log detectors are not registry-managed
-		logDetectors: []observerdef.LogDetector{
+		// Log extractors are not registry-managed
+		extractors: []observerdef.LogMetricsExtractor{
 			&LogMetricsExtractor{
 				MaxEvalBytes: 4096,
 				ExcludeFields: map[string]struct{}{
@@ -494,37 +494,16 @@ func (r *parquetTraceStatRow) GetOkSummary() []byte         { return r.data.OkSu
 func (r *parquetTraceStatRow) GetErrorSummary() []byte      { return r.data.ErrorSummary }
 func (r *parquetTraceStatRow) GetPeerTags() []string        { return r.data.PeerTags }
 
-// runLogDetectors runs all the log detectors on the raw logs.
-func (tb *TestBench) runLogDetectors() error {
+// runLogExtractors runs all the log extractors on the raw logs.
+func (tb *TestBench) runLogExtractors() error {
 	for _, log := range tb.rawLogs {
-		// Process through log detectors
-		for _, detector := range tb.logDetectors {
-			result := detector.Process(log)
+		// Process through log extractors
+		for _, extractor := range tb.extractors {
+			metrics := extractor.ProcessLog(log)
 			ts := log.GetTimestampMs()
-			for _, m := range result.Metrics {
+			for _, m := range metrics {
 				tb.storage.Add("logs", "_virtual."+m.Name, m.Value, ts/1000, m.Tags)
 			}
-			for _, anomaly := range result.Anomalies {
-				// Fill in fields the detector may not have set
-				anomaly.Type = observerdef.AnomalyTypeLog
-				if anomaly.DetectorName == "" {
-					anomaly.DetectorName = detector.Name()
-				}
-				if anomaly.Timestamp == 0 {
-					anomaly.Timestamp = ts / 1000
-				}
-				// If still zero (log had no parseable timestamp), use current time
-				if anomaly.Timestamp == 0 {
-					anomaly.Timestamp = time.Now().Unix()
-				}
-				if anomaly.Source == "" {
-					anomaly.Source = "logs"
-				}
-				tb.logAnomalies = append(tb.logAnomalies, anomaly)
-				tb.logAnomaliesByDetector[anomaly.DetectorName] = append(
-					tb.logAnomaliesByDetector[anomaly.DetectorName], anomaly)
-			}
-			tb.handleTelemetry(result.Telemetry, detector.Name(), ts)
 		}
 	}
 
@@ -587,7 +566,7 @@ func (tb *TestBench) GetStatus() StatusResponse {
 		SeriesCount:           tb.seriesCount(),
 		AnomalyCount:          len(tb.metricsAnomalies),
 		LogAnomalyCount:       len(tb.logAnomalies),
-		ComponentCount:        len(tb.logDetectors) + len(tb.components),
+		ComponentCount:        len(tb.extractors) + len(tb.components),
 		CorrelatorsProcessing: tb.correlatorsProcessing,
 		ScenarioStart:         scenarioStartPtr,
 		ScenarioEnd:           scenarioEndPtr,
@@ -604,8 +583,8 @@ func (tb *TestBench) GetStatus() StatusResponse {
 func (tb *TestBench) rerunDetectorsLocked() {
 	// --- Logs ---
 	// We want to process logs first in case they produce metrics that are used by other detectors.
-	if err := tb.runLogDetectors(); err != nil {
-		fmt.Printf("  Warning: failed to run log detectors: %v\n", err)
+	if err := tb.runLogExtractors(); err != nil {
+		fmt.Printf("  Warning: failed to run log extractors: %v\n", err)
 	}
 
 	// --- Metrics ---
@@ -622,56 +601,21 @@ func (tb *TestBench) rerunDetectorsLocked() {
 	// Reset ALL components (not just enabled) so disabled ones clear stale state
 	tb.resetAllState()
 
-	detectors := tb.enabledDetectors()
-
-	// Phase 1 (sync): Run time series detectors to collect anomalies
-	for _, ns := range tb.storage.Namespaces() {
-		for _, agg := range []Aggregate{AggregateAverage, AggregateCount} {
-			allSeries := tb.storage.AllSeries(ns, agg)
-			for _, series := range allSeries {
-				seriesCopy := series
-				seriesCopy.Name = series.Name + ":" + aggSuffix(agg)
-
-				for _, detector := range detectors {
-					result := detector.Detect(seriesCopy)
-					for _, anomaly := range result.Anomalies {
-						anomaly.Type = observerdef.AnomalyTypeMetric
-						anomaly.DetectorName = detector.Name()
-						anomaly.Source = observerdef.MetricName(seriesCopy.Name)
-						anomaly.SourceSeriesID = observerdef.SeriesID(seriesKey(seriesCopy.Namespace, seriesCopy.Name, seriesCopy.Tags))
-						if anomaly.DetectorName == "" || anomaly.Source == "" || anomaly.Timestamp == 0 {
-							fmt.Printf("  Warning: dropping invalid anomaly (detector=%q source=%q ts=%d)\n",
-								anomaly.DetectorName, anomaly.Source, anomaly.Timestamp)
-							continue
-						}
-
-						tb.metricsAnomalies = append(tb.metricsAnomalies, anomaly)
-						tb.metricsByDetector[anomaly.DetectorName] = append(tb.metricsByDetector[anomaly.DetectorName], anomaly)
-						if anomaly.SourceSeriesID != "" {
-							tb.metricsBySeriesID[anomaly.SourceSeriesID] = append(tb.metricsBySeriesID[anomaly.SourceSeriesID], anomaly)
-						}
-					}
-
-					baseTimestamp := time.Now().Unix()
-					if len(seriesCopy.Points) > 0 {
-						baseTimestamp = seriesCopy.Points[0].Timestamp
-					}
-					tb.handleTelemetry(result.Telemetry, detector.Name(), baseTimestamp)
-				}
-			}
-		}
-	}
-
-	// Phase 1b (sync): Run multi-series detectors (pull-based, e.g. RRCF)
+	// Run all detectors (both SeriesDetector-based via adapter and native Detector)
 	dataTime := tb.storage.MaxTimestamp()
-	for _, detector := range tb.enabledMultiDetectors() {
-		multiResult := detector.Detect(tb.storage, dataTime)
-		for _, anomaly := range multiResult.Anomalies {
+	for _, detector := range tb.enabledDetectors() {
+		result := detector.Detect(tb.storage, dataTime)
+		for _, anomaly := range result.Anomalies {
 			// If the anomaly has a Source (telemetry metric name) but no SourceSeriesID,
 			// resolve it to the telemetry series using the same naming convention as handleTelemetry.
 			if anomaly.SourceSeriesID == "" && anomaly.Source != "" {
 				telemetryName := "telemetry." + detector.Name() + "." + string(anomaly.Source)
 				anomaly.SourceSeriesID = observerdef.SeriesID(seriesKey("telemetry", telemetryName+":avg", nil))
+			}
+			if anomaly.DetectorName == "" || anomaly.Source == "" || anomaly.Timestamp == 0 {
+				fmt.Printf("  Warning: dropping invalid anomaly (detector=%q source=%q ts=%d)\n",
+					anomaly.DetectorName, anomaly.Source, anomaly.Timestamp)
+				continue
 			}
 			tb.metricsAnomalies = append(tb.metricsAnomalies, anomaly)
 			tb.metricsByDetector[anomaly.DetectorName] = append(tb.metricsByDetector[anomaly.DetectorName], anomaly)
@@ -679,7 +623,7 @@ func (tb *TestBench) rerunDetectorsLocked() {
 				tb.metricsBySeriesID[anomaly.SourceSeriesID] = append(tb.metricsBySeriesID[anomaly.SourceSeriesID], anomaly)
 			}
 		}
-		tb.handleTelemetry(multiResult.Telemetry, detector.Name(), dataTime)
+		tb.handleTelemetry(result.Telemetry, detector.Name(), dataTime)
 	}
 
 	// --- Correlations ---
@@ -919,10 +863,9 @@ func (tb *TestBench) GetDetectorComponentMap() map[string]string {
 		if comp.Registration.Category != "detector" {
 			continue
 		}
-		if detector, ok := comp.Instance.(observerdef.MetricsDetector); ok {
+		if detector, ok := comp.Instance.(observerdef.Detector); ok {
 			result[detector.Name()] = componentName
-		}
-		if detector, ok := comp.Instance.(observerdef.MultiSeriesDetector); ok {
+		} else if detector, ok := comp.Instance.(observerdef.SeriesDetector); ok {
 			result[detector.Name()] = componentName
 		}
 	}

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -43,7 +43,7 @@ func (v *logDataView) GetTags() []string {
 	return v.data.Tags
 }
 
-func (v *logDataView) GetTimestampMs() int64 {
+func (v *logDataView) GetTimestampUnixMilli() int64 {
 	return v.data.TimestampMs
 }
 
@@ -433,7 +433,7 @@ type storageHandle struct {
 }
 
 func (h *storageHandle) ObserveMetric(sample observerdef.MetricView) {
-	h.storage.Add(h.namespace, sample.GetName(), sample.GetValue(), int64(sample.GetTimestamp()), sample.GetRawTags())
+	h.storage.Add(h.namespace, sample.GetName(), sample.GetValue(), sample.GetTimestampUnix(), sample.GetRawTags())
 }
 func (h *storageHandle) ObserveLog(_ observerdef.LogView)               {}
 func (h *storageHandle) ObserveTrace(_ observerdef.TraceView)           {}
@@ -476,23 +476,25 @@ func (r *parquetTraceStatRow) GetClientHostname() string    { return r.data.Clie
 func (r *parquetTraceStatRow) GetClientEnv() string         { return r.data.ClientEnv }
 func (r *parquetTraceStatRow) GetClientVersion() string     { return r.data.ClientVersion }
 func (r *parquetTraceStatRow) GetClientContainerID() string { return r.data.ClientContainerID }
-func (r *parquetTraceStatRow) GetBucketStart() uint64       { return r.data.BucketStart }
-func (r *parquetTraceStatRow) GetBucketDuration() uint64    { return r.data.BucketDuration }
-func (r *parquetTraceStatRow) GetService() string           { return r.data.Service }
-func (r *parquetTraceStatRow) GetName() string              { return r.data.Name }
-func (r *parquetTraceStatRow) GetResource() string          { return r.data.Resource }
-func (r *parquetTraceStatRow) GetType() string              { return r.data.Type }
-func (r *parquetTraceStatRow) GetHTTPStatusCode() uint32    { return r.data.HTTPStatusCode }
-func (r *parquetTraceStatRow) GetSpanKind() string          { return r.data.SpanKind }
-func (r *parquetTraceStatRow) GetIsTraceRoot() int32        { return r.data.IsTraceRoot }
-func (r *parquetTraceStatRow) GetSynthetics() bool          { return r.data.Synthetics }
-func (r *parquetTraceStatRow) GetHits() uint64              { return r.data.Hits }
-func (r *parquetTraceStatRow) GetErrors() uint64            { return r.data.Errors }
-func (r *parquetTraceStatRow) GetTopLevelHits() uint64      { return r.data.TopLevelHits }
-func (r *parquetTraceStatRow) GetDuration() uint64          { return r.data.Duration }
-func (r *parquetTraceStatRow) GetOkSummary() []byte         { return r.data.OkSummary }
-func (r *parquetTraceStatRow) GetErrorSummary() []byte      { return r.data.ErrorSummary }
-func (r *parquetTraceStatRow) GetPeerTags() []string        { return r.data.PeerTags }
+func (r *parquetTraceStatRow) GetBucketStartUnixNano() uint64 {
+	return r.data.BucketStart
+}
+func (r *parquetTraceStatRow) GetBucketDurationNano() uint64 { return r.data.BucketDuration }
+func (r *parquetTraceStatRow) GetService() string            { return r.data.Service }
+func (r *parquetTraceStatRow) GetName() string               { return r.data.Name }
+func (r *parquetTraceStatRow) GetResource() string           { return r.data.Resource }
+func (r *parquetTraceStatRow) GetType() string               { return r.data.Type }
+func (r *parquetTraceStatRow) GetHTTPStatusCode() uint32     { return r.data.HTTPStatusCode }
+func (r *parquetTraceStatRow) GetSpanKind() string           { return r.data.SpanKind }
+func (r *parquetTraceStatRow) GetIsTraceRoot() int32         { return r.data.IsTraceRoot }
+func (r *parquetTraceStatRow) GetSynthetics() bool           { return r.data.Synthetics }
+func (r *parquetTraceStatRow) GetHits() uint64               { return r.data.Hits }
+func (r *parquetTraceStatRow) GetErrors() uint64             { return r.data.Errors }
+func (r *parquetTraceStatRow) GetTopLevelHits() uint64       { return r.data.TopLevelHits }
+func (r *parquetTraceStatRow) GetDurationNano() uint64       { return r.data.Duration }
+func (r *parquetTraceStatRow) GetOkSummary() []byte          { return r.data.OkSummary }
+func (r *parquetTraceStatRow) GetErrorSummary() []byte       { return r.data.ErrorSummary }
+func (r *parquetTraceStatRow) GetPeerTags() []string         { return r.data.PeerTags }
 
 // runLogExtractors runs all the log extractors on the raw logs.
 func (tb *TestBench) runLogExtractors() error {
@@ -500,7 +502,7 @@ func (tb *TestBench) runLogExtractors() error {
 		// Process through log extractors
 		for _, extractor := range tb.extractors {
 			metrics := extractor.ProcessLog(log)
-			ts := log.GetTimestampMs()
+			ts := log.GetTimestampUnixMilli()
 			for _, m := range metrics {
 				tb.storage.Add("logs", "_virtual."+m.Name, m.Value, ts/1000, m.Tags)
 			}
@@ -535,7 +537,7 @@ func (tb *TestBench) GetStatus() StatusResponse {
 
 	// Extend bounds to include log timestamps (parquet logs can fall outside the metrics range)
 	for _, l := range tb.rawLogs {
-		ts := l.GetTimestampMs()
+		ts := l.GetTimestampUnixMilli()
 		if ts == 0 {
 			continue
 		}
@@ -721,7 +723,7 @@ func (tb *TestBench) handleTelemetry(telemetry []observerdef.ObserverTelemetry, 
 				name:      telemetryEvent.Metric.GetName(),
 				value:     telemetryEvent.Metric.GetValue(),
 				tags:      telemetryEvent.Metric.GetRawTags(),
-				timestamp: int64(telemetryEvent.Metric.GetTimestamp()),
+				timestamp: telemetryEvent.Metric.GetTimestampUnix(),
 			}
 			if metric.timestamp == 0 {
 				metric.timestamp = baseTimestampMs / 1000
@@ -734,7 +736,7 @@ func (tb *TestBench) handleTelemetry(telemetry []observerdef.ObserverTelemetry, 
 		}
 
 		if telemetryEvent.Log != nil {
-			timestamp := telemetryEvent.Log.GetTimestampMs()
+			timestamp := telemetryEvent.Log.GetTimestampUnixMilli()
 			if timestamp == 0 {
 				timestamp = baseTimestampMs
 			}

--- a/comp/observer/impl/testbench_api.go
+++ b/comp/observer/impl/testbench_api.go
@@ -483,7 +483,7 @@ func (api *TestBenchAPI) handleLogs(w http.ResponseWriter, r *http.Request) {
 		// 	tags = append(tags, "status:"+l.Status)
 		// }
 		response = append(response, logEntryResponse{
-			TimestampMs: l.GetTimestampMs(),
+			TimestampMs: l.GetTimestampUnixMilli(),
 			Status:      l.GetStatus(),
 			Content:     string(l.GetContent()),
 			Hostname:    l.GetHostname(),

--- a/comp/observer/impl/testbench_registry.go
+++ b/comp/observer/impl/testbench_registry.go
@@ -103,26 +103,16 @@ var defaultRegistry = []ComponentRegistration{
 	},
 }
 
-// enabledDetectors returns all enabled MetricsDetector instances (per-series detectors).
-func (tb *TestBench) enabledDetectors() []observerdef.MetricsDetector {
-	var result []observerdef.MetricsDetector
+// enabledDetectors returns all enabled Detector instances.
+// SeriesDetector implementations are wrapped with seriesDetectorAdapter.
+func (tb *TestBench) enabledDetectors() []observerdef.Detector {
+	var result []observerdef.Detector
 	for _, comp := range tb.components {
 		if comp.Enabled && comp.Registration.Category == "detector" {
-			if a, ok := comp.Instance.(observerdef.MetricsDetector); ok {
-				result = append(result, a)
-			}
-		}
-	}
-	return result
-}
-
-// enabledMultiDetectors returns all enabled MultiSeriesDetector instances (pull-based).
-func (tb *TestBench) enabledMultiDetectors() []observerdef.MultiSeriesDetector {
-	var result []observerdef.MultiSeriesDetector
-	for _, comp := range tb.components {
-		if comp.Enabled && comp.Registration.Category == "detector" {
-			if d, ok := comp.Instance.(observerdef.MultiSeriesDetector); ok {
+			if d, ok := comp.Instance.(observerdef.Detector); ok {
 				result = append(result, d)
+			} else if sd, ok := comp.Instance.(observerdef.SeriesDetector); ok {
+				result = append(result, newSeriesDetectorAdapter(sd, defaultAggregations))
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Renames and simplifies the observer's detection interfaces. For metrics detectors, this is purely a rename for clarity:

- `MetricsDetector` → `SeriesDetector` (analyzes one series at a time)
- `MultiSeriesDetector` → `Detector` (pulls from storage, supports multivariate)
- `MetricsDetectionResult` / `MultiSeriesDetectionResult` → `DetectionResult`

For log detectors, we split what was a single `LogDetector` interface into two distinct concepts:

- `LogMetricsExtractor` — stateless transform from logs to metrics (the metrics then flow through normal detection)
- `LogObserver` — optional interface on Detectors for direct log observation, allowing log-based anomaly detection without going through metrics extraction

Also rewrites the README to explain the pipeline model and framework/component separation, and wires in BOCPD as a default SeriesDetector.