### PR TITLE
[observer] Encode time units in view interface method names

### DIFF
--- a/comp/observer/def/component.go
+++ b/comp/observer/def/component.go
@@ -53,7 +53,8 @@ type MetricView interface {
 	GetName() string
 	GetValue() float64
 	GetRawTags() []string
-	GetTimestamp() float64
+	// GetTimestampUnix returns the sample timestamp in Unix seconds.
+	GetTimestampUnix() int64
 	GetSampleRate() float64
 }
 
@@ -66,7 +67,8 @@ type LogView interface {
 	GetStatus() string
 	GetTags() []string
 	GetHostname() string
-	GetTimestampMs() int64
+	// GetTimestampUnixMilli returns the log timestamp in Unix milliseconds.
+	GetTimestampUnixMilli() int64
 }
 
 // TraceView provides read-only access to a trace (collection of spans with the same trace ID).
@@ -87,10 +89,10 @@ type TraceView interface {
 	GetHostname() string
 	// GetContainerID returns the container ID where the trace originated.
 	GetContainerID() string
-	// GetTimestamp returns the trace start time in nanoseconds since epoch.
-	GetTimestamp() int64
-	// GetDuration returns the trace duration in nanoseconds.
-	GetDuration() int64
+	// GetTimestampUnixNano returns the trace start time in Unix nanoseconds.
+	GetTimestampUnixNano() int64
+	// GetDurationNano returns the trace duration in nanoseconds.
+	GetDurationNano() int64
 	// GetPriority returns the sampling priority.
 	GetPriority() int32
 	// IsError returns true if this trace contains an error.
@@ -125,10 +127,10 @@ type SpanView interface {
 	GetResource() string
 	// GetType returns the span type (e.g., "web", "db", "cache").
 	GetType() string
-	// GetStart returns the span start time in nanoseconds since epoch.
-	GetStart() int64
-	// GetDuration returns the span duration in nanoseconds.
-	GetDuration() int64
+	// GetStartUnixNano returns the span start time in Unix nanoseconds.
+	GetStartUnixNano() int64
+	// GetDurationNano returns the span duration in nanoseconds.
+	GetDurationNano() int64
 	// GetError returns the error code (0 = no error, 1 = error).
 	GetError() int32
 	// GetMeta returns string tags/metadata for this span.
@@ -171,8 +173,8 @@ type TraceStatRow interface {
 	GetClientVersion() string
 	GetClientContainerID() string
 	// Time bucket window (from ClientStatsBucket)
-	GetBucketStart() uint64    // nanoseconds since epoch
-	GetBucketDuration() uint64 // nanoseconds
+	GetBucketStartUnixNano() uint64 // Unix nanoseconds
+	GetBucketDurationNano() uint64  // nanoseconds
 	// Aggregation dimensions (from ClientGroupedStats)
 	GetService() string
 	GetName() string // operation name
@@ -186,7 +188,7 @@ type TraceStatRow interface {
 	GetHits() uint64
 	GetErrors() uint64
 	GetTopLevelHits() uint64
-	GetDuration() uint64     // total duration in nanoseconds
+	GetDurationNano() uint64 // total duration in nanoseconds
 	GetOkSummary() []byte    // DDSketch encoded latency distribution for ok spans
 	GetErrorSummary() []byte // DDSketch encoded latency distribution for error spans
 	GetPeerTags() []string
@@ -213,10 +215,10 @@ type ProfileView interface {
 	GetHostname() string
 	// GetContainerID returns the container ID where the profile was collected.
 	GetContainerID() string
-	// GetTimestamp returns the profile timestamp in nanoseconds since epoch.
-	GetTimestamp() int64
-	// GetDuration returns the profile duration in nanoseconds.
-	GetDuration() int64
+	// GetTimestampUnixNano returns the profile timestamp in Unix nanoseconds.
+	GetTimestampUnixNano() int64
+	// GetDurationNano returns the profile duration in nanoseconds.
+	GetDurationNano() int64
 	// GetTags returns profile tags.
 	GetTags() map[string]string
 	// GetContentType returns the original Content-Type header (profile format is language-specific).

--- a/comp/observer/impl/fetcher.go
+++ b/comp/observer/impl/fetcher.go
@@ -262,7 +262,7 @@ func (v *tracerPayloadView) GetService() string          { return "" } // Servic
 func (v *tracerPayloadView) GetHostname() string         { return v.payload.Hostname }
 func (v *tracerPayloadView) GetContainerID() string      { return v.payload.ContainerID }
 func (v *tracerPayloadView) GetTimestampUnixNano() int64 { return v.receivedAt }
-func (v *tracerPayloadView) GetDurationNano() int64      { return 0 } // Would need to calculate
+func (v *tracerPayloadView) GetDurationNano() int64      { return 0 } // TODO(agent-q-anomaly-detection): Would need to calculate
 func (v *tracerPayloadView) GetPriority() int32 {
 	if len(v.payload.Chunks) > 0 {
 		return v.payload.Chunks[0].Priority

--- a/comp/observer/impl/fetcher.go
+++ b/comp/observer/impl/fetcher.go
@@ -257,12 +257,12 @@ func (v *tracerPayloadView) Reset() {
 	v.spanIdx = -1
 }
 
-func (v *tracerPayloadView) GetEnv() string         { return v.payload.Env }
-func (v *tracerPayloadView) GetService() string     { return "" } // Service is per-span
-func (v *tracerPayloadView) GetHostname() string    { return v.payload.Hostname }
-func (v *tracerPayloadView) GetContainerID() string { return v.payload.ContainerID }
-func (v *tracerPayloadView) GetTimestamp() int64    { return v.receivedAt }
-func (v *tracerPayloadView) GetDuration() int64     { return 0 } // Would need to calculate
+func (v *tracerPayloadView) GetEnv() string              { return v.payload.Env }
+func (v *tracerPayloadView) GetService() string          { return "" } // Service is per-span
+func (v *tracerPayloadView) GetHostname() string         { return v.payload.Hostname }
+func (v *tracerPayloadView) GetContainerID() string      { return v.payload.ContainerID }
+func (v *tracerPayloadView) GetTimestampUnixNano() int64 { return v.receivedAt }
+func (v *tracerPayloadView) GetDurationNano() int64      { return 0 } // Would need to calculate
 func (v *tracerPayloadView) GetPriority() int32 {
 	if len(v.payload.Chunks) > 0 {
 		return v.payload.Chunks[0].Priority
@@ -292,8 +292,8 @@ func (v *spanView) GetService() string             { return v.span.Service }
 func (v *spanView) GetName() string                { return v.span.Name }
 func (v *spanView) GetResource() string            { return v.span.Resource }
 func (v *spanView) GetType() string                { return v.span.Type }
-func (v *spanView) GetStart() int64                { return v.span.Start }
-func (v *spanView) GetDuration() int64             { return v.span.Duration }
+func (v *spanView) GetStartUnixNano() int64        { return v.span.Start }
+func (v *spanView) GetDurationNano() int64         { return v.span.Duration }
 func (v *spanView) GetError() int32                { return v.span.Error }
 func (v *spanView) GetMeta() map[string]string     { return v.span.Meta }
 func (v *spanView) GetMetrics() map[string]float64 { return v.span.Metrics }
@@ -303,16 +303,16 @@ type profileDataView struct {
 	data *pbcore.ProfileData
 }
 
-func (v *profileDataView) GetProfileID() string       { return v.data.ProfileId }
-func (v *profileDataView) GetProfileType() string     { return v.data.ProfileType }
-func (v *profileDataView) GetService() string         { return v.data.Service }
-func (v *profileDataView) GetEnv() string             { return v.data.Env }
-func (v *profileDataView) GetVersion() string         { return v.data.Version }
-func (v *profileDataView) GetHostname() string        { return v.data.Hostname }
-func (v *profileDataView) GetContainerID() string     { return v.data.ContainerId }
-func (v *profileDataView) GetTimestamp() int64        { return v.data.TimestampNs }
-func (v *profileDataView) GetDuration() int64         { return v.data.DurationNs }
-func (v *profileDataView) GetTags() map[string]string { return v.data.Tags }
-func (v *profileDataView) GetContentType() string     { return v.data.ContentType }
-func (v *profileDataView) GetRawData() []byte         { return v.data.InlineData }
-func (v *profileDataView) GetExternalPath() string    { return "" }
+func (v *profileDataView) GetProfileID() string        { return v.data.ProfileId }
+func (v *profileDataView) GetProfileType() string      { return v.data.ProfileType }
+func (v *profileDataView) GetService() string          { return v.data.Service }
+func (v *profileDataView) GetEnv() string              { return v.data.Env }
+func (v *profileDataView) GetVersion() string          { return v.data.Version }
+func (v *profileDataView) GetHostname() string         { return v.data.Hostname }
+func (v *profileDataView) GetContainerID() string      { return v.data.ContainerId }
+func (v *profileDataView) GetTimestampUnixNano() int64 { return v.data.TimestampNs }
+func (v *profileDataView) GetDurationNano() int64      { return v.data.DurationNs }
+func (v *profileDataView) GetTags() map[string]string  { return v.data.Tags }
+func (v *profileDataView) GetContentType() string      { return v.data.ContentType }
+func (v *profileDataView) GetRawData() []byte          { return v.data.InlineData }
+func (v *profileDataView) GetExternalPath() string     { return "" }

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -82,9 +82,7 @@ func (m *metricObs) GetRawTags() []string {
 	return m.tags
 }
 
-func (m *metricObs) GetTimestamp() float64 {
-	return float64(m.timestamp)
-}
+func (m *metricObs) GetTimestampUnix() int64 { return m.timestamp }
 
 // Observer does not store samplerate; just return 1.0
 func (m *metricObs) GetSampleRate() float64 {
@@ -169,7 +167,7 @@ func (l *logObs) GetHostname() string {
 }
 
 // Optionally, for logs that provide timestamp interface (if needed elsewhere)
-func (l *logObs) GetTimestampMs() int64 {
+func (l *logObs) GetTimestampUnixMilli() int64 {
 	return l.timestampMs
 }
 
@@ -353,13 +351,13 @@ func samplePass(rate float64, n uint64) bool {
 
 // observerImpl is the implementation of the observer component.
 type observerImpl struct {
-	extractors []observerdef.LogMetricsExtractor
-	detectors  []observerdef.Detector
-	correlators    []observerdef.Correlator
-	reporters      []observerdef.Reporter
-	storage        *timeSeriesStorage
-	obsCh          chan observation
-	handleFunc observerdef.HandleFunc // Handle factory (may wrap with recorder middleware)
+	extractors  []observerdef.LogMetricsExtractor
+	detectors   []observerdef.Detector
+	correlators []observerdef.Correlator
+	reporters   []observerdef.Reporter
+	storage     *timeSeriesStorage
+	obsCh       chan observation
+	handleFunc  observerdef.HandleFunc // Handle factory (may wrap with recorder middleware)
 
 	// Raw anomaly tracking for test bench display
 	rawAnomalies     []observerdef.Anomaly
@@ -372,7 +370,7 @@ type observerImpl struct {
 	fetcher              *observerFetcher
 	totalAnomalyCount    int                             // total count of all anomalies ever detected (no cap)
 	uniqueAnomalySources map[observerdef.MetricName]bool // unique sources that had anomalies
-	lastAnalyzedDataTime int64 // data timestamp up to which we've analyzed
+	lastAnalyzedDataTime int64                           // data timestamp up to which we've analyzed
 }
 
 // run is the main dispatch loop, processing all observations sequentially.
@@ -697,7 +695,7 @@ type handle struct {
 
 // ObserveMetric observes a DogStatsD metric sample.
 func (h *handle) ObserveMetric(sample observerdef.MetricView) {
-	timestamp := int64(sample.GetTimestamp())
+	timestamp := sample.GetTimestampUnix()
 	if timestamp == 0 {
 		timestamp = time.Now().Unix()
 	}
@@ -724,7 +722,7 @@ func (h *handle) ObserveMetric(sample observerdef.MetricView) {
 // ObserveLog observes a log message.
 func (h *handle) ObserveLog(msg observerdef.LogView) {
 	// Use provided timestampMs if available, otherwise use current time
-	timestampMs := msg.GetTimestampMs()
+	timestampMs := msg.GetTimestampUnixMilli()
 
 	obs := observation{
 		source: h.source,
@@ -760,8 +758,8 @@ func (h *handle) ObserveTrace(trace observerdef.TraceView) {
 			name:     sv.GetName(),
 			resource: sv.GetResource(),
 			spanType: sv.GetType(),
-			start:    sv.GetStart(),
-			duration: sv.GetDuration(),
+			start:    sv.GetStartUnixNano(),
+			duration: sv.GetDurationNano(),
 			error:    sv.GetError(),
 			meta:     copyStringMap(sv.GetMeta()),
 			metrics:  copyFloat64Map(sv.GetMetrics()),
@@ -778,8 +776,8 @@ func (h *handle) ObserveTrace(trace observerdef.TraceView) {
 			service:      trace.GetService(),
 			hostname:     trace.GetHostname(),
 			containerID:  trace.GetContainerID(),
-			timestamp:    trace.GetTimestamp(),
-			duration:     trace.GetDuration(),
+			timestamp:    trace.GetTimestampUnixNano(),
+			duration:     trace.GetDurationNano(),
 			priority:     trace.GetPriority(),
 			isError:      trace.IsError(),
 			tags:         copyStringMap(trace.GetTags()),
@@ -814,8 +812,8 @@ func (h *handle) ObserveProfile(profile observerdef.ProfileView) {
 			version:      profile.GetVersion(),
 			hostname:     profile.GetHostname(),
 			containerID:  profile.GetContainerID(),
-			timestamp:    profile.GetTimestamp(),
-			duration:     profile.GetDuration(),
+			timestamp:    profile.GetTimestampUnixNano(),
+			duration:     profile.GetDurationNano(),
 			tags:         copyStringMap(profile.GetTags()),
 			contentType:  profile.GetContentType(),
 			rawData:      copyBytes(profile.GetRawData()),
@@ -835,11 +833,11 @@ type logView struct {
 	obs *logObs
 }
 
-func (v *logView) GetContent() []byte    { return v.obs.content }
-func (v *logView) GetStatus() string     { return v.obs.status }
-func (v *logView) GetTags() []string     { return v.obs.tags }
-func (v *logView) GetHostname() string   { return v.obs.hostname }
-func (v *logView) GetTimestampMs() int64 { return v.obs.timestampMs }
+func (v *logView) GetContent() []byte           { return v.obs.content }
+func (v *logView) GetStatus() string            { return v.obs.status }
+func (v *logView) GetTags() []string            { return v.obs.tags }
+func (v *logView) GetHostname() string          { return v.obs.hostname }
+func (v *logView) GetTimestampUnixMilli() int64 { return v.obs.timestampMs }
 
 // agentLogView is a minimal LogView implementation for agent-internal logs.
 // It is immediately copied by the observer handle, so it must not be retained.
@@ -851,11 +849,11 @@ type agentLogView struct {
 	timestampMs int64
 }
 
-func (v *agentLogView) GetContent() []byte    { return v.content }
-func (v *agentLogView) GetStatus() string     { return v.status }
-func (v *agentLogView) GetTags() []string     { return v.tags }
-func (v *agentLogView) GetHostname() string   { return v.hostname }
-func (v *agentLogView) GetTimestampMs() int64 { return v.timestampMs }
+func (v *agentLogView) GetContent() []byte           { return v.content }
+func (v *agentLogView) GetStatus() string            { return v.status }
+func (v *agentLogView) GetTags() []string            { return v.tags }
+func (v *agentLogView) GetHostname() string          { return v.hostname }
+func (v *agentLogView) GetTimestampUnixMilli() int64 { return v.timestampMs }
 
 // copyBytes creates a copy of a byte slice.
 func copyBytes(b []byte) []byte {

--- a/comp/observer/impl/stats_metrics.go
+++ b/comp/observer/impl/stats_metrics.go
@@ -37,26 +37,26 @@ func processStatsView(handle observerdef.Handle, stats observerdef.TraceStatsVie
 	rows := stats.GetRows()
 	for rows.Next() {
 		row := rows.Row()
-		// Convert bucket start from nanoseconds to seconds for metric timestamp
-		timestamp := float64(row.GetBucketStart()) / 1e9
+		// Metrics storage uses Unix seconds.
+		timestampUnix := int64(row.GetBucketStartUnixNano() / 1e9)
 		tags := buildStatsTagsFromRow(agentHostname, agentEnv, row)
 
-		handle.ObserveMetric(&statsMetricView{name: "trace.hits", value: float64(row.GetHits()), tags: tags, timestamp: timestamp})
-		handle.ObserveMetric(&statsMetricView{name: "trace.errors", value: float64(row.GetErrors()), tags: tags, timestamp: timestamp})
-		handle.ObserveMetric(&statsMetricView{name: "trace.duration", value: float64(row.GetDuration()), tags: tags, timestamp: timestamp})
-		handle.ObserveMetric(&statsMetricView{name: "trace.top_level_hits", value: float64(row.GetTopLevelHits()), tags: tags, timestamp: timestamp})
+		handle.ObserveMetric(&statsMetricView{name: "trace.hits", value: float64(row.GetHits()), tags: tags, timestampUnix: timestampUnix})
+		handle.ObserveMetric(&statsMetricView{name: "trace.errors", value: float64(row.GetErrors()), tags: tags, timestampUnix: timestampUnix})
+		handle.ObserveMetric(&statsMetricView{name: "trace.duration", value: float64(row.GetDurationNano()), tags: tags, timestampUnix: timestampUnix})
+		handle.ObserveMetric(&statsMetricView{name: "trace.top_level_hits", value: float64(row.GetTopLevelHits()), tags: tags, timestampUnix: timestampUnix})
 
 		if okSummary := row.GetOkSummary(); len(okSummary) > 0 {
-			emitPercentiles(handle, "trace.latency.ok", okSummary, tags, timestamp)
+			emitPercentiles(handle, "trace.latency.ok", okSummary, tags, timestampUnix)
 		}
 		if errSummary := row.GetErrorSummary(); len(errSummary) > 0 {
-			emitPercentiles(handle, "trace.latency.error", errSummary, tags, timestamp)
+			emitPercentiles(handle, "trace.latency.error", errSummary, tags, timestampUnix)
 		}
 	}
 }
 
 // emitPercentiles extracts percentiles from a DDSketch and emits them as metrics.
-func emitPercentiles(handle observerdef.Handle, metricPrefix string, sketchBytes []byte, tags []string, timestamp float64) {
+func emitPercentiles(handle observerdef.Handle, metricPrefix string, sketchBytes []byte, tags []string, timestampUnix int64) {
 	sketch, err := decodeSketch(sketchBytes)
 	if err != nil {
 		pkglog.Debugf("[observer] failed to decode ddsketch: %v", err)
@@ -75,10 +75,10 @@ func emitPercentiles(handle observerdef.Handle, metricPrefix string, sketchBytes
 
 		metricName := fmt.Sprintf("%s.%s", metricPrefix, pq.suffix)
 		handle.ObserveMetric(&statsMetricView{
-			name:      metricName,
-			value:     value,
-			tags:      tags,
-			timestamp: timestamp,
+			name:          metricName,
+			value:         value,
+			tags:          tags,
+			timestampUnix: timestampUnix,
 		})
 	}
 }
@@ -149,16 +149,18 @@ func buildStatsTagsFromRow(agentHostname, agentEnv string, row observerdef.Trace
 
 // statsMetricView implements the MetricView interface for stats-derived metrics.
 type statsMetricView struct {
-	name      string
-	value     float64
-	tags      []string
-	timestamp float64
+	name          string
+	value         float64
+	tags          []string
+	timestampUnix int64
 }
 
-func (m *statsMetricView) GetName() string        { return m.name }
-func (m *statsMetricView) GetValue() float64      { return m.value }
-func (m *statsMetricView) GetRawTags() []string   { return m.tags }
-func (m *statsMetricView) GetTimestamp() float64  { return m.timestamp }
+func (m *statsMetricView) GetName() string      { return m.name }
+func (m *statsMetricView) GetValue() float64    { return m.value }
+func (m *statsMetricView) GetRawTags() []string { return m.tags }
+func (m *statsMetricView) GetTimestampUnix() int64 {
+	return m.timestampUnix
+}
 func (m *statsMetricView) GetSampleRate() float64 { return 1.0 }
 
 // statsPayloadView adapts a *pb.StatsPayload to the TraceStatsView interface.
@@ -215,24 +217,24 @@ type statsRowView struct {
 	group  *pb.ClientGroupedStats
 }
 
-func (r *statsRowView) GetClientHostname() string    { return r.client.Hostname }
-func (r *statsRowView) GetClientEnv() string         { return r.client.Env }
-func (r *statsRowView) GetClientVersion() string     { return r.client.Version }
-func (r *statsRowView) GetClientContainerID() string { return r.client.ContainerID }
-func (r *statsRowView) GetBucketStart() uint64       { return r.bucket.Start }
-func (r *statsRowView) GetBucketDuration() uint64    { return r.bucket.Duration }
-func (r *statsRowView) GetService() string           { return r.group.Service }
-func (r *statsRowView) GetName() string              { return r.group.Name }
-func (r *statsRowView) GetResource() string          { return r.group.Resource }
-func (r *statsRowView) GetType() string              { return r.group.Type }
-func (r *statsRowView) GetHTTPStatusCode() uint32    { return r.group.HTTPStatusCode }
-func (r *statsRowView) GetSpanKind() string          { return r.group.SpanKind }
-func (r *statsRowView) GetIsTraceRoot() int32        { return int32(r.group.IsTraceRoot) }
-func (r *statsRowView) GetSynthetics() bool          { return r.group.Synthetics }
-func (r *statsRowView) GetHits() uint64              { return r.group.Hits }
-func (r *statsRowView) GetErrors() uint64            { return r.group.Errors }
-func (r *statsRowView) GetTopLevelHits() uint64      { return r.group.TopLevelHits }
-func (r *statsRowView) GetDuration() uint64          { return r.group.Duration }
-func (r *statsRowView) GetOkSummary() []byte         { return r.group.OkSummary }
-func (r *statsRowView) GetErrorSummary() []byte      { return r.group.ErrorSummary }
-func (r *statsRowView) GetPeerTags() []string        { return r.group.PeerTags }
+func (r *statsRowView) GetClientHostname() string      { return r.client.Hostname }
+func (r *statsRowView) GetClientEnv() string           { return r.client.Env }
+func (r *statsRowView) GetClientVersion() string       { return r.client.Version }
+func (r *statsRowView) GetClientContainerID() string   { return r.client.ContainerID }
+func (r *statsRowView) GetBucketStartUnixNano() uint64 { return r.bucket.Start }
+func (r *statsRowView) GetBucketDurationNano() uint64  { return r.bucket.Duration }
+func (r *statsRowView) GetService() string             { return r.group.Service }
+func (r *statsRowView) GetName() string                { return r.group.Name }
+func (r *statsRowView) GetResource() string            { return r.group.Resource }
+func (r *statsRowView) GetType() string                { return r.group.Type }
+func (r *statsRowView) GetHTTPStatusCode() uint32      { return r.group.HTTPStatusCode }
+func (r *statsRowView) GetSpanKind() string            { return r.group.SpanKind }
+func (r *statsRowView) GetIsTraceRoot() int32          { return int32(r.group.IsTraceRoot) }
+func (r *statsRowView) GetSynthetics() bool            { return r.group.Synthetics }
+func (r *statsRowView) GetHits() uint64                { return r.group.Hits }
+func (r *statsRowView) GetErrors() uint64              { return r.group.Errors }
+func (r *statsRowView) GetTopLevelHits() uint64        { return r.group.TopLevelHits }
+func (r *statsRowView) GetDurationNano() uint64        { return r.group.Duration }
+func (r *statsRowView) GetOkSummary() []byte           { return r.group.OkSummary }
+func (r *statsRowView) GetErrorSummary() []byte        { return r.group.ErrorSummary }
+func (r *statsRowView) GetPeerTags() []string          { return r.group.PeerTags }

--- a/comp/observer/impl/test_helpers_test.go
+++ b/comp/observer/impl/test_helpers_test.go
@@ -14,8 +14,8 @@ type mockLogView struct {
 	timestampMs int64
 }
 
-func (m *mockLogView) GetContent() []byte    { return m.content }
-func (m *mockLogView) GetStatus() string     { return m.status }
-func (m *mockLogView) GetTags() []string     { return m.tags }
-func (m *mockLogView) GetHostname() string   { return m.hostname }
-func (m *mockLogView) GetTimestampMs() int64 { return m.timestampMs }
+func (m *mockLogView) GetContent() []byte           { return m.content }
+func (m *mockLogView) GetStatus() string            { return m.status }
+func (m *mockLogView) GetTags() []string            { return m.tags }
+func (m *mockLogView) GetHostname() string          { return m.hostname }
+func (m *mockLogView) GetTimestampUnixMilli() int64 { return m.timestampMs }

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -43,7 +43,7 @@ func (v *logDataView) GetTags() []string {
 	return v.data.Tags
 }
 
-func (v *logDataView) GetTimestampMs() int64 {
+func (v *logDataView) GetTimestampUnixMilli() int64 {
 	return v.data.TimestampMs
 }
 
@@ -433,7 +433,7 @@ type storageHandle struct {
 }
 
 func (h *storageHandle) ObserveMetric(sample observerdef.MetricView) {
-	h.storage.Add(h.namespace, sample.GetName(), sample.GetValue(), int64(sample.GetTimestamp()), sample.GetRawTags())
+	h.storage.Add(h.namespace, sample.GetName(), sample.GetValue(), sample.GetTimestampUnix(), sample.GetRawTags())
 }
 func (h *storageHandle) ObserveLog(_ observerdef.LogView)               {}
 func (h *storageHandle) ObserveTrace(_ observerdef.TraceView)           {}
@@ -476,23 +476,25 @@ func (r *parquetTraceStatRow) GetClientHostname() string    { return r.data.Clie
 func (r *parquetTraceStatRow) GetClientEnv() string         { return r.data.ClientEnv }
 func (r *parquetTraceStatRow) GetClientVersion() string     { return r.data.ClientVersion }
 func (r *parquetTraceStatRow) GetClientContainerID() string { return r.data.ClientContainerID }
-func (r *parquetTraceStatRow) GetBucketStart() uint64       { return r.data.BucketStart }
-func (r *parquetTraceStatRow) GetBucketDuration() uint64    { return r.data.BucketDuration }
-func (r *parquetTraceStatRow) GetService() string           { return r.data.Service }
-func (r *parquetTraceStatRow) GetName() string              { return r.data.Name }
-func (r *parquetTraceStatRow) GetResource() string          { return r.data.Resource }
-func (r *parquetTraceStatRow) GetType() string              { return r.data.Type }
-func (r *parquetTraceStatRow) GetHTTPStatusCode() uint32    { return r.data.HTTPStatusCode }
-func (r *parquetTraceStatRow) GetSpanKind() string          { return r.data.SpanKind }
-func (r *parquetTraceStatRow) GetIsTraceRoot() int32        { return r.data.IsTraceRoot }
-func (r *parquetTraceStatRow) GetSynthetics() bool          { return r.data.Synthetics }
-func (r *parquetTraceStatRow) GetHits() uint64              { return r.data.Hits }
-func (r *parquetTraceStatRow) GetErrors() uint64            { return r.data.Errors }
-func (r *parquetTraceStatRow) GetTopLevelHits() uint64      { return r.data.TopLevelHits }
-func (r *parquetTraceStatRow) GetDuration() uint64          { return r.data.Duration }
-func (r *parquetTraceStatRow) GetOkSummary() []byte         { return r.data.OkSummary }
-func (r *parquetTraceStatRow) GetErrorSummary() []byte      { return r.data.ErrorSummary }
-func (r *parquetTraceStatRow) GetPeerTags() []string        { return r.data.PeerTags }
+func (r *parquetTraceStatRow) GetBucketStartUnixNano() uint64 {
+	return r.data.BucketStart
+}
+func (r *parquetTraceStatRow) GetBucketDurationNano() uint64 { return r.data.BucketDuration }
+func (r *parquetTraceStatRow) GetService() string            { return r.data.Service }
+func (r *parquetTraceStatRow) GetName() string               { return r.data.Name }
+func (r *parquetTraceStatRow) GetResource() string           { return r.data.Resource }
+func (r *parquetTraceStatRow) GetType() string               { return r.data.Type }
+func (r *parquetTraceStatRow) GetHTTPStatusCode() uint32     { return r.data.HTTPStatusCode }
+func (r *parquetTraceStatRow) GetSpanKind() string           { return r.data.SpanKind }
+func (r *parquetTraceStatRow) GetIsTraceRoot() int32         { return r.data.IsTraceRoot }
+func (r *parquetTraceStatRow) GetSynthetics() bool           { return r.data.Synthetics }
+func (r *parquetTraceStatRow) GetHits() uint64               { return r.data.Hits }
+func (r *parquetTraceStatRow) GetErrors() uint64             { return r.data.Errors }
+func (r *parquetTraceStatRow) GetTopLevelHits() uint64       { return r.data.TopLevelHits }
+func (r *parquetTraceStatRow) GetDurationNano() uint64       { return r.data.Duration }
+func (r *parquetTraceStatRow) GetOkSummary() []byte          { return r.data.OkSummary }
+func (r *parquetTraceStatRow) GetErrorSummary() []byte       { return r.data.ErrorSummary }
+func (r *parquetTraceStatRow) GetPeerTags() []string         { return r.data.PeerTags }
 
 // runLogExtractors runs all the log extractors on the raw logs.
 func (tb *TestBench) runLogExtractors() error {
@@ -500,7 +502,7 @@ func (tb *TestBench) runLogExtractors() error {
 		// Process through log extractors
 		for _, extractor := range tb.extractors {
 			metrics := extractor.ProcessLog(log)
-			ts := log.GetTimestampMs()
+			ts := log.GetTimestampUnixMilli()
 			for _, m := range metrics {
 				tb.storage.Add("logs", "_virtual."+m.Name, m.Value, ts/1000, m.Tags)
 			}
@@ -535,7 +537,7 @@ func (tb *TestBench) GetStatus() StatusResponse {
 
 	// Extend bounds to include log timestamps (parquet logs can fall outside the metrics range)
 	for _, l := range tb.rawLogs {
-		ts := l.GetTimestampMs()
+		ts := l.GetTimestampUnixMilli()
 		if ts == 0 {
 			continue
 		}
@@ -721,7 +723,7 @@ func (tb *TestBench) handleTelemetry(telemetry []observerdef.ObserverTelemetry, 
 				name:      telemetryEvent.Metric.GetName(),
 				value:     telemetryEvent.Metric.GetValue(),
 				tags:      telemetryEvent.Metric.GetRawTags(),
-				timestamp: int64(telemetryEvent.Metric.GetTimestamp()),
+				timestamp: telemetryEvent.Metric.GetTimestampUnix(),
 			}
 			if metric.timestamp == 0 {
 				metric.timestamp = baseTimestampMs / 1000
@@ -734,7 +736,7 @@ func (tb *TestBench) handleTelemetry(telemetry []observerdef.ObserverTelemetry, 
 		}
 
 		if telemetryEvent.Log != nil {
-			timestamp := telemetryEvent.Log.GetTimestampMs()
+			timestamp := telemetryEvent.Log.GetTimestampUnixMilli()
 			if timestamp == 0 {
 				timestamp = baseTimestampMs
 			}

--- a/comp/observer/impl/testbench_api.go
+++ b/comp/observer/impl/testbench_api.go
@@ -483,7 +483,7 @@ func (api *TestBenchAPI) handleLogs(w http.ResponseWriter, r *http.Request) {
 		// 	tags = append(tags, "status:"+l.Status)
 		// }
 		response = append(response, logEntryResponse{
-			TimestampMs: l.GetTimestampMs(),
+			TimestampMs: l.GetTimestampUnixMilli(),
 			Status:      l.GetStatus(),
 			Content:     string(l.GetContent()),
 			Hostname:    l.GetHostname(),


### PR DESCRIPTION
## Summary
- Renames all timestamp/duration getters on view interfaces (`MetricView`, `LogView`, `TraceView`, `SpanView`, `ProfileView`, `TraceStatRow`) to encode their unit: `GetTimestampUnix`, `GetTimestampUnixMilli`, `GetTimestampUnixNano`, `GetDurationNano`, etc.
- Fixes `MetricView.GetTimestamp` which returned `float64` wrapping an `int64` — now returns `int64` directly as `GetTimestampUnix`. This float snuck in and was always immediately cast back to int64 at call sites.
- Updates all implementations and call sites to match.

## Test plan
- [ ] `go test ./comp/observer/impl/` passes
- [ ] `go build ./cmd/observer-testbench/` compiles